### PR TITLE
CLI-120 Implement command to self-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,10 @@ Update sonar CLI to the latest version
 
 **Options:**
 
-| Option     | Type    | Required | Description                                  | Default |
-| ---------- | ------- | -------- | -------------------------------------------- | ------- |
-| `--status` | boolean | No       | Check for a newer version without installing | -       |
+| Option     | Type    | Required | Description                                           | Default |
+| ---------- | ------- | -------- | ----------------------------------------------------- | ------- |
+| `--status` | boolean | No       | Check for a newer version without installing          | -       |
+| `--force`  | boolean | No       | Install the latest version even if already up to date | -       |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,18 @@ sonar config telemetry --disabled
 
 ---
 
+### `sonar self-update`
+
+Update sonar CLI to the latest version
+
+**Options:**
+
+| Option     | Type    | Required | Description                                  | Default |
+| ---------- | ------- | -------- | -------------------------------------------- | ------- |
+| `--status` | boolean | No       | Check for a newer version without installing | -       |
+
+---
+
 ## Option Types
 
 - `string` — text value (e.g. `--server https://sonarcloud.io`)

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -181,6 +181,7 @@ configure
 COMMAND_TREE.command('self-update')
   .description('Update sonar CLI to the latest version')
   .option('--status', 'Check for a newer version without installing')
+  .option('--force', 'Install the latest version even if already up to date')
   .action((options: SelfUpdateOptions) => runCommand(() => selfUpdate(options)));
 
 // Hidden flush command — only registered when running as a telemetry worker.

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -33,7 +33,7 @@ import { integrateClaude, type IntegrateClaudeOptions } from './commands/integra
 import { analyzeSecrets, type AnalyzeSecretsOptions } from './commands/analyze/secrets';
 import { flushTelemetry, storeEvent, TELEMETRY_FLUSH_MODE_ENV } from '../telemetry';
 import { configureTelemetry, type ConfigureTelemetryOptions } from './commands/config/telemetry';
-import { selfUpdate, type SelfUpdateOptions } from './commands/self-update';
+import { selfUpdate, type SelfUpdateOptions } from './commands/self-update/self-update';
 import { parseInteger } from './commands/_common/parsing';
 import { MAX_PAGE_SIZE } from '../sonarqube/projects';
 

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -33,6 +33,7 @@ import { integrateClaude, type IntegrateClaudeOptions } from './commands/integra
 import { analyzeSecrets, type AnalyzeSecretsOptions } from './commands/analyze/secrets';
 import { flushTelemetry, storeEvent, TELEMETRY_FLUSH_MODE_ENV } from '../telemetry';
 import { configureTelemetry, type ConfigureTelemetryOptions } from './commands/config/telemetry';
+import { selfUpdate } from './commands/self-update';
 import { parseInteger } from './commands/_common/parsing';
 import { MAX_PAGE_SIZE } from '../sonarqube/projects';
 
@@ -175,6 +176,11 @@ configure
   .option('--enabled', 'Enable collection of anonymous usage statistics')
   .option('--disabled', 'Disable collection of anonymous usage statistics')
   .action((options: ConfigureTelemetryOptions) => runCommand(() => configureTelemetry(options)));
+
+// Update the CLI to the latest version
+COMMAND_TREE.command('self-update')
+  .description('Update sonar CLI to the latest version')
+  .action(() => runCommand(() => selfUpdate()));
 
 // Hidden flush command — only registered when running as a telemetry worker.
 if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -33,7 +33,7 @@ import { integrateClaude, type IntegrateClaudeOptions } from './commands/integra
 import { analyzeSecrets, type AnalyzeSecretsOptions } from './commands/analyze/secrets';
 import { flushTelemetry, storeEvent, TELEMETRY_FLUSH_MODE_ENV } from '../telemetry';
 import { configureTelemetry, type ConfigureTelemetryOptions } from './commands/config/telemetry';
-import { selfUpdate } from './commands/self-update';
+import { selfUpdate, type SelfUpdateOptions } from './commands/self-update';
 import { parseInteger } from './commands/_common/parsing';
 import { MAX_PAGE_SIZE } from '../sonarqube/projects';
 
@@ -180,7 +180,8 @@ configure
 // Update the CLI to the latest version
 COMMAND_TREE.command('self-update')
   .description('Update sonar CLI to the latest version')
