### PR TITLE
CLI-52 Fix typos in help and error messages

### DIFF
--- a/src/bootstrap/auth.ts
+++ b/src/bootstrap/auth.ts
@@ -31,7 +31,7 @@ import { openBrowser } from '../lib/browser.js';
 import { SonarQubeClient } from '../sonarqube/client.js';
 import { startLoopbackServer } from '../lib/loopback-server.js';
 import logger from '../lib/logger.js';
-import { warn, print, pressAnyKeyPrompt, isMockActive } from '../ui/index.js';
+import { warn, print, pressEnterKeyPrompt, isMockActive } from '../ui/index.js';
 import { green, dim } from '../ui/colors.js';
 
 const HTTP_STATUS_OK = 200;
@@ -345,7 +345,7 @@ export async function generateTokenViaBrowser(
 
   print('Obtaining access token from SonarQube...');
   print(`URL: ${authURL}`);
-  await pressAnyKeyPrompt('Press any key to open the browser');
+  await pressEnterKeyPrompt('Press Enter to open the browser');
   await openBrowserFn(authURL);
 
   let token: string | undefined;

--- a/src/commands/secret-scan.ts
+++ b/src/commands/secret-scan.ts
@@ -162,24 +162,14 @@ async function performFileScan(
 function validateCheckCommandEnvironment(binaryPath: string): void {
   if (!existsSync(binaryPath)) {
     error('sonar-secrets is not installed');
-    text('  Install with: sonar secret install');
+    text('  Install with: sonar install secrets');
     process.exit(1);
   }
 }
 
 function logAuthConfigError(): void {
   error('sonar-secrets authentication is not configured');
-  text(
-    [
-      '',
-      'Configure authentication by setting environment variables:',
-      '  export SONAR_SECRETS_AUTH_URL=<url>',
-      '  export SONAR_SECRETS_TOKEN=<token>',
-      '',
-      'For SonarQube Cloud: SONAR_SECRETS_AUTH_URL=https://sonarcloud.io',
-      'For on-premise: SONAR_SECRETS_AUTH_URL=https://your-sonarqube-server',
-    ].join('\n'),
-  );
+  text('  Run: sonar auth login');
 }
 
 async function runScan(
@@ -358,10 +348,10 @@ function handleScanError(err: unknown): void {
     );
   } else if (errorMessage.includes('ENOENT')) {
     text(
-      '\nThe binary file was not found or is not executable.\nReinstall with: sonar secret install --force',
+      '\nThe binary file was not found or is not executable.\nReinstall with: sonar install secrets --force',
     );
   } else {
-    text('\nCheck installation with: sonar secret status');
+    text('\nCheck installation with: sonar install secrets --status');
   }
 
   blank();

--- a/src/commands/secret.ts
+++ b/src/commands/secret.ts
@@ -147,7 +147,7 @@ export async function secretStatusCommand({ binDir }: { binDir?: string } = {}):
 
     if (!existsSync(binaryPath)) {
       text('Status: Not installed');
-      text('  Install with: sonar secret install');
+      text('  Install with: sonar install secrets');
       return;
     }
 
@@ -179,8 +179,8 @@ export async function secretStatusCommand({ binDir }: { binDir?: string } = {}):
 
     warn('Binary exists but not working');
     text(`Path: ${binaryPath}`);
-    text('  Reinstall with: sonar secret install --force');
-    throw new Error('Binary not working. Reinstall with: sonar secret install --force');
+    text('  Reinstall with: sonar install secrets --force');
+    throw new Error('Binary not working. Reinstall with: sonar install secrets --force');
   });
 }
 

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -62,7 +62,7 @@ export class SonarQubeClient {
     if (!response.ok) {
       if (response.status === HTTP_STATUS_FORBIDDEN || response.status === HTTP_STATUS_NOT_FOUND) {
         throw new Error(
-          `Access denied (HTTP ${response.status}). Check your token and organization permissions.`,
+          `Access denied (HTTP ${response.status}). Check that the supplied token and organization are valid.`,
         );
       }
       throw new Error(`SonarQube API error: ${response.status} ${response.statusText}`);

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -25,6 +25,8 @@ import logger from '../lib/logger.js';
 
 const GET_REQUEST_TIMEOUT_MS = 30000; // 30 seconds
 const POST_REQUEST_TIMEOUT_MS = 60000; // 60 seconds for analysis
+const HTTP_STATUS_FORBIDDEN = 403;
+const HTTP_STATUS_NOT_FOUND = 404;
 
 export class SonarQubeClient {
   private readonly serverURL: string;
@@ -58,6 +60,11 @@ export class SonarQubeClient {
     });
 
     if (!response.ok) {
+      if (response.status === HTTP_STATUS_FORBIDDEN || response.status === HTTP_STATUS_NOT_FOUND) {
+        throw new Error(
+          `Access denied (HTTP ${response.status}). Check your token and organization permissions.`,
+        );
+      }
       throw new Error(`SonarQube API error: ${response.status} ${response.statusText}`);
     }
 

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -36,4 +36,4 @@ export {
 export type { UiCall } from './mock.js';
 export type { NoteOptions, PhaseOptions, LogOptions, ColorFn } from './types.js';
 export { withSpinner } from './components/spinner.js';
-export { textPrompt, confirmPrompt, pressAnyKeyPrompt } from './components/prompts.js';
+export { textPrompt, confirmPrompt, pressEnterKeyPrompt } from './components/prompts.js';

--- a/tests/unit/prompts.test.ts
+++ b/tests/unit/prompts.test.ts
@@ -25,7 +25,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { textPrompt, confirmPrompt, pressAnyKeyPrompt } from '../../src/ui/components/prompts.js';
+import { textPrompt, confirmPrompt, pressEnterKeyPrompt } from '../../src/ui/components/prompts.js';
 import {
   setMockUi,
   getMockUiCalls,
@@ -143,7 +143,7 @@ describe('pressAnyKeyPrompt', () => {
     setMockUi(true);
     clearMockUiCalls();
     try {
-      await pressAnyKeyPrompt('Press Enter to continue');
+      await pressEnterKeyPrompt('Press Enter to continue');
       const calls = getMockUiCalls();
       expect(
         calls.some(
@@ -160,7 +160,7 @@ describe('pressAnyKeyPrompt', () => {
     process.env['CI'] = 'true';
     clearMockUiCalls();
     try {
-      await pressAnyKeyPrompt('Press Enter');
+      await pressEnterKeyPrompt('Press Enter');
       const calls = getMockUiCalls().filter((c) => c.method === 'pressAnyKeyPrompt');
       expect(calls).toHaveLength(0);
     } finally {

--- a/tests/unit/secret-scan.test.ts
+++ b/tests/unit/secret-scan.test.ts
@@ -105,7 +105,7 @@ describe('secretCheckCommand: auth failures', () => {
     const texts = getMockUiCalls()
       .filter((c) => c.method === 'text')
       .map((c) => String(c.args[0]));
-    expect(texts.some((m) => m.includes('SONAR_SECRETS_AUTH_URL'))).toBe(true);
+    expect(texts.some((m) => m.includes('sonar auth login'))).toBe(true);
   });
 
   it('exits 1 when connection exists but no token is stored in keychain', async () => {
@@ -334,7 +334,7 @@ describe('secretCheckCommand: scan error handling', () => {
     const texts = getMockUiCalls()
       .filter((c) => c.method === 'text')
       .map((c) => String(c.args[0]));
-    expect(texts.some((m) => m.includes('sonar secret install --force'))).toBe(true);
+    expect(texts.some((m) => m.includes('sonar install secrets --force'))).toBe(true);
   });
 
   it('shows generic status check hint and exits 1 for unexpected errors', async () => {
@@ -352,7 +352,7 @@ describe('secretCheckCommand: scan error handling', () => {
     const texts = getMockUiCalls()
       .filter((c) => c.method === 'text')
       .map((c) => String(c.args[0]));
-    expect(texts.some((m) => m.includes('sonar secret status'))).toBe(true);
+    expect(texts.some((m) => m.includes('sonar install secrets --status'))).toBe(true);
   });
 });
 


### PR DESCRIPTION
- Fix wrong command hints: 'sonar secret install' → 'sonar install secrets'
- Fix wrong command hints: 'sonar secret status' → 'sonar install secrets --status'
- Fix auth error message: replace env var instructions with 'sonar auth login'
- Fix 'Press any key' prompt: rename to pressEnterKeyPrompt, implement raw stdin so only Enter advances and all other keys are silently consumed
- Fix misleading 404 error: map HTTP 403/404 to 'Access denied' message (SonarQube servers return 404 in place of 403 for auth failures)