### PR TITLE
Remove token from interactive login command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ sonar auth login
 Interactive login for SonarCloud with browser
 
 ```bash
-sonar auth login -o my-org -t squ_abc123
+sonar auth login -o my-org
 ```
 Non-interactive login with direct token
 


### PR DESCRIPTION
While following the documentation, it looks like the command below had a typo, i.e. if the login is interactive we shouldn't need to put the token