### PR TITLE
CLI-43: Add -g/--global flag to sonar integrate claude

### DIFF
--- a/build-scripts/validate-commands.js
+++ b/build-scripts/validate-commands.js
@@ -235,28 +235,27 @@ function parseIndexCommands(content) {
 }
 
 /**
- * Parse options from command registration block
+ * Parse options from command registration block.
+ * Handles both single-line and multi-line .option() / .requiredOption() calls.
  */
 function parseOptions(optionsBlock) {
   const options = [];
 
   if (!optionsBlock) return options;
 
-  // Match .option() and .requiredOption() - simplified with split approach
-  const lines = optionsBlock.split('\n');
-
-  for (const line of lines) {
-    const isOption = line.includes('.option(') || line.includes('.requiredOption(');
-    if (!isOption) continue;
-
-    const isRequired = line.includes('requiredOption');
+  // Match full .option(...) and .requiredOption(...) calls, including multi-line ones
+  const optionPattern = /\.(option|requiredOption)\(([\s\S]*?)\)/g;
+  let match;
+  while ((match = optionPattern.exec(optionsBlock)) !== null) {
+    const isRequired = match[1] === 'requiredOption';
+    const argsBlock = match[2];
 
     // Extract quoted strings (flags, description, default)
     const quoted = /['"]([^'"]{0,100})['"]/g;
     const matches = [];
-    let match;
-    while ((match = quoted.exec(line)) !== null) {
-      matches.push(match[1]);
+    let qMatch;
+    while ((qMatch = quoted.exec(argsBlock)) !== null) {
+      matches.push(qMatch[1]);
     }
 
     if (matches.length === 0) continue;

--- a/spec.yaml
+++ b/spec.yaml
@@ -141,12 +141,21 @@ commands:
         description: Skip hooks installation
         default: false
 
+      - name: global
+        alias: g
+        type: boolean
+        description: Install hooks and config globally to ~/.claude instead of project directory
+        default: false
+
     examples:
       - command: sonar integrate claude -s https://sonarcloud.io -p my-project
         description: Integrate Claude Code with interactive setup
 
       - command: sonar integrate claude --skip-hooks
         description: Integrate without installing hooks
+
+      - command: sonar integrate claude -g -s https://sonarcloud.io -p my-project
+        description: Integrate globally - install hooks to ~/.claude for all projects
 
   # List Sonar resources
   - name: list

--- a/spec.yaml
+++ b/spec.yaml
@@ -155,7 +155,7 @@ commands:
         description: Integrate without installing hooks
 
       - command: sonar integrate claude -g -s https://sonarcloud.io -p my-project
-        description: Integrate globally - install hooks to ~/.claude for all projects
+        description: Integrate globally and install hooks to ~/.claude for all projects
 
   # List Sonar resources
   - name: list

--- a/src/bootstrap/hooks.ts
+++ b/src/bootstrap/hooks.ts
@@ -156,13 +156,10 @@ export async function installSecretScanningHooks(
     settings.hooks ??= {};
 
     // Global hooks use absolute paths; project hooks use paths relative to project root
-    const preToolCommand = isGlobal
-      ? join(baseDir, CLAUDE_DIR, HOOKS_DIR, 'sonar-secrets', 'build-scripts', `pretool-secrets${scriptExt}`)
-      : join(CLAUDE_DIR, HOOKS_DIR, 'sonar-secrets', 'build-scripts', `pretool-secrets${scriptExt}`);
-
-    const promptCommand = isGlobal
-      ? join(baseDir, CLAUDE_DIR, HOOKS_DIR, 'sonar-secrets', 'build-scripts', `prompt-secrets${scriptExt}`)
-      : join(CLAUDE_DIR, HOOKS_DIR, 'sonar-secrets', 'build-scripts', `prompt-secrets${scriptExt}`);
+    const hooksRelativeDir = join(CLAUDE_DIR, HOOKS_DIR, 'sonar-secrets', 'build-scripts');
+    const hooksScriptsDir = isGlobal ? join(baseDir, hooksRelativeDir) : hooksRelativeDir;
+    const preToolCommand = join(hooksScriptsDir, `pretool-secrets${scriptExt}`);
+    const promptCommand = join(hooksScriptsDir, `prompt-secrets${scriptExt}`);
 
     // Add sonar-secrets hooks to settings
     settings.hooks.PreToolUse = [

--- a/src/commands/integrate.ts
+++ b/src/commands/integrate.ts
@@ -20,6 +20,7 @@
 
 // Integrate command - setup SonarQube integration for Claude Code
 
+import { homedir } from 'node:os';
 import { discoverProject, type ProjectInfo } from '../bootstrap/discovery.js';
 import { runHealthChecks } from '../bootstrap/health.js';
 import { runRepair } from '../bootstrap/repair.js';
@@ -47,6 +48,7 @@ export interface OnboardAgentOptions {
   org?: string;
   nonInteractive?: boolean;
   skipHooks?: boolean;
+  global?: boolean;
 }
 
 interface ConfigurationData {
@@ -278,6 +280,7 @@ async function runHealthCheckAndRepair(
   token: string | undefined,
   organization: string | undefined,
   skipHooks: boolean | undefined,
+  hooksGlobal?: boolean,
 ): Promise<string | undefined> {
   text('\nPhase 2/3: Health Check & Repair');
   blank();
@@ -287,18 +290,20 @@ async function runHealthCheckAndRepair(
     return undefined;
   }
 
+  const hooksRoot = hooksGlobal ? homedir() : projectInfo.root;
+
   const healthResult = await runHealthChecks(
     serverURL,
     token,
     projectKey,
-    projectInfo.root,
+    hooksRoot,
     organization,
   );
 
   if (healthResult.errors.length === 0) {
     success('All checks passed! Configuration is healthy.');
     if (!skipHooks) {
-      await installSecretScanningHooks(projectInfo.root);
+      await installSecretScanningHooks(projectInfo.root, hooksGlobal ? homedir() : undefined);
     }
     return token;
   }
@@ -428,6 +433,8 @@ export async function integrateCommand(agent: string, options: OnboardAgentOptio
     // Ensure token is available
     let token = await ensureToken(config.token, serverURL, config.organization);
 
+    const hooksRoot = options.global ? homedir() : projectInfo.root;
+
     // Phase 2 & 3: Health Check and Repair
     if (token) {
       token = await runHealthCheckAndRepair(
@@ -437,6 +444,7 @@ export async function integrateCommand(agent: string, options: OnboardAgentOptio
         token,
         config.organization,
         options.skipHooks,
+        options.global,
       );
 
       if (token) {
@@ -448,7 +456,7 @@ export async function integrateCommand(agent: string, options: OnboardAgentOptio
           serverURL,
           token,
           projectKey,
-          projectInfo.root,
+          hooksRoot,
           config.organization,
           false,
         );
@@ -474,7 +482,7 @@ export async function integrateCommand(agent: string, options: OnboardAgentOptio
       serverURL,
       token,
       projectKey,
-      projectInfo.root,
+      hooksRoot,
       config.organization,
       false,
     );

--- a/src/commands/integrate.ts
+++ b/src/commands/integrate.ts
@@ -292,13 +292,7 @@ async function runHealthCheckAndRepair(
 
   const hooksRoot = hooksGlobal ? homedir() : projectInfo.root;
 
-  const healthResult = await runHealthChecks(
-    serverURL,
-    token,
-    projectKey,
-    hooksRoot,
-    organization,
-  );
+  const healthResult = await runHealthChecks(serverURL, token, projectKey, hooksRoot, organization);
 
   if (healthResult.errors.length === 0) {
     success('All checks passed! Configuration is healthy.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ program
   .option('-o, --org <org>', 'Organization key (for SonarCloud)')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .option('--skip-hooks', 'Skip hooks installation')
+  .option('-g, --global', 'Install hooks and config globally to ~/.claude instead of project directory')
   .action(async (agent, options) => {
     await runCommand(async () => {
       if (!VALID_TOOLS.includes(agent)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,10 @@ program
   .option('-o, --org <org>', 'Organization key (for SonarCloud)')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .option('--skip-hooks', 'Skip hooks installation')
-  .option('-g, --global', 'Install hooks and config globally to ~/.claude instead of project directory')
+  .option(
+    '-g, --global',
+    'Install hooks and config globally to ~/.claude instead of project directory',
+  )
   .action(async (agent, options) => {
     await runCommand(async () => {
       if (!VALID_TOOLS.includes(agent)) {

--- a/tests/unit/integrate.test.ts
+++ b/tests/unit/integrate.test.ts
@@ -467,6 +467,69 @@ describe('integrateCommand: discovered project configuration', () => {
   });
 });
 
+// ─── global flag ──────────────────────────────────────────────────────────────
+
+describe('integrateCommand: --global flag', () => {
+  let mockExit: ReturnType<typeof spyOn>;
+  let loadStateSpy: ReturnType<typeof spyOn>;
+  let saveStateSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
+    mockExit = spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
+    saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    mockExit.mockRestore();
+    loadStateSpy.mockRestore();
+    saveStateSpy.mockRestore();
+    setMockUi(false);
+  });
+
+  it('exits 0 when global onboarding succeeds', async () => {
+    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
+    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+
+    try {
+      await integrateCommand('claude', {
+        server: 'https://sonarcloud.io',
+        project: 'my-project',
+        token: 'test-token',
+        org: 'test-org',
+        skipHooks: true,
+        global: true,
+      });
+      expect(mockExit).toHaveBeenCalledWith(0);
+    } finally {
+      discoverSpy.mockRestore();
+      healthSpy.mockRestore();
+    }
+  });
+
+  it('completes successfully with --global and skipHooks=false', async () => {
+    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
+    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+
+    try {
+      await integrateCommand('claude', {
+        server: 'https://sonarcloud.io',
+        project: 'my-project',
+        token: 'test-token',
+        org: 'test-org',
+        skipHooks: false,
+        global: true,
+      });
+      expect(mockExit).toHaveBeenCalledWith(0);
+    } finally {
+      discoverSpy.mockRestore();
+      healthSpy.mockRestore();
+    }
+  });
+});
+
 // ─── no token path ────────────────────────────────────────────────────────────
 
 describe('integrateCommand: no token available', () => {


### PR DESCRIPTION
When --global (-g) is passed, hooks and settings.json are installed to ~/.claude/ instead of the project-level .claude/ directory.