### PR TITLE
CLI-142 CLI-143 CLI-144 CLI-148 Dogfooding bug fixes

### DIFF
--- a/src/cli/commands/integrate/claude/hook-templates.ts
+++ b/src/cli/commands/integrate/claude/hook-templates.ts
@@ -32,15 +32,15 @@ if ! command -v sonar &> /dev/null; then
   exit 0
 fi
 
-# Read JSON from stdin and extract fields using grep/cut (no external runtimes required)
+# Read JSON from stdin and extract fields using sed (handles both compact and pretty-printed JSON)
 stdin_data=$(cat)
-tool_name=$(echo "$stdin_data" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+tool_name=$(echo "$stdin_data" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 
 if [[ "$tool_name" != "Read" ]]; then
   exit 0
 fi
 
-file_path=$(echo "$stdin_data" | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4)
+file_path=$(echo "$stdin_data" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 
 if [[ -z "$file_path" ]] || [[ ! -f "$file_path" ]]; then
   exit 0
@@ -125,7 +125,7 @@ fi
 stdin_data=$(cat)
 
 # Extract prompt field using sed
-prompt=$(echo "$stdin_data" | sed -n 's/.*"prompt":"\([^"]*\)".*/\1/p' | head -1)
+prompt=$(echo "$stdin_data" | sed -n 's/.*"prompt"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 
 if [[ -z "$prompt" ]]; then
   exit 0
@@ -164,15 +164,15 @@ if ! command -v sonar &> /dev/null; then
   exit 0
 fi
 
-# Read JSON from stdin and extract fields using grep/cut (no external runtimes required)
+# Read JSON from stdin and extract fields using sed (handles both compact and pretty-printed JSON)
 stdin_data=$(cat)
-tool_name=$(echo "$stdin_data" | grep -o '"tool_name":"[^"]*"' | cut -d'"' -f4)
+tool_name=$(echo "$stdin_data" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 
 if [[ "$tool_name" != "Edit" ]] && [[ "$tool_name" != "Write" ]]; then
   exit 0
 fi
 
-file_path=$(echo "$stdin_data" | grep -o '"file_path":"[^"]*"' | cut -d'"' -f4)
+file_path=$(echo "$stdin_data" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)
 
 if [[ -z "$file_path" ]] || [[ ! -f "$file_path" ]]; then
   exit 0

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -557,11 +557,13 @@ function updateStateAfterConfiguration(context: ConfigurationContext): void {
     addInstalledHook(state, 'claude-code', 'sonar-secrets', 'PreToolUse');
     addInstalledHook(state, 'claude-code', 'sonar-secrets', 'UserPromptSubmit');
 
-    // Register extensions in the new registry
+    // Register extensions in the new registry.
+    // For global installs, use homedir() as projectRoot so it doesn't collide with project-level entries.
     const now = new Date().toISOString();
+    const effectiveRoot = isGlobal ? homedir() : projectRoot;
     const baseExt = {
       agentId: 'claude-code',
-      projectRoot,
+      projectRoot: effectiveRoot,
       global: isGlobal,
       projectKey,
       orgKey: organization,
@@ -591,6 +593,7 @@ function updateStateAfterConfiguration(context: ConfigurationContext): void {
     if (context.hasA3s) {
       upsertAgentExtension(state, {
         ...baseExt,
+        projectRoot,
         global: false,
         id: randomUUID(),
         kind: 'hook',

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -585,11 +585,13 @@ function updateStateAfterConfiguration(context: ConfigurationContext): void {
       hookType: 'UserPromptSubmit',
     });
 
-    // Register A3S hook only when org has entitlement
+    // Register A3S hook only when org has entitlement.
+    // A3S is always project-level (never global), regardless of the -g flag.
     const isCloud = serverURL.includes(SONARCLOUD_HOSTNAME);
     if (context.hasA3s) {
       upsertAgentExtension(state, {
         ...baseExt,
+        global: false,
         id: randomUUID(),
         kind: 'hook',
         name: 'sonar-a3s',

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -119,13 +119,13 @@ function migrateToExtensionsRegistry(
   projectRoot: string,
   globalDir: string | undefined,
 ): void {
+  const isGlobal = globalDir !== undefined;
   const existingExtensions = state.agentExtensions.filter(
-    (e) => e.agentId === 'claude-code' && e.projectRoot === projectRoot,
+    (e) => e.agentId === 'claude-code' && e.projectRoot === projectRoot && e.global === isGlobal,
   );
 
   const connection = getActiveConnection(state);
   const now = new Date().toISOString();
-  const isGlobal = globalDir !== undefined;
 
   const baseExt = {
     agentId: 'claude-code',

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -137,7 +137,8 @@ function migrateToExtensionsRegistry(
     updatedAt: now,
   };
 
-  // Migrate entries from old hooks.installed that don't yet have a registry entry
+  // Migrate entries from old hooks.installed that don't yet have a registry entry.
+  // sonar-a3s is always project-level (never global), regardless of the -g flag.
   const oldHooks = state.agents['claude-code'].hooks.installed;
   for (const hook of oldHooks) {
     const alreadyMigrated = existingExtensions.some(
@@ -147,6 +148,7 @@ function migrateToExtensionsRegistry(
     if (!alreadyMigrated) {
       upsertAgentExtension(state, {
         ...baseExt,
+        global: hook.name === 'sonar-a3s' ? false : isGlobal,
         id: randomUUID(),
         kind: 'hook',
         name: hook.name,
@@ -155,11 +157,13 @@ function migrateToExtensionsRegistry(
     }
   }
 
-  // Add the new sonar-a3s PostToolUse extension for cloud connections
+  // Add the new sonar-a3s PostToolUse extension for cloud connections.
+  // A3S is always project-level (never global), regardless of the -g flag.
   const isCloud = connection?.type === 'cloud';
   if (isCloud) {
     upsertAgentExtension(state, {
       ...baseExt,
+      global: false,
       id: randomUUID(),
       kind: 'hook',
       name: 'sonar-a3s',

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -120,8 +120,10 @@ function migrateToExtensionsRegistry(
   globalDir: string | undefined,
 ): void {
   const isGlobal = globalDir !== undefined;
+  // For global installs, use globalDir as projectRoot so it doesn't collide with project-level entries.
+  const effectiveProjectRoot = globalDir ?? projectRoot;
   const existingExtensions = state.agentExtensions.filter(
-    (e) => e.agentId === 'claude-code' && e.projectRoot === projectRoot && e.global === isGlobal,
+    (e) => e.agentId === 'claude-code' && e.projectRoot === effectiveProjectRoot,
   );
 
   const connection = getActiveConnection(state);
@@ -129,7 +131,7 @@ function migrateToExtensionsRegistry(
 
   const baseExt = {
     agentId: 'claude-code',
-    projectRoot,
+    projectRoot: effectiveProjectRoot,
     global: isGlobal,
     orgKey: connection?.orgKey,
     serverUrl: connection?.serverUrl,
@@ -146,9 +148,11 @@ function migrateToExtensionsRegistry(
         e.kind === 'hook' && e.name === hook.name && e.hookType === hook.type,
     );
     if (!alreadyMigrated) {
+      const isA3s = hook.name === 'sonar-a3s';
       upsertAgentExtension(state, {
         ...baseExt,
-        global: hook.name === 'sonar-a3s' ? false : isGlobal,
+        projectRoot: isA3s ? projectRoot : effectiveProjectRoot,
+        global: isA3s ? false : isGlobal,
         id: randomUUID(),
         kind: 'hook',
         name: hook.name,
@@ -163,6 +167,7 @@ function migrateToExtensionsRegistry(
   if (isCloud) {
     upsertAgentExtension(state, {
       ...baseExt,
+      projectRoot,
       global: false,
       id: randomUUID(),
       kind: 'hook',

--- a/src/lib/state-manager.ts
+++ b/src/lib/state-manager.ts
@@ -210,12 +210,13 @@ export function addInstalledHook(
 
 /**
  * Upsert an agent extension in the registry.
- * Matches by agentId + projectRoot + kind + name + (hookType for hooks).
+ * Matches by agentId + projectRoot + global + kind + name + (hookType for hooks).
  */
 export function upsertAgentExtension(state: CliState, extension: AgentExtension): void {
   const idx = state.agentExtensions.findIndex((e) => {
     if (e.agentId !== extension.agentId) return false;
     if (e.projectRoot !== extension.projectRoot) return false;
+    if (e.global !== extension.global) return false;
     if (e.kind !== extension.kind) return false;
     if (e.name !== extension.name) return false;
     if (e.kind === 'hook' && extension.kind === 'hook') {

--- a/src/lib/state-manager.ts
+++ b/src/lib/state-manager.ts
@@ -210,13 +210,13 @@ export function addInstalledHook(
 
 /**
  * Upsert an agent extension in the registry.
- * Matches by agentId + projectRoot + global + kind + name + (hookType for hooks).
+ * Matches by agentId + projectRoot + kind + name + (hookType for hooks).
+ * For global installs, projectRoot is set to homedir() so it naturally differs from project-level.
  */
 export function upsertAgentExtension(state: CliState, extension: AgentExtension): void {
   const idx = state.agentExtensions.findIndex((e) => {
     if (e.agentId !== extension.agentId) return false;
     if (e.projectRoot !== extension.projectRoot) return false;
-    if (e.global !== extension.global) return false;
     if (e.kind !== extension.kind) return false;
     if (e.name !== extension.name) return false;
     if (e.kind === 'hook' && extension.kind === 'hook') {

--- a/tests/integration/specs/integrate/integrate.test.ts
+++ b/tests/integration/specs/integrate/integrate.test.ts
@@ -825,9 +825,7 @@ describe('integrate claude — file placement (local vs global)', () => {
         expect(projectSecretsHooks.length).toBe(2);
 
         // Global sonar-secrets hooks must also be added
-        const globalSecretsHooks = extensions.filter(
-          (e) => e.name === 'sonar-secrets' && e.global,
-        );
+        const globalSecretsHooks = extensions.filter((e) => e.name === 'sonar-secrets' && e.global);
         expect(globalSecretsHooks.length).toBeGreaterThan(0);
 
         // sonar-a3s is always project-level, even when -g is used

--- a/tests/integration/specs/integrate/integrate.test.ts
+++ b/tests/integration/specs/integrate/integrate.test.ts
@@ -404,6 +404,29 @@ describe('integrate claude', () => {
     },
     { timeout: 30000 },
   );
+  it(
+    'prompt-secrets.sh uses correct subcommand (sonar analyze secrets) after integration',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project')
+        .start();
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=my-project'].join('\n'),
+      );
+
+      await harness.run('integrate claude --token test-token --non-interactive');
+
+      const promptScriptContent = harness.cwd
+        .file('.claude', 'hooks', 'sonar-secrets', 'build-scripts', 'prompt-secrets.sh')
+        .asText();
+      expect(promptScriptContent).toContain('sonar analyze secrets');
+      expect(promptScriptContent).not.toContain('sonar analyze --file');
+    },
+    { timeout: 30000 },
+  );
 });
 
 // ─── A3S entitlement guard ────────────────────────────────────────────────────

--- a/tests/integration/specs/integrate/integrate.test.ts
+++ b/tests/integration/specs/integrate/integrate.test.ts
@@ -733,7 +733,7 @@ describe('integrate claude — file placement (local vs global)', () => {
     );
 
     it(
-      'updates existing project-level agentExtensions to global when -g is passed, but keeps sonar-a3s as project-level',
+      'keeps existing project-level agentExtensions and adds global ones when -g is passed (CLI-148)',
       async () => {
         const server = await harness
           .newFakeServer()
@@ -818,12 +818,17 @@ describe('integrate claude — file placement (local vs global)', () => {
           global: boolean;
         }>;
 
-        // sonar-secrets hooks must be global after upgrading to -g
-        const secretsHooks = extensions.filter((e) => e.name === 'sonar-secrets');
-        expect(secretsHooks.length).toBeGreaterThan(0);
-        for (const hook of secretsHooks) {
-          expect(hook.global).toBe(true);
-        }
+        // Project-level sonar-secrets hooks must still be present (not overwritten by -g run)
+        const projectSecretsHooks = extensions.filter(
+          (e) => e.name === 'sonar-secrets' && !e.global,
+        );
+        expect(projectSecretsHooks.length).toBe(2);
+
+        // Global sonar-secrets hooks must also be added
+        const globalSecretsHooks = extensions.filter(
+          (e) => e.name === 'sonar-secrets' && e.global,
+        );
+        expect(globalSecretsHooks.length).toBeGreaterThan(0);
 
         // sonar-a3s is always project-level, even when -g is used
         const a3sHooks = extensions.filter((e) => e.name === 'sonar-a3s');

--- a/tests/integration/specs/integrate/integrate.test.ts
+++ b/tests/integration/specs/integrate/integrate.test.ts
@@ -21,8 +21,11 @@
 // Integration tests for `sonar integrate claude`
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { realpathSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { isAbsolute } from 'node:path';
 import { TestHarness } from '../../harness';
+import { version as CURRENT_VERSION } from '../../../../package.json';
 
 describe('integrate claude', () => {
   let harness: TestHarness;
@@ -482,6 +485,41 @@ describe('integrate claude — A3S entitlement guard', () => {
     },
     { timeout: 30000 },
   );
+
+  it(
+    'sonar-a3s agentExtension is always project-level even when -g flag is used',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('cloud-token')
+        .withOrganizations([{ key: 'my-org', name: 'My Org' }])
+        .withA3sEntitlement('my-org', 'test-uuid-1234')
+        .withProject('my-project')
+        .start();
+      const serverUrl = server.baseUrl();
+
+      const result = await harness.run(
+        `integrate claude -g --token cloud-token --server ${serverUrl} --org my-org --project my-project --non-interactive`,
+        {
+          extraEnv: {
+            SONAR_CLI_SONARCLOUD_URL: serverUrl,
+            SONAR_CLI_SONARCLOUD_API_URL: serverUrl,
+          },
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+
+      const state = harness.stateJsonFile.asJson();
+      const a3sExt = (state.agentExtensions as Array<{ name: string; global: boolean }>).find(
+        (e) => e.name === 'sonar-a3s',
+      );
+
+      expect(a3sExt).toBeDefined();
+      expect(a3sExt!.global).toBe(false);
+    },
+    { timeout: 30000 },
+  );
 });
 
 // ─── Local vs Global file placement ──────────────────────────────────────────
@@ -667,6 +705,108 @@ describe('integrate claude — file placement (local vs global)', () => {
         expect(preToolCmd.startsWith(harness.userHome.path)).toBe(true);
         expect(isAbsolute(promptCmd)).toBe(true);
         expect(promptCmd.startsWith(harness.userHome.path)).toBe(true);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'updates existing project-level agentExtensions to global when -g is passed, but keeps sonar-a3s as project-level',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('tok')
+          .withProject('proj')
+          .start();
+        harness.cwd.writeFile(
+          'sonar-project.properties',
+          [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+        );
+
+        // Simulate state from a previous project-level integration: agentExtensions with global: false
+        const projectRoot = realpathSync(harness.cwd.path);
+        harness.state().withRawState(
+          JSON.stringify({
+            version: 1,
+            config: { cliVersion: CURRENT_VERSION },
+            auth: {
+              isAuthenticated: true,
+              connections: [
+                {
+                  id: 'conn-1',
+                  type: 'on-premise',
+                  serverUrl: server.baseUrl(),
+                  authenticatedAt: new Date().toISOString(),
+                  keystoreKey: `sonarqube-cli:${server.baseUrl()}`,
+                },
+              ],
+              activeConnectionId: 'conn-1',
+            },
+            agents: {
+              'claude-code': {
+                configured: true,
+                configuredByCliVersion: CURRENT_VERSION,
+                hooks: {
+                  installed: [
+                    { name: 'sonar-secrets', type: 'PreToolUse' },
+                    { name: 'sonar-secrets', type: 'UserPromptSubmit' },
+                  ],
+                },
+              },
+            },
+            tools: { installed: [] },
+            telemetry: { enabled: false },
+            agentExtensions: [
+              {
+                id: randomUUID(),
+                agentId: 'claude-code',
+                projectRoot,
+                global: false,
+                serverUrl: server.baseUrl(),
+                updatedByCliVersion: CURRENT_VERSION,
+                updatedAt: new Date().toISOString(),
+                kind: 'hook',
+                name: 'sonar-secrets',
+                hookType: 'PreToolUse',
+              },
+              {
+                id: randomUUID(),
+                agentId: 'claude-code',
+                projectRoot,
+                global: false,
+                serverUrl: server.baseUrl(),
+                updatedByCliVersion: CURRENT_VERSION,
+                updatedAt: new Date().toISOString(),
+                kind: 'hook',
+                name: 'sonar-secrets',
+                hookType: 'UserPromptSubmit',
+              },
+            ],
+          }),
+        );
+
+        const result = await harness.run('integrate claude -g --token tok --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+
+        const state = harness.stateJsonFile.asJson();
+        const extensions = state.agentExtensions as Array<{
+          name: string;
+          hookType: string;
+          global: boolean;
+        }>;
+
+        // sonar-secrets hooks must be global after upgrading to -g
+        const secretsHooks = extensions.filter((e) => e.name === 'sonar-secrets');
+        expect(secretsHooks.length).toBeGreaterThan(0);
+        for (const hook of secretsHooks) {
+          expect(hook.global).toBe(true);
+        }
+
+        // sonar-a3s is always project-level, even when -g is used
+        const a3sHooks = extensions.filter((e) => e.name === 'sonar-a3s');
+        for (const hook of a3sHooks) {
+          expect(hook.global).toBe(false);
+        }
       },
       { timeout: 30000 },
     );

--- a/tests/unit/hooks.test.ts
+++ b/tests/unit/hooks.test.ts
@@ -417,6 +417,64 @@ describe('Hooks', () => {
     }
   });
 
+  // CLI-144: bash hooks parse both compact and pretty-printed JSON
+  it('hooks: pretool-secrets.sh uses sed with optional whitespace for JSON parsing', async () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-sed-pretool-' + Date.now());
+    mkdirSync(testDir, { recursive: true });
+
+    try {
+      await installHooks(testDir, undefined, false);
+
+      const content = readFileSync(
+        join(testDir, '.claude', 'hooks', 'sonar-secrets', 'build-scripts', 'pretool-secrets.sh'),
+        'utf-8',
+      );
+
+      expect(content).toContain('[[:space:]]*:[[:space:]]*');
+      expect(content).not.toContain('grep -o');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('hooks: prompt-secrets.sh uses sed with optional whitespace for JSON parsing', async () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-sed-prompt-' + Date.now());
+    mkdirSync(testDir, { recursive: true });
+
+    try {
+      await installHooks(testDir, undefined, false);
+
+      const content = readFileSync(
+        join(testDir, '.claude', 'hooks', 'sonar-secrets', 'build-scripts', 'prompt-secrets.sh'),
+        'utf-8',
+      );
+
+      expect(content).toContain('[[:space:]]*:[[:space:]]*');
+      expect(content).not.toContain('grep -o');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('hooks: posttool-a3s.sh uses sed with optional whitespace for JSON parsing', async () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-sed-posttool-' + Date.now());
+    mkdirSync(testDir, { recursive: true });
+
+    try {
+      await installHooks(testDir, undefined, true, 'test-project');
+
+      const content = readFileSync(
+        join(testDir, '.claude', 'hooks', 'sonar-a3s', 'build-scripts', 'posttool-a3s.sh'),
+        'utf-8',
+      );
+
+      expect(content).toContain('[[:space:]]*:[[:space:]]*');
+      expect(content).not.toContain('grep -o');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it('hooks: areHooksInstalled returns false when settings.json contains malformed JSON', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-malformed-' + Date.now());
     const claudeDir = join(testDir, '.claude');

--- a/tests/unit/hooks.test.ts
+++ b/tests/unit/hooks.test.ts
@@ -368,6 +368,55 @@ describe('Hooks', () => {
     }
   });
 
+  // CLI-142: correct analyze subcommand in hook scripts
+  it('hooks: prompt-secrets.sh uses sonar analyze secrets subcommand', async () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-secrets-cmd-' + Date.now());
+    mkdirSync(testDir, { recursive: true });
+
+    try {
+      await installHooks(testDir, undefined, false);
+
+      const scriptPath = join(
+        testDir,
+        '.claude',
+        'hooks',
+        'sonar-secrets',
+        'build-scripts',
+        'prompt-secrets.sh',
+      );
+      const content = readFileSync(scriptPath, 'utf-8');
+
+      expect(content).toContain('sonar analyze secrets');
+      expect(content).not.toContain('sonar analyze --file');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('hooks: pretool-secrets.sh uses sonar analyze secrets subcommand', async () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-pretool-cmd-' + Date.now());
+    mkdirSync(testDir, { recursive: true });
+
+    try {
+      await installHooks(testDir, undefined, false);
+
+      const scriptPath = join(
+        testDir,
+        '.claude',
+        'hooks',
+        'sonar-secrets',
+        'build-scripts',
+        'pretool-secrets.sh',
+      );
+      const content = readFileSync(scriptPath, 'utf-8');
+
+      expect(content).toContain('sonar analyze secrets');
+      expect(content).not.toContain('sonar analyze --file');
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
   it('hooks: areHooksInstalled returns false when settings.json contains malformed JSON', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-malformed-' + Date.now());
     const claudeDir = join(testDir, '.claude');

--- a/tests/unit/integrate.test.ts
+++ b/tests/unit/integrate.test.ts
@@ -578,6 +578,69 @@ describe('integrateCommand: --global flag', () => {
       addOrUpdateConnectionSpy.mockRestore();
     }
   });
+
+  // CLI-148: global and project-level agentExtensions must coexist without collision.
+  // Scenario: cd my-project && sonar integrate claude, then sonar integrate claude -g.
+  // The project-level sonar-secrets hooks (global: false) must NOT be lost after the global run.
+  it('keeps separate agentExtensions for project-level and global integrations from same dir', async () => {
+    const capturedState = getDefaultState('test');
+    loadStateSpy.mockReturnValue(capturedState);
+    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
+    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+
+    try {
+      // Step 1: project-level integration (sonar integrate claude)
+      await integrateClaude({
+        server: 'https://sonarcloud.io',
+        project: 'my-project',
+        token: 'test-token',
+        org: 'test-org',
+        global: false,
+      });
+
+      // Verify project-level secrets hooks are registered
+      const projectSecretsPreTool = capturedState.agentExtensions.find(
+        (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && !e.global,
+      );
+      const projectSecretsPrompt = capturedState.agentExtensions.find(
+        (e) => e.name === 'sonar-secrets' && e.hookType === 'UserPromptSubmit' && !e.global,
+      );
+      expect(projectSecretsPreTool).toBeDefined();
+      expect(projectSecretsPrompt).toBeDefined();
+
+      // Step 2: global integration from same directory (sonar integrate claude -g)
+      await integrateClaude({
+        server: 'https://sonarcloud.io',
+        project: 'my-project',
+        token: 'test-token',
+        org: 'test-org',
+        global: true,
+      });
+
+      // Project-level secrets hooks must still be present and unmodified
+      const projectSecretsPreToolAfter = capturedState.agentExtensions.find(
+        (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && !e.global,
+      );
+      const projectSecretsPromptAfter = capturedState.agentExtensions.find(
+        (e) => e.name === 'sonar-secrets' && e.hookType === 'UserPromptSubmit' && !e.global,
+      );
+      expect(projectSecretsPreToolAfter).toBeDefined();
+      expect(projectSecretsPromptAfter).toBeDefined();
+
+      // Global secrets hooks must also be present
+      const globalSecretsPreTool = capturedState.agentExtensions.find(
+        (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && e.global,
+      );
+      const globalSecretsPrompt = capturedState.agentExtensions.find(
+        (e) => e.name === 'sonar-secrets' && e.hookType === 'UserPromptSubmit' && e.global,
+      );
+      expect(globalSecretsPreTool).toBeDefined();
+      expect(globalSecretsPrompt).toBeDefined();
+    } finally {
+      discoverSpy.mockRestore();
+      healthSpy.mockRestore();
+    }
+  });
 });
 
 // ─── no token path ────────────────────────────────────────────────────────────

--- a/tests/unit/integrate.test.ts
+++ b/tests/unit/integrate.test.ts
@@ -33,6 +33,7 @@ import * as stateManager from '../../src/lib/state-manager.js';
 import { getDefaultState } from '../../src/lib/state.js';
 import { setMockUi, getMockUiCalls, clearMockUiCalls } from '../../src/ui';
 import { ENV_TOKEN, ENV_SERVER } from '../../src/lib/auth-resolver.js';
+import { SonarQubeClient } from '../../src/sonarqube/client.js';
 
 const FAKE_PROJECT_INFO = {
   root: '/fake/project',
@@ -296,6 +297,35 @@ describe('integrateCommand: full flow', () => {
       discoverSpy.mockRestore();
       healthSpy.mockRestore();
       addInstalledHookSpy.mockRestore();
+    }
+  });
+
+  // CLI-143: sonar-a3s agentExtension must always be project-level
+  it('registers sonar-a3s agentExtension with global:false even when -g is set', async () => {
+    const capturedState = getDefaultState('test');
+    loadStateSpy.mockReturnValue(capturedState);
+    saveStateSpy.mockImplementation(() => {});
+
+    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
+    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+    const a3sSpy = spyOn(SonarQubeClient.prototype, 'hasA3sEntitlement').mockResolvedValue(true);
+
+    try {
+      await integrateClaude({
+        server: 'https://sonarcloud.io',
+        project: 'my-project',
+        token: 'test-token',
+        org: 'test-org',
+        global: true,
+      });
+
+      const a3sExt = capturedState.agentExtensions.find((e) => e.name === 'sonar-a3s');
+      expect(a3sExt).toBeDefined();
+      expect(a3sExt!.global).toBe(false);
+    } finally {
+      discoverSpy.mockRestore();
+      healthSpy.mockRestore();
+      a3sSpy.mockRestore();
     }
   });
 });

--- a/tests/unit/integrate.test.ts
+++ b/tests/unit/integrate.test.ts
@@ -598,12 +598,18 @@ describe('integrateCommand: --global flag', () => {
         global: false,
       });
 
-      // Verify project-level secrets hooks are registered
+      // Verify project-level secrets hooks are registered with project's root path
       const projectSecretsPreTool = capturedState.agentExtensions.find(
-        (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && !e.global,
+        (e) =>
+          e.name === 'sonar-secrets' &&
+          e.hookType === 'PreToolUse' &&
+          e.projectRoot === FAKE_PROJECT_INFO.root,
       );
       const projectSecretsPrompt = capturedState.agentExtensions.find(
-        (e) => e.name === 'sonar-secrets' && e.hookType === 'UserPromptSubmit' && !e.global,
+        (e) =>
+          e.name === 'sonar-secrets' &&
+          e.hookType === 'UserPromptSubmit' &&
+          e.projectRoot === FAKE_PROJECT_INFO.root,
       );
       expect(projectSecretsPreTool).toBeDefined();
       expect(projectSecretsPrompt).toBeDefined();
@@ -617,22 +623,32 @@ describe('integrateCommand: --global flag', () => {
         global: true,
       });
 
-      // Project-level secrets hooks must still be present and unmodified
+      // Project-level secrets hooks must still be present (projectRoot = project dir, not homedir)
       const projectSecretsPreToolAfter = capturedState.agentExtensions.find(
-        (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && !e.global,
+        (e) =>
+          e.name === 'sonar-secrets' &&
+          e.hookType === 'PreToolUse' &&
+          e.projectRoot === FAKE_PROJECT_INFO.root,
       );
       const projectSecretsPromptAfter = capturedState.agentExtensions.find(
-        (e) => e.name === 'sonar-secrets' && e.hookType === 'UserPromptSubmit' && !e.global,
+        (e) =>
+          e.name === 'sonar-secrets' &&
+          e.hookType === 'UserPromptSubmit' &&
+          e.projectRoot === FAKE_PROJECT_INFO.root,
       );
       expect(projectSecretsPreToolAfter).toBeDefined();
       expect(projectSecretsPromptAfter).toBeDefined();
 
-      // Global secrets hooks must also be present
+      // Global secrets hooks must be present with homedir as projectRoot
       const globalSecretsPreTool = capturedState.agentExtensions.find(
-        (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && e.global,
+        (e) =>
+          e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && e.projectRoot === homedir(),
       );
       const globalSecretsPrompt = capturedState.agentExtensions.find(
-        (e) => e.name === 'sonar-secrets' && e.hookType === 'UserPromptSubmit' && e.global,
+        (e) =>
+          e.name === 'sonar-secrets' &&
+          e.hookType === 'UserPromptSubmit' &&
+          e.projectRoot === homedir(),
       );
       expect(globalSecretsPreTool).toBeDefined();
       expect(globalSecretsPrompt).toBeDefined();

--- a/tests/unit/migration.test.ts
+++ b/tests/unit/migration.test.ts
@@ -23,7 +23,7 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, homedir } from 'node:os';
 import { setMockUi } from '../../src/ui';
 import * as stateManager from '../../src/lib/state-manager.js';
 import * as hooks from '../../src/cli/commands/integrate/claude/hooks';
@@ -248,11 +248,12 @@ describe('runMigrations — migration execution', () => {
       orgKey: 'my-org',
       keystoreKey: 'sonarcloud.io:my-org',
     });
-    // Pre-populate a global entry for the same hook (as if integrate -g already ran)
+    // Pre-populate a global entry for the same hook (as if integrate -g already ran).
+    // Global entries use homedir() as projectRoot — that's the new invariant after CLI-148.
     stateManager.upsertAgentExtension(state, {
       id: 'pre-existing',
       agentId: 'claude-code',
-      projectRoot: '/some/project',
+      projectRoot: homedir(),
       global: true,
       kind: 'hook',
       name: 'sonar-secrets',
@@ -266,7 +267,10 @@ describe('runMigrations — migration execution', () => {
     await runMigrations('/some/project');
 
     const projectExts = state.agentExtensions.filter(
-      (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && !e.global,
+      (e) =>
+        e.name === 'sonar-secrets' &&
+        e.hookType === 'PreToolUse' &&
+        e.projectRoot === '/some/project',
     );
     expect(projectExts.length).toBe(1);
   });

--- a/tests/unit/migration.test.ts
+++ b/tests/unit/migration.test.ts
@@ -234,6 +234,42 @@ describe('runMigrations — migration execution', () => {
     expect(secretsExts.length).toBe(1);
     expect(secretsExts[0].projectRoot).toBe('/some/project');
   });
+
+  // CLI-148: existing global agentExtensions must not be counted as "already migrated"
+  // when running a project-level migration for the same hook name
+  it('creates project-level agentExtensions even when global entries for same hook exist', async () => {
+    const state = makeConfiguredState(OLD_VERSION);
+    state.agents['claude-code'].hooks.installed.push({
+      name: 'sonar-secrets',
+      type: 'PreToolUse',
+      installedAt: new Date().toISOString(),
+    });
+    stateManager.addOrUpdateConnection(state, 'https://sonarcloud.io', 'cloud', {
+      orgKey: 'my-org',
+      keystoreKey: 'sonarcloud.io:my-org',
+    });
+    // Pre-populate a global entry for the same hook (as if integrate -g already ran)
+    stateManager.upsertAgentExtension(state, {
+      id: 'pre-existing',
+      agentId: 'claude-code',
+      projectRoot: '/some/project',
+      global: true,
+      kind: 'hook',
+      name: 'sonar-secrets',
+      hookType: 'PreToolUse',
+      serverUrl: 'https://sonarcloud.io',
+      updatedByCliVersion: '0.0.0',
+      updatedAt: new Date().toISOString(),
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    await runMigrations('/some/project');
+
+    const projectExts = state.agentExtensions.filter(
+      (e) => e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && !e.global,
+    );
+    expect(projectExts.length).toBe(1);
+  });
 });
 
 describe('runMigrations — CLI-105 patch', () => {


### PR DESCRIPTION
* CLI-143 sonar-a3s hook must always be project-level, even with -g flag
* CLI-142 Fix incorrect analyze subcommand in hook scripts
* CLI-144 Fix bash hook JSON parsing to handle pretty-printed format
* CLI-148 Fix global integrate overwriting project-level agentExtensions