-  .action(() => runCommand(() => selfUpdate()));
+  .option('--status', 'Check for a newer version without installing')
+  .action((options: SelfUpdateOptions) => runCommand(() => selfUpdate(options)));
 
 // Hidden flush command — only registered when running as a telemetry worker.
 if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -49,7 +49,8 @@ export function extractVersion(scriptContent: string): string | null {
  * the CLI version from package.json only has three segments ("0.5.0").
  */
 export function stripBuildNumber(version: string): string {
-  return version.split('.').slice(0, 3).join('.');
+  const SEMVER_SEGMENTS = 3;
+  return version.split('.').slice(0, SEMVER_SEGMENTS).join('.');
 }
 
 /** Returns true when `candidate` is strictly newer than `current` (semver, numeric comparison). */

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -97,6 +97,7 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
 
 export interface SelfUpdateOptions {
   status?: boolean;
+  force?: boolean;
 }
 
 async function selfUpdateStatus(): Promise<void> {
@@ -127,12 +128,16 @@ export async function selfUpdate(options: SelfUpdateOptions = {}): Promise<void>
   const { currentVersion, latestVersion, updateAvailable, scriptContent, scriptName } =
     await checkForUpdate();
 
-  if (!updateAvailable) {
+  if (!updateAvailable && !options.force) {
     success(`Already up to date (v${currentVersion})`);
     return;
   }
 
-  info(`Updating v${currentVersion} → v${latestVersion}...`);
+  if (updateAvailable) {
+    info(`Updating v${currentVersion} → v${latestVersion}...`);
+  } else {
+    info(`Force installing v${latestVersion}...`);
+  }
 
   const tempPath = join(tmpdir(), scriptName);
 

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -22,25 +22,121 @@ import { spawn, spawnSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { version as CURRENT_VERSION } from '../../../package.json';
 import { UPDATE_SCRIPT_BASE_URL } from '../../lib/config-constants';
-import { info } from '../../ui';
+import { info, success, warn, text, blank } from '../../ui';
 
-export async function selfUpdate(): Promise<void> {
+const VERSION_PATTERNS = [
+  // Shell:       version="1.2.3"  or  version='1.2.3'
+  /\bversion\s*=\s*["'](\d+\.\d+\.\d+(?:\.\d+)?)["']/,
+  // PowerShell:  $SonarVersion = "1.2.3"
+  /\$SonarVersion\s*=\s*["'](\d+\.\d+\.\d+(?:\.\d+)?)["']/i,
+];
+
+/** Extract the pinned version from an install script. Returns null if not found. */
+export function extractVersion(scriptContent: string): string | null {
+  for (const pattern of VERSION_PATTERNS) {
+    const match = pattern.exec(scriptContent);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/** Returns true when `candidate` is strictly newer than `current` (semver, numeric comparison). */
+export function isNewerVersion(current: string, candidate: string): boolean {
+  const parse = (v: string): number[] => v.split('.').map(Number);
+  const curr = parse(current);
+  const cand = parse(candidate);
+  for (let i = 0; i < Math.max(curr.length, cand.length); i++) {
+    const c = curr[i] ?? 0;
+    const f = cand[i] ?? 0;
+    if (f > c) return true;
+    if (f < c) return false;
+  }
+  return false;
+}
+
+export interface UpdateCheckResult {
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+  /** Downloaded script content — reuse in selfUpdate() to avoid a second fetch. */
+  scriptContent: string;
+  /** Platform-appropriate script filename ('install.sh' or 'install.ps1'). */
+  scriptName: string;
+}
+
+/**
+ * Fetches the install script from GitHub and returns version comparison data.
+ * Throws on network failure or when the version cannot be extracted from the script.
+ */
+export async function checkForUpdate(): Promise<UpdateCheckResult> {
   const isWindows = process.platform === 'win32';
   const scriptName = isWindows ? 'install.ps1' : 'install.sh';
   const scriptUrl = `${UPDATE_SCRIPT_BASE_URL}/${scriptName}`;
 
-  info('Downloading latest install script...');
-
   const response = await fetch(scriptUrl);
   if (!response.ok) {
-    throw new Error(`Failed to download update script: HTTP ${response.status}`);
+    throw new Error(`Failed to fetch update script: HTTP ${response.status}`);
   }
 
   const scriptContent = await response.text();
+  const latestVersion = extractVersion(scriptContent);
+  if (latestVersion === null) {
+    throw new Error('Could not determine the latest version from the install script');
+  }
+
+  return {
+    currentVersion: CURRENT_VERSION,
+    latestVersion,
+    updateAvailable: isNewerVersion(CURRENT_VERSION, latestVersion),
+    scriptContent,
+    scriptName,
+  };
+}
+
+export interface SelfUpdateOptions {
+  status?: boolean;
+}
+
+async function selfUpdateStatus(): Promise<void> {
+  info('Checking for updates...');
+
+  const { currentVersion, latestVersion, updateAvailable } = await checkForUpdate();
+
+  text(`Current version: v${currentVersion}`);
+  text(`Latest version:  v${latestVersion}`);
+  blank();
+
+  if (updateAvailable) {
+    warn(`Update available: v${latestVersion}`);
+    text('  Run: sonar self-update');
+  } else {
+    success('Already up to date');
+  }
+}
+
+export async function selfUpdate(options: SelfUpdateOptions = {}): Promise<void> {
+  if (options.status) {
+    await selfUpdateStatus();
+    return;
+  }
+
+  info('Checking for updates...');
+
+  const { currentVersion, latestVersion, updateAvailable, scriptContent, scriptName } =
+    await checkForUpdate();
+
+  if (!updateAvailable) {
+    success(`Already up to date (v${currentVersion})`);
+    return;
+  }
+
+  info(`Updating v${currentVersion} → v${latestVersion}...`);
+
   const tempPath = join(tmpdir(), scriptName);
 
-  if (isWindows) {
+  if (process.platform === 'win32') {
     // On Windows the running binary is file-locked, so the parent must exit
     // before the script can overwrite it. Open PowerShell in a new window so
     // it has its own console and the user can see the output.

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -159,21 +159,20 @@ export async function selfUpdate(options: SelfUpdateOptions = {}): Promise<void>
     // it has its own console and the user can see the output.
     writeFileSync(tempPath, scriptContent, 'utf8');
     info('Starting update in a new terminal window...');
+    // The ComSpec environment variable (always points to the system cmd.exe)
+    const cmdExe = process.env.ComSpec ?? String.raw`C:\Windows\System32\cmd.exe`;
     const child = spawn(
-      'cmd',
+      cmdExe,
       ['/c', 'start', 'powershell', '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', tempPath],
       { detached: true, stdio: 'ignore' },
     );
     child.unref();
-    // Throw instead of process.exit(0) so runCommand() can set the exit code
-    // and the postAction telemetry hook runs before the process terminates.
-    // The detached child is already unref'd and will outlive the parent.
     throw new CommandFailedError('', 0);
   } else {
     // On Unix the binary is not locked, so run the script synchronously and
     // stream its output directly to the terminal.
     writeFileSync(tempPath, scriptContent, { encoding: 'utf8', mode: 0o755 });
-    const result = spawnSync('bash', [tempPath], { stdio: 'inherit' });
+    const result = spawnSync('/bin/bash', [tempPath], { stdio: 'inherit' });
     if (result.status !== 0) {
       throw new Error(`Update script exited with code ${String(result.status ?? 'unknown')}`);
     }

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -42,6 +42,15 @@ export function extractVersion(scriptContent: string): string | null {
   return null;
 }
 
+/**
+ * Strips the build number (4th segment) from a version string.
+ * The install script version may include a build number (e.g. "0.5.0.241") while
+ * the CLI version from package.json only has three segments ("0.5.0").
+ */
+export function stripBuildNumber(version: string): string {
+  return version.split('.').slice(0, 3).join('.');
+}
+
 /** Returns true when `candidate` is strictly newer than `current` (semver, numeric comparison). */
 export function isNewerVersion(current: string, candidate: string): boolean {
   const parse = (v: string): number[] => v.split('.').map(Number);
@@ -89,7 +98,7 @@ export async function checkForUpdate(): Promise<UpdateCheckResult> {
   return {
     currentVersion: CURRENT_VERSION,
     latestVersion,
-    updateAvailable: isNewerVersion(CURRENT_VERSION, latestVersion),
+    updateAvailable: isNewerVersion(CURRENT_VERSION, stripBuildNumber(latestVersion)),
     scriptContent,
     scriptName,
   };
@@ -105,12 +114,13 @@ async function selfUpdateStatus(): Promise<void> {
 
   const { currentVersion, latestVersion, updateAvailable } = await checkForUpdate();
 
+  const displayLatest = stripBuildNumber(latestVersion);
   text(`Current version: v${currentVersion}`);
-  text(`Latest version:  v${latestVersion}`);
+  text(`Latest version:  v${displayLatest}`);
   blank();
 
   if (updateAvailable) {
-    warn(`Update available: v${latestVersion}`);
+    warn(`Update available: v${displayLatest}`);
     text('  Run: sonar self-update');
   } else {
     success('Already up to date');

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -24,6 +24,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { version as CURRENT_VERSION } from '../../../package.json';
 import { UPDATE_SCRIPT_BASE_URL } from '../../lib/config-constants';
+import { CommandFailedError } from './common/error';
 import { info, success, warn, text, blank } from '../../ui';
 
 const VERSION_PATTERNS = [
@@ -163,7 +164,10 @@ export async function selfUpdate(options: SelfUpdateOptions = {}): Promise<void>
       { detached: true, stdio: 'ignore' },
     );
     child.unref();
-    process.exit(0);
+    // Throw instead of process.exit(0) so runCommand() can set the exit code
+    // and the postAction telemetry hook runs before the process terminates.
+    // The detached child is already unref'd and will outlive the parent.
+    throw new CommandFailedError('', 0);
   } else {
     // On Unix the binary is not locked, so run the script synchronously and
     // stream its output directly to the terminal.

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -1,0 +1,65 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) 2026 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { UPDATE_SCRIPT_BASE_URL } from '../../lib/config-constants';
+import { info } from '../../ui';
+
+export async function selfUpdate(): Promise<void> {
+  const isWindows = process.platform === 'win32';
+  const scriptName = isWindows ? 'install.ps1' : 'install.sh';
+  const scriptUrl = `${UPDATE_SCRIPT_BASE_URL}/${scriptName}`;
+
+  info('Downloading latest install script...');
+
+  const response = await fetch(scriptUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to download update script: HTTP ${response.status}`);
+  }
+
+  const scriptContent = await response.text();
+  const tempPath = join(tmpdir(), scriptName);
+
+  if (isWindows) {
+    // On Windows the running binary is file-locked, so the parent must exit
+    // before the script can overwrite it. Open PowerShell in a new window so
+    // it has its own console and the user can see the output.
+    writeFileSync(tempPath, scriptContent, 'utf8');
+    info('Starting update in a new terminal window...');
+    const child = spawn(
+      'cmd',
+      ['/c', 'start', 'powershell', '-NoExit', '-ExecutionPolicy', 'Bypass', '-File', tempPath],
+      { detached: true, stdio: 'ignore' },
+    );
+    child.unref();
+    process.exit(0);
+  } else {
+    // On Unix the binary is not locked, so run the script synchronously and
+    // stream its output directly to the terminal.
+    writeFileSync(tempPath, scriptContent, { encoding: 'utf8', mode: 0o755 });
+    const result = spawnSync('bash', [tempPath], { stdio: 'inherit' });
+    if (result.status !== 0) {
+      throw new Error(`Update script exited with code ${String(result.status ?? 'unknown')}`);
+    }
+  }
+}

--- a/src/cli/commands/self-update.ts
+++ b/src/cli/commands/self-update.ts
@@ -24,7 +24,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { version as CURRENT_VERSION } from '../../../package.json';
 import { UPDATE_SCRIPT_BASE_URL } from '../../lib/config-constants';
-import { CommandFailedError } from './common/error';
 import { info, success, warn, text, blank } from '../../ui';
 
 const VERSION_PATTERNS = [
@@ -167,7 +166,6 @@ export async function selfUpdate(options: SelfUpdateOptions = {}): Promise<void>
       { detached: true, stdio: 'ignore' },
     );
     child.unref();
-    throw new CommandFailedError('', 0);
   } else {
     // On Unix the binary is not locked, so run the script synchronously and
     // stream its output directly to the terminal.

--- a/src/cli/commands/self-update/self-update.ts
+++ b/src/cli/commands/self-update/self-update.ts
@@ -153,9 +153,10 @@ export async function selfUpdate(options: SelfUpdateOptions = {}): Promise<void>
   const tempPath = join(tmpdir(), scriptName);
 
   if (process.platform === 'win32') {
-    // On Windows the running binary is file-locked, so the parent must exit
-    // before the script can overwrite it. Open PowerShell in a new window so
-    // it has its own console and the user can see the output.
+    // On Windows the running binary is file-locked, so the parent must exit immediately
+    // so that the script can overwrite the executable. Otherwise, the update will fail and
+    // has to be manually retried by the user.
+    // Open PowerShell in a new window so it has its own console and the user can see the output.
     writeFileSync(tempPath, scriptContent, 'utf8');
     info('Starting update in a new terminal window...');
     // The ComSpec environment variable (always points to the system cmd.exe)

--- a/src/cli/commands/self-update/self-update.ts
+++ b/src/cli/commands/self-update/self-update.ts
@@ -22,9 +22,9 @@ import { spawn, spawnSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { version as CURRENT_VERSION } from '../../../package.json';
-import { UPDATE_SCRIPT_BASE_URL } from '../../lib/config-constants';
-import { info, success, warn, text, blank } from '../../ui';
+import { version as CURRENT_VERSION } from '../../../../package.json';
+import { UPDATE_SCRIPT_BASE_URL } from '../../../lib/config-constants';
+import { info, success, warn, text, blank } from '../../../ui';
 
 const VERSION_PATTERNS = [
   // Shell:       version="1.2.3"  or  version='1.2.3'

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -68,6 +68,8 @@ export const BIN_DIR = join(CLI_DIR, 'bin');
 export const SONARSOURCE_BINARIES_URL =
   process.env.SONAR_CLI_BINARIES_URL ?? 'https://binaries.sonarsource.com';
 export const SONAR_SECRETS_DIST_PREFIX = 'CommercialDistribution/sonar-secrets';
+export const UPDATE_SCRIPT_BASE_URL =
+  'https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts';
 
 // ---------------------------------------------------------------------------
 // SonarCloud

--- a/tests/unit/discovery.test.ts
+++ b/tests/unit/discovery.test.ts
@@ -20,12 +20,12 @@
 
 // Discovery module tests
 
-import { it, expect } from 'bun:test';
-import { execSync } from 'node:child_process';
+import { it, expect, spyOn } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { discoverProject } from '../../src/cli/commands/_common/discovery';
+import * as processLib from '../../src/lib/process.js';
 it('discovery: sonar-project.properties parsing', async () => {
   const testDir = join(tmpdir(), 'sonarqube-cli-test-discovery-' + Date.now());
   mkdirSync(testDir, { recursive: true });
@@ -139,19 +139,20 @@ it('discovery: detects git repository when .git dir present', async () => {
 
 it('discovery: reads git remote when git repository has origin', async () => {
   const testDir = join(tmpdir(), 'sonarqube-cli-test-gitremote-' + Date.now());
-  mkdirSync(testDir, { recursive: true });
+  mkdirSync(join(testDir, '.git'), { recursive: true });
+
+  const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
+    exitCode: 0,
+    stdout: 'https://github.com/example/test-project.git',
+    stderr: '',
+  });
 
   try {
-    execSync('git init', { cwd: testDir, stdio: 'pipe' });
-    execSync('git remote add origin https://github.com/example/test-project.git', {
-      cwd: testDir,
-      stdio: 'pipe',
-    });
-
     const info = await discoverProject(testDir);
     expect(info.isGitRepo).toBe(true);
     expect(info.gitRemote).toBe('https://github.com/example/test-project.git');
   } finally {
+    spawnSpy.mockRestore();
     rmSync(testDir, { recursive: true, force: true });
   }
 });

--- a/tests/unit/self-update.test.ts
+++ b/tests/unit/self-update.test.ts
@@ -120,7 +120,10 @@ describe('checkForUpdate', () => {
 
   it('returns updateAvailable: true when latest > current (with build number)', async () => {
     const scriptContent = 'version="99.0.0.241"\necho hi';
-    fetchSpy.mockResolvedValue({ ok: true, text: async () => scriptContent } as Response);
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: async () => Promise.resolve(scriptContent),
+    } as Response);
 
     const result = await checkForUpdate();
 
@@ -134,7 +137,10 @@ describe('checkForUpdate', () => {
     // Same major.minor.patch as current; build number must be ignored.
     const [major, minor, patch] = (await import('../../package.json')).version.split('.');
     const scriptContent = `version="${major}.${minor}.${patch}.999"\necho hi`;
-    fetchSpy.mockResolvedValue({ ok: true, text: async () => scriptContent } as Response);
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: async () => Promise.resolve(scriptContent),
+    } as Response);
 
     const result = await checkForUpdate();
 
@@ -151,7 +157,7 @@ describe('checkForUpdate', () => {
   it('throws when version cannot be extracted from the script', () => {
     fetchSpy.mockResolvedValue({
       ok: true,
-      text: async () => '#!/bin/bash\necho "no version here"',
+      text: async () => Promise.resolve('#!/bin/bash\necho "no version here"'),
     } as Response);
 
     expect(checkForUpdate()).rejects.toThrow('Could not determine the latest version');
@@ -175,7 +181,7 @@ describe('selfUpdate --status', () => {
   it('reports an available update without installing', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
-      text: async () => 'version="99.0.0.241"\necho hi',
+      text: async () => Promise.resolve('version="99.0.0.241"\necho hi'),
     } as Response);
 
     await selfUpdate({ status: true });
@@ -189,7 +195,7 @@ describe('selfUpdate --status', () => {
   it('reports already up to date', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
-      text: async () => 'version="0.0.1"\necho hi',
+      text: async () => Promise.resolve('version="0.0.1"\necho hi'),
     } as Response);
 
     await selfUpdate({ status: true });
@@ -201,7 +207,6 @@ describe('selfUpdate --status', () => {
 
 describe('selfUpdate --force', () => {
   let fetchSpy: ReturnType<typeof spyOn>;
-  let exitSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     setMockUi(true);
@@ -209,23 +214,30 @@ describe('selfUpdate --force', () => {
     spawnMock.mockClear();
     spawnSyncMock.mockClear();
     fetchSpy = spyOn(globalThis, 'fetch');
-    // Prevent process.exit(0) from terminating the test runner (Windows path).
-    exitSpy = spyOn(process, 'exit').mockImplementation(() => undefined as never);
   });
 
   afterEach(() => {
     fetchSpy.mockRestore();
-    exitSpy.mockRestore();
     setMockUi(false);
   });
 
-  it('installs even when already up to date', async () => {
+  // On Windows the install spawns a detached child then throws CommandFailedError(exitCode=0)
+  // so runCommand() can set the exit code and let telemetry run before the process exits.
+  // Tests catch that throw and verify the UI messages printed before it.
+  async function runForce(scriptContent: string): Promise<void> {
     fetchSpy.mockResolvedValue({
       ok: true,
-      text: async () => 'version="0.0.1"\necho hi',
+      text: async () => Promise.resolve(scriptContent),
     } as Response);
+    try {
+      await selfUpdate({ force: true });
+    } catch (err) {
+      if ((err as { exitCode?: number }).exitCode !== 0) throw err;
+    }
+  }
 
-    await selfUpdate({ force: true });
+  it('installs even when already up to date', async () => {
+    await runForce('version="0.0.1"\necho hi');
 
     const messages = getMockUiCalls().map((c) => c.args.join(' '));
     expect(messages.some((m) => /up to date/i.test(m))).toBe(false);
@@ -233,12 +245,7 @@ describe('selfUpdate --force', () => {
   });
 
   it('shows the normal update message when an update is also available', async () => {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      text: async () => 'version="99.0.0"\necho hi',
-    } as Response);
-
-    await selfUpdate({ force: true });
+    await runForce('version="99.0.0"\necho hi');
 
     const messages = getMockUiCalls().map((c) => c.args.join(' '));
     expect(messages.some((m) => /updating/i.test(m))).toBe(true);

--- a/tests/unit/self-update.test.ts
+++ b/tests/unit/self-update.test.ts
@@ -1,0 +1,177 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) 2026 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, it, expect, spyOn, beforeEach, afterEach } from 'bun:test';
+import {
+  extractVersion,
+  isNewerVersion,
+  checkForUpdate,
+  selfUpdate,
+} from '../../src/cli/commands/self-update';
+import { setMockUi, getMockUiCalls, clearMockUiCalls } from '../../src/ui';
+
+describe('extractVersion', () => {
+  it('extracts version from a shell script (double quotes)', () => {
+    const script = `#!/usr/bin/env bash\nversion="1.5.0"\necho "installing $version"`;
+    expect(extractVersion(script)).toBe('1.5.0');
+  });
+
+  it('extracts version from a shell script (single quotes)', () => {
+    const script = `version='2.0.1'\necho hi`;
+    expect(extractVersion(script)).toBe('2.0.1');
+  });
+
+  it('extracts $SonarVersion from a PowerShell script', () => {
+    const script = `$SonarVersion = "1.10.3"\nWrite-Host "installing $SonarVersion"`;
+    expect(extractVersion(script)).toBe('1.10.3');
+  });
+
+  it('extracts $sonarversion (case-insensitive) from a PowerShell script', () => {
+    const script = `$sonarversion = "0.9.0"\nWrite-Host $sonarversion`;
+    expect(extractVersion(script)).toBe('0.9.0');
+  });
+
+  it('returns null when no version is found', () => {
+    expect(extractVersion('#!/usr/bin/env bash\necho "hello"')).toBeNull();
+  });
+});
+
+describe('isNewerVersion', () => {
+  it('returns true when candidate has a higher major', () => {
+    expect(isNewerVersion('1.0.0', '2.0.0')).toBe(true);
+  });
+
+  it('returns true when candidate has a higher minor', () => {
+    expect(isNewerVersion('1.2.0', '1.3.0')).toBe(true);
+  });
+
+  it('returns true when candidate has a higher patch', () => {
+    expect(isNewerVersion('1.2.3', '1.2.4')).toBe(true);
+  });
+
+  it('returns false when versions are equal', () => {
+    expect(isNewerVersion('1.2.3', '1.2.3')).toBe(false);
+  });
+
+  it('returns false when current is higher', () => {
+    expect(isNewerVersion('2.0.0', '1.9.9')).toBe(false);
+  });
+
+  it('handles four-segment versions', () => {
+    expect(isNewerVersion('1.2.3.0', '1.2.3.1')).toBe(true);
+    expect(isNewerVersion('1.2.3.1', '1.2.3.0')).toBe(false);
+  });
+
+  it('treats a missing segment as 0', () => {
+    expect(isNewerVersion('1.2.3', '1.2.3.0')).toBe(false);
+    expect(isNewerVersion('1.2.3', '1.2.3.1')).toBe(true);
+  });
+});
+
+describe('checkForUpdate', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('returns updateAvailable: true when latest > current', async () => {
+    const scriptContent = 'version="99.0.0"\necho hi';
+    fetchSpy.mockResolvedValue({ ok: true, text: async () => scriptContent } as Response);
+
+    const result = await checkForUpdate();
+
+    expect(result.updateAvailable).toBe(true);
+    expect(result.latestVersion).toBe('99.0.0');
+    expect(result.scriptContent).toBe(scriptContent);
+    expect(result.scriptName).toMatch(/install\.(sh|ps1)$/);
+  });
+
+  it('returns updateAvailable: false when latest <= current', async () => {
+    const scriptContent = 'version="0.0.1"\necho hi';
+    fetchSpy.mockResolvedValue({ ok: true, text: async () => scriptContent } as Response);
+
+    const result = await checkForUpdate();
+
+    expect(result.updateAvailable).toBe(false);
+    expect(result.currentVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('throws on HTTP error', async () => {
+    fetchSpy.mockResolvedValue({ ok: false, status: 404 } as Response);
+
+    await expect(checkForUpdate()).rejects.toThrow('HTTP 404');
+  });
+
+  it('throws when version cannot be extracted from the script', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: async () => '#!/bin/bash\necho "no version here"',
+    } as Response);
+
+    await expect(checkForUpdate()).rejects.toThrow('Could not determine the latest version');
+  });
+});
+
+describe('selfUpdate --status', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
+    fetchSpy = spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    setMockUi(false);
+  });
+
+  it('reports an available update without installing', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: async () => 'version="99.0.0"\necho hi',
+    } as Response);
+
+    await selfUpdate({ status: true });
+
+    const calls = getMockUiCalls();
+    const messages = calls.map((c) => c.args.join(' '));
+    expect(messages.some((m) => m.includes('99.0.0'))).toBe(true);
+    expect(messages.some((m) => /update available/i.test(m))).toBe(true);
+  });
+
+  it('reports already up to date', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: async () => 'version="0.0.1"\necho hi',
+    } as Response);
+
+    await selfUpdate({ status: true });
+
+    const calls = getMockUiCalls();
+    const messages = calls.map((c) => c.args.join(' '));
+    expect(messages.some((m) => /up to date/i.test(m))).toBe(true);
+  });
+});

--- a/tests/unit/self-update.test.ts
+++ b/tests/unit/self-update.test.ts
@@ -221,19 +221,12 @@ describe('selfUpdate --force', () => {
     setMockUi(false);
   });
 
-  // On Windows the install spawns a detached child then throws CommandFailedError(exitCode=0)
-  // so runCommand() can set the exit code and let telemetry run before the process exits.
-  // Tests catch that throw and verify the UI messages printed before it.
   async function runForce(scriptContent: string): Promise<void> {
     fetchSpy.mockResolvedValue({
       ok: true,
       text: async () => Promise.resolve(scriptContent),
     } as Response);
-    try {
-      await selfUpdate({ force: true });
-    } catch (err) {
-      if ((err as { exitCode?: number }).exitCode !== 0) throw err;
-    }
+    await selfUpdate({ force: true });
   }
 
   it('installs even when already up to date', async () => {

--- a/tests/unit/self-update.test.ts
+++ b/tests/unit/self-update.test.ts
@@ -32,7 +32,7 @@ void mock.module('node:child_process', () => ({
   spawnSync: spawnSyncMock as unknown as typeof childProcess.spawnSync,
 }));
 
-const { extractVersion, isNewerVersion, checkForUpdate, selfUpdate } =
+const { extractVersion, isNewerVersion, stripBuildNumber, checkForUpdate, selfUpdate } =
   await import('../../src/cli/commands/self-update');
 
 describe('extractVersion', () => {
@@ -93,6 +93,20 @@ describe('isNewerVersion', () => {
   });
 });
 
+describe('stripBuildNumber', () => {
+  it('removes the 4th segment from a version with a build number', () => {
+    expect(stripBuildNumber('0.5.0.241')).toBe('0.5.0');
+  });
+
+  it('leaves a 3-segment version unchanged', () => {
+    expect(stripBuildNumber('1.2.3')).toBe('1.2.3');
+  });
+
+  it('leaves a 2-segment version unchanged', () => {
+    expect(stripBuildNumber('1.2')).toBe('1.2');
+  });
+});
+
 describe('checkForUpdate', () => {
   let fetchSpy: ReturnType<typeof spyOn>;
 
@@ -104,41 +118,43 @@ describe('checkForUpdate', () => {
     fetchSpy.mockRestore();
   });
 
-  it('returns updateAvailable: true when latest > current', async () => {
-    const scriptContent = 'version="99.0.0"\necho hi';
+  it('returns updateAvailable: true when latest > current (with build number)', async () => {
+    const scriptContent = 'version="99.0.0.241"\necho hi';
     fetchSpy.mockResolvedValue({ ok: true, text: async () => scriptContent } as Response);
 
     const result = await checkForUpdate();
 
     expect(result.updateAvailable).toBe(true);
-    expect(result.latestVersion).toBe('99.0.0');
+    expect(result.latestVersion).toBe('99.0.0.241');
     expect(result.scriptContent).toBe(scriptContent);
     expect(result.scriptName).toMatch(/install\.(sh|ps1)$/);
   });
 
-  it('returns updateAvailable: false when latest <= current', async () => {
-    const scriptContent = 'version="0.0.1"\necho hi';
+  it('returns updateAvailable: false when latest matches current (with build number)', async () => {
+    // Same major.minor.patch as current; build number must be ignored.
+    const [major, minor, patch] = (await import('../../package.json')).version.split('.');
+    const scriptContent = `version="${major}.${minor}.${patch}.999"\necho hi`;
     fetchSpy.mockResolvedValue({ ok: true, text: async () => scriptContent } as Response);
 
     const result = await checkForUpdate();
 
     expect(result.updateAvailable).toBe(false);
-    expect(result.currentVersion).toMatch(/^\d+\.\d+\.\d+/);
+    expect(result.latestVersion).toMatch(/\.\d+$/); // still contains build number for display
   });
 
-  it('throws on HTTP error', async () => {
+  it('throws on HTTP error', () => {
     fetchSpy.mockResolvedValue({ ok: false, status: 404 } as Response);
 
-    await expect(checkForUpdate()).rejects.toThrow('HTTP 404');
+    expect(checkForUpdate()).rejects.toThrow('HTTP 404');
   });
 
-  it('throws when version cannot be extracted from the script', async () => {
+  it('throws when version cannot be extracted from the script', () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       text: async () => '#!/bin/bash\necho "no version here"',
     } as Response);
 
-    await expect(checkForUpdate()).rejects.toThrow('Could not determine the latest version');
+    expect(checkForUpdate()).rejects.toThrow('Could not determine the latest version');
   });
 });
 
@@ -159,13 +175,14 @@ describe('selfUpdate --status', () => {
   it('reports an available update without installing', async () => {
     fetchSpy.mockResolvedValue({
       ok: true,
-      text: async () => 'version="99.0.0"\necho hi',
+      text: async () => 'version="99.0.0.241"\necho hi',
     } as Response);
 
     await selfUpdate({ status: true });
 
     const messages = getMockUiCalls().map((c) => c.args.join(' '));
-    expect(messages.some((m) => m.includes('99.0.0'))).toBe(true);
+    // Build number must be stripped from displayed versions
+    expect(messages.some((m) => m.includes('99.0.0') && !m.includes('99.0.0.241'))).toBe(true);
     expect(messages.some((m) => /update available/i.test(m))).toBe(true);
   });
 

--- a/tests/unit/self-update.test.ts
+++ b/tests/unit/self-update.test.ts
@@ -18,14 +18,22 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { describe, it, expect, spyOn, beforeEach, afterEach } from 'bun:test';
-import {
-  extractVersion,
-  isNewerVersion,
-  checkForUpdate,
-  selfUpdate,
-} from '../../src/cli/commands/self-update';
+import { mock, describe, it, expect, spyOn, beforeEach, afterEach } from 'bun:test';
 import { setMockUi, getMockUiCalls, clearMockUiCalls } from '../../src/ui';
+
+// Mock node:child_process before importing self-update so that the named
+// imports (spawn, spawnSync) in self-update.ts resolve to the test doubles.
+const childProcess = await import('node:child_process');
+const spawnMock = mock(() => ({ unref: () => {} }));
+const spawnSyncMock = mock(() => ({ status: 0 }));
+void mock.module('node:child_process', () => ({
+  ...childProcess,
+  spawn: spawnMock as unknown as typeof childProcess.spawn,
+  spawnSync: spawnSyncMock as unknown as typeof childProcess.spawnSync,
+}));
+
+const { extractVersion, isNewerVersion, checkForUpdate, selfUpdate } =
+  await import('../../src/cli/commands/self-update');
 
 describe('extractVersion', () => {
   it('extracts version from a shell script (double quotes)', () => {
@@ -156,8 +164,7 @@ describe('selfUpdate --status', () => {
 
     await selfUpdate({ status: true });
 
-    const calls = getMockUiCalls();
-    const messages = calls.map((c) => c.args.join(' '));
+    const messages = getMockUiCalls().map((c) => c.args.join(' '));
     expect(messages.some((m) => m.includes('99.0.0'))).toBe(true);
     expect(messages.some((m) => /update available/i.test(m))).toBe(true);
   });
@@ -170,8 +177,53 @@ describe('selfUpdate --status', () => {
 
     await selfUpdate({ status: true });
 
-    const calls = getMockUiCalls();
-    const messages = calls.map((c) => c.args.join(' '));
+    const messages = getMockUiCalls().map((c) => c.args.join(' '));
     expect(messages.some((m) => /up to date/i.test(m))).toBe(true);
+  });
+});
+
+describe('selfUpdate --force', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
+    spawnMock.mockClear();
+    spawnSyncMock.mockClear();
+    fetchSpy = spyOn(globalThis, 'fetch');
+    // Prevent process.exit(0) from terminating the test runner (Windows path).
+    exitSpy = spyOn(process, 'exit').mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    exitSpy.mockRestore();
+    setMockUi(false);
+  });
+
+  it('installs even when already up to date', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: async () => 'version="0.0.1"\necho hi',
+    } as Response);
+
+    await selfUpdate({ force: true });
+
+    const messages = getMockUiCalls().map((c) => c.args.join(' '));
+    expect(messages.some((m) => /up to date/i.test(m))).toBe(false);
+    expect(messages.some((m) => /force/i.test(m))).toBe(true);
+  });
+
+  it('shows the normal update message when an update is also available', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      text: async () => 'version="99.0.0"\necho hi',
+    } as Response);
+
+    await selfUpdate({ force: true });
+
+    const messages = getMockUiCalls().map((c) => c.args.join(' '));
+    expect(messages.some((m) => /updating/i.test(m))).toBe(true);
   });
 });

--- a/tests/unit/self-update.test.ts
+++ b/tests/unit/self-update.test.ts
@@ -33,7 +33,7 @@ void mock.module('node:child_process', () => ({
 }));
 
 const { extractVersion, isNewerVersion, stripBuildNumber, checkForUpdate, selfUpdate } =
-  await import('../../src/cli/commands/self-update');
+  await import('../../src/cli/commands/self-update/self-update');
 
 describe('extractVersion', () => {
   it('extracts version from a shell script (double quotes)', () => {


### PR DESCRIPTION
Create a new command `sonar self-update` to update the sonar cli itself.

# How
* The self-update is checking the version from the latest install.ps1 or install.sh on Github (the same that the users will use to fresh install)
* If the current version is lower than the fetched then calls the install.ps1 or install.sh and the cli exits
* The install script is working as usual (no change)
* On Windows the install scripts runs on a new terminal window so that the progress is visible to the users (no need for that on linux, it already works on the same terminal)

# Options
* `--status` will report if there is a new version
* `--force` will proceed to call the install script, no matter what the current version is