### PR TITLE
CLI-108 Fix list command to work with auth env variables

### DIFF
--- a/src/cli/commands/list.ts
+++ b/src/cli/commands/list.ts
@@ -20,6 +20,7 @@
 
 // Issues command - search for SonarQube issues
 
+import { resolveAuth } from '../../lib/auth-resolver';
 import { SonarQubeClient } from '../../sonarqube/client';
 import { IssuesClient } from '../../sonarqube/issues';
 import { encode as encodeToToon } from '@toon-format/toon';
@@ -27,8 +28,6 @@ import { formatTable } from '../../formatter/table';
 import { formatCSV } from '../../formatter/csv';
 import type { IssuesSearchParams } from '../../lib/types';
 import { print } from '../../ui';
-import { getActiveConnection, loadState } from '../../lib/state-manager';
-import { getToken } from '../../lib/keychain';
 import { MAX_PAGE_SIZE, ProjectsClient } from '../../sonarqube/projects';
 
 const VALID_FORMATS = ['json', 'toon', 'table', 'csv'];
@@ -53,7 +52,8 @@ export interface ListIssuesOptions {
  * Issues search command handler
  */
 export async function listIssues(options: ListIssuesOptions): Promise<void> {
-  // Validate options before any auth/network operations
+  const resolvedAuth = await resolveAuth({});
+
   const format = options.format ?? 'json';
   if (!VALID_FORMATS.includes(format.toLowerCase())) {
     throw new Error(`Invalid format: '${format}'. Must be one of: ${VALID_FORMATS.join(', ')}`);
@@ -82,24 +82,12 @@ export async function listIssues(options: ListIssuesOptions): Promise<void> {
     throw new Error('--project is required');
   }
 
-  const state = loadState();
-  const activeConnection = getActiveConnection(state);
-
-  if (!activeConnection) {
-    throw new Error('No active connection found. Run: sonar auth login');
-  }
-
-  const token = await getToken(activeConnection.serverUrl, activeConnection.orgKey);
-  if (!token) {
-    throw new Error('No token found. Run: sonar auth login');
-  }
-
-  const client = new SonarQubeClient(activeConnection.serverUrl, token);
+  const client = new SonarQubeClient(resolvedAuth.serverUrl, resolvedAuth.token);
   const issuesClient = new IssuesClient(client);
 
   const params: IssuesSearchParams = {
     projects: options.project,
-    organization: activeConnection.orgKey,
+    organization: resolvedAuth.orgKey,
     severities: options.severity?.toUpperCase(),
     types: options.type,
     statuses: options.status,
@@ -146,17 +134,7 @@ export interface ListProjectsOptions {
  * Projects search command handler
  */
 export async function listProjects(options: ListProjectsOptions): Promise<void> {
-  const state = loadState();
-  const activeConnection = getActiveConnection(state);
-
-  if (!activeConnection) {
-    throw new Error('No active connection found. Run: sonar auth login');
-  }
-
-  const token = await getToken(activeConnection.serverUrl, activeConnection.orgKey);
-  if (!token) {
-    throw new Error('No token found. Run: sonar auth login');
-  }
+  const resolvedAuth = await resolveAuth({});
 
   const pageSize = options.pageSize;
   if (pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
@@ -170,14 +148,14 @@ export async function listProjects(options: ListProjectsOptions): Promise<void> 
     throw new Error(`Invalid --page option: '${page}'. Must be an integer >= 1`);
   }
 
-  const client = new SonarQubeClient(activeConnection.serverUrl, token);
+  const client = new SonarQubeClient(resolvedAuth.serverUrl, resolvedAuth.token);
   const projectsClient = new ProjectsClient(client);
 
   const result = await projectsClient.searchProjects({
     q: options.query,
     ps: pageSize,
     p: options.page,
-    organization: activeConnection.orgKey,
+    organization: resolvedAuth.orgKey,
   });
 
   const hasNextPage = result.paging.pageIndex * result.paging.pageSize < result.paging.total;

--- a/tests/unit/list.test.ts
+++ b/tests/unit/list.test.ts
@@ -33,8 +33,7 @@ import type {
 import { listIssues } from '../../src/cli/commands/list.js';
 import { setMockUi } from '../../src/ui';
 import { MAX_PAGE_SIZE, ProjectsClient } from '../../src/sonarqube/projects';
-import * as stateManager from '../../src/lib/state-manager.js';
-import * as keychain from '../../src/lib/keychain.js';
+import * as authResolver from '../../src/lib/auth-resolver.js';
 
 // Test constants
 const DEFAULT_PAGE_SIZE = 500;
@@ -349,33 +348,49 @@ describe('IssuesClient', () => {
 });
 
 describe('issuesSearchCommand', () => {
-  let loadStateSpy: ReturnType<typeof spyOn>;
-  let getActiveConnectionSpy: ReturnType<typeof spyOn>;
-  let getTokenSpy: ReturnType<typeof spyOn>;
+  let resolveAuthSpy: ReturnType<typeof spyOn>;
 
-  const mockConnection = {
-    id: 'test-id',
-    type: 'cloud' as const,
-    authenticatedAt: new Date().toISOString(),
-    keystoreKey: 'test-keystore-key',
+  const mockAuth = {
+    token: 'test-token',
     serverUrl: 'https://sonarcloud.io',
     orgKey: 'test-org',
   };
 
+  const emptyApiResponse = {
+    issues: [],
+    total: 0,
+    p: 1,
+    ps: 500,
+    paging: { pageIndex: 1, pageSize: 500, total: 0 },
+  };
+
   beforeEach(() => {
     setMockUi(true);
-    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue({} as never);
-    getActiveConnectionSpy = spyOn(stateManager, 'getActiveConnection').mockReturnValue(
-      mockConnection,
-    );
-    getTokenSpy = spyOn(keychain, 'getToken').mockResolvedValue('test-token');
+    resolveAuthSpy = spyOn(authResolver, 'resolveAuth').mockResolvedValue(mockAuth);
   });
 
   afterEach(() => {
     setMockUi(false);
-    loadStateSpy.mockRestore();
-    getActiveConnectionSpy.mockRestore();
-    getTokenSpy.mockRestore();
+    resolveAuthSpy.mockRestore();
+  });
+
+  it('calls resolveAuth', async () => {
+    const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockResolvedValue(emptyApiResponse);
+
+    try {
+      await listIssues({ project: 'my-project', page: 1, pageSize: 500 });
+      expect(resolveAuthSpy).toHaveBeenCalledWith({});
+    } finally {
+      getSpy.mockRestore();
+    }
+  });
+
+  it('propagates auth errors', () => {
+    resolveAuthSpy.mockRejectedValue(new Error('Not authenticated. Run: sonar auth login'));
+
+    expect(listIssues({ project: 'proj', page: 1, pageSize: 500 })).rejects.toThrow(
+      'sonar auth login',
+    );
   });
 
   it('throws when --project is missing', () => {
@@ -383,55 +398,28 @@ describe('issuesSearchCommand', () => {
   });
 
   it('throws when --format is invalid', () => {
-    expect(
-      listIssues({
-        project: 'proj',
-        format: 'xml',
-        page: 1,
-        pageSize: 500,
-      }),
-    ).rejects.toThrow('xml');
+    expect(listIssues({ project: 'proj', format: 'xml', page: 1, pageSize: 500 })).rejects.toThrow(
+      'xml',
+    );
   });
 
   it('throws when --page is 0', () => {
-    expect(
-      listIssues({
-        project: 'proj',
-        page: 0,
-        pageSize: 500,
-      }),
-    ).rejects.toThrow('page');
+    expect(listIssues({ project: 'proj', page: 0, pageSize: 500 })).rejects.toThrow('page');
   });
 
   it('throws when --page-size is 0', () => {
-    expect(
-      listIssues({
-        project: 'proj',
-        page: 1,
-        pageSize: 0,
-      }),
-    ).rejects.toThrow('page-size');
+    expect(listIssues({ project: 'proj', page: 1, pageSize: 0 })).rejects.toThrow('page-size');
   });
 
-  it('throws when --page-size exceeds 500', () => {
-    expect(
-      listIssues({
-        project: 'proj',
-
-        page: 1,
-        pageSize: 501,
-      }),
-    ).rejects.toThrow('page-size');
+  it('throws when --page-size exceeds maximum', () => {
+    expect(listIssues({ project: 'proj', page: 1, pageSize: MAX_PAGE_SIZE + 1 })).rejects.toThrow(
+      'page-size',
+    );
   });
 
   it('throws when --severity is invalid', () => {
     expect(
-      listIssues({
-        project: 'proj',
-        severity: 'EXTREME',
-        page: 1,
-        pageSize: 500,
-      }),
+      listIssues({ project: 'proj', severity: 'EXTREME', page: 1, pageSize: 500 }),
     ).rejects.toThrow('EXTREME');
   });
 
@@ -440,44 +428,23 @@ describe('issuesSearchCommand', () => {
     const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockImplementation(
       <T>(_endpoint: string, params?: Record<string, string | number | boolean>) => {
         capturedSeverities = (params as Record<string, string>)?.severities;
-        return Promise.resolve({
-          issues: [],
-          total: 0,
-          p: 1,
-          ps: 500,
-          paging: { pageIndex: 1, pageSize: 500, total: 0 },
-        } as unknown as T);
+        return Promise.resolve(emptyApiResponse as unknown as T);
       },
     );
 
     try {
-      await listIssues({
-        project: 'my-project',
-        severity: 'major',
-        page: 1,
-        pageSize: 500,
-      });
+      await listIssues({ project: 'my-project', severity: 'major', page: 1, pageSize: 500 });
       expect(capturedSeverities).toBe('MAJOR');
     } finally {
       getSpy.mockRestore();
     }
   });
 
-  it('exits 0 when issues search succeeds', async () => {
-    const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockResolvedValue({
-      issues: [],
-      total: 0,
-      p: 1,
-      ps: 500,
-      paging: { pageIndex: 1, pageSize: 500, total: 0 },
-    });
+  it('succeeds when issues search returns results', async () => {
+    const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockResolvedValue(emptyApiResponse);
 
     try {
-      await listIssues({
-        project: 'my-project',
-        page: 1,
-        pageSize: 500,
-      });
+      await listIssues({ project: 'my-project', page: 1, pageSize: 500 });
     } finally {
       getSpy.mockRestore();
     }

--- a/tests/unit/projects-command.test.ts
+++ b/tests/unit/projects-command.test.ts
@@ -6,11 +6,8 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { MAX_PAGE_SIZE } from '../../src/sonarqube/projects.js';
 import { listProjects, ListProjectsOptions } from '../../src/cli/commands/list';
 import { SonarQubeClient } from '../../src/sonarqube/client.js';
-import * as stateManager from '../../src/lib/state-manager.js';
-import * as keychain from '../../src/lib/keychain.js';
+import * as authResolver from '../../src/lib/auth-resolver.js';
 import { setMockUi, getMockUiCalls, clearMockUiCalls } from '../../src/ui/index.js';
-import { getDefaultState } from '../../src/lib/state.js';
-import type { AuthConnection } from '../../src/lib/state.js';
 import type { ProjectsSearchResponse } from '../../src/lib/types.js';
 
 const DEFAULT_OPTIONS: ListProjectsOptions = {
@@ -18,31 +15,10 @@ const DEFAULT_OPTIONS: ListProjectsOptions = {
   pageSize: 500,
 };
 
-const MOCK_CONNECTION: AuthConnection = {
-  id: 'test-conn-id',
-  type: 'on-premise',
+const mockAuth = {
+  token: 'test-token',
   serverUrl: 'https://sonar.example.com',
-  orgKey: undefined,
-  authenticatedAt: new Date().toISOString(),
-  keystoreKey: 'test-keystore-key',
 };
-
-const MOCK_CLOUD_CONNECTION: AuthConnection = {
-  id: 'test-cloud-conn-id',
-  type: 'cloud',
-  serverUrl: 'https://sonarcloud.io',
-  orgKey: 'my-org',
-  authenticatedAt: new Date().toISOString(),
-  keystoreKey: 'test-cloud-keystore-key',
-};
-
-function makeStateWithConnection(connection: AuthConnection) {
-  const state = getDefaultState('test');
-  state.auth.connections = [connection];
-  state.auth.activeConnectionId = connection.id;
-  state.auth.isAuthenticated = true;
-  return state;
-}
 
 function makeProjectsResponse(
   components: { key: string; name: string }[],
@@ -62,68 +38,48 @@ afterEach(() => {
 });
 
 describe('projectsSearchCommand', () => {
-  let loadStateSpy: ReturnType<typeof spyOn>;
-  let getTokenSpy: ReturnType<typeof spyOn>;
+  let resolveAuthSpy: ReturnType<typeof spyOn>;
   let getSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(
-      makeStateWithConnection(MOCK_CONNECTION),
-    );
-    getTokenSpy = spyOn(keychain, 'getToken').mockResolvedValue('test-token');
+    resolveAuthSpy = spyOn(authResolver, 'resolveAuth').mockResolvedValue(mockAuth);
     getSpy = spyOn(SonarQubeClient.prototype, 'get').mockResolvedValue(
       makeProjectsResponse([]) as unknown as never,
     );
   });
 
   afterEach(() => {
-    loadStateSpy.mockRestore();
-    getTokenSpy.mockRestore();
+    resolveAuthSpy.mockRestore();
     getSpy.mockRestore();
   });
 
+  it('calls resolveAuth', async () => {
+    await listProjects(DEFAULT_OPTIONS);
+
+    expect(resolveAuthSpy).toHaveBeenCalledWith({});
+  });
+
+  it('propagates auth errors', () => {
+    resolveAuthSpy.mockRejectedValue(new Error('Not authenticated. Run: sonar auth login'));
+
+    expect(listProjects(DEFAULT_OPTIONS)).rejects.toThrow('sonar auth login');
+  });
+
   describe('error conditions', () => {
-    it('throws when there is no active connection', () => {
-      loadStateSpy.mockReturnValue(getDefaultState('test'));
-
-      expect(listProjects(DEFAULT_OPTIONS)).rejects.toThrow(
-        'No active connection found. Run: sonar auth login',
-      );
-    });
-
-    it('throws when no token is found in the keychain', () => {
-      getTokenSpy.mockResolvedValue(null);
-
-      expect(listProjects(DEFAULT_OPTIONS)).rejects.toThrow(
-        'No token found. Run: sonar auth login',
-      );
-    });
-
     it('throws when page size is not positive', () => {
-      expect(
-        listProjects({
-          page: 1,
-          pageSize: 0,
-        }),
-      ).rejects.toThrow(`Invalid --page-size option: '0'. Must be an integer between 1 and 500`);
+      expect(listProjects({ page: 1, pageSize: 0 })).rejects.toThrow(
+        `Invalid --page-size option: '0'. Must be an integer between 1 and 500`,
+      );
     });
 
     it('throws when page is not positive', () => {
-      expect(
-        listProjects({
-          page: 0,
-          pageSize: 500,
-        }),
-      ).rejects.toThrow(`Invalid --page option: '0'. Must be an integer >= 1`);
+      expect(listProjects({ page: 0, pageSize: 500 })).rejects.toThrow(
+        `Invalid --page option: '0'. Must be an integer >= 1`,
+      );
     });
 
     it('throws when page size exceeds the maximum', () => {
-      expect(
-        listProjects({
-          page: 1,
-          pageSize: MAX_PAGE_SIZE + 1,
-        }),
-      ).rejects.toThrow(
+      expect(listProjects({ page: 1, pageSize: MAX_PAGE_SIZE + 1 })).rejects.toThrow(
         `Invalid --page-size option: '${MAX_PAGE_SIZE + 1}'. Must be an integer between 1 and 500`,
       );
     });
@@ -140,7 +96,6 @@ describe('projectsSearchCommand', () => {
   describe('successful execution', () => {
     it('prints JSON with empty projects array when no results', async () => {
       clearMockUiCalls();
-      getSpy.mockResolvedValue(makeProjectsResponse([]) as unknown as never);
 
       await listProjects(DEFAULT_OPTIONS);
 
@@ -201,12 +156,6 @@ describe('projectsSearchCommand', () => {
       expect(prints[0].paging.hasNextPage).toBe(false);
     });
 
-    it('uses the active connection server URL to create the client', async () => {
-      await listProjects(DEFAULT_OPTIONS);
-
-      expect(getTokenSpy).toHaveBeenCalledWith(MOCK_CONNECTION.serverUrl, MOCK_CONNECTION.orgKey);
-    });
-
     it('passes query option to the API', async () => {
       let capturedParams: Record<string, unknown> | undefined;
       getSpy.mockImplementation((_endpoint: string, params?: Record<string, unknown>) => {
@@ -214,10 +163,7 @@ describe('projectsSearchCommand', () => {
         return makeProjectsResponse([]);
       });
 
-      await listProjects({
-        query: 'my-project',
-        ...DEFAULT_OPTIONS,
-      });
+      await listProjects({ query: 'my-project', ...DEFAULT_OPTIONS });
 
       expect(capturedParams?.q).toBe('my-project');
     });
@@ -229,10 +175,7 @@ describe('projectsSearchCommand', () => {
         return makeProjectsResponse([]);
       });
 
-      await listProjects({
-        page: 3,
-        pageSize: 500,
-      });
+      await listProjects({ page: 3, pageSize: 500 });
 
       expect(capturedParams?.p).toBe(3);
     });
@@ -244,17 +187,17 @@ describe('projectsSearchCommand', () => {
         return makeProjectsResponse([]);
       });
 
-      await listProjects({
-        page: 1,
-        pageSize: 50,
-      });
+      await listProjects({ page: 1, pageSize: 50 });
 
       expect(capturedParams?.ps).toBe(50);
     });
 
     it('passes organization key for SonarCloud connections', async () => {
-      loadStateSpy.mockReturnValue(makeStateWithConnection(MOCK_CLOUD_CONNECTION));
-      getTokenSpy.mockResolvedValue('cloud-token');
+      resolveAuthSpy.mockResolvedValue({
+        token: 'cloud-token',
+        serverUrl: 'https://sonarcloud.io',
+        orgKey: 'my-org',
+      });
 
       let capturedParams: Record<string, unknown> | undefined;
       getSpy.mockImplementation((_endpoint: string, params?: Record<string, unknown>) => {


### PR DESCRIPTION
This should allow using the env variables for authentication on the `sonar list` commands by reusing the `resolveAuth` logic.