### PR TITLE
CLI-88 Use GitHub releases to fetch latest version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -259,11 +259,6 @@ jobs:
       - name: Copy user scripts to dist
         run: cp user-scripts/install.sh user-scripts/install.ps1 dist/
 
-      - name: Generate latest-version.txt
-        env:
-          PROJECT_VERSION: ${{ needs.prepare.outputs.PROJECT_VERSION }}
-        run: echo "${PROJECT_VERSION}" > dist/latest-version.txt
-
       - name: Upload binaries to Artifactory
         env:
           ARTIFACTORY_URL: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_URL }}

--- a/user-scripts/install.ps1
+++ b/user-scripts/install.ps1
@@ -10,8 +10,14 @@ $BaseUrl    = 'https://binaries.sonarsource.com/Distribution/sonarqube-cli'
 $Platform   = 'windows-x86-64'
 
 function Resolve-LatestVersion {
-    $Version = (Invoke-WebRequest -Uri "$BaseUrl/latest-version.txt" -UseBasicParsing).Content.Trim()
-    if (-not $Version) {
+    $ReleasesUrl = 'https://github.com/SonarSource/sonarqube-cli/releases/latest'
+    $Request = [System.Net.WebRequest]::Create($ReleasesUrl)
+    $Request.AllowAutoRedirect = $true
+    $Response = $Request.GetResponse()
+    $FinalUrl = $Response.ResponseUri.AbsoluteUri
+    $Response.Close()
+    $Version = ($FinalUrl -split '/')[-1] -replace '^v', ''
+    if (-not $Version -or $Version -eq 'latest') {
         Write-Error 'Could not determine the latest version.'
         exit 1
     }
@@ -42,10 +48,8 @@ function Add-ToUserPath {
 
 # --- Main ---
 
-#Write-Host 'Fetching latest version...'
-#$SonarVersion = Resolve-LatestVersion
-
-$SonarVersion = "0.4.0.345"
+Write-Host 'Fetching latest version...'
+$SonarVersion = Resolve-LatestVersion
 Write-Host "Latest version: $SonarVersion"
 
 $Filename     = "sonarqube-cli-$SonarVersion-$Platform.exe"

--- a/user-scripts/install.sh
+++ b/user-scripts/install.sh
@@ -30,18 +30,19 @@ detect_platform() {
 }
 
 resolve_latest_version() {
+  local releases_url="https://github.com/SonarSource/sonarqube-cli/releases/latest"
   local version
   if command -v curl &>/dev/null; then
-    version="$(curl -fsSL "$BASE_URL/latest-version.txt")"
+    version="$(curl -fsSL -o /dev/null -w '%{url_effective}' "$releases_url" | grep -oE '[^/]+$')"
   elif command -v wget &>/dev/null; then
-    version="$(wget -qO- "$BASE_URL/latest-version.txt")"
+    version="$(wget -qO /dev/null --server-response "$releases_url" 2>&1 | grep -i 'location:' | tail -1 | grep -oE '[^/]+$')"
   else
     echo "Error: neither curl nor wget is available. Please install one and retry." >&2
     exit 1
   fi
 
-  version="$(printf '%s' "$version" | tr -d '[:space:]')"
-  if [[ -z "$version" ]]; then
+  version="$(printf '%s' "$version" | tr -d '[:space:]' | sed 's/^v//')"
+  if [[ -z "$version" ]] || [[ "$version" == "latest" ]]; then
     echo "Error: could not determine the latest version." >&2
     exit 1
   fi
@@ -68,9 +69,8 @@ main() {
   platform="$(detect_platform)"
 
   local version
-  #echo "Fetching latest version..."
-  #version="$(resolve_latest_version)"
-  version="0.4.0.345"
+  echo "Fetching latest version..."
+  version="$(resolve_latest_version)"
   echo "Latest version: $version"
 
   local filename="sonarqube-cli-${version}-${platform}.exe"


### PR DESCRIPTION
Replace hardcoded version with dynamic resolution in install scripts
                                                                                                                                                                                                                                                                                                                    
The install scripts (install.sh, install.ps1) previously hardcoded the latest version number as a workaround after the `latest-version.txt` approach failed.                                                                                                                                     

Now that the project is public on GitHub, the scripts resolve the latest version dynamically by following the GitHub releases redirect (/releases/latest → /releases/tag/VERSION) and extracting the version from the final URL. Alternatively we could use the GitHub API, however, it has the drawbacks of requiring API token after the unauthenticated rate limit is reached which makes it less ideal.

The `latest-version.txt` generation step has also been removed from the build pipeline as it is no longer used.