### PR TITLE
CLI-151 Display issues even when A3S response also contains errors

### DIFF
--- a/src/cli/commands/analyze/a3s.ts
+++ b/src/cli/commands/analyze/a3s.ts
@@ -170,17 +170,8 @@ function displayA3sResults(
   issues: A3sIssue[],
   errors?: Array<{ code: string; message: string }> | null,
 ): void {
-  if (errors && errors.length > 0) {
-    blank();
-    error('A3S analysis returned errors:');
-    errors.forEach((e) => {
-      text(`  [${e.code}] ${e.message}`);
-    });
-    blank();
-    return;
-  }
-
   blank();
+
   if (issues.length === 0) {
     success('A3S analysis completed — no issues found.');
   } else {
@@ -192,5 +183,14 @@ function displayA3sResults(
       text(`      Rule: ${issue.rule}`);
     });
   }
+
+  if (errors && errors.length > 0) {
+    blank();
+    error('A3S analysis returned errors:');
+    errors.forEach((e) => {
+      text(`  [${e.code}] ${e.message}`);
+    });
+  }
+
   blank();
 }

--- a/tests/unit/analyze-a3s.test.ts
+++ b/tests/unit/analyze-a3s.test.ts
@@ -276,6 +276,30 @@ describe('analyzeA3s: API call and result display', () => {
     expect(output).toContain('not entitled');
   });
 
+  it('displays both issues and errors when response contains both', async () => {
+    analyzeFileSpy.mockResolvedValue({
+      id: 'a1',
+      issues: [
+        {
+          rule: 'cpp:S1186',
+          message: 'Add a nested comment explaining why this method is empty.',
+          textRange: { startLine: 2, endLine: 2, startOffset: 28, endOffset: 30 },
+        },
+      ],
+      errors: [{ code: 'PARSE_ERROR', message: "'NonExistentHeader.h' file not found" }],
+    });
+
+    await analyzeA3s({ file: 'src/index.ts' });
+
+    const output = getMockUiCalls()
+      .map((c) => String(c.args[0]))
+      .join('\n');
+    expect(output).toContain('cpp:S1186');
+    expect(output).toContain('Add a nested comment');
+    expect(output).toContain('PARSE_ERROR');
+    expect(output).toContain('NonExistentHeader.h');
+  });
+
   it('throws CommandFailedError when A3S API call fails', () => {
     analyzeFileSpy.mockRejectedValue(new Error('Network error'));
 


### PR DESCRIPTION
# Example output
## Before
```
Running A3S analysis...

❌ A3S analysis returned errors:
  [PARSE_ERROR] '}' expected.
```

## After
```
Running A3S analysis...

❌ A3S analysis found 1 issue:

  [1] '}' expected. (line 30)
      Rule: javascript:S2260

❌ A3S analysis returned errors:
  [PARSE_ERROR] '}' expected.
```