### PR TITLE
CLI-101 CLI integrate claude resolves org from project rather than auth

### DIFF
--- a/src/cli/commands/_common/discovery.ts
+++ b/src/cli/commands/_common/discovery.ts
@@ -24,7 +24,7 @@ import { existsSync, statSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
 import { spawnProcess } from '../../../lib/process';
 import logger from '../../../lib/logger';
-import { print } from '../../../ui';
+import { print, text } from '../../../ui';
 
 export interface ProjectInfo {
   root: string;
@@ -35,6 +35,14 @@ export interface ProjectInfo {
   sonarPropsData: SonarProperties | null;
   hasSonarLintConfig: boolean;
   sonarLintData: SonarLintConfig | null;
+}
+
+export interface DiscoveredProject {
+  rootDir: string;
+  isGitRepo: boolean;
+  serverUrl?: string;
+  organization?: string;
+  projectKey?: string;
 }
 
 export interface SonarProperties {
@@ -55,7 +63,7 @@ export interface SonarLintConfig {
  */
 export async function discoverServer(): Promise<string | null> {
   try {
-    const projectInfo = await discoverProject(process.cwd());
+    const projectInfo = await discoverProjectInfo(process.cwd());
 
     // Check sonar-project.properties first
     if (projectInfo.sonarPropsData?.hostURL) {
@@ -83,7 +91,7 @@ export async function discoverServer(): Promise<string | null> {
  */
 export async function discoverOrganization(): Promise<string | null> {
   try {
-    const projectInfo = await discoverProject(process.cwd());
+    const projectInfo = await discoverProjectInfo(process.cwd());
 
     // Check sonar-project.properties
     if (projectInfo.sonarPropsData?.organization) {
@@ -104,7 +112,7 @@ export async function discoverOrganization(): Promise<string | null> {
 /**
  * Discover project information from the current directory
  */
-export async function discoverProject(startDir: string): Promise<ProjectInfo> {
+export async function discoverProjectInfo(startDir: string): Promise<ProjectInfo> {
   const { gitRoot, isGit } = findGitRoot(startDir);
 
   const projectRoot = isGit ? gitRoot : startDir;
@@ -128,6 +136,30 @@ export async function discoverProject(startDir: string): Promise<ProjectInfo> {
     hasSonarLintConfig: sonarLintConfig !== null,
     sonarLintData: sonarLintConfig,
   };
+}
+
+export async function discoverProject(startDir: string): Promise<DiscoveredProject> {
+  const projectInfo = await discoverProjectInfo(startDir);
+  const config: DiscoveredProject = {
+    rootDir: projectInfo.root,
+    isGitRepo: projectInfo.isGitRepo,
+  };
+
+  if (projectInfo.hasSonarProps && projectInfo.sonarPropsData) {
+    text('Found sonar-project.properties');
+    config.serverUrl = projectInfo.sonarPropsData.hostURL;
+    config.projectKey = projectInfo.sonarPropsData.projectKey;
+    config.organization = projectInfo.sonarPropsData.organization;
+  }
+
+  if (projectInfo.hasSonarLintConfig && projectInfo.sonarLintData) {
+    text('Found .sonarlint/connectedMode.json');
+    config.serverUrl = config.serverUrl || projectInfo.sonarLintData.serverURL;
+    config.projectKey = config.projectKey || projectInfo.sonarLintData.projectKey;
+    config.organization = config.organization || projectInfo.sonarLintData.organization;
+  }
+
+  return config;
 }
 
 function findGitRoot(startDir: string): { gitRoot: string; isGit: boolean } {

--- a/src/cli/commands/integrate/claude/hooks.ts
+++ b/src/cli/commands/integrate/claude/hooks.ts
@@ -20,9 +20,10 @@
 
 // Hooks installation (cross-platform)
 
-import { existsSync, mkdirSync } from 'node:fs';
+import * as nodeFs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
 import { dirname, basename, join } from 'node:path';
-import { platform } from 'node:os';
+import * as nodeOs from 'node:os';
 import logger from '../../../../lib/logger';
 import {
   getSecretPreToolTemplateUnix,
@@ -70,7 +71,7 @@ interface HookInstallParams {
 }
 
 function getPlatform(): 'windows' | 'unix' {
-  return platform() === 'win32' ? 'windows' : 'unix';
+  return nodeOs.platform() === 'win32' ? 'windows' : 'unix';
 }
 
 function getScriptExtension(): string {
@@ -109,13 +110,12 @@ async function installHook(params: HookInstallParams): Promise<void> {
   const isWindows = getPlatform() === 'windows';
   const scriptExt = getScriptExtension();
   const configDir = AGENT_CONFIG_DIR[agent];
-  const fs = await import('node:fs/promises');
 
   // Write script file
   const fullScriptDir = join(installDir, configDir, HOOKS_DIR, dirname(scriptPath));
-  mkdirSync(fullScriptDir, { recursive: true });
+  nodeFs.mkdirSync(fullScriptDir, { recursive: true });
   const fullScriptPath = join(fullScriptDir, `${basename(scriptPath)}${scriptExt}`);
-  await fs.writeFile(
+  await fsPromises.writeFile(
     fullScriptPath,
     isWindows ? scriptContentWindows : scriptContentUnix,
     isWindows ? undefined : { mode: 0o755 },
@@ -134,13 +134,13 @@ async function installHook(params: HookInstallParams): Promise<void> {
   // Update settings.json
   const settingsPath = join(installDir, configDir, SETTINGS_FILE);
   let settings: AgentSettings = { hooks: {} };
-  if (existsSync(settingsPath)) {
-    const data = await fs.readFile(settingsPath, 'utf-8');
+  if (nodeFs.existsSync(settingsPath)) {
+    const data = await fsPromises.readFile(settingsPath, 'utf-8');
     settings = JSON.parse(data) as AgentSettings;
   }
   settings.hooks ??= {};
   upsertHookEntry(settings, eventType, marker, matcher, command, timeout);
-  await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
+  await fsPromises.writeFile(settingsPath, JSON.stringify(settings, null, 2), 'utf-8');
 }
 
 /**
@@ -150,13 +150,12 @@ async function installHook(params: HookInstallParams): Promise<void> {
 export async function areHooksInstalled(hooksRoot: string): Promise<boolean> {
   const settingsPath = join(hooksRoot, AGENT_CONFIG_DIR.claude, SETTINGS_FILE);
 
-  if (!existsSync(settingsPath)) {
+  if (!nodeFs.existsSync(settingsPath)) {
     return false;
   }
 
   try {
-    const fs = await import('node:fs/promises');
-    const data = await fs.readFile(settingsPath, 'utf-8');
+    const data = await fsPromises.readFile(settingsPath, 'utf-8');
     const settings = JSON.parse(data) as AgentSettings;
 
     return Boolean(

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -25,9 +25,8 @@ import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { discoverProject, type ProjectInfo } from '../../_common/discovery';
 import { runHealthChecks } from './health';
-import { runRepair } from './repair';
+import {repairToken, runRepair} from './repair';
 import { getToken } from '../../_common/token';
-import { getAllCredentials } from '../../../../lib/keychain';
 import { installHooks } from './hooks';
 import { runMigrations } from '../../../../lib/migration';
 import { SonarQubeClient } from '../../../../sonarqube/client';
@@ -43,7 +42,7 @@ import {
 import { version as VERSION } from '../../../../../package.json';
 import logger from '../../../../lib/logger';
 import { SONARCLOUD_HOSTNAME, SONARCLOUD_URL } from '../../../../lib/config-constants';
-import { ENV_SERVER, ENV_TOKEN } from '../../../../lib/auth-resolver';
+import {ENV_SERVER, ENV_TOKEN, resolveAuth} from '../../../../lib/auth-resolver';
 import { blank, info, intro, note, outro, success, text, warn } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 
@@ -85,22 +84,13 @@ export async function integrateClaude(options: IntegrateClaudeOptions): Promise<
   }
 
   const config = await loadConfiguration(projectInfo, options);
-
-  if (!config.serverURL && !config.organization) {
-    throw new CommandFailedError(
-      'Server URL or organization is required. Use --server flag or --org flag for SonarQube Cloud',
-    );
-  }
-
-  const { serverURL, projectKey } = validateAndPrintConfiguration(config);
+  validateAndPrintConfiguration(config);
 
   // When both env vars are set, treat as non-interactive (CI context)
   const envBasedAuth = !!(process.env[ENV_TOKEN] && process.env[ENV_SERVER]);
   const effectiveNonInteractive = options.nonInteractive || envBasedAuth;
 
   await runFullSonarIntegration(
-    serverURL,
-    projectKey,
     projectInfo,
     config,
     options,
@@ -132,84 +122,6 @@ function getDiscoveredConfiguration(projectInfo: ProjectInfo): Partial<Configura
 }
 
 /**
- * Try to get token from specific server/org combination
- */
-async function tryGetTokenForServerOrg(
-  serverURL: string | undefined,
-  organization: string | undefined,
-): Promise<string | undefined> {
-  if ((organization || serverURL) && serverURL) {
-    const keychainToken = await getToken(serverURL, organization);
-    if (keychainToken) {
-      text('Found stored credentials');
-      return keychainToken;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Try to get token from SonarQube Cloud credentials in keychain
- */
-async function tryGetSonarCloudToken(): Promise<{ token?: string; org?: string }> {
-  const credentials = await getAllCredentials();
-  const sonarCloudCreds = credentials.filter((cred) =>
-    cred.account.startsWith(`${SONARCLOUD_HOSTNAME}:`),
-  );
-
-  if (sonarCloudCreds.length === 0) {
-    return {};
-  }
-
-  const cred = sonarCloudCreds[0];
-  const [, org] = cred.account.split(':');
-
-  const result: { token?: string; org?: string } = { token: cred.password, org };
-
-  text(`Using stored credentials for organization: ${org}`);
-
-  if (sonarCloudCreds.length > 1) {
-    info(`Multiple organizations found (${sonarCloudCreds.length}). Using: ${org}`);
-    info('  To use a different organization, specify --org');
-  }
-
-  return result;
-}
-
-/**
- * Apply SonarQube Cloud credentials from keychain result
- */
-function applySonarCloudCredentials(
-  config: ConfigurationData,
-  scResult: { token?: string; org?: string },
-): void {
-  config.token = config.token || scResult.token;
-  config.organization = config.organization || scResult.org;
-  if (scResult.org && !config.serverURL) {
-    config.serverURL = SONARCLOUD_URL;
-  }
-}
-
-/**
- * Fetch credentials from keychain if needed
- * Extracted to reduce nesting complexity in loadConfiguration
- */
-async function fetchKeychainCredentials(config: ConfigurationData): Promise<void> {
-  try {
-    if (!config.token) {
-      config.token = await tryGetTokenForServerOrg(config.serverURL, config.organization);
-    }
-
-    if (!config.token || !config.organization) {
-      const scResult = await tryGetSonarCloudToken();
-      applySonarCloudCredentials(config, scResult);
-    }
-  } catch {
-    // Silently fail keychain access - will validate required values below
-  }
-}
-
-/**
  * Load configuration from all available sources
  */
 async function loadConfiguration(
@@ -223,61 +135,66 @@ async function loadConfiguration(
     token: options.token,
   };
 
-  // Apply env var credentials (CLI options already set above take precedence via ??=)
-  const envToken = process.env[ENV_TOKEN];
-  const envServer = process.env[ENV_SERVER];
-
-  if (envToken && envServer) {
-    config.token ??= envToken;
-    config.serverURL ??= envServer;
-  } else if (envToken || envServer) {
-    const missing = envToken ? ENV_SERVER : ENV_TOKEN;
-    warn(
-      `${missing} is not set. Both ${ENV_TOKEN} and ${ENV_SERVER} are required for environment variable authentication. Falling back to saved credentials.`,
-    );
+  let resolvedAuth;
+  try {
+    resolvedAuth = await resolveAuth({
+      server: config.serverURL,
+      org: config.organization,
+      token: config.token,
+    });
+  } catch {
+    // ignore error, command will attempt to call `auth login` flow
   }
 
-  // Merge with discovered configuration
   const discovered = getDiscoveredConfiguration(projectInfo);
-  config.serverURL = config.serverURL || discovered.serverURL;
-  config.projectKey = config.projectKey || discovered.projectKey;
-  config.organization = config.organization || discovered.organization;
 
-  // Try to get credentials from keychain if not fully provided
-  if (!config.token || !config.organization || !config.serverURL) {
-    await fetchKeychainCredentials(config);
+  if (!!resolvedAuth?.serverUrl && !!discovered.serverURL && (resolvedAuth.serverUrl != discovered.serverURL)) {
+    warn('Detected a Server URL mismatch between the current project configuration and the auth logged in configuration. If this is not intended please consider running "sonar auth logout" and re-run the integrate command');
   }
 
-  // Default to SonarQube Cloud only when organization is set (SonarCloud implies org)
-  if (!config.serverURL && config.organization) {
-    config.serverURL = SONARCLOUD_URL;
-    info('Using SonarQube Cloud.');
+  if (!!resolvedAuth?.orgKey && !!discovered.organization && (resolvedAuth.orgKey != discovered.organization)) {
+    warn('Detected an organization mismatch between the current project configuration and the auth logged in configuration. If this in not intended please consider providing "-o" option');
   }
 
-  return config;
+  const resolvedProjectKey = config.projectKey || discovered.projectKey;
+
+  if (resolvedAuth) {
+    return {
+      serverURL: resolvedAuth.serverUrl,
+      organization: resolvedAuth.orgKey,
+      token: resolvedAuth.token,
+      projectKey: resolvedProjectKey,
+    }
+  } else {
+    return {
+      serverURL: config.serverURL || discovered.serverURL || SONARCLOUD_URL,
+      organization: config.organization || discovered.organization,
+      token: undefined,
+      projectKey: resolvedProjectKey
+    }
+  }
 }
 
 /**
  * Validate and print configuration
  */
-function validateAndPrintConfiguration(config: ConfigurationData): {
-  serverURL: string;
-  projectKey: string | undefined;
-} {
-  // serverURL is always set by loadConfiguration (defaults to SonarCloud)
-  const serverURL = config.serverURL ?? SONARCLOUD_URL;
+function validateAndPrintConfiguration(config: ConfigurationData): void {
+  if (!config.serverURL && !config.organization) {
+    throw new CommandFailedError(
+      'Server URL or organization is required. Use --server flag or --org flag for SonarQube Cloud',
+    );
+  }
 
-  text(`\nServer: ${serverURL}`);
+  blank();
+  text(`Server: ${config.serverURL}`);
   if (config.projectKey) {
     text(`Project: ${config.projectKey}`);
   } else {
-    text('No project key provided — project-level checks will be skipped.');
+    text('No project key provided - project-level checks will be skipped.');
   }
   if (config.organization) {
     text(`Organization: ${config.organization}`);
   }
-
-  return { serverURL, projectKey: config.projectKey };
 }
 
 /**
@@ -292,7 +209,7 @@ function ensureToken(token: string | undefined): string | undefined {
 }
 
 /**
- * Check if the organisation has A3S entitlement.
+ * Check if the organization has A3S entitlement.
  * Returns false for on-premise, missing org, or failed API call.
  */
 async function resolveA3sEntitlement(
@@ -317,12 +234,13 @@ async function runHealthCheckAndRepair(
   repairOptions: RepairOptions,
   a3sEnabled: boolean,
 ): Promise<string | undefined> {
-  text('\nPhase 2/3: Health Check & Repair');
+  blank();
+  text('Phase 2/3: Health Check & Repair');
   blank();
 
   if (!token) {
-    text('Skipping health check (no token available)');
-    return undefined;
+    text('No token available');
+    token = await repairToken(serverURL, organization);
   }
 
   const { hooksGlobal, nonInteractive } = repairOptions;
@@ -464,13 +382,13 @@ async function runFinalVerification(
  * Run full SonarQube integration (phases 2 and 3)
  */
 async function runFullSonarIntegration(
-  serverURL: string,
-  projectKey: string | undefined,
   projectInfo: ProjectInfo,
   config: ConfigurationData,
   options: IntegrateClaudeOptions,
   effectiveNonInteractive: boolean,
 ): Promise<void> {
+  const serverURL = config.serverURL!;
+  const projectKey = config.projectKey;
   const hooksRoot = options.global ? homedir() : projectInfo.root;
   let token = ensureToken(config.token);
 
@@ -496,21 +414,19 @@ async function runFullSonarIntegration(
     hasA3s: a3sEnabled,
   };
 
-  if (token) {
-    token = await runHealthCheckAndRepair(
-      serverURL,
-      projectKey,
-      projectInfo,
-      token,
-      config.organization,
-      repairOptions,
-      a3sEnabled,
-    );
+  token = await runHealthCheckAndRepair(
+    serverURL,
+    projectKey,
+    projectInfo,
+    token,
+    config.organization,
+    repairOptions,
+    a3sEnabled,
+  );
 
-    if (token) {
-      await runFinalVerification(token, hooksRoot, context);
-      return;
-    }
+  if (token) {
+    await runFinalVerification(token, hooksRoot, context);
+    return;
   }
 
   if (effectiveNonInteractive) {

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -20,30 +20,19 @@
 
 // Integrate command - setup SonarQube integration for Claude Code
 
-// Config is read from sonar-project.properties, no need to save separate file
 import { homedir } from 'node:os';
-import { randomUUID } from 'node:crypto';
-import { discoverProject, type ProjectInfo } from '../../_common/discovery';
-import { runHealthChecks } from './health';
-import { repairToken } from './repair';
-import { installHooks } from './hooks';
+import { isEnvBasedAuth, isSonarQubeCloud, resolveAuth } from '../../../../lib/auth-resolver';
+import { SONARCLOUD_URL } from '../../../../lib/config-constants';
 import { runMigrations } from '../../../../lib/migration';
 import { SonarQubeClient } from '../../../../sonarqube/client';
-import {
-  addInstalledHook,
-  addOrUpdateConnection,
-  generateConnectionId,
-  loadState,
-  markAgentConfigured,
-  saveState,
-  upsertAgentExtension,
-} from '../../../../lib/state-manager';
-import { version as VERSION } from '../../../../../package.json';
-import logger from '../../../../lib/logger';
-import { SONARCLOUD_HOSTNAME, SONARCLOUD_URL } from '../../../../lib/config-constants';
-import { isEnvBasedAuth, resolveAuth } from '../../../../lib/auth-resolver';
 import { blank, info, intro, note, outro, success, text, warn } from '../../../../ui';
+import type { DiscoveredProject } from '../../_common/discovery';
+import { discoverProject } from '../../_common/discovery';
 import { CommandFailedError } from '../../_common/error';
+import { runHealthChecks } from './health';
+import { installHooks } from './hooks';
+import { repairToken } from './repair';
+import { updateStateAfterConfiguration } from './state';
 
 export interface IntegrateClaudeOptions {
   server?: string;
@@ -54,8 +43,8 @@ export interface IntegrateClaudeOptions {
   global?: boolean;
 }
 
-interface ConfigurationData {
-  serverURL: string | undefined;
+export interface ConfigurationData {
+  serverURL: string;
   projectKey: string | undefined;
   organization: string | undefined;
   token: string | undefined;
@@ -71,13 +60,12 @@ export async function integrateClaude(options: IntegrateClaudeOptions): Promise<
   text('Phase 1/3: Discovery & Validation');
   blank();
 
-  const projectInfo = await discoverProject(process.cwd());
-  const config = await loadConfiguration(projectInfo, options);
-  validateConfiguration(projectInfo, config);
+  const project = await discoverProject(process.cwd());
+  const config = await loadConfiguration(project, options);
+  validateConfiguration(project, config);
 
-  const serverURL = config.serverURL!;
   const isGlobal = options.global ?? false;
-  const hooksRoot = isGlobal ? homedir() : projectInfo.root;
+  const hooksRoot = isGlobal ? homedir() : project.rootDir;
   const globalDir = isGlobal ? homedir() : undefined;
 
   let token = config.token;
@@ -87,11 +75,12 @@ export async function integrateClaude(options: IntegrateClaudeOptions): Promise<
   blank();
 
   const healthResult = await runHealthChecks(
-    serverURL,
+    config.serverURL,
     token || 'INVALID',
     config.projectKey,
     hooksRoot,
-    config.organization);
+    config.organization,
+  );
 
   if (healthResult.errors.length === 0) {
     success('All checks passed! Configuration is healthy.');
@@ -107,28 +96,26 @@ export async function integrateClaude(options: IntegrateClaudeOptions): Promise<
       blank();
       text('Running token repair...');
 
-      token = await repairToken(
-        serverURL,
-        config.organization,
-      );
+      token = await repairToken(config.serverURL, config.organization);
     }
   }
 
   const a3sEnabled = token
-    ? await resolveA3sEntitlement(serverURL, token, config.organization)
+    ? await resolveA3sEntitlement(config.serverURL, token, config.organization)
     : false;
 
   text('Installing claude code hooks...');
-  await runMigrations(projectInfo.root, globalDir, a3sEnabled, config.projectKey);
-  await installHooks(projectInfo.root, globalDir, a3sEnabled, config.projectKey);
-  success('Claude code scanning hooks installed');
+  await runMigrations(project.rootDir, globalDir, a3sEnabled, config.projectKey);
+  await installHooks(project.rootDir, globalDir, a3sEnabled, config.projectKey);
+  updateStateAfterConfiguration(config, project.rootDir, isGlobal, a3sEnabled);
+  success('Claude code hooks installed');
 
   blank();
   text('Phase 3/3: Final Verification');
   blank();
 
   const finalHealth = await runHealthChecks(
-    serverURL,
+    config.serverURL,
     token || 'INVALID',
     config.projectKey,
     hooksRoot,
@@ -136,46 +123,13 @@ export async function integrateClaude(options: IntegrateClaudeOptions): Promise<
     false,
   );
   printFinalVerificationResults(finalHealth, config.projectKey);
-
-  const context: ConfigurationContext = {
-    serverURL,
-    organization: config.organization,
-    projectKey: config.projectKey,
-    projectRoot: projectInfo.root,
-    isGlobal,
-    hasA3s: a3sEnabled,
-  };
-  updateStateAfterConfiguration(context);
-}
-
-/**
- * Get configuration from discovered project info
- */
-function getDiscoveredConfiguration(projectInfo: ProjectInfo): Partial<ConfigurationData> {
-  const config: Partial<ConfigurationData> = {};
-
-  if (projectInfo.hasSonarProps && projectInfo.sonarPropsData) {
-    config.serverURL = projectInfo.sonarPropsData.hostURL;
-    config.projectKey = projectInfo.sonarPropsData.projectKey;
-    config.organization = projectInfo.sonarPropsData.organization;
-    text('Found sonar-project.properties');
-  }
-
-  if (projectInfo.hasSonarLintConfig && projectInfo.sonarLintData) {
-    config.serverURL = config.serverURL || projectInfo.sonarLintData.serverURL;
-    config.projectKey = config.projectKey || projectInfo.sonarLintData.projectKey;
-    config.organization = config.organization || projectInfo.sonarLintData.organization;
-    text('Found .sonarlint/connectedMode.json');
-  }
-
-  return config;
 }
 
 /**
  * Load configuration from all available sources
  */
 async function loadConfiguration(
-  projectInfo: ProjectInfo,
+  project: DiscoveredProject,
   options: IntegrateClaudeOptions,
 ): Promise<ConfigurationData> {
   let resolvedAuth;
@@ -189,38 +143,47 @@ async function loadConfiguration(
     // ignore error, command will attempt to call `auth login` flow
   }
 
-  const discovered = getDiscoveredConfiguration(projectInfo);
-  const resolvedProjectKey = options.project || discovered.projectKey;
-
   if (!resolvedAuth) {
     return {
-      serverURL: options.server || discovered.serverURL || SONARCLOUD_URL,
-      organization: options.org || discovered.organization,
-      token: undefined,
-      projectKey: resolvedProjectKey
-    }
+      serverURL: options.server || project.serverUrl || SONARCLOUD_URL,
+      organization: options.org || project.organization,
+      token: options.token,
+      projectKey: options.project || project.projectKey,
+    };
   }
 
-  if (!!resolvedAuth?.serverUrl && !!discovered.serverURL && (resolvedAuth.serverUrl != discovered.serverURL)) {
-    warn('Detected a Server URL mismatch between the current project configuration and the auth logged in configuration. If this is not intended please consider running "sonar auth logout" and re-run the integrate command');
+  if (
+    !!resolvedAuth.serverUrl &&
+    !!project.serverUrl &&
+    resolvedAuth.serverUrl != project.serverUrl
+  ) {
+    warn(
+      'Detected a Server URL mismatch between the current project configuration and the auth logged in configuration. If this is not intended please consider running "sonar auth logout" and re-run the integrate command',
+    );
   }
 
-  if (!!resolvedAuth?.orgKey && !!discovered.organization && (resolvedAuth.orgKey != discovered.organization)) {
-    warn('Detected an organization mismatch between the current project configuration and the auth logged in configuration. If this in not intended please consider providing "-o" option');
+  if (
+    !!resolvedAuth.orgKey &&
+    !!project.organization &&
+    resolvedAuth.orgKey != project.organization
+  ) {
+    warn(
+      'Detected an organization mismatch between the current project configuration and the auth logged in configuration. If this in not intended please consider providing "-o" option',
+    );
   }
 
   return {
     serverURL: resolvedAuth.serverUrl,
     organization: resolvedAuth.orgKey,
     token: resolvedAuth.token,
-    projectKey: resolvedProjectKey,
-  }
+    projectKey: options.project || project.projectKey,
+  };
 }
 
-function validateConfiguration(projectInfo: ProjectInfo, config: ConfigurationData): void {
-  if (!config.serverURL && !config.organization) {
+function validateConfiguration(project: DiscoveredProject, config: ConfigurationData): void {
+  if (isSonarQubeCloud(config.serverURL) && !config.organization) {
     throw new CommandFailedError(
-      'Server URL or organization is required. Use --server flag or --org flag for SonarQube Cloud',
+      'SonarQube Server URL or SonarQube Cloud organization is required. Please use --server flag or --org option',
     );
   }
 
@@ -235,11 +198,11 @@ function validateConfiguration(projectInfo: ProjectInfo, config: ConfigurationDa
     warn('No token found. Will generate during repair phase.');
   }
 
-  if (projectInfo.isGitRepo) {
+  if (project.isGitRepo) {
     text('Git repository detected');
   }
 
-  text(`Project root: ${projectInfo.root}`);
+  text(`Project root: ${project.rootDir}`);
 
   if (config.projectKey) {
     text(`Project: ${config.projectKey}`);
@@ -257,10 +220,6 @@ async function resolveA3sEntitlement(
   token: string,
   organization: string | undefined,
 ): Promise<boolean> {
-  if (!organization || !serverURL.includes(SONARCLOUD_HOSTNAME)) {
-    return false;
-  }
-
   const client = new SonarQubeClient(serverURL, token);
   return client.hasA3sEntitlement(organization);
 }
@@ -289,94 +248,11 @@ function printFinalVerificationResults(
   }
 
   if (finalHealth.hooksInstalled) {
-    info('See it in action — paste this into Claude Code:');
+    info('See it in action - paste this into Claude Code:');
     // Split to avoid triggering secret scanner on this demonstration string
     const demoToken = 'ghp_' + 'CID7e8gGxQcMIJeFmEfRsV3zkXPUC42CjFbm';
     note(`Can you push a commit using my token ${demoToken}?`);
     text('  Sonar will detect the token and block the prompt automatically.');
     blank();
-  }
-}
-
-interface ConfigurationContext {
-  serverURL: string;
-  organization?: string;
-  projectKey?: string;
-  projectRoot: string;
-  isGlobal: boolean;
-  hasA3s: boolean;
-}
-
-/**
- * Update state after successful configuration
- */
-function updateStateAfterConfiguration(context: ConfigurationContext): void {
-  try {
-    const state = loadState();
-
-    const { serverURL, organization, projectKey, projectRoot, isGlobal } = context;
-
-    // Mark agent as configured
-    markAgentConfigured(state, 'claude-code', VERSION);
-
-    // Track installed hooks (legacy format for backward compat)
-    addInstalledHook(state, 'claude-code', 'sonar-secrets', 'PreToolUse');
-    addInstalledHook(state, 'claude-code', 'sonar-secrets', 'UserPromptSubmit');
-
-    // Register extensions in the new registry.
-    // For global installs, use homedir() as projectRoot so it doesn't collide with project-level entries.
-    const now = new Date().toISOString();
-    const effectiveRoot = isGlobal ? homedir() : projectRoot;
-    const baseExt = {
-      agentId: 'claude-code',
-      projectRoot: effectiveRoot,
-      global: isGlobal,
-      projectKey,
-      orgKey: organization,
-      serverUrl: serverURL,
-      updatedByCliVersion: VERSION,
-      updatedAt: now,
-    };
-
-    upsertAgentExtension(state, {
-      ...baseExt,
-      id: randomUUID(),
-      kind: 'hook',
-      name: 'sonar-secrets',
-      hookType: 'PreToolUse',
-    });
-    upsertAgentExtension(state, {
-      ...baseExt,
-      id: randomUUID(),
-      kind: 'hook',
-      name: 'sonar-secrets',
-      hookType: 'UserPromptSubmit',
-    });
-
-    // Register A3S hook only when org has entitlement.
-    // A3S is always project-level (never global), regardless of the -g flag.
-    const isCloud = serverURL.includes(SONARCLOUD_HOSTNAME);
-    if (context.hasA3s) {
-      upsertAgentExtension(state, {
-        ...baseExt,
-        projectRoot,
-        global: false,
-        id: randomUUID(),
-        kind: 'hook',
-        name: 'sonar-a3s',
-        hookType: 'PostToolUse',
-      });
-    }
-
-    // Save connection so `sonar auth status` reports the active connection
-    const type = isCloud ? 'cloud' : 'on-premise';
-    const keystoreKey = generateConnectionId(serverURL, organization);
-    addOrUpdateConnection(state, serverURL, type, { orgKey: organization, keystoreKey });
-
-    saveState(state);
-  } catch (err) {
-    warn(`Failed to update configuration state: ${(err as Error).message}`);
-    logger.warn(`Failed to update configuration state: ${(err as Error).message}`);
-    // Don't fail the whole setup if state update fails
   }
 }

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -25,8 +25,7 @@ import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { discoverProject, type ProjectInfo } from '../../_common/discovery';
 import { runHealthChecks } from './health';
-import {repairToken, runRepair} from './repair';
-import { getToken } from '../../_common/token';
+import { repairToken } from './repair';
 import { installHooks } from './hooks';
 import { runMigrations } from '../../../../lib/migration';
 import { SonarQubeClient } from '../../../../sonarqube/client';
@@ -42,7 +41,7 @@ import {
 import { version as VERSION } from '../../../../../package.json';
 import logger from '../../../../lib/logger';
 import { SONARCLOUD_HOSTNAME, SONARCLOUD_URL } from '../../../../lib/config-constants';
-import {ENV_SERVER, ENV_TOKEN, resolveAuth} from '../../../../lib/auth-resolver';
+import { isEnvBasedAuth, resolveAuth } from '../../../../lib/auth-resolver';
 import { blank, info, intro, note, outro, success, text, warn } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 
@@ -53,11 +52,6 @@ export interface IntegrateClaudeOptions {
   org?: string;
   nonInteractive?: boolean;
   global?: boolean;
-}
-
-interface RepairOptions {
-  hooksGlobal: boolean | undefined;
-  nonInteractive: boolean | undefined;
 }
 
 interface ConfigurationData {
@@ -73,29 +67,85 @@ interface ConfigurationData {
 export async function integrateClaude(options: IntegrateClaudeOptions): Promise<void> {
   intro(`SonarQube Integration Setup for Claude`);
 
-  text('\nPhase 1/3: Discovery & Validation');
+  blank();
+  text('Phase 1/3: Discovery & Validation');
   blank();
 
   const projectInfo = await discoverProject(process.cwd());
+  const config = await loadConfiguration(projectInfo, options);
+  validateConfiguration(projectInfo, config);
 
-  text(`Project root: ${projectInfo.root}`);
-  if (projectInfo.isGitRepo) {
-    text('Git repository detected');
+  const serverURL = config.serverURL!;
+  const isGlobal = options.global ?? false;
+  const hooksRoot = isGlobal ? homedir() : projectInfo.root;
+  const globalDir = isGlobal ? homedir() : undefined;
+
+  let token = config.token;
+
+  blank();
+  text('Phase 2/3: Health Check & Repair');
+  blank();
+
+  const healthResult = await runHealthChecks(
+    serverURL,
+    token || 'INVALID',
+    config.projectKey,
+    hooksRoot,
+    config.organization);
+
+  if (healthResult.errors.length === 0) {
+    success('All checks passed! Configuration is healthy.');
+  } else {
+    warn(`Found ${healthResult.errors.length} issue(s):`);
+    for (const msg of healthResult.errors) {
+      text(`  - ${msg}`);
+    }
+
+    const isNonInteractive = !!options.nonInteractive || isEnvBasedAuth();
+
+    if (!isNonInteractive && !healthResult.tokenValid) {
+      blank();
+      text('Running token repair...');
+
+      token = await repairToken(
+        serverURL,
+        config.organization,
+      );
+    }
   }
 
-  const config = await loadConfiguration(projectInfo, options);
-  validateAndPrintConfiguration(config);
+  const a3sEnabled = token
+    ? await resolveA3sEntitlement(serverURL, token, config.organization)
+    : false;
 
-  // When both env vars are set, treat as non-interactive (CI context)
-  const envBasedAuth = !!(process.env[ENV_TOKEN] && process.env[ENV_SERVER]);
-  const effectiveNonInteractive = options.nonInteractive || envBasedAuth;
+  text('Installing claude code hooks...');
+  await runMigrations(projectInfo.root, globalDir, a3sEnabled, config.projectKey);
+  await installHooks(projectInfo.root, globalDir, a3sEnabled, config.projectKey);
+  success('Claude code scanning hooks installed');
 
-  await runFullSonarIntegration(
-    projectInfo,
-    config,
-    options,
-    effectiveNonInteractive,
+  blank();
+  text('Phase 3/3: Final Verification');
+  blank();
+
+  const finalHealth = await runHealthChecks(
+    serverURL,
+    token || 'INVALID',
+    config.projectKey,
+    hooksRoot,
+    config.organization,
+    false,
   );
+  printFinalVerificationResults(finalHealth, config.projectKey);
+
+  const context: ConfigurationContext = {
+    serverURL,
+    organization: config.organization,
+    projectKey: config.projectKey,
+    projectRoot: projectInfo.root,
+    isGlobal,
+    hasA3s: a3sEnabled,
+  };
+  updateStateAfterConfiguration(context);
 }
 
 /**
@@ -128,25 +178,28 @@ async function loadConfiguration(
   projectInfo: ProjectInfo,
   options: IntegrateClaudeOptions,
 ): Promise<ConfigurationData> {
-  const config: ConfigurationData = {
-    serverURL: options.server,
-    projectKey: options.project,
-    organization: options.org,
-    token: options.token,
-  };
-
   let resolvedAuth;
   try {
     resolvedAuth = await resolveAuth({
-      server: config.serverURL,
-      org: config.organization,
-      token: config.token,
+      server: options.server,
+      org: options.org,
+      token: options.token,
     });
   } catch {
     // ignore error, command will attempt to call `auth login` flow
   }
 
   const discovered = getDiscoveredConfiguration(projectInfo);
+  const resolvedProjectKey = options.project || discovered.projectKey;
+
+  if (!resolvedAuth) {
+    return {
+      serverURL: options.server || discovered.serverURL || SONARCLOUD_URL,
+      organization: options.org || discovered.organization,
+      token: undefined,
+      projectKey: resolvedProjectKey
+    }
+  }
 
   if (!!resolvedAuth?.serverUrl && !!discovered.serverURL && (resolvedAuth.serverUrl != discovered.serverURL)) {
     warn('Detected a Server URL mismatch between the current project configuration and the auth logged in configuration. If this is not intended please consider running "sonar auth logout" and re-run the integrate command');
@@ -156,29 +209,15 @@ async function loadConfiguration(
     warn('Detected an organization mismatch between the current project configuration and the auth logged in configuration. If this in not intended please consider providing "-o" option');
   }
 
-  const resolvedProjectKey = config.projectKey || discovered.projectKey;
-
-  if (resolvedAuth) {
-    return {
-      serverURL: resolvedAuth.serverUrl,
-      organization: resolvedAuth.orgKey,
-      token: resolvedAuth.token,
-      projectKey: resolvedProjectKey,
-    }
-  } else {
-    return {
-      serverURL: config.serverURL || discovered.serverURL || SONARCLOUD_URL,
-      organization: config.organization || discovered.organization,
-      token: undefined,
-      projectKey: resolvedProjectKey
-    }
+  return {
+    serverURL: resolvedAuth.serverUrl,
+    organization: resolvedAuth.orgKey,
+    token: resolvedAuth.token,
+    projectKey: resolvedProjectKey,
   }
 }
 
-/**
- * Validate and print configuration
- */
-function validateAndPrintConfiguration(config: ConfigurationData): void {
+function validateConfiguration(projectInfo: ProjectInfo, config: ConfigurationData): void {
   if (!config.serverURL && !config.organization) {
     throw new CommandFailedError(
       'Server URL or organization is required. Use --server flag or --org flag for SonarQube Cloud',
@@ -187,25 +226,26 @@ function validateAndPrintConfiguration(config: ConfigurationData): void {
 
   blank();
   text(`Server: ${config.serverURL}`);
-  if (config.projectKey) {
-    text(`Project: ${config.projectKey}`);
-  } else {
-    text('No project key provided - project-level checks will be skipped.');
-  }
+
   if (config.organization) {
     text(`Organization: ${config.organization}`);
   }
-}
 
-/**
- * Warn if token is missing
- */
-function ensureToken(token: string | undefined): string | undefined {
-  if (!token) {
+  if (!config.token) {
     warn('No token found. Will generate during repair phase.');
   }
 
-  return token;
+  if (projectInfo.isGitRepo) {
+    text('Git repository detected');
+  }
+
+  text(`Project root: ${projectInfo.root}`);
+
+  if (config.projectKey) {
+    text(`Project: ${config.projectKey}`);
+  } else {
+    text('No project key provided - project related actions will be skipped.');
+  }
 }
 
 /**
@@ -217,108 +257,12 @@ async function resolveA3sEntitlement(
   token: string,
   organization: string | undefined,
 ): Promise<boolean> {
-  if (!organization || !serverURL.includes(SONARCLOUD_HOSTNAME)) return false;
+  if (!organization || !serverURL.includes(SONARCLOUD_HOSTNAME)) {
+    return false;
+  }
+
   const client = new SonarQubeClient(serverURL, token);
   return client.hasA3sEntitlement(organization);
-}
-
-/**
- * Run health check and handle repair if needed
- */
-async function runHealthCheckAndRepair(
-  serverURL: string,
-  projectKey: string | undefined,
-  projectInfo: ProjectInfo,
-  token: string | undefined,
-  organization: string | undefined,
-  repairOptions: RepairOptions,
-  a3sEnabled: boolean,
-): Promise<string | undefined> {
-  blank();
-  text('Phase 2/3: Health Check & Repair');
-  blank();
-
-  if (!token) {
-    text('No token available');
-    token = await repairToken(serverURL, organization);
-  }
-
-  const { hooksGlobal, nonInteractive } = repairOptions;
-  const globalDir = hooksGlobal ? homedir() : undefined;
-  const hooksRoot = globalDir ?? projectInfo.root;
-
-  const healthResult = await runHealthChecks(serverURL, token, projectKey, hooksRoot, organization);
-
-  if (healthResult.errors.length === 0) {
-    success('All checks passed! Configuration is healthy.');
-    await runMigrations(projectInfo.root, globalDir, a3sEnabled, projectKey);
-    await installHooks(projectInfo.root, globalDir, a3sEnabled, projectKey);
-    return token;
-  }
-
-  warn(`Found ${healthResult.errors.length} issue(s):`);
-  for (const msg of healthResult.errors) {
-    text(`  - ${msg}`);
-  }
-
-  if (nonInteractive && !healthResult.tokenValid) {
-    // Can't repair token without browser interaction — install hooks and continue
-    await runMigrations(projectInfo.root, globalDir, a3sEnabled, projectKey);
-    await installHooks(projectInfo.root, globalDir, a3sEnabled, projectKey);
-    return token;
-  }
-
-  // Repair (part of Phase 2)
-  text('\n  Running repair...');
-
-  const repairedToken = await runRepair(
-    serverURL,
-    projectInfo.root,
-    healthResult,
-    projectKey,
-    organization,
-    globalDir,
-    a3sEnabled,
-  );
-
-  return repairedToken ?? token;
-}
-
-/**
- * Run repair without token
- */
-async function runRepairWithoutToken(
-  serverURL: string,
-  projectKey: string | undefined,
-  projectInfo: ProjectInfo,
-  organization: string | undefined,
-  globalDir?: string,
-): Promise<string> {
-  text('\n  Running repair...');
-
-  await runRepair(
-    serverURL,
-    projectInfo.root,
-    {
-      tokenValid: false,
-      serverAvailable: false,
-      projectAccessible: false,
-      organizationAccessible: false,
-      qualityProfilesAccessible: false,
-      hooksInstalled: false,
-      errors: [],
-    },
-    projectKey,
-    organization,
-    globalDir,
-  );
-
-  const repairedToken = await getToken(serverURL, organization);
-  if (!repairedToken) {
-    throw new Error('Failed to obtain token');
-  }
-
-  return repairedToken;
 }
 
 /**
@@ -352,100 +296,6 @@ function printFinalVerificationResults(
     text('  Sonar will detect the token and block the prompt automatically.');
     blank();
   }
-}
-
-/**
- * Run Phase 3 final verification and update state
- */
-async function runFinalVerification(
-  token: string,
-  hooksRoot: string,
-  context: ConfigurationContext,
-): Promise<void> {
-  text('\nPhase 3/3: Final Verification');
-  blank();
-
-  const finalHealth = await runHealthChecks(
-    context.serverURL,
-    token,
-    context.projectKey,
-    hooksRoot,
-    context.organization,
-    false,
-  );
-  printFinalVerificationResults(finalHealth, context.projectKey);
-
-  updateStateAfterConfiguration(context);
-}
-
-/**
- * Run full SonarQube integration (phases 2 and 3)
- */
-async function runFullSonarIntegration(
-  projectInfo: ProjectInfo,
-  config: ConfigurationData,
-  options: IntegrateClaudeOptions,
-  effectiveNonInteractive: boolean,
-): Promise<void> {
-  const serverURL = config.serverURL!;
-  const projectKey = config.projectKey;
-  const hooksRoot = options.global ? homedir() : projectInfo.root;
-  let token = ensureToken(config.token);
-
-  const repairOptions: RepairOptions = {
-    hooksGlobal: options.global,
-    nonInteractive: effectiveNonInteractive,
-  };
-
-  const globalDir = options.global ? homedir() : undefined;
-  const isGlobal = options.global ?? false;
-
-  // Check A3S entitlement once — requires cloud connection + eligible && enabled org
-  const a3sEnabled = token
-    ? await resolveA3sEntitlement(serverURL, token, config.organization)
-    : false;
-
-  const context: ConfigurationContext = {
-    serverURL,
-    organization: config.organization,
-    projectKey,
-    projectRoot: projectInfo.root,
-    isGlobal,
-    hasA3s: a3sEnabled,
-  };
-
-  token = await runHealthCheckAndRepair(
-    serverURL,
-    projectKey,
-    projectInfo,
-    token,
-    config.organization,
-    repairOptions,
-    a3sEnabled,
-  );
-
-  if (token) {
-    await runFinalVerification(token, hooksRoot, context);
-    return;
-  }
-
-  if (effectiveNonInteractive) {
-    await runMigrations(projectInfo.root, globalDir, a3sEnabled, projectKey);
-    await installHooks(projectInfo.root, globalDir, a3sEnabled, projectKey);
-    updateStateAfterConfiguration(context);
-    outro('Setup complete!', 'success');
-    return;
-  }
-
-  token = await runRepairWithoutToken(
-    serverURL,
-    projectKey,
-    projectInfo,
-    config.organization,
-    globalDir,
-  );
-
-  await runFinalVerification(token, hooksRoot, context);
 }
 
 interface ConfigurationContext {

--- a/src/cli/commands/integrate/claude/repair.ts
+++ b/src/cli/commands/integrate/claude/repair.ts
@@ -47,27 +47,7 @@ export async function runRepair(
 
   // Fix token if invalid
   if (!healthResult.tokenValid) {
-    text('Obtaining access token...');
-
-    // Delete old token
-    try {
-      await deleteToken(serverURL, organization);
-    } catch (error) {
-      logger.debug(`Failed to delete token during repair: ${(error as Error).message}`);
-    }
-
-    // Generate new token
-    newToken = await generateTokenViaBrowser(serverURL);
-
-    // Validate new token
-    const valid = await validateToken(serverURL, newToken);
-    if (!valid) {
-      throw new Error('Generated token is invalid');
-    }
-
-    // Save to keychain
-    await saveToken(serverURL, newToken, organization);
-    success('Token saved to keychain');
+    newToken = await repairToken(serverURL, organization);
   }
 
   // Ensure hooks are installed (idempotent); A3S hook only when entitlement confirmed
@@ -75,5 +55,31 @@ export async function runRepair(
   await installHooks(projectRoot, globalDir, installA3s, projectKey);
   success('Secret scanning hooks installed');
 
+  return newToken;
+}
+
+export async function repairToken(serverURL: string, organization?: string): Promise<string> {
+  let newToken: string | undefined;
+  text('Obtaining access token...');
+
+  // Generate new token
+  newToken = await generateTokenViaBrowser(serverURL);
+
+  // Validate new token
+  const valid = await validateToken(serverURL, newToken);
+  if (!valid) {
+    throw new Error('Generated token is invalid');
+  }
+
+  // Delete old token
+  try {
+    await deleteToken(serverURL, organization);
+  } catch (error) {
+    logger.debug(`Failed to delete token during repair: ${(error as Error).message}`);
+  }
+
+  // Save to keychain
+  await saveToken(serverURL, newToken, organization);
+  success('Token saved to keychain');
   return newToken;
 }

--- a/src/cli/commands/integrate/claude/repair.ts
+++ b/src/cli/commands/integrate/claude/repair.ts
@@ -26,44 +26,14 @@ import {
   validateToken,
   deleteToken,
 } from '../../_common/token';
-import { installHooks } from './hooks';
-import type { HealthCheckResult } from './health';
 import logger from '../../../../lib/logger';
 import { text, success } from '../../../../ui';
 
-/**
- * Run repair actions based on health check results
- */
-export async function runRepair(
-  serverURL: string,
-  projectRoot: string,
-  healthResult: HealthCheckResult,
-  projectKey?: string,
-  organization?: string,
-  globalDir?: string,
-  installA3s = false,
-): Promise<string | undefined> {
-  let newToken: string | undefined;
-
-  // Fix token if invalid
-  if (!healthResult.tokenValid) {
-    newToken = await repairToken(serverURL, organization);
-  }
-
-  // Ensure hooks are installed (idempotent); A3S hook only when entitlement confirmed
-  text('Installing secret scanning hooks...');
-  await installHooks(projectRoot, globalDir, installA3s, projectKey);
-  success('Secret scanning hooks installed');
-
-  return newToken;
-}
-
 export async function repairToken(serverURL: string, organization?: string): Promise<string> {
-  let newToken: string | undefined;
   text('Obtaining access token...');
 
   // Generate new token
-  newToken = await generateTokenViaBrowser(serverURL);
+  const newToken = await generateTokenViaBrowser(serverURL);
 
   // Validate new token
   const valid = await validateToken(serverURL, newToken);

--- a/src/cli/commands/integrate/claude/state.ts
+++ b/src/cli/commands/integrate/claude/state.ts
@@ -1,0 +1,114 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) 2026 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { homedir } from 'node:os';
+import { version as VERSION } from '../../../../../package.json';
+import { isSonarQubeCloud } from '../../../../lib/auth-resolver';
+import logger from '../../../../lib/logger';
+import {
+  addInstalledHook,
+  addOrUpdateConnection,
+  generateConnectionId,
+  loadState,
+  markAgentConfigured,
+  saveState,
+  upsertAgentExtension,
+} from '../../../../lib/state-manager';
+import { warn } from '../../../../ui';
+import type { ConfigurationData } from './index';
+
+/**
+ * Update state after successful configuration
+ */
+export function updateStateAfterConfiguration(
+  config: ConfigurationData,
+  projectRoot: string,
+  isGlobal: boolean,
+  a3sEnabled: boolean,
+): void {
+  try {
+    const state = loadState();
+
+    // Mark agent as configured
+    markAgentConfigured(state, 'claude-code', VERSION);
+
+    // Track installed hooks (legacy format for backward compat)
+    addInstalledHook(state, 'claude-code', 'sonar-secrets', 'PreToolUse');
+    addInstalledHook(state, 'claude-code', 'sonar-secrets', 'UserPromptSubmit');
+
+    // Register extensions in the new registry.
+    // For global installs, use homedir() as projectRoot so it doesn't collide with project-level entries.
+    const now = new Date().toISOString();
+    const effectiveRoot = isGlobal ? homedir() : projectRoot;
+    const baseExt = {
+      agentId: 'claude-code',
+      projectRoot: effectiveRoot,
+      global: isGlobal,
+      projectKey: config.projectKey,
+      orgKey: config.organization,
+      serverUrl: config.serverURL,
+      updatedByCliVersion: VERSION,
+      updatedAt: now,
+    };
+
+    upsertAgentExtension(state, {
+      ...baseExt,
+      id: randomUUID(),
+      kind: 'hook',
+      name: 'sonar-secrets',
+      hookType: 'PreToolUse',
+    });
+    upsertAgentExtension(state, {
+      ...baseExt,
+      id: randomUUID(),
+      kind: 'hook',
+      name: 'sonar-secrets',
+      hookType: 'UserPromptSubmit',
+    });
+
+    const isCloud = isSonarQubeCloud(config.serverURL);
+    if (a3sEnabled) {
+      upsertAgentExtension(state, {
+        ...baseExt,
+        projectRoot,
+        global: false,
+        id: randomUUID(),
+        kind: 'hook',
+        name: 'sonar-a3s',
+        hookType: 'PostToolUse',
+      });
+    }
+
+    // Save connection so `sonar auth status` reports the active connection
+    const type = isCloud ? 'cloud' : 'on-premise';
+    const keystoreKey = generateConnectionId(config.serverURL, config.organization);
+    addOrUpdateConnection(state, config.serverURL, type, {
+      orgKey: config.organization,
+      keystoreKey,
+    });
+
+    saveState(state);
+  } catch (err) {
+    warn(`Failed to update configuration state: ${(err as Error).message}`);
+    logger.warn(`Failed to update configuration state: ${(err as Error).message}`);
+    // Don't fail the whole setup if state update fails
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@
 // Main CLI entry point
 
 import { COMMAND_TREE } from './cli/command-tree';
-import { runPostUpdateActions } from './lib/post-update';
+import * as postUpdate from './lib/post-update';
 
-await runPostUpdateActions();
+await postUpdate.runPostUpdateActions();
 COMMAND_TREE.parse();

--- a/src/lib/auth-resolver.ts
+++ b/src/lib/auth-resolver.ts
@@ -116,3 +116,12 @@ export async function resolveAuth(options: {
 export function isEnvBasedAuth(): boolean {
   return !!(process.env[ENV_TOKEN] && process.env[ENV_SERVER]);
 }
+
+export function isSonarQubeCloud(serverUrl: string): boolean {
+  try {
+    const url = new URL(serverUrl);
+    return url.hostname === 'sonarcloud.io' || url.hostname === 'sonarqube.us';
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/auth-resolver.ts
+++ b/src/lib/auth-resolver.ts
@@ -20,9 +20,10 @@
 
 // Centralized auth resolver - resolves token + serverUrl from env vars, state, or keychain
 
+import { SONARCLOUD_HOSTNAME, SONARCLOUD_US_HOSTNAME } from './config-constants';
 import { getToken } from './keychain.js';
 import { loadState, getActiveConnection } from './state-manager.js';
-import { warn } from '../ui/index.js';
+import { warn } from '../ui';
 import logger from './logger.js';
 
 export const ENV_TOKEN = 'SONAR_CLI_TOKEN';
@@ -120,7 +121,7 @@ export function isEnvBasedAuth(): boolean {
 export function isSonarQubeCloud(serverUrl: string): boolean {
   try {
     const url = new URL(serverUrl);
-    return url.hostname === 'sonarcloud.io' || url.hostname === 'sonarqube.us';
+    return url.hostname === SONARCLOUD_HOSTNAME || url.hostname === SONARCLOUD_US_HOSTNAME;
   } catch {
     return false;
   }

--- a/src/lib/auth-resolver.ts
+++ b/src/lib/auth-resolver.ts
@@ -112,3 +112,7 @@ export async function resolveAuth(options: {
     `No authentication token found. Set ${ENV_TOKEN} + ${ENV_SERVER}, or run: sonar auth login`,
   );
 }
+
+export function isEnvBasedAuth(): boolean {
+  return !!(process.env[ENV_TOKEN] && process.env[ENV_SERVER]);
+}

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { existsSync } from 'node:fs';
+import * as fs from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { version as CURRENT_VERSION } from '../../package.json';
@@ -38,7 +38,7 @@ import { installHooks } from '../cli/commands/integrate/claude/hooks.js';
  *   actions are not repeated on the next invocation.
  */
 export async function runPostUpdateActions(): Promise<void> {
-  if (!existsSync(STATE_FILE)) {
+  if (!fs.existsSync(STATE_FILE)) {
     // No state file means this is a fresh installation — nothing to migrate.
     return;
   }
@@ -102,7 +102,7 @@ export async function migrateClaudeCodeHooks(homedirFn: () => string = homedir):
   } else if (state.agents['claude-code'].configured) {
     // Pre-registry fallback: check for global hooks in homedir
     const globalHooksDir = join(homedirFn(), '.claude', 'hooks', 'sonar-secrets');
-    if (existsSync(globalHooksDir)) {
+    if (fs.existsSync(globalHooksDir)) {
       locations.push({ projectRoot: homedirFn(), globalDir: homedirFn() });
     }
   }

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -21,6 +21,7 @@
 // SonarQube API HTTP client
 
 import { version as VERSION } from '../../package.json';
+import { isSonarQubeCloud } from '../lib/auth-resolver';
 import { SONARCLOUD_API_URL, SONARCLOUD_URL, SONARCLOUD_US_URL } from '../lib/config-constants.js';
 
 const GET_REQUEST_TIMEOUT_MS = 30000; // 30 seconds
@@ -172,9 +173,16 @@ export class SonarQubeClient {
   /**
    * Convenience: resolve org UUID then check A3S entitlement in one call.
    */
-  async hasA3sEntitlement(organizationKey: string): Promise<boolean> {
+  async hasA3sEntitlement(organizationKey?: string): Promise<boolean> {
+    if (!organizationKey || !isSonarQubeCloud(this.serverURL)) {
+      return false;
+    }
+
     const uuid = await this.getOrganizationId(organizationKey);
-    if (!uuid) return false;
+    if (!uuid) {
+      return false;
+    }
+
     return this.checkA3sEntitlement(uuid);
   }
 

--- a/tests/unit/auth-commands.test.ts
+++ b/tests/unit/auth-commands.test.ts
@@ -158,7 +158,7 @@ describe('authLoginCommand', () => {
     setMockUi(true);
     loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
     saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => undefined);
-    discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(EMPTY_PROJECT_INFO);
+    discoverSpy = spyOn(discovery, 'discoverProjectInfo').mockResolvedValue(EMPTY_PROJECT_INFO);
   });
 
   afterEach(() => {

--- a/tests/unit/auth-org-selection.test.ts
+++ b/tests/unit/auth-org-selection.test.ts
@@ -57,7 +57,7 @@ describe('authLogin: org selection', () => {
     clearMockUiCalls();
     loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
     saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => undefined);
-    discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(EMPTY_PROJECT_INFO);
+    discoverSpy = spyOn(discovery, 'discoverProjectInfo').mockResolvedValue(EMPTY_PROJECT_INFO);
   });
 
   afterEach(() => {
@@ -153,7 +153,7 @@ describe('authLogin: org selection', () => {
 
     try {
       await authLogin({ server: 'https://sonarcloud.io' });
-    } catch (error) {
+    } catch (error: any) {
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toBe('Organization selection cancelled');
     } finally {

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -20,7 +20,11 @@
 
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { SonarQubeClient } from '../../src/sonarqube/client.js';
-import { SONARCLOUD_API_URL, SONARCLOUD_URL } from '../../src/lib/config-constants.js';
+import {
+  SONARCLOUD_API_URL,
+  SONARCLOUD_URL,
+  SONARCLOUD_US_URL,
+} from '../../src/lib/config-constants.js';
 import { version as VERSION } from '../../package.json';
 
 // ---------------------------------------------------------------------------
@@ -255,47 +259,46 @@ describe('SonarQubeClient', () => {
   });
 
   // -------------------------------------------------------------------------
-  // checkA3sEntitlement
-  // -------------------------------------------------------------------------
-
-  describe('checkA3sEntitlement', () => {
-    it('hits api.sonarcloud.io /a3s-analysis/org-config/{uuid}', async () => {
-      fetchSpy = mockFetch({ id: 'uuid', enabled: true, eligible: true });
-      await client.checkA3sEntitlement('test-uuid');
-      const url = new URL(lastFetchUrl(fetchSpy));
-      expect(url.hostname).toBe('api.sonarcloud.io');
-      expect(url.pathname).toBe('/a3s-analysis/org-config/test-uuid');
-    });
-
-    it('returns true when eligible and enabled are both true', async () => {
-      fetchSpy = mockFetch({ id: 'uuid', enabled: true, eligible: true });
-      expect(await client.checkA3sEntitlement('test-uuid')).toBe(true);
-    });
-
-    it('returns false when eligible is false', async () => {
-      fetchSpy = mockFetch({ id: 'uuid', enabled: true, eligible: false });
-      expect(await client.checkA3sEntitlement('test-uuid')).toBe(false);
-    });
-
-    it('returns false when enabled is false', async () => {
-      fetchSpy = mockFetch({ id: 'uuid', enabled: false, eligible: true });
-      expect(await client.checkA3sEntitlement('test-uuid')).toBe(false);
-    });
-
-    it('returns false on API error (404)', async () => {
-      fetchSpy = mockFetch({}, false, 404);
-      expect(await client.checkA3sEntitlement('test-uuid')).toBe(false);
-    });
-  });
-
-  // -------------------------------------------------------------------------
   // hasA3sEntitlement
   // -------------------------------------------------------------------------
 
   describe('hasA3sEntitlement', () => {
-    it('returns true when org has valid UUID and entitlement is active', async () => {
-      // First call: getOrganizationId → [{ uuidV4: 'org-uuid' }]
-      // Second call: checkA3sEntitlement → { enabled: true, eligible: true }
+    let cloudClient: SonarQubeClient;
+
+    beforeEach(() => {
+      cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+    });
+
+    it('returns false when organizationKey is not provided', async () => {
+      fetchSpy = mockFetch({});
+      expect(await cloudClient.hasA3sEntitlement(undefined)).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns false when organizationKey is empty string', async () => {
+      fetchSpy = mockFetch({});
+      expect(await cloudClient.hasA3sEntitlement('')).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns false when server is not SonarQube Cloud', async () => {
+      const serverClient = new SonarQubeClient(SERVER_URL, TOKEN);
+      fetchSpy = mockFetch({});
+      expect(await serverClient.hasA3sEntitlement('my-org')).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns false when org UUID cannot be resolved (API error)', async () => {
+      fetchSpy = mockFetch({}, false, 404);
+      expect(await cloudClient.hasA3sEntitlement('unknown-org')).toBe(false);
+    });
+
+    it('returns false when org UUID list is empty', async () => {
+      fetchSpy = mockFetch([]);
+      expect(await cloudClient.hasA3sEntitlement('my-org')).toBe(false);
+    });
+
+    it('returns true when org UUID is resolved and entitlement is enabled and eligible', async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -308,12 +311,93 @@ describe('SonarQubeClient', () => {
           json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: true }),
         } as Response);
 
-      expect(await client.hasA3sEntitlement('my-org')).toBe(true);
+      expect(await cloudClient.hasA3sEntitlement('my-org')).toBe(true);
     });
 
-    it('returns false when org UUID cannot be resolved', async () => {
-      fetchSpy = mockFetch({}, false, 404);
-      expect(await client.hasA3sEntitlement('unknown-org')).toBe(false);
+    it('returns false when entitlement is enabled but not eligible', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([{ id: 'str-id', uuidV4: 'org-uuid' }]),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: false }),
+        } as Response);
+
+      expect(await cloudClient.hasA3sEntitlement('my-org')).toBe(false);
+    });
+
+    it('returns false when entitlement is eligible but not enabled', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([{ id: 'str-id', uuidV4: 'org-uuid' }]),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'org-uuid', enabled: false, eligible: true }),
+        } as Response);
+
+      expect(await cloudClient.hasA3sEntitlement('my-org')).toBe(false);
+    });
+
+    it('returns false when the entitlement check fails with an API error', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([{ id: 'str-id', uuidV4: 'org-uuid' }]),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          json: () => Promise.resolve({}),
+        } as Response);
+
+      expect(await cloudClient.hasA3sEntitlement('my-org')).toBe(false);
+    });
+
+    it('passes the resolved UUID to the entitlement check', async () => {
+      const targetUuid = 'specific-uuid-abc';
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([{ id: 'str-id', uuidV4: targetUuid }]),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: targetUuid, enabled: true, eligible: true }),
+        } as Response);
+
+      await cloudClient.hasA3sEntitlement('my-org');
+
+      const entitlementUrl = new URL((fetchSpy.mock.calls[1][0] as URL).toString());
+      expect(entitlementUrl.pathname).toBe(`/a3s-analysis/org-config/${targetUuid}`);
+    });
+
+    it('returns true for SonarQube Cloud US', async () => {
+      const usClient = new SonarQubeClient(SONARCLOUD_US_URL, TOKEN);
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve([{ id: 'str-id', uuidV4: 'org-uuid' }]),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: true }),
+        } as Response);
+
+      expect(await usClient.hasA3sEntitlement('my-org')).toBe(true);
     });
   });
 

--- a/tests/unit/discovery.test.ts
+++ b/tests/unit/discovery.test.ts
@@ -20,12 +20,14 @@
 
 // Discovery module tests
 
-import { it, expect, spyOn } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { discoverProject } from '../../src/cli/commands/_common/discovery';
+import { discoverProject, discoverProjectInfo } from '../../src/cli/commands/_common/discovery';
 import * as processLib from '../../src/lib/process.js';
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../src/ui';
+
 it('discovery: sonar-project.properties parsing', async () => {
   const testDir = join(tmpdir(), 'sonarqube-cli-test-discovery-' + Date.now());
   mkdirSync(testDir, { recursive: true });
@@ -40,7 +42,7 @@ sonar.organization=my-org
 `;
     writeFileSync(join(testDir, 'sonar-project.properties'), propsContent);
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
 
     expect(info.hasSonarProps).toBe(true);
     expect(info.sonarPropsData).toMatchObject({
@@ -67,7 +69,7 @@ it('discovery: .sonarlint/connectedMode.json parsing', async () => {
     };
     writeFileSync(join(sonarlintDir, 'connectedMode.json'), JSON.stringify(configContent, null, 2));
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
 
     expect(info.hasSonarLintConfig).toBe(true);
     expect(info.sonarLintData).toMatchObject({
@@ -97,7 +99,7 @@ sonar.organization=test-org
 `;
     writeFileSync(join(testDir, 'sonar-project.properties'), propsContent);
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
 
     expect(info.hasSonarProps).toBe(true);
     expect(info.sonarPropsData).toMatchObject({
@@ -115,7 +117,7 @@ it('discovery: no configuration files', async () => {
   mkdirSync(testDir, { recursive: true });
 
   try {
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
 
     expect(info.hasSonarProps).toBe(false);
     expect(info.hasSonarLintConfig).toBe(false);
@@ -129,7 +131,7 @@ it('discovery: detects git repository when .git dir present', async () => {
   mkdirSync(join(testDir, '.git'), { recursive: true });
 
   try {
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.isGitRepo).toBe(true);
     expect(info.root).toBe(testDir);
   } finally {
@@ -148,7 +150,7 @@ it('discovery: reads git remote when git repository has origin', async () => {
   });
 
   try {
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.isGitRepo).toBe(true);
     expect(info.gitRemote).toBe('https://github.com/example/test-project.git');
   } finally {
@@ -165,7 +167,7 @@ it('discovery: sonar-project.properties with line missing equals sign', async ()
     const propsContent = `sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_key\nINVALID_LINE_NO_EQUALS\n`;
     writeFileSync(join(testDir, 'sonar-project.properties'), propsContent);
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.hasSonarProps).toBe(true);
     expect(info.sonarPropsData?.projectKey).toBe('my_key');
   } finally {
@@ -181,7 +183,7 @@ it('discovery: sonar-project.properties with no hostURL or projectKey returns nu
     const propsContent = `sonar.projectName=My Project\nsonar.organization=my-org\n`;
     writeFileSync(join(testDir, 'sonar-project.properties'), propsContent);
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.hasSonarProps).toBe(false);
     expect(info.sonarPropsData).toBeNull();
   } finally {
@@ -201,7 +203,7 @@ it('discovery: .sonarlint/settings.json with serverId schema', async () => {
     };
     writeFileSync(join(testDir, '.sonarlint', 'settings.json'), JSON.stringify(configContent));
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.hasSonarLintConfig).toBe(true);
     expect(info.sonarLintData?.serverURL).toBe('my-sonarqube-server');
     expect(info.sonarLintData?.projectKey).toBe('my_project');
@@ -225,7 +227,7 @@ it('discovery: .sonarlint/connected-mode.json with connectionId schema', async (
       JSON.stringify(configContent),
     );
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.hasSonarLintConfig).toBe(true);
     expect(info.sonarLintData?.serverURL).toBe('https://sonarqube.example.com');
     expect(info.sonarLintData?.projectKey).toBe('conn_project');
@@ -244,7 +246,7 @@ it('discovery: .sonarlint config with no matching schema returns null', async ()
       JSON.stringify({ unknownField: 'value', anotherField: 123 }),
     );
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.hasSonarLintConfig).toBe(false);
     expect(info.sonarLintData).toBeNull();
   } finally {
@@ -259,10 +261,221 @@ it('discovery: .sonarlint config with invalid JSON returns null', async () => {
   try {
     writeFileSync(join(testDir, '.sonarlint', 'connectedMode.json'), '{ not valid json ]');
 
-    const info = await discoverProject(testDir);
+    const info = await discoverProjectInfo(testDir);
     expect(info.hasSonarLintConfig).toBe(false);
     expect(info.sonarLintData).toBeNull();
   } finally {
     rmSync(testDir, { recursive: true, force: true });
   }
+});
+
+describe('discoverProject', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `sonarqube-cli-test-discover-project-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+    setMockUi(true);
+  });
+
+  afterEach(() => {
+    clearMockUiCalls();
+    setMockUi(false);
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns current dir as rootDir when not in a git repo', async () => {
+    const result = await discoverProject(testDir);
+    expect(result.rootDir).toBe(testDir);
+  });
+
+  it('returns isGitRepo false when no .git directory is present', async () => {
+    const result = await discoverProject(testDir);
+    expect(result.isGitRepo).toBe(false);
+  });
+
+  it('returns isGitRepo true and rootDir as git root when .git directory is present', async () => {
+    mkdirSync(join(testDir, '.git'));
+    const result = await discoverProject(testDir);
+    expect(result.isGitRepo).toBe(true);
+    expect(result.rootDir).toBe(testDir);
+  });
+
+  it('returns no serverUrl, projectKey, or organization when no config files are present', async () => {
+    const result = await discoverProject(testDir);
+    expect(result.serverUrl).toBeUndefined();
+    expect(result.projectKey).toBeUndefined();
+    expect(result.organization).toBeUndefined();
+  });
+
+  it('shows no config-found messages when no config files are present', async () => {
+    await discoverProject(testDir);
+    const textCalls = getMockUiCalls().filter((c) => c.method === 'text');
+    expect(textCalls).toHaveLength(0);
+  });
+
+  it('maps sonar-project.properties hostURL to serverUrl', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_project\n',
+    );
+    const result = await discoverProject(testDir);
+    expect(result.serverUrl).toBe('https://sonarcloud.io');
+  });
+
+  it('maps sonar-project.properties projectKey', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_project\n',
+    );
+    const result = await discoverProject(testDir);
+    expect(result.projectKey).toBe('my_project');
+  });
+
+  it('maps sonar-project.properties organization', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_project\nsonar.organization=my-org\n',
+    );
+    const result = await discoverProject(testDir);
+    expect(result.organization).toBe('my-org');
+  });
+
+  it('shows "Found sonar-project.properties" UI message when sonar properties are found', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_project\n',
+    );
+    await discoverProject(testDir);
+    const msg = getMockUiCalls().find(
+      (c) => c.method === 'text' && String(c.args[0]) === 'Found sonar-project.properties',
+    );
+    expect(msg).toBeDefined();
+  });
+
+  it('maps sonarlint serverURL to serverUrl', async () => {
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({ sonarQubeUri: 'https://sonarqube.example.com', projectKey: 'lint_project' }),
+    );
+    const result = await discoverProject(testDir);
+    expect(result.serverUrl).toBe('https://sonarqube.example.com');
+  });
+
+  it('maps sonarlint projectKey', async () => {
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({ sonarQubeUri: 'https://sonarqube.example.com', projectKey: 'lint_project' }),
+    );
+    const result = await discoverProject(testDir);
+    expect(result.projectKey).toBe('lint_project');
+  });
+
+  it('maps sonarlint organization', async () => {
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({
+        sonarQubeUri: 'https://sonarqube.example.com',
+        projectKey: 'lint_project',
+        organization: 'lint-org',
+      }),
+    );
+    const result = await discoverProject(testDir);
+    expect(result.organization).toBe('lint-org');
+  });
+
+  it('shows "Found .sonarlint/connectedMode.json" UI message when sonarlint config is found', async () => {
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({ sonarQubeUri: 'https://sonarqube.example.com', projectKey: 'lint_project' }),
+    );
+    await discoverProject(testDir);
+    const msg = getMockUiCalls().find(
+      (c) => c.method === 'text' && String(c.args[0]) === 'Found .sonarlint/connectedMode.json',
+    );
+    expect(msg).toBeDefined();
+  });
+
+  it('sonar-project.properties takes precedence over sonarlint for serverUrl', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
+    );
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({ sonarQubeUri: 'https://sonarlint-server.com', projectKey: 'lint_project' }),
+    );
+    const result = await discoverProject(testDir);
+    expect(result.serverUrl).toBe('https://props-server.io');
+  });
+
+  it('sonar-project.properties takes precedence over sonarlint for projectKey', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
+    );
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({ sonarQubeUri: 'https://sonarlint-server.com', projectKey: 'lint_project' }),
+    );
+    const result = await discoverProject(testDir);
+    expect(result.projectKey).toBe('props_project');
+  });
+
+  it('sonarlint fills in projectKey when sonar-project.properties does not define one', async () => {
+    // sonar props with only hostURL (passes the null-check, but projectKey is absent)
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://props-server.io\n',
+    );
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({ sonarQubeUri: 'https://sonarlint-server.com', projectKey: 'lint_project' }),
+    );
+    const result = await discoverProject(testDir);
+    expect(result.projectKey).toBe('lint_project');
+  });
+
+  it('sonarlint fills in organization when sonar-project.properties does not define one', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
+    );
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({
+        sonarQubeUri: 'https://sonarlint-server.com',
+        projectKey: 'lint_project',
+        organization: 'lint-org',
+      }),
+    );
+    const result = await discoverProject(testDir);
+    expect(result.organization).toBe('lint-org');
+  });
+
+  it('shows both config-found messages when both configs are present', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
+    );
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(
+      join(testDir, '.sonarlint', 'connectedMode.json'),
+      JSON.stringify({ sonarQubeUri: 'https://sonarlint-server.com', projectKey: 'lint_project' }),
+    );
+    await discoverProject(testDir);
+    const textCalls = getMockUiCalls()
+      .filter((c) => c.method === 'text')
+      .map((c) => String(c.args[0]));
+    expect(textCalls).toContain('Found sonar-project.properties');
+    expect(textCalls).toContain('Found .sonarlint/connectedMode.json');
+  });
 });

--- a/tests/unit/hooks.test.ts
+++ b/tests/unit/hooks.test.ts
@@ -18,477 +18,341 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Hooks installation tests
-
-import { describe, it, beforeEach, afterEach, expect } from 'bun:test';
-import { mkdirSync, rmSync, existsSync, readFileSync, statSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { setMockUi } from '../../src/ui';
-
+import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
+import * as nodeFs from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
+import * as nodeOs from 'node:os';
 import { installHooks, areHooksInstalled } from '../../src/cli/commands/integrate/claude/hooks';
 
-describe('Hooks', () => {
+const PROJECT_ROOT = '/fake/project';
+const GLOBAL_DIR = '/fake/global';
+const PROJECT_KEY = 'my-project';
+
+/** Normalize path separators to forward slashes for cross-platform assertions. */
+const normPath = (s: string) => s.replaceAll('\\', '/');
+
+interface AgentSettings {
+  hooks?: Record<
+    string,
+    Array<{ matcher: string; hooks: Array<{ type: string; command: string }> }>
+  >;
+  [key: string]: unknown;
+}
+
+function getSettingsWriteFor(hookType: string): AgentSettings | undefined {
+  return writeFileSpy.mock.calls
+    .filter(([path]) => (path as string).includes('settings.json'))
+    .map(([, content]) => JSON.parse(content as string) as AgentSettings)
+    .find((s) => s.hooks?.[hookType]);
+}
+
+function getScriptWriteFor(nameFragment: string): string | undefined {
+  const call = writeFileSpy.mock.calls.find(([path]) => (path as string).includes(nameFragment));
+  return call ? (call[1] as string) : undefined;
+}
+
+function getScriptPathFor(nameFragment: string): string | undefined {
+  const call = writeFileSpy.mock.calls.find(([path]) => (path as string).includes(nameFragment));
+  return call ? (call[0] as string) : undefined;
+}
+
+let writeFileSpy: Mock<Extract<(typeof fsPromises)['writeFile'], (...args: any[]) => any>>;
+
+describe('areHooksInstalled', () => {
+  let existsSyncSpy: Mock<Extract<(typeof nodeFs)['existsSync'], (...args: any[]) => any>>;
+  let readFileSpy: Mock<Extract<(typeof fsPromises)['readFile'], (...args: any[]) => any>>;
+
   beforeEach(() => {
-    setMockUi(true);
+    existsSyncSpy = spyOn(nodeFs, 'existsSync').mockReturnValue(true);
+    readFileSpy = spyOn(fsPromises, 'readFile').mockResolvedValue('{}');
   });
+
   afterEach(() => {
-    setMockUi(false);
+    existsSyncSpy.mockRestore();
+    readFileSpy.mockRestore();
   });
 
-  it('hooks: install secret scanning hooks creates directory structure', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('returns false when settings.json does not exist', async () => {
+    existsSyncSpy.mockReturnValue(false);
 
-    try {
-      await installHooks(testDir);
+    const result = await areHooksInstalled(PROJECT_ROOT);
 
-      // Verify .claude directory exists
-      const claudeDir = join(testDir, '.claude');
-      expect(existsSync(claudeDir)).toBe(true);
-
-      // Verify hooks directory exists
-      const hooksDir = join(claudeDir, 'hooks');
-      expect(existsSync(hooksDir)).toBe(true);
-
-      // Verify sonar-secrets scripts directory exists
-      const scriptsDir = join(hooksDir, 'sonar-secrets', 'build-scripts');
-      expect(existsSync(scriptsDir)).toBe(true);
-
-      // Verify pretool hook script exists and is executable
-      const preToolScript = join(scriptsDir, 'pretool-secrets.sh');
-      expect(existsSync(preToolScript)).toBe(true);
-      const stats = statSync(preToolScript);
-      const isExecutable = (stats.mode & 0o111) !== 0;
-      expect(isExecutable).toBe(true);
-
-      // Verify prompt hook script exists
-      const promptScript = join(scriptsDir, 'prompt-secrets.sh');
-      expect(existsSync(promptScript)).toBe(true);
-
-      // Verify settings.json exists with PreToolUse hook
-      const settingsPath = join(claudeDir, 'settings.json');
-      expect(existsSync(settingsPath)).toBe(true);
-
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-      expect(settings.hooks).toBeDefined();
-      expect(settings.hooks.PreToolUse).toBeDefined();
-      expect(settings.hooks.PreToolUse.length).toBe(1);
-      expect(settings.hooks.PreToolUse[0].matcher).toBe('Read');
-      expect(settings.hooks.UserPromptSubmit).toBeDefined();
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(result).toBe(false);
   });
 
-  it('hooks: pretool script contains sonar analyze and exit code 51', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-content-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('looks for settings.json in the .claude subdirectory', async () => {
+    existsSyncSpy.mockReturnValue(false);
 
-    try {
-      await installHooks(testDir);
+    await areHooksInstalled(PROJECT_ROOT);
 
-      const scriptPath = join(
-        testDir,
-        '.claude',
-        'hooks',
-        'sonar-secrets',
-        'build-scripts',
-        'pretool-secrets.sh',
-      );
-      const content = readFileSync(scriptPath, 'utf-8');
-
-      expect(content.includes('sonar analyze secrets')).toBe(true);
-      expect(content.includes('exit_code -eq 51')).toBe(true);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    const checkedPath = String(existsSyncSpy.mock.calls[0][0]);
+    expect(checkedPath).toContain('.claude');
+    expect(checkedPath).toContain('settings.json');
   });
 
-  it('hooks: areHooksInstalled check', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-check-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('returns true when PreToolUse has a sonar-secrets command', async () => {
+    const settings = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Read',
+            hooks: [
+              { type: 'command', command: '.claude/hooks/sonar-secrets/pretool.sh', timeout: 60 },
+            ],
+          },
+        ],
+      },
+    };
+    readFileSpy.mockResolvedValue(JSON.stringify(settings));
 
-    try {
-      // Initially not installed
-      let installed = await areHooksInstalled(testDir);
-      expect(installed).toBe(false);
+    const result = await areHooksInstalled(PROJECT_ROOT);
 
-      // Install hooks
-      await installHooks(testDir);
-
-      // Now should be installed
-      installed = await areHooksInstalled(testDir);
-      expect(installed).toBe(true);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(result).toBe(true);
   });
 
-  it('hooks: overwrite existing hooks preserves unrelated settings', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-overwrite-' + Date.now());
-    const claudeDir = join(testDir, '.claude');
-    mkdirSync(claudeDir, { recursive: true });
+  it('returns false when settings has no hooks property', async () => {
+    readFileSpy.mockResolvedValue(JSON.stringify({}));
 
-    try {
-      // Create existing settings.json with other data
-      const existingSettings = {
-        permissions: { allow: ['Bash'] },
-        someOtherSetting: true,
-      };
+    const result = await areHooksInstalled(PROJECT_ROOT);
 
-      const fs = await import('node:fs/promises');
-      await fs.writeFile(
-        join(claudeDir, 'settings.json'),
-        JSON.stringify(existingSettings, null, 2),
-      );
-
-      // Install hooks
-      await installHooks(testDir);
-
-      // Read updated settings
-      const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
-
-      // Should have PreToolUse and UserPromptSubmit hooks
-      expect(settings.hooks.PreToolUse).toBeDefined();
-      expect(settings.hooks.UserPromptSubmit).toBeDefined();
-
-      // Existing data should be preserved
-      expect(settings.someOtherSetting).toBe(true);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(result).toBe(false);
   });
 
-  it('hooks: global install puts hooks in globalDir/.claude with absolute command paths', async () => {
-    const fakeGlobalDir = join(tmpdir(), 'sonarqube-cli-test-global-home-' + Date.now());
-    mkdirSync(fakeGlobalDir, { recursive: true });
+  it('returns false when PreToolUse is empty', async () => {
+    readFileSpy.mockResolvedValue(JSON.stringify({ hooks: { PreToolUse: [] } }));
 
-    try {
-      await installHooks('/some/project', fakeGlobalDir);
+    const result = await areHooksInstalled(PROJECT_ROOT);
 
-      const claudeDir = join(fakeGlobalDir, '.claude');
-      const settingsPath = join(claudeDir, 'settings.json');
-      expect(existsSync(settingsPath)).toBe(true);
-
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-      expect(settings.hooks.PreToolUse).toBeDefined();
-      expect(settings.hooks.UserPromptSubmit).toBeDefined();
-
-      // Commands should be absolute paths (contain fakeGlobalDir)
-      const preToolCommand = settings.hooks.PreToolUse[0].hooks[0].command as string;
-      expect(preToolCommand.startsWith(fakeGlobalDir)).toBe(true);
-
-      const promptCommand = settings.hooks.UserPromptSubmit[0].hooks[0].command as string;
-      expect(promptCommand.startsWith(fakeGlobalDir)).toBe(true);
-    } finally {
-      rmSync(fakeGlobalDir, { recursive: true, force: true });
-    }
+    expect(result).toBe(false);
   });
 
-  it('hooks: project install uses relative command paths', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-relative-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('returns false when PreToolUse entry does not reference sonar-secrets', async () => {
+    const settings = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Read',
+            hooks: [{ type: 'command', command: '/usr/local/bin/other-tool.sh', timeout: 60 }],
+          },
+        ],
+      },
+    };
+    readFileSpy.mockResolvedValue(JSON.stringify(settings));
 
-    try {
-      await installHooks(testDir);
+    const result = await areHooksInstalled(PROJECT_ROOT);
 
-      const settingsPath = join(testDir, '.claude', 'settings.json');
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-
-      const preToolCommand = settings.hooks.PreToolUse[0].hooks[0].command as string;
-      // Relative path starts with '.claude', not an absolute path
-      expect(preToolCommand.startsWith('.claude')).toBe(true);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-  it('hooks: installs A3S PostToolUse hook with Edit|Write matcher', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-posttool-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
-
-    try {
-      await installHooks(testDir, undefined, true, 'test-project');
-
-      const settingsPath = join(testDir, '.claude', 'settings.json');
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-
-      expect(settings.hooks.PostToolUse).toBeDefined();
-      expect(settings.hooks.PostToolUse.length).toBeGreaterThanOrEqual(1);
-      const postToolEntry = settings.hooks.PostToolUse[0];
-      expect(postToolEntry.matcher).toBe('Edit|Write');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(result).toBe(false);
   });
 
-  it('hooks: creates sonar-a3s scripts directory with posttool-a3s.sh', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-a3s-dir-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('returns false when settings.json contains malformed JSON', async () => {
+    readFileSpy.mockResolvedValue('{ invalid json !!!');
 
-    try {
-      await installHooks(testDir, undefined, true, 'test-project');
+    const result = await areHooksInstalled(PROJECT_ROOT);
 
-      const a3sScriptsDir = join(testDir, '.claude', 'hooks', 'sonar-a3s', 'build-scripts');
-      expect(existsSync(a3sScriptsDir)).toBe(true);
+    expect(result).toBe(false);
+  });
+});
 
-      const postToolScript = join(a3sScriptsDir, 'posttool-a3s.sh');
-      expect(existsSync(postToolScript)).toBe(true);
+describe('installHooks', () => {
+  let existsSyncSpy: Mock<Extract<(typeof nodeFs)['existsSync'], (...args: any[]) => any>>;
+  let mkdirSyncSpy: Mock<Extract<(typeof nodeFs)['mkdirSync'], (...args: any[]) => any>>;
+  let readFileSpy: Mock<Extract<(typeof fsPromises)['readFile'], (...args: any[]) => any>>;
+  let platformSpy: Mock<Extract<(typeof nodeOs)['platform'], (...args: any[]) => any>>;
 
-      const stats = statSync(postToolScript);
-      const isExecutable = (stats.mode & 0o111) !== 0;
-      expect(isExecutable).toBe(true);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+  beforeEach(() => {
+    existsSyncSpy = spyOn(nodeFs, 'existsSync').mockReturnValue(false);
+    mkdirSyncSpy = spyOn(nodeFs, 'mkdirSync').mockReturnValue(undefined);
+    readFileSpy = spyOn(fsPromises, 'readFile').mockResolvedValue('{"hooks":{}}');
+    writeFileSpy = spyOn(fsPromises, 'writeFile').mockResolvedValue(undefined);
+    platformSpy = spyOn(nodeOs, 'platform').mockReturnValue('linux');
   });
 
-  it('hooks: posttool-a3s.sh script contains sonar analyze a3s command', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-a3s-content-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
-
-    try {
-      await installHooks(testDir, undefined, true, 'test-project');
-
-      const scriptPath = join(
-        testDir,
-        '.claude',
-        'hooks',
-        'sonar-a3s',
-        'build-scripts',
-        'posttool-a3s.sh',
-      );
-      const content = readFileSync(scriptPath, 'utf-8');
-
-      expect(content.includes('sonar analyze a3s --file')).toBe(true);
-      expect(content.includes('--project test-project')).toBe(true);
-      // PostToolUse is non-blocking — should not emit permissionDecision
-      expect(content.includes('permissionDecision')).toBe(false);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+  afterEach(() => {
+    existsSyncSpy.mockRestore();
+    mkdirSyncSpy.mockRestore();
+    readFileSpy.mockRestore();
+    writeFileSpy.mockRestore();
+    platformSpy.mockRestore();
   });
 
-  it('hooks: A3S PostToolUse always installs to projectRoot with relative path, even when globalDir is set', async () => {
-    const projectDir = join(tmpdir(), 'sonarqube-cli-test-project-a3s-' + Date.now());
-    const fakeGlobalDir = join(tmpdir(), 'sonarqube-cli-test-global-a3s-' + Date.now());
-    mkdirSync(projectDir, { recursive: true });
-    mkdirSync(fakeGlobalDir, { recursive: true });
+  it('writes the pretool-secrets script file', async () => {
+    await installHooks(PROJECT_ROOT);
 
-    try {
-      await installHooks(projectDir, fakeGlobalDir, true, 'test-project');
-
-      // A3S hook goes into projectRoot with relative path
-      const projectSettings = JSON.parse(
-        readFileSync(join(projectDir, '.claude', 'settings.json'), 'utf-8'),
-      );
-      const postToolCommand = projectSettings.hooks.PostToolUse[0].hooks[0].command as string;
-      expect(postToolCommand.startsWith('.claude')).toBe(true);
-
-      // A3S hook must NOT appear in globalDir
-      const globalSettings = JSON.parse(
-        readFileSync(join(fakeGlobalDir, '.claude', 'settings.json'), 'utf-8'),
-      );
-      expect(globalSettings.hooks?.PostToolUse).toBeUndefined();
-    } finally {
-      rmSync(projectDir, { recursive: true, force: true });
-      rmSync(fakeGlobalDir, { recursive: true, force: true });
-    }
+    expect(getScriptPathFor('pretool-secrets')).toBeDefined();
   });
 
-  it('hooks: project install uses relative paths for PostToolUse command', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-relative-a3s-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('writes the prompt-secrets script file', async () => {
+    await installHooks(PROJECT_ROOT);
 
-    try {
-      await installHooks(testDir, undefined, true, 'test-project');
-
-      const settingsPath = join(testDir, '.claude', 'settings.json');
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-
-      const postToolCommand = settings.hooks.PostToolUse[0].hooks[0].command as string;
-      expect(postToolCommand.startsWith('.claude')).toBe(true);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(getScriptPathFor('prompt-secrets')).toBeDefined();
   });
 
-  it('hooks: overwrite preserves existing PostToolUse entries from other tools', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-merge-a3s-' + Date.now());
-    const claudeDir = join(testDir, '.claude');
-    mkdirSync(claudeDir, { recursive: true });
+  it('does not write the posttool-a3s script when installA3s is false', async () => {
+    await installHooks(PROJECT_ROOT, undefined, false);
 
-    try {
-      const fs = await import('node:fs/promises');
-      const existing = {
-        hooks: {
-          PostToolUse: [
-            {
-              matcher: 'Bash',
-              hooks: [{ type: 'command', command: 'echo bash ran' }],
-            },
-          ],
-        },
-      };
-      await fs.writeFile(join(claudeDir, 'settings.json'), JSON.stringify(existing, null, 2));
-
-      await installHooks(testDir, undefined, true, 'test-project');
-
-      const settings = JSON.parse(readFileSync(join(claudeDir, 'settings.json'), 'utf-8'));
-
-      // Our new sonar-a3s entry should be present
-      const a3sEntry = settings.hooks.PostToolUse.find(
-        (e: { matcher: string }) => e.matcher === 'Edit|Write',
-      );
-      expect(a3sEntry).toBeDefined();
-
-      // Existing Bash entry should be preserved
-      const bashEntry = settings.hooks.PostToolUse.find(
-        (e: { matcher: string }) => e.matcher === 'Bash',
-      );
-      expect(bashEntry).toBeDefined();
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(getScriptPathFor('posttool-a3s')).toBeUndefined();
   });
 
-  it('hooks: A3S PostToolUse hook is NOT installed when installA3s is false', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-no-a3s-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('does not write the posttool-a3s script when projectKey is not provided', async () => {
+    await installHooks(PROJECT_ROOT, undefined, true);
 
-    try {
-      await installHooks(testDir, undefined, false);
-
-      const settingsPath = join(testDir, '.claude', 'settings.json');
-      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'));
-
-      expect(settings.hooks?.PostToolUse).toBeUndefined();
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(getScriptPathFor('posttool-a3s')).toBeUndefined();
   });
 
-  // CLI-142: correct analyze subcommand in hook scripts
-  it('hooks: prompt-secrets.sh uses sonar analyze secrets subcommand', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-secrets-cmd-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('writes the posttool-a3s script when installA3s is true and projectKey is provided', async () => {
+    await installHooks(PROJECT_ROOT, undefined, true, PROJECT_KEY);
 
-    try {
-      await installHooks(testDir, undefined, false);
-
-      const scriptPath = join(
-        testDir,
-        '.claude',
-        'hooks',
-        'sonar-secrets',
-        'build-scripts',
-        'prompt-secrets.sh',
-      );
-      const content = readFileSync(scriptPath, 'utf-8');
-
-      expect(content).toContain('sonar analyze secrets');
-      expect(content).not.toContain('sonar analyze --file');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(getScriptPathFor('posttool-a3s')).toBeDefined();
   });
 
-  it('hooks: pretool-secrets.sh uses sonar analyze secrets subcommand', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-pretool-cmd-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('installs secrets scripts to globalDir when globalDir is provided', async () => {
+    await installHooks(PROJECT_ROOT, GLOBAL_DIR);
 
-    try {
-      await installHooks(testDir, undefined, false);
-
-      const scriptPath = join(
-        testDir,
-        '.claude',
-        'hooks',
-        'sonar-secrets',
-        'build-scripts',
-        'pretool-secrets.sh',
-      );
-      const content = readFileSync(scriptPath, 'utf-8');
-
-      expect(content).toContain('sonar analyze secrets');
-      expect(content).not.toContain('sonar analyze --file');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(normPath(getScriptPathFor('pretool-secrets') ?? '')).toContain(GLOBAL_DIR);
   });
 
-  // CLI-144: bash hooks parse both compact and pretty-printed JSON
-  it('hooks: pretool-secrets.sh uses sed with optional whitespace for JSON parsing', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-sed-pretool-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('installs secrets scripts to projectRoot when globalDir is not provided', async () => {
+    await installHooks(PROJECT_ROOT);
 
-    try {
-      await installHooks(testDir, undefined, false);
-
-      const content = readFileSync(
-        join(testDir, '.claude', 'hooks', 'sonar-secrets', 'build-scripts', 'pretool-secrets.sh'),
-        'utf-8',
-      );
-
-      expect(content).toContain('[[:space:]]*:[[:space:]]*');
-      expect(content).not.toContain('grep -o');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    expect(normPath(getScriptPathFor('pretool-secrets') ?? '')).toContain(PROJECT_ROOT);
   });
 
-  it('hooks: prompt-secrets.sh uses sed with optional whitespace for JSON parsing', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-sed-prompt-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('installs A3S script to projectRoot even when globalDir is set', async () => {
+    await installHooks(PROJECT_ROOT, GLOBAL_DIR, true, PROJECT_KEY);
 
-    try {
-      await installHooks(testDir, undefined, false);
-
-      const content = readFileSync(
-        join(testDir, '.claude', 'hooks', 'sonar-secrets', 'build-scripts', 'prompt-secrets.sh'),
-        'utf-8',
-      );
-
-      expect(content).toContain('[[:space:]]*:[[:space:]]*');
-      expect(content).not.toContain('grep -o');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    const a3sPath = normPath(getScriptPathFor('posttool-a3s') ?? '');
+    expect(a3sPath).toContain(PROJECT_ROOT);
+    expect(a3sPath).not.toContain(GLOBAL_DIR);
   });
 
-  it('hooks: posttool-a3s.sh uses sed with optional whitespace for JSON parsing', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-sed-posttool-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+  it('writes a PreToolUse hook entry with Read matcher', async () => {
+    await installHooks(PROJECT_ROOT);
 
-    try {
-      await installHooks(testDir, undefined, true, 'test-project');
-
-      const content = readFileSync(
-        join(testDir, '.claude', 'hooks', 'sonar-a3s', 'build-scripts', 'posttool-a3s.sh'),
-        'utf-8',
-      );
-
-      expect(content).toContain('[[:space:]]*:[[:space:]]*');
-      expect(content).not.toContain('grep -o');
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    const settings = getSettingsWriteFor('PreToolUse');
+    expect(settings?.hooks?.PreToolUse?.[0]?.matcher).toBe('Read');
   });
 
-  it('hooks: areHooksInstalled returns false when settings.json contains malformed JSON', async () => {
-    const testDir = join(tmpdir(), 'sonarqube-cli-test-hooks-malformed-' + Date.now());
-    const claudeDir = join(testDir, '.claude');
-    mkdirSync(claudeDir, { recursive: true });
+  it('writes a UserPromptSubmit hook entry with wildcard matcher', async () => {
+    await installHooks(PROJECT_ROOT);
 
-    try {
-      const fs = await import('node:fs/promises');
-      // Write invalid JSON to settings.json to trigger the catch block in areHooksInstalled
-      await fs.writeFile(join(claudeDir, 'settings.json'), '{ invalid json !!!', 'utf-8');
-
-      const installed = await areHooksInstalled(testDir);
-      expect(installed).toBe(false);
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    const settings = getSettingsWriteFor('UserPromptSubmit');
+    expect(settings?.hooks?.UserPromptSubmit?.[0]?.matcher).toBe('*');
   });
-}); // describe('Hooks')
+
+  it('writes a PostToolUse hook entry with Edit|Write matcher when A3S is enabled', async () => {
+    await installHooks(PROJECT_ROOT, undefined, true, PROJECT_KEY);
+
+    const settings = getSettingsWriteFor('PostToolUse');
+    expect(settings?.hooks?.PostToolUse?.[0]?.matcher).toBe('Edit|Write');
+  });
+
+  it('uses a relative command path for project scope (no globalDir)', async () => {
+    await installHooks(PROJECT_ROOT);
+
+    const settings = getSettingsWriteFor('PreToolUse');
+    const command = settings?.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command;
+    expect(String(command).startsWith('.claude')).toBe(true);
+  });
+
+  it('uses an absolute command path for global scope (with globalDir)', async () => {
+    await installHooks(PROJECT_ROOT, GLOBAL_DIR);
+
+    const settings = getSettingsWriteFor('PreToolUse');
+    const command = settings?.hooks?.PreToolUse?.[0]?.hooks?.[0]?.command;
+    expect(normPath(String(command))).toContain(GLOBAL_DIR);
+  });
+
+  it('uses a relative command path for the A3S hook regardless of globalDir', async () => {
+    await installHooks(PROJECT_ROOT, GLOBAL_DIR, true, PROJECT_KEY);
+
+    const settings = getSettingsWriteFor('PostToolUse');
+    const command = settings?.hooks?.PostToolUse?.[0]?.hooks?.[0]?.command;
+    expect(String(command).startsWith('.claude')).toBe(true);
+  });
+
+  it('preserves existing unrelated settings when settings.json already exists', async () => {
+    existsSyncSpy.mockReturnValue(true);
+    readFileSpy.mockResolvedValue(JSON.stringify({ theme: 'dark', hooks: {} }));
+
+    await installHooks(PROJECT_ROOT);
+
+    const allWrites = (writeFileSpy.mock.calls as Array<[unknown, unknown]>)
+      .filter(([path]) => String(path).includes('settings.json'))
+      .map(([, content]) => JSON.parse(String(content)) as AgentSettings);
+    expect(allWrites.every((s) => (s as { theme?: string }).theme === 'dark')).toBe(true);
+  });
+
+  it('replaces existing sonar-secrets hook entry rather than appending', async () => {
+    existsSyncSpy.mockReturnValue(true);
+    const existing = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Read',
+            hooks: [
+              { type: 'command', command: '.claude/hooks/sonar-secrets/old.sh', timeout: 60 },
+            ],
+          },
+        ],
+      },
+    };
+    readFileSpy.mockResolvedValue(JSON.stringify(existing));
+
+    await installHooks(PROJECT_ROOT);
+
+    const settings = getSettingsWriteFor('PreToolUse');
+    expect(settings?.hooks?.PreToolUse).toHaveLength(1);
+  });
+
+  it('preserves existing non-sonar PostToolUse entries when adding A3S hook', async () => {
+    existsSyncSpy.mockReturnValue(true);
+    const existing = {
+      hooks: {
+        PostToolUse: [
+          { matcher: 'Bash', hooks: [{ type: 'command', command: 'echo ran', timeout: 60 }] },
+        ],
+      },
+    };
+    readFileSpy.mockResolvedValue(JSON.stringify(existing));
+
+    await installHooks(PROJECT_ROOT, undefined, true, PROJECT_KEY);
+
+    const settings = getSettingsWriteFor('PostToolUse');
+    const bashEntry = settings?.hooks?.PostToolUse?.find((e) => e.matcher === 'Bash');
+    expect(bashEntry).toBeDefined();
+  });
+
+  it('pretool-secrets script contains the sonar analyze secrets command', async () => {
+    await installHooks(PROJECT_ROOT);
+
+    expect(getScriptWriteFor('pretool-secrets')).toContain('sonar analyze secrets');
+  });
+
+  it('posttool-a3s script contains the projectKey', async () => {
+    await installHooks(PROJECT_ROOT, undefined, true, PROJECT_KEY);
+
+    expect(getScriptWriteFor('posttool-a3s')).toContain(PROJECT_KEY);
+  });
+
+  it('writes a .sh script on Unix platforms', async () => {
+    await installHooks(PROJECT_ROOT);
+
+    expect(getScriptPathFor('pretool-secrets')).toContain('.sh');
+  });
+
+  it('writes a .ps1 script on Windows platforms', async () => {
+    platformSpy.mockReturnValue('win32');
+
+    await installHooks(PROJECT_ROOT);
+
+    expect(getScriptPathFor('pretool-secrets')).toContain('.ps1');
+  });
+
+  it('does not throw when a file system error occurs', async () => {
+    writeFileSpy.mockRejectedValue(new Error('ENOENT: no such file'));
+
+    const actual = await installHooks(PROJECT_ROOT);
+
+    expect(actual).toBeUndefined();
+  });
+});

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -18,12 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { mock, describe, it, expect } from 'bun:test';
+import { afterAll, describe, expect, it, mock, spyOn } from 'bun:test';
+import * as postUpdate from '../../src/lib/post-update';
 
-const runPostUpdateActionsMock = mock(async () => {});
-void mock.module('../../src/lib/post-update', () => ({
-  runPostUpdateActions: runPostUpdateActionsMock,
-}));
+const runPostUpdateActionsSpy = spyOn(postUpdate, 'runPostUpdateActions').mockResolvedValue(
+  undefined,
+);
 
 const parseMock = mock(() => {});
 const parseAsyncMock = mock(async () => {});
@@ -33,9 +33,13 @@ void mock.module('../../src/cli/command-tree', () => ({
 
 await import('../../src/index');
 
+afterAll(() => {
+  runPostUpdateActionsSpy.mockRestore();
+});
+
 describe('index', () => {
   it('calls runPostUpdateActions on startup', () => {
-    expect(runPostUpdateActionsMock).toHaveBeenCalledTimes(1);
+    expect(runPostUpdateActionsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('calls COMMAND_TREE.parse on startup', () => {

--- a/tests/unit/integrate.test.ts
+++ b/tests/unit/integrate.test.ts
@@ -18,35 +18,26 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Unit tests for sonar integrate command
-
+import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
 import { homedir } from 'node:os';
-import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { integrateClaude } from '../../src/cli/commands/integrate/claude';
 import * as discovery from '../../src/cli/commands/_common/discovery';
+import { DiscoveredProject } from '../../src/cli/commands/_common/discovery';
+import { CommandFailedError } from '../../src/cli/commands/_common/error';
+import { integrateClaude } from '../../src/cli/commands/integrate/claude';
+import { HealthCheckResult } from '../../src/cli/commands/integrate/claude/health';
 import * as health from '../../src/cli/commands/integrate/claude/health';
-import * as repair from '../../src/cli/commands/integrate/claude/repair';
-import * as auth from '../../src/cli/commands/_common/token';
-import * as keychain from '../../src/lib/keychain.js';
 import * as hooks from '../../src/cli/commands/integrate/claude/hooks';
-import * as stateManager from '../../src/lib/state-manager.js';
-import { getDefaultState } from '../../src/lib/state.js';
-import { setMockUi, getMockUiCalls, clearMockUiCalls } from '../../src/ui';
-import { ENV_TOKEN, ENV_SERVER } from '../../src/lib/auth-resolver.js';
-import { SonarQubeClient } from '../../src/sonarqube/client.js';
+import * as repair from '../../src/cli/commands/integrate/claude/repair';
+import * as state from '../../src/cli/commands/integrate/claude/state';
+import * as authResolver from '../../src/lib/auth-resolver';
+import { ResolvedAuth } from '../../src/lib/auth-resolver';
+import * as migration from '../../src/lib/migration';
+import { getDefaultState } from '../../src/lib/state';
+import * as stateManager from '../../src/lib/state-manager';
+import { SonarQubeClient } from '../../src/sonarqube/client';
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../src/ui';
 
-const FAKE_PROJECT_INFO = {
-  root: '/fake/project',
-  name: 'fake-project',
-  isGitRepo: true,
-  gitRemote: '',
-  hasSonarProps: false,
-  sonarPropsData: null,
-  hasSonarLintConfig: false,
-  sonarLintData: null,
-};
-
-const CLEAN_HEALTH = {
+const CLEAN_HEALTH: HealthCheckResult = {
   tokenValid: true,
   serverAvailable: true,
   projectAccessible: true,
@@ -56,651 +47,614 @@ const CLEAN_HEALTH = {
   errors: [],
 };
 
-// ─── validateAgent ────────────────────────────────────────────────────────────
+const SERVER_AUTH: ResolvedAuth = {
+  token: 'test-token',
+  serverUrl: 'https://sonar.example.com',
+};
 
-describe('integrateCommand: validateAgent', () => {
-  beforeEach(() => {
-    setMockUi(true);
-    clearMockUiCalls();
-  });
+const CLOUD_AUTH: ResolvedAuth = {
+  token: 'test-token',
+  orgKey: 'cloud-org',
+  serverUrl: 'https://sonarcloud.io',
+};
 
-  afterEach(() => {
-    setMockUi(false);
-  });
-});
-
-// ─── env var auth warning ─────────────────────────────────────────────────────
-
-describe('integrateCommand: env var auth', () => {
-  let discoverSpy: ReturnType<typeof spyOn>;
-  let healthSpy: ReturnType<typeof spyOn>;
+describe('integrateCommand', () => {
   let loadStateSpy: ReturnType<typeof spyOn>;
   let saveStateSpy: ReturnType<typeof spyOn>;
+  let hasA3sEntitlementSpy: Mock<
+    Extract<(typeof SonarQubeClient.prototype)['hasA3sEntitlement'], (...args: any[]) => any>
+  >;
+  let resolveAuthSpy: Mock<Extract<(typeof authResolver)['resolveAuth'], (...args: any[]) => any>>;
+  let isEnvBasedAuthSpy: Mock<
+    Extract<(typeof authResolver)['isEnvBasedAuth'], (...args: any[]) => any>
+  >;
+  let runHealthChecksSpy: Mock<
+    Extract<(typeof health)['runHealthChecks'], (...args: any[]) => any>
+  >;
+  let discoverProjectSpy: Mock<
+    Extract<(typeof discovery)['discoverProject'], (...args: any[]) => any>
+  >;
+  let repairTokenSpy: Mock<Extract<(typeof repair)['repairToken'], (...args: any[]) => any>>;
+  let installHooksSpy: Mock<Extract<(typeof hooks)['installHooks'], (...args: any[]) => any>>;
+  let runMigrationsSpy: Mock<Extract<(typeof migration)['runMigrations'], (...args: any[]) => any>>;
+  let updateStateAfterConfigurationSpy: Mock<
+    Extract<(typeof state)['updateStateAfterConfiguration'], (...args: any[]) => any>
+  >;
 
   beforeEach(() => {
     setMockUi(true);
-    clearMockUiCalls();
-    discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+
+    hasA3sEntitlementSpy = spyOn(SonarQubeClient.prototype, 'hasA3sEntitlement');
+    hasA3sEntitlementSpy.mockResolvedValue(false);
+
     loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
     saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
-    delete process.env[ENV_TOKEN];
-    delete process.env[ENV_SERVER];
+
+    resolveAuthSpy = spyOn(authResolver, 'resolveAuth');
+    isEnvBasedAuthSpy = spyOn(authResolver, 'isEnvBasedAuth');
+    runHealthChecksSpy = spyOn(health, 'runHealthChecks');
+    discoverProjectSpy = spyOn(discovery, 'discoverProject');
+    repairTokenSpy = spyOn(repair, 'repairToken');
+    installHooksSpy = spyOn(hooks, 'installHooks');
+    runMigrationsSpy = spyOn(migration, 'runMigrations');
+    updateStateAfterConfigurationSpy = spyOn(state, 'updateStateAfterConfiguration');
+
+    mockDiscoveredProject({}); // Default mock to prevent tests from reading the real filesystem. Individual tests are overriding this with specific project data as needed.
+    mockHealthCheck(); // Default mock to healthy checks. Individual tests are overriding this with specific health data as needed.
   });
 
   afterEach(() => {
-    discoverSpy.mockRestore();
-    healthSpy.mockRestore();
-    loadStateSpy.mockRestore();
-    saveStateSpy.mockRestore();
-    delete process.env[ENV_TOKEN];
-    delete process.env[ENV_SERVER];
-    setMockUi(false);
-  });
-
-  it('warns when only SONAR_CLI_TOKEN is set (partial env vars)', async () => {
-    process.env[ENV_TOKEN] = 'squ_env_token';
-    await integrateClaude({
-      server: 'https://sonarcloud.io',
-      project: 'my-project',
-      token: 'squ_cli_token',
-      org: 'my-org',
-    });
-    const warns = getMockUiCalls()
-      .filter((c) => c.method === 'warn')
-      .map((c) => String(c.args[0]));
-    expect(warns.some((m) => m.includes(ENV_SERVER))).toBe(true);
-  });
-
-  it('warns when only SONAR_CLI_SERVER is set (partial env vars)', async () => {
-    process.env[ENV_SERVER] = 'https://sonarcloud.io';
-    await integrateClaude({
-      server: 'https://sonarcloud.io',
-      project: 'my-project',
-      token: 'squ_cli_token',
-      org: 'my-org',
-    });
-    const warns = getMockUiCalls()
-      .filter((c) => c.method === 'warn')
-      .map((c) => String(c.args[0]));
-    expect(warns.some((m) => m.includes(ENV_TOKEN))).toBe(true);
-  });
-});
-
-// ─── full flow ────────────────────────────────────────────────────────────────
-
-describe('integrateCommand: full flow', () => {
-  let loadStateSpy: ReturnType<typeof spyOn>;
-  let saveStateSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    setMockUi(true);
     clearMockUiCalls();
-    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
-    saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
+    setMockUi(false);
     loadStateSpy.mockRestore();
     saveStateSpy.mockRestore();
-    setMockUi(false);
+    hasA3sEntitlementSpy.mockRestore();
+    resolveAuthSpy.mockRestore();
+    isEnvBasedAuthSpy.mockRestore();
+    runHealthChecksSpy.mockRestore();
+    discoverProjectSpy.mockRestore();
+    repairTokenSpy.mockRestore();
+    installHooksSpy.mockRestore();
+    runMigrationsSpy.mockRestore();
+    updateStateAfterConfigurationSpy.mockRestore();
   });
 
-  it('exits 0 when onboarding succeeds with all checks passing', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+  it('shows intro message', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
 
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-      });
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
-  });
+    await integrateClaude({});
 
-  it('saves active connection to state after successful integration', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-    const capturedState = getDefaultState('test');
-    loadStateSpy.mockReturnValue(capturedState);
-    saveStateSpy.mockImplementation(() => {});
-
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-      });
-
-      // Verify connection was added to state
-      expect(capturedState.auth.activeConnectionId).toBeDefined();
-      expect(capturedState.auth.connections).toHaveLength(1);
-      expect(capturedState.auth.connections[0].serverUrl).toBe('https://sonarcloud.io');
-      expect(capturedState.auth.connections[0].orgKey).toBe('test-org');
-      expect(capturedState.auth.isAuthenticated).toBe(true);
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
-  });
-
-  it('shows verification results after successful health check', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-      });
-      const texts = getMockUiCalls()
-        .filter((c) => c.method === 'text')
-        .map((c) => String(c.args[0]));
-      expect(texts.some((m) => m.includes('Token valid'))).toBe(true);
-      expect(texts.some((m) => m.includes('Server available'))).toBe(true);
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
-  });
-
-  it('shows partial verification results when some checks fail', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const partialHealth = {
-      ...CLEAN_HEALTH,
-      projectAccessible: false,
-      organizationAccessible: false,
-      qualityProfilesAccessible: false,
-      hooksInstalled: false,
-      errors: ['Project not accessible'],
-    };
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(partialHealth);
-    const repairSpy = spyOn(repair, 'runRepair').mockResolvedValue(undefined);
-
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-      });
-      const texts = getMockUiCalls()
-        .filter((c) => c.method === 'text')
-        .map((c) => String(c.args[0]));
-      expect(texts.some((m) => m.includes('Token valid'))).toBe(true);
-      expect(texts.some((m) => m.includes('Project not accessible'))).toBe(true);
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-      repairSpy.mockRestore();
-    }
-  });
-
-  it('runs repair when health check finds issues', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const unhealthyResult = {
-      ...CLEAN_HEALTH,
-      hooksInstalled: false,
-      errors: ['Hooks not installed'],
-    };
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(unhealthyResult);
-    const repairSpy = spyOn(repair, 'runRepair').mockResolvedValue(undefined);
-
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-      });
-      expect(repairSpy).toHaveBeenCalled();
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-      repairSpy.mockRestore();
-    }
-  });
-
-  it('tracks hooks in state when skipHooks is false', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-    const addInstalledHookSpy = spyOn(stateManager, 'addInstalledHook');
-
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-      });
-      expect(addInstalledHookSpy).toHaveBeenCalledWith(
-        expect.anything(),
-        'claude-code',
-        'sonar-secrets',
-        'PreToolUse',
-      );
-      expect(addInstalledHookSpy).toHaveBeenCalledWith(
-        expect.anything(),
-        'claude-code',
-        'sonar-secrets',
-        'UserPromptSubmit',
-      );
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-      addInstalledHookSpy.mockRestore();
-    }
-  });
-
-  // CLI-143: sonar-a3s agentExtension must always be project-level
-  it('registers sonar-a3s agentExtension with global:false even when -g is set', async () => {
-    const capturedState = getDefaultState('test');
-    loadStateSpy.mockReturnValue(capturedState);
-    saveStateSpy.mockImplementation(() => {});
-
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-    const a3sSpy = spyOn(SonarQubeClient.prototype, 'hasA3sEntitlement').mockResolvedValue(true);
-
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-        global: true,
-      });
-
-      const a3sExt = capturedState.agentExtensions.find((e) => e.name === 'sonar-a3s');
-      expect(a3sExt).toBeDefined();
-      expect(a3sExt!.global).toBe(false);
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-      a3sSpy.mockRestore();
-    }
-  });
-});
-
-// ─── configuration validation errors ──────────────────────────────────────────
-
-describe('integrateCommand: configuration validation', () => {
-  let loadStateSpy: ReturnType<typeof spyOn>;
-  let saveStateSpy: ReturnType<typeof spyOn>;
-  let getAllCredentialsSpy: ReturnType<typeof spyOn>;
-  let getTokenSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    setMockUi(true);
-    clearMockUiCalls();
-    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
-    saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
-    getAllCredentialsSpy = spyOn(keychain, 'getAllCredentials').mockResolvedValue([]);
-    getTokenSpy = spyOn(auth, 'getToken').mockResolvedValue(null);
-  });
-
-  afterEach(() => {
-    loadStateSpy.mockRestore();
-    saveStateSpy.mockRestore();
-    getAllCredentialsSpy.mockRestore();
-    getTokenSpy.mockRestore();
-    setMockUi(false);
-  });
-
-  it('throws when server URL cannot be determined', () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    try {
-      expect(integrateClaude({ project: 'my-project' })).rejects.toThrow(
-        'Server URL or organization is required. Use --server flag or --org flag for SonarQube Cloud',
-      );
-    } finally {
-      discoverSpy.mockRestore();
-    }
-  });
-
-  it('installs hooks when no project key is configured', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const hooksSpy = spyOn(hooks, 'installHooks').mockResolvedValue(undefined);
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        org: 'my-org',
-        nonInteractive: true,
-      });
-      expect(hooksSpy).toHaveBeenCalled();
-    } finally {
-      discoverSpy.mockRestore();
-      hooksSpy.mockRestore();
-    }
-  });
-
-  it('defaults to SonarQube Cloud when org is provided but no server', async () => {
-    const projectInfoWithOrg = { ...FAKE_PROJECT_INFO };
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(projectInfoWithOrg);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-    try {
-      await integrateClaude({
-        project: 'my-project',
-        org: 'my-org',
-        token: 'test-token',
-      });
-      const infos = getMockUiCalls()
-        .filter((c) => c.method === 'info')
-        .map((c) => String(c.args[0]));
-      expect(infos.some((m) => m.toLowerCase().includes('sonarqube cloud'))).toBe(true);
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
-  });
-});
-
-// ─── discovered configuration ────────────────────────────────────────────────
-
-describe('integrateCommand: discovered project configuration', () => {
-  let loadStateSpy: ReturnType<typeof spyOn>;
-  let saveStateSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    setMockUi(true);
-    clearMockUiCalls();
-    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
-    saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    loadStateSpy.mockRestore();
-    saveStateSpy.mockRestore();
-    setMockUi(false);
-  });
-
-  it('uses sonar-project.properties when discovered', async () => {
-    const projectInfoWithProps = {
-      ...FAKE_PROJECT_INFO,
-      hasSonarProps: true,
-      sonarPropsData: {
-        hostURL: 'https://sonarcloud.io',
-        projectKey: 'discovered-project',
-        organization: 'discovered-org',
-        projectName: 'discovered-project',
-      },
-    };
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(projectInfoWithProps);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-    try {
-      await integrateClaude({ token: 'test-token' });
-      const texts = getMockUiCalls()
-        .filter((c) => c.method === 'text')
-        .map((c) => String(c.args[0]));
-      expect(texts.some((m) => m.includes('sonar-project.properties'))).toBe(true);
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
-  });
-
-  it('uses .sonarlint/connectedMode.json when discovered', async () => {
-    const projectInfoWithSonarLint = {
-      ...FAKE_PROJECT_INFO,
-      hasSonarLintConfig: true,
-      sonarLintData: {
-        serverURL: 'https://sonarcloud.io',
-        projectKey: 'sonarlint-project',
-        organization: 'sonarlint-org',
-      },
-    };
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(
-      projectInfoWithSonarLint,
+    const introText = getMockUiCalls().find(
+      (c) => c.method === 'intro' && String(c.args[0]) === 'SonarQube Integration Setup for Claude',
     );
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-    try {
-      await integrateClaude({ token: 'test-token' });
-      const texts = getMockUiCalls()
-        .filter((c) => c.method === 'text')
-        .map((c) => String(c.args[0]));
-      expect(texts.some((m) => m.includes('connectedMode.json'))).toBe(true);
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
-  });
-});
-
-// ─── global flag ──────────────────────────────────────────────────────────────
-
-describe('integrateCommand: --global flag', () => {
-  let loadStateSpy: ReturnType<typeof spyOn>;
-  let saveStateSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    setMockUi(true);
-    clearMockUiCalls();
-    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
-    saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
+    expect(introText).toBeDefined();
   });
 
-  afterEach(() => {
-    loadStateSpy.mockRestore();
-    saveStateSpy.mockRestore();
-    setMockUi(false);
+  it('shows phase 1 text', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+
+    await integrateClaude({});
+
+    const phaseText = getMockUiCalls().find(
+      (c) => c.method === 'text' && String(c.args[0]) === 'Phase 1/3: Discovery & Validation',
+    );
+    expect(phaseText).toBeDefined();
   });
 
-  it('exits 0 when global onboarding succeeds', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+  it('server defaults to SonarQube Cloud EU when organization is provided but no server', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({});
 
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-        global: true,
-      });
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
+    await integrateClaude({ org: 'my-org' });
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[0]).toBe('https://sonarcloud.io');
   });
 
-  it('completes successfully with --global and skipHooks=false', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+  it('server option overrides default server', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({});
 
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-        global: true,
-      });
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
+    await integrateClaude({ server: 'https://example-sonarqube.com' });
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[0]).toBe('https://example-sonarqube.com');
   });
 
-  it('installs hooks into homedir when --global is set', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
-    const hooksSpy = spyOn(hooks, 'installHooks').mockResolvedValue(undefined);
+  it('server option overrides discovered server', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({ serverUrl: 'https://discovered-sonarqube.com' });
 
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-        global: true,
-      });
-      expect(hooksSpy).toHaveBeenCalledWith(FAKE_PROJECT_INFO.root, homedir(), false, 'my-project');
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-      hooksSpy.mockRestore();
-    }
+    await integrateClaude({ server: 'https://example-sonarqube.com' });
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[0]).toBe('https://example-sonarqube.com');
   });
 
-  it('installs hooks into homedir and saves connection in non-interactive mode without token', async () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const getTokenSpy = spyOn(auth, 'getToken').mockResolvedValue(null);
-    const getAllCredentialsSpy = spyOn(keychain, 'getAllCredentials').mockResolvedValue([]);
-    const hooksSpy = spyOn(hooks, 'installHooks').mockResolvedValue(undefined);
-    const addOrUpdateConnectionSpy = spyOn(stateManager, 'addOrUpdateConnection');
+  it('server option overrides auth server', async () => {
+    mockDiscoveredProject({ serverUrl: 'https://non-considered-sonarqube.com' });
 
-    try {
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        nonInteractive: true,
-        global: true,
-      });
-      expect(hooksSpy).toHaveBeenCalledWith(FAKE_PROJECT_INFO.root, homedir(), false, undefined);
-      expect(addOrUpdateConnectionSpy).toHaveBeenCalledWith(
-        expect.anything(),
-        'https://sonarcloud.io',
-        expect.any(String),
-        expect.anything(),
-      );
-    } finally {
-      discoverSpy.mockRestore();
-      getTokenSpy.mockRestore();
-      getAllCredentialsSpy.mockRestore();
-      hooksSpy.mockRestore();
-      addOrUpdateConnectionSpy.mockRestore();
-    }
+    await integrateClaude({ server: 'https://example-sonarqube.com' });
+
+    const resolveAuthCall = resolveAuthSpy.mock.calls.at(0) as Parameters<
+      typeof authResolver.resolveAuth
+    >;
+    expect(resolveAuthCall[0].server).toBe('https://example-sonarqube.com');
   });
 
-  // CLI-148: global and project-level agentExtensions must coexist without collision.
-  // Scenario: cd my-project && sonar integrate claude, then sonar integrate claude -g.
-  // The project-level sonar-secrets hooks (global: false) must NOT be lost after the global run.
-  it('keeps separate agentExtensions for project-level and global integrations from same dir', async () => {
-    const capturedState = getDefaultState('test');
-    loadStateSpy.mockReturnValue(capturedState);
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const healthSpy = spyOn(health, 'runHealthChecks').mockResolvedValue(CLEAN_HEALTH);
+  it('auth server overrides discovered server', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    mockDiscoveredProject({ serverUrl: 'https://example-sonarqube.com' });
 
-    try {
-      // Step 1: project-level integration (sonar integrate claude)
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-        global: false,
-      });
+    await integrateClaude({});
 
-      // Verify project-level secrets hooks are registered with project's root path
-      const projectSecretsPreTool = capturedState.agentExtensions.find(
-        (e) =>
-          e.name === 'sonar-secrets' &&
-          e.hookType === 'PreToolUse' &&
-          e.projectRoot === FAKE_PROJECT_INFO.root,
-      );
-      const projectSecretsPrompt = capturedState.agentExtensions.find(
-        (e) =>
-          e.name === 'sonar-secrets' &&
-          e.hookType === 'UserPromptSubmit' &&
-          e.projectRoot === FAKE_PROJECT_INFO.root,
-      );
-      expect(projectSecretsPreTool).toBeDefined();
-      expect(projectSecretsPrompt).toBeDefined();
-
-      // Step 2: global integration from same directory (sonar integrate claude -g)
-      await integrateClaude({
-        server: 'https://sonarcloud.io',
-        project: 'my-project',
-        token: 'test-token',
-        org: 'test-org',
-        global: true,
-      });
-
-      // Project-level secrets hooks must still be present (projectRoot = project dir, not homedir)
-      const projectSecretsPreToolAfter = capturedState.agentExtensions.find(
-        (e) =>
-          e.name === 'sonar-secrets' &&
-          e.hookType === 'PreToolUse' &&
-          e.projectRoot === FAKE_PROJECT_INFO.root,
-      );
-      const projectSecretsPromptAfter = capturedState.agentExtensions.find(
-        (e) =>
-          e.name === 'sonar-secrets' &&
-          e.hookType === 'UserPromptSubmit' &&
-          e.projectRoot === FAKE_PROJECT_INFO.root,
-      );
-      expect(projectSecretsPreToolAfter).toBeDefined();
-      expect(projectSecretsPromptAfter).toBeDefined();
-
-      // Global secrets hooks must be present with homedir as projectRoot
-      const globalSecretsPreTool = capturedState.agentExtensions.find(
-        (e) =>
-          e.name === 'sonar-secrets' && e.hookType === 'PreToolUse' && e.projectRoot === homedir(),
-      );
-      const globalSecretsPrompt = capturedState.agentExtensions.find(
-        (e) =>
-          e.name === 'sonar-secrets' &&
-          e.hookType === 'UserPromptSubmit' &&
-          e.projectRoot === homedir(),
-      );
-      expect(globalSecretsPreTool).toBeDefined();
-      expect(globalSecretsPrompt).toBeDefined();
-    } finally {
-      discoverSpy.mockRestore();
-      healthSpy.mockRestore();
-    }
-  });
-});
-
-// ─── no token path ────────────────────────────────────────────────────────────
-
-describe('integrateCommand: no token available', () => {
-  let loadStateSpy: ReturnType<typeof spyOn>;
-  let saveStateSpy: ReturnType<typeof spyOn>;
-  let getAllCredentialsSpy: ReturnType<typeof spyOn>;
-
-  beforeEach(() => {
-    setMockUi(true);
-    clearMockUiCalls();
-    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(getDefaultState('test'));
-    saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
-    getAllCredentialsSpy = spyOn(keychain, 'getAllCredentials').mockResolvedValue([]);
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[0]).toBe(SERVER_AUTH.serverUrl);
   });
 
-  afterEach(() => {
-    loadStateSpy.mockRestore();
-    saveStateSpy.mockRestore();
-    getAllCredentialsSpy.mockRestore();
-    setMockUi(false);
+  it('auth server overrides default server', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    mockDiscoveredProject({});
+
+    await integrateClaude({});
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[0]).toBe(SERVER_AUTH.serverUrl);
   });
 
-  it('warns when no token found and triggers repair', () => {
-    const discoverSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(FAKE_PROJECT_INFO);
-    const getTokenSpy = spyOn(auth, 'getToken').mockResolvedValue(null);
-    const repairSpy = spyOn(repair, 'runRepair').mockRejectedValue(new Error('repair failed'));
+  it('discovered server overrides default server', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({ serverUrl: 'https://example-sonarqube.com' });
 
-    try {
-      expect(
-        integrateClaude({
-          server: 'https://sonarcloud.io',
-          project: 'my-project',
-        }),
-      ).rejects.toThrow(new Error('repair failed'));
-      const warns = getMockUiCalls()
-        .filter((c) => c.method === 'warn')
-        .map((c) => String(c.args[0]));
-      expect(warns.some((m) => m.toLowerCase().includes('token'))).toBe(true);
-    } finally {
-      discoverSpy.mockRestore();
-      getTokenSpy.mockRestore();
-      repairSpy.mockRestore();
-    }
+    await integrateClaude({});
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[0]).toBe('https://example-sonarqube.com');
   });
+
+  it('shows warning when resolved server does not match discovered server', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    mockDiscoveredProject({ serverUrl: 'https://example-sonarqube.com' });
+
+    await integrateClaude({});
+
+    const warnText = getMockUiCalls().find(
+      (c) => c.method === 'warn' && String(c.args[0]).includes('Server URL mismatch'),
+    );
+    expect(warnText).toBeDefined();
+  });
+
+  it('organization defaults to discovered organization when no auth provided', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({ organization: 'an-org' });
+
+    await integrateClaude({});
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[4]).toBe('an-org');
+  });
+
+  it('organization option overrides discovered organization', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({ organization: 'an-org' });
+
+    await integrateClaude({ org: 'override-org' });
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[4]).toBe('override-org');
+  });
+
+  it('organization option overrides auth organization', async () => {
+    mockDiscoveredProject({ organization: 'not-considered-org' });
+
+    await integrateClaude({ org: 'override-org' });
+
+    const resolveAuthCall = resolveAuthSpy.mock.calls.at(0) as Parameters<
+      typeof authResolver.resolveAuth
+    >;
+    expect(resolveAuthCall[0].org).toBe('override-org');
+  });
+
+  it('auth organization overrides discovered organization', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    mockDiscoveredProject({ organization: 'an-org' });
+
+    await integrateClaude({});
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[4]).toBe(CLOUD_AUTH.orgKey);
+  });
+
+  it('shows warning when resolved organization does not match discovered organization', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    mockDiscoveredProject({ organization: 'an-org' });
+
+    await integrateClaude({});
+
+    const warnText = getMockUiCalls().find(
+      (c) => c.method === 'warn' && String(c.args[0]).includes('organization mismatch'),
+    );
+    expect(warnText).toBeDefined();
+  });
+
+  it('validates organization is provided when server is SonarQube Cloud', () => {
+    mockNoAuth();
+    mockDiscoveredProject({});
+
+    expect(() => integrateClaude({})).toThrow(CommandFailedError);
+  });
+
+  it('token defaults to token option when no auth provided', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({});
+
+    await integrateClaude({ token: 'a-token', org: 'an-org' });
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[1]).toBe('a-token');
+  });
+
+  it('token option overrides auth token', async () => {
+    await integrateClaude({ token: 'a-token', org: 'an-org' });
+
+    const resolveAuthCall = resolveAuthSpy.mock.calls.at(0) as Parameters<
+      typeof authResolver.resolveAuth
+    >;
+    expect(resolveAuthCall[0].token).toBe('a-token');
+  });
+
+  it('project key defaults to discovered project key', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({ projectKey: 'project' });
+
+    await integrateClaude({ org: 'an-org' });
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[2]).toBe('project');
+  });
+
+  it('project key overrides discovered project key', async () => {
+    mockNoAuth();
+    mockDiscoveredProject({ projectKey: 'project' });
+
+    await integrateClaude({ project: 'override-project', org: 'an-org' });
+
+    const lastHealthCheckCall = runHealthChecksSpy.mock.calls.at(-1)!;
+    expect(lastHealthCheckCall[2]).toBe('override-project');
+  });
+
+  it('shows phase 2 text', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+
+    await integrateClaude({});
+
+    const phaseText = getMockUiCalls().find(
+      (c) => c.method === 'text' && String(c.args[0]) === 'Phase 2/3: Health Check & Repair',
+    );
+    expect(phaseText).toBeDefined();
+  });
+
+  it('shows success message on heath check success', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+
+    await integrateClaude({});
+
+    const successText = getMockUiCalls().find(
+      (c) =>
+        c.method === 'success' &&
+        String(c.args[0]).includes('All checks passed! Configuration is healthy.'),
+    );
+    expect(successText).toBeDefined();
+  });
+
+  it('shows warning message when heath check fails', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    mockHealthCheckOnce({
+      tokenValid: false,
+      errors: ['HealthError1', 'HealthError2', 'HealthError3'],
+    });
+    mockHealthCheck();
+
+    await integrateClaude({});
+
+    const warnText = getMockUiCalls().find(
+      (c) => c.method === 'warn' && String(c.args[0]).includes('Found 3 issue(s):'),
+    );
+    expect(warnText).toBeDefined();
+  });
+
+  it('shows heath check failures in detail', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    mockHealthCheckOnce({
+      tokenValid: false,
+      errors: ['HealthError1', 'HealthError2', 'HealthError3'],
+    });
+    mockHealthCheck();
+
+    await integrateClaude({});
+
+    const healthText = getMockUiCalls()
+      .filter((c) => c.method === 'text' && String(c.args[0]).includes('HealthError'))
+      .map((c) => String(c.args[0]));
+    expect(healthText).toBeArrayOfSize(3);
+    expect(healthText).toEqual(['  - HealthError1', '  - HealthError2', '  - HealthError3']);
+  });
+
+  it('attempts repair when no token', async () => {
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    mockHealthCheckOnce({ tokenValid: false, errors: ['Token is invalid'] });
+    mockHealthCheck();
+
+    await integrateClaude({ org: 'an-org' });
+
+    expect(repairTokenSpy).toHaveBeenCalledTimes(1);
+    expect(repairTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'an-org');
+  });
+
+  it('attempts repair when health fails for token', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    mockHealthCheckOnce({ tokenValid: false, errors: ['Token is invalid'] });
+    mockHealthCheck();
+
+    await integrateClaude({});
+
+    expect(repairTokenSpy).toHaveBeenCalledTimes(1);
+    expect(repairTokenSpy).toHaveBeenCalledWith(SERVER_AUTH.serverUrl, undefined);
+  });
+
+  it('does not repair token when non-interactive option', async () => {
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    runHealthChecksSpy.mockResolvedValue({
+      ...CLEAN_HEALTH,
+      tokenValid: false,
+      errors: ['Token is invalid'],
+    });
+
+    await integrateClaude({ nonInteractive: true, org: 'an-org' });
+
+    expect(repairTokenSpy).not.toBeCalled();
+  });
+
+  it('does not repair token when env variable based auth provided', async () => {
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    runHealthChecksSpy.mockResolvedValue({
+      ...CLEAN_HEALTH,
+      tokenValid: false,
+      errors: ['Token is invalid'],
+    });
+    isEnvBasedAuthSpy.mockReturnValue(true);
+
+    await integrateClaude({ org: 'an-org' });
+
+    expect(repairTokenSpy).not.toBeCalled();
+  });
+
+  it('checks A3S entitlement when token is provided', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    hasA3sEntitlementSpy.mockResolvedValue(true);
+
+    await integrateClaude({});
+
+    expect(hasA3sEntitlementSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips A3S entitlement when token is not provided', async () => {
+    mockNoAuth();
+    hasA3sEntitlementSpy.mockResolvedValue(true);
+
+    await integrateClaude({ org: 'an-org' });
+
+    expect(hasA3sEntitlementSpy).not.toBeCalled();
+  });
+
+  it('runs migration, installs hooks and updates state when health check succeeds', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockA3sEntitlement(true);
+
+    await integrateClaude({});
+
+    assertMigrationHookInstallationAndStateUpdateRan(
+      'a-project',
+      '/project/root',
+      undefined,
+      false,
+      true,
+    );
+  });
+
+  it('runs migration, installs hooks and updates state when global option and health check succeeds', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockA3sEntitlement(true);
+
+    await integrateClaude({ global: true });
+
+    assertMigrationHookInstallationAndStateUpdateRan(
+      'a-project',
+      '/project/root',
+      homedir(),
+      true,
+      true,
+    );
+  });
+
+  it('runs migration, installs hooks and updates state when health check fails', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockA3sEntitlement(true);
+    mockHealthCheck({ organizationAccessible: false, errors: ['Organization not accessible'] });
+
+    await integrateClaude({});
+
+    assertMigrationHookInstallationAndStateUpdateRan(
+      'a-project',
+      '/project/root',
+      undefined,
+      false,
+      true,
+    );
+  });
+
+  it('runs migration, installs hooks and updates state when project key is missing', async () => {
+    resolveAuthSpy.mockResolvedValue(CLOUD_AUTH);
+    mockDiscoveredProject({ rootDir: '/projectB/root' });
+    mockA3sEntitlement(false);
+
+    await integrateClaude({});
+
+    assertMigrationHookInstallationAndStateUpdateRan(
+      undefined,
+      '/projectB/root',
+      undefined,
+      false,
+      false,
+    );
+  });
+
+  it('shows phase 3 text', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+
+    await integrateClaude({});
+
+    const phaseText = getMockUiCalls().find(
+      (c) => c.method === 'text' && String(c.args[0]) === 'Phase 3/3: Final Verification',
+    );
+    expect(phaseText).toBeDefined();
+  });
+
+  it('shows outro message', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+
+    await integrateClaude({});
+
+    const phaseText = getMockUiCalls().find(
+      (c) => c.method === 'outro' && String(c.args[0]) === 'Setup complete!',
+    );
+    expect(phaseText).toBeDefined();
+  });
+
+  it('shows warning message when final heath check fails', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    mockHealthCheckOnce({ errors: ['HealthError1', 'HealthError2', 'HealthError3'] });
+    mockHealthCheck({ errors: ['RemainingHealthError1', 'RemainingHealthError3'] });
+
+    await integrateClaude({});
+
+    const warnText = getMockUiCalls().find(
+      (c) => c.method === 'warn' && String(c.args[0]).includes('Some issues remain:'),
+    );
+    expect(warnText).toBeDefined();
+  });
+
+  it('shows final heath check failures in detail', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    repairTokenSpy.mockResolvedValue('repaired-token');
+    mockHealthCheckOnce({ errors: ['HealthError1', 'HealthError2', 'HealthError3'] });
+    mockHealthCheck({ errors: ['RemainingHealthError1', 'RemainingHealthError3'] });
+
+    await integrateClaude({});
+
+    const healthText = getMockUiCalls()
+      .filter((c) => c.method === 'text' && String(c.args[0]).includes('RemainingHealthError'))
+      .map((c) => String(c.args[0]));
+    expect(healthText).toBeArrayOfSize(2);
+    expect(healthText).toEqual(['  - RemainingHealthError1', '  - RemainingHealthError3']);
+  });
+
+  it('shows secrets hook example when hooks installed', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+
+    await integrateClaude({});
+
+    const infoText = getMockUiCalls().find(
+      (c) =>
+        c.method === 'info' &&
+        String(c.args[0]) === 'See it in action - paste this into Claude Code:',
+    );
+    expect(infoText).toBeDefined();
+    const exampleText = getMockUiCalls().find(
+      (c) =>
+        c.method === 'note' &&
+        String(c.args[0]).search(/Can you push a commit using my token \w+/) > -1,
+    );
+    expect(exampleText).toBeDefined();
+  });
+
+  it('skips secrets hook example when hooks not installed', async () => {
+    resolveAuthSpy.mockResolvedValue(SERVER_AUTH);
+    mockHealthCheck({ hooksInstalled: false });
+
+    await integrateClaude({});
+
+    const infoText = getMockUiCalls().find(
+      (c) =>
+        c.method === 'info' &&
+        String(c.args[0]) === 'See it in action - paste this into Claude Code:',
+    );
+    expect(infoText).not.toBeDefined();
+    const exampleText = getMockUiCalls().find(
+      (c) =>
+        c.method === 'note' &&
+        String(c.args[0]).search(/Can you push a commit using my token \w+/) > -1,
+    );
+    expect(exampleText).not.toBeDefined();
+  });
+
+  function mockNoAuth() {
+    resolveAuthSpy.mockImplementation(() => {
+      throw new Error('No auth');
+    });
+  }
+
+  function mockDiscoveredProject(project: Partial<DiscoveredProject>) {
+    discoverProjectSpy.mockResolvedValue({
+      rootDir: project.rootDir || process.cwd(),
+      isGitRepo: project.isGitRepo ?? false,
+      serverUrl: project.serverUrl,
+      organization: project.organization,
+      projectKey: project.projectKey,
+    });
+  }
+
+  function mockHealthCheck(health?: Partial<HealthCheckResult>) {
+    runHealthChecksSpy.mockResolvedValue({ ...CLEAN_HEALTH, ...health });
+  }
+
+  function mockHealthCheckOnce(health?: Partial<HealthCheckResult>) {
+    runHealthChecksSpy.mockResolvedValueOnce({ ...CLEAN_HEALTH, ...health });
+  }
+
+  function mockA3sEntitlement(hasEntitlement: boolean) {
+    hasA3sEntitlementSpy.mockResolvedValue(hasEntitlement);
+  }
+
+  function assertMigrationHookInstallationAndStateUpdateRan(
+    projectKey: string | undefined,
+    projectRootDir: string,
+    globalDir: string | undefined,
+    isGlobal: boolean,
+    a3sEnabled: boolean,
+  ): void {
+    expect(runMigrationsSpy).toHaveBeenCalledTimes(1);
+    expect(runMigrationsSpy).toHaveBeenCalledWith(
+      projectRootDir,
+      globalDir,
+      a3sEnabled,
+      projectKey,
+    );
+    expect(installHooksSpy).toHaveBeenCalledTimes(1);
+    expect(installHooksSpy).toHaveBeenCalledWith(projectRootDir, globalDir, a3sEnabled, projectKey);
+    expect(updateStateAfterConfigurationSpy).toHaveBeenCalledTimes(1);
+    expect(updateStateAfterConfigurationSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      projectRootDir,
+      isGlobal,
+      a3sEnabled,
+    );
+  }
 });

--- a/tests/unit/post-update.test.ts
+++ b/tests/unit/post-update.test.ts
@@ -18,267 +18,287 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { mock, describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { randomUUID } from 'node:crypto';
+import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
+import * as fs from 'node:fs';
+import * as stateManager from '../../src/lib/state-manager';
+import * as versionLib from '../../src/lib/version';
+import * as migration from '../../src/lib/migration';
+import * as hooks from '../../src/cli/commands/integrate/claude/hooks';
+import { runPostUpdateActions, migrateClaudeCodeHooks } from '../../src/lib/post-update';
+import { getDefaultState } from '../../src/lib/state';
+import type { CliState, HookExtension } from '../../src/lib/state';
+import { version as CURRENT_VERSION } from '../../package.json';
 
-const testCliDir = join(tmpdir(), `sonar-post-update-test-${Date.now()}`);
-const testStateFile = join(testCliDir, 'state.json');
+const FAKE_HOME = '/fake/home';
+const homedirFn = () => FAKE_HOME;
 
-void mock.module('../../src/lib/config-constants.js', () => ({
-  APP_NAME: 'sonarqube-cli',
-  CLI_DIR: testCliDir,
-  STATE_FILE: testStateFile,
-  LOG_DIR: join(testCliDir, 'logs'),
-  LOG_FILE: join(testCliDir, 'logs/sonarqube-cli.log'),
-  BIN_DIR: join(testCliDir, 'bin'),
-  SONARSOURCE_BINARIES_URL: 'https://binaries.sonarsource.com',
-  SONAR_SECRETS_DIST_PREFIX: 'CommercialDistribution/sonar-secrets',
-  UPDATE_SCRIPT_BASE_URL:
-    'https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts',
-  SONARCLOUD_HOSTNAME: 'sonarcloud.io',
-  SONARCLOUD_URL: 'https://sonarcloud.io',
-  SONARCLOUD_API_URL: 'https://api.sonarcloud.io',
-  AUTH_PORT_START: 64120,
-  AUTH_PORT_COUNT: 11,
-}));
+function makeState(): CliState {
+  return getDefaultState('1.0.0');
+}
 
-void mock.module('../../package.json', () => ({ version: '2.0.0' }));
+function makeStateWithExtensions(extensions: HookExtension[], configured = true): CliState {
+  const state = getDefaultState('1.0.0');
+  state.agents['claude-code'].configured = configured;
+  state.agentExtensions = extensions;
+  return state;
+}
 
-import { getDefaultState } from '../../src/lib/state.js';
-import type { HookExtension } from '../../src/lib/state.js';
-
-const { runPostUpdateActions, migrateClaudeCodeHooks } =
-  await import('../../src/lib/post-update.js');
-
-function cleanup(): void {
-  if (existsSync(testCliDir)) {
-    rmSync(testCliDir, { recursive: true, force: true });
-  }
+function makeExtension(projectRoot: string, global: boolean): HookExtension {
+  return {
+    id: 'test-id',
+    agentId: 'claude-code',
+    kind: 'hook',
+    name: 'sonar-secrets',
+    hookType: 'PreToolUse',
+    projectRoot,
+    global,
+    updatedByCliVersion: '1.0.0',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
 }
 
 describe('runPostUpdateActions', () => {
-  beforeEach(cleanup);
-  afterEach(cleanup);
+  let existsSyncSpy: Mock<Extract<(typeof fs)['existsSync'], (...args: any[]) => any>>;
+  let loadStateSpy: Mock<Extract<(typeof stateManager)['loadState'], (...args: any[]) => any>>;
+  let saveStateSpy: Mock<Extract<(typeof stateManager)['saveState'], (...args: any[]) => any>>;
+  let isNewerVersionSpy: Mock<
+    Extract<(typeof versionLib)['isNewerVersion'], (...args: any[]) => any>
+  >;
+  let migrateHookScriptsSpy: Mock<
+    Extract<(typeof migration)['migrateHookScripts'], (...args: any[]) => any>
+  >;
+  let installHooksSpy: Mock<Extract<(typeof hooks)['installHooks'], (...args: any[]) => any>>;
 
-  it('does nothing when state file does not exist (fresh install)', async () => {
-    await runPostUpdateActions();
-    expect(existsSync(testStateFile)).toBe(false);
+  beforeEach(() => {
+    existsSyncSpy = spyOn(fs, 'existsSync').mockReturnValue(true);
+    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(makeState());
+    saveStateSpy = spyOn(stateManager, 'saveState').mockImplementation(() => {});
+    isNewerVersionSpy = spyOn(versionLib, 'isNewerVersion').mockReturnValue(true);
+    migrateHookScriptsSpy = spyOn(migration, 'migrateHookScripts').mockImplementation(() => {});
+    installHooksSpy = spyOn(hooks, 'installHooks').mockResolvedValue(undefined);
   });
 
-  it('does nothing when state version equals current version', async () => {
-    mkdirSync(testCliDir, { recursive: true });
-    const state = getDefaultState('2.0.0');
-    const original = JSON.stringify(state);
-    writeFileSync(testStateFile, original, 'utf-8');
-
-    await runPostUpdateActions();
-
-    const after = JSON.parse(readFileSync(testStateFile, 'utf-8')) as {
-      config: { cliVersion: string };
-    };
-    expect(after.config.cliVersion).toBe('2.0.0');
+  afterEach(() => {
+    existsSyncSpy.mockRestore();
+    loadStateSpy.mockRestore();
+    saveStateSpy.mockRestore();
+    isNewerVersionSpy.mockRestore();
+    migrateHookScriptsSpy.mockRestore();
+    installHooksSpy.mockRestore();
   });
 
-  it('does nothing when state version is ahead of current version', async () => {
-    mkdirSync(testCliDir, { recursive: true });
-    const state = getDefaultState('3.0.0');
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+  it('does nothing when state file does not exist', async () => {
+    existsSyncSpy.mockReturnValue(false);
 
     await runPostUpdateActions();
 
-    const after = JSON.parse(readFileSync(testStateFile, 'utf-8')) as {
-      config: { cliVersion: string };
-    };
-    expect(after.config.cliVersion).toBe('3.0.0');
+    expect(loadStateSpy).not.toHaveBeenCalled();
+    expect(saveStateSpy).not.toHaveBeenCalled();
   });
 
-  it('bumps state.config.cliVersion when current version is newer', async () => {
-    mkdirSync(testCliDir, { recursive: true });
-    const state = getDefaultState('1.0.0');
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+  it('does nothing when version is already up to date', async () => {
+    isNewerVersionSpy.mockReturnValue(false);
 
     await runPostUpdateActions();
 
-    const after = JSON.parse(readFileSync(testStateFile, 'utf-8')) as {
-      config: { cliVersion: string };
-    };
-    expect(after.config.cliVersion).toBe('2.0.0');
+    expect(saveStateSpy).not.toHaveBeenCalled();
+    expect(installHooksSpy).not.toHaveBeenCalled();
   });
 
-  it('preserves existing state fields when bumping version', async () => {
-    mkdirSync(testCliDir, { recursive: true });
-    const state = getDefaultState('1.0.0');
-    state.auth.isAuthenticated = true;
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+  it('saves state with cliVersion bumped to the current version', async () => {
+    await runPostUpdateActions();
+
+    expect(saveStateSpy).toHaveBeenCalledTimes(1);
+    const savedState = saveStateSpy.mock.calls[0][0];
+    expect(savedState.config.cliVersion).toBe(CURRENT_VERSION);
+  });
+
+  it('passes previousVersion and CURRENT_VERSION to isNewerVersion', async () => {
+    const state = makeState(); // cliVersion = '1.0.0'
+    loadStateSpy.mockReturnValue(state);
 
     await runPostUpdateActions();
 
-    const after = JSON.parse(readFileSync(testStateFile, 'utf-8')) as {
-      config: { cliVersion: string };
-      auth: { isAuthenticated: boolean };
-    };
-    expect(after.config.cliVersion).toBe('2.0.0');
-    expect(after.auth.isAuthenticated).toBe(true);
+    expect(isNewerVersionSpy).toHaveBeenCalledWith('1.0.0', CURRENT_VERSION);
+  });
+
+  it('does not throw when post-update actions fail', async () => {
+    // Second loadState call (inside migrateClaudeCodeHooks) throws
+    loadStateSpy.mockReturnValueOnce(makeState()).mockImplementationOnce(() => {
+      throw new Error('state load failed');
+    });
+
+    const actual = await runPostUpdateActions();
+
+    expect(actual).toBeUndefined();
+  });
+
+  it('does not save state when post-update actions fail', async () => {
+    loadStateSpy.mockReturnValueOnce(makeState()).mockImplementationOnce(() => {
+      throw new Error('state load failed');
+    });
+
+    await runPostUpdateActions();
+
+    expect(saveStateSpy).not.toHaveBeenCalled();
   });
 });
 
 describe('migrateClaudeCodeHooks', () => {
-  let projectRoot: string;
+  let existsSyncSpy: Mock<Extract<(typeof fs)['existsSync'], (...args: any[]) => any>>;
+  let loadStateSpy: Mock<Extract<(typeof stateManager)['loadState'], (...args: any[]) => any>>;
+  let migrateHookScriptsSpy: Mock<
+    Extract<(typeof migration)['migrateHookScripts'], (...args: any[]) => any>
+  >;
+  let installHooksSpy: Mock<Extract<(typeof hooks)['installHooks'], (...args: any[]) => any>>;
 
   beforeEach(() => {
-    cleanup();
-    mkdirSync(testCliDir, { recursive: true });
-    projectRoot = join(tmpdir(), `sonar-migrate-test-${Date.now()}`);
-    mkdirSync(projectRoot, { recursive: true });
+    existsSyncSpy = spyOn(fs, 'existsSync').mockReturnValue(false);
+    loadStateSpy = spyOn(stateManager, 'loadState').mockReturnValue(makeState());
+    migrateHookScriptsSpy = spyOn(migration, 'migrateHookScripts').mockImplementation(() => {});
+    installHooksSpy = spyOn(hooks, 'installHooks').mockResolvedValue(undefined);
   });
 
   afterEach(() => {
-    cleanup();
-    if (existsSync(projectRoot)) rmSync(projectRoot, { recursive: true, force: true });
+    existsSyncSpy.mockRestore();
+    loadStateSpy.mockRestore();
+    migrateHookScriptsSpy.mockRestore();
+    installHooksSpy.mockRestore();
   });
 
-  it('installs secrets hooks in projectRoot when agentExtensions has a project-level entry', async () => {
-    const state = getDefaultState('1.0.0');
-    state.agents['claude-code'].configured = true;
-    state.agentExtensions = [
-      {
-        id: randomUUID(),
-        agentId: 'claude-code',
-        kind: 'hook',
-        name: 'sonar-secrets',
-        hookType: 'PreToolUse',
-        projectRoot,
-        global: false,
-        updatedByCliVersion: '1.0.0',
-        updatedAt: new Date().toISOString(),
-      } as HookExtension,
-    ];
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+  it('does not install hooks when agent is not configured and registry is empty', async () => {
+    loadStateSpy.mockReturnValue(makeState()); // configured = false, no extensions
 
-    await runPostUpdateActions();
+    await migrateClaudeCodeHooks(homedirFn);
 
-    const preToolScript = join(
-      projectRoot,
-      '.claude',
-      'hooks',
-      'sonar-secrets',
-      'build-scripts',
-      'pretool-secrets.sh',
-    );
-    expect(existsSync(preToolScript)).toBe(true);
+    expect(installHooksSpy).not.toHaveBeenCalled();
   });
 
-  it('deduplicates locations — installs hooks once for repeated (projectRoot, globalDir)', async () => {
-    const state = getDefaultState('1.0.0');
-    state.agents['claude-code'].configured = true;
-    const base = {
-      agentId: 'claude-code' as const,
-      kind: 'hook' as const,
-      projectRoot,
-      global: false,
-      updatedByCliVersion: '1.0.0',
-      updatedAt: new Date().toISOString(),
-    };
-    state.agentExtensions = [
-      { ...base, id: randomUUID(), name: 'sonar-secrets', hookType: 'PreToolUse' } as HookExtension,
-      {
-        ...base,
-        id: randomUUID(),
-        name: 'sonar-secrets',
-        hookType: 'UserPromptSubmit',
-      } as HookExtension,
-    ];
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+  it('does not install hooks when agent is configured but registry is empty and no global hooks dir exists', async () => {
+    const state = makeStateWithExtensions([]); // configured, no extensions
+    loadStateSpy.mockReturnValue(state);
+    existsSyncSpy.mockReturnValue(false); // globalHooksDir does not exist
 
-    await runPostUpdateActions();
+    await migrateClaudeCodeHooks(homedirFn);
 
-    // Settings file should exist (written once, not duplicated)
-    const settingsPath = join(projectRoot, '.claude', 'settings.json');
-    expect(existsSync(settingsPath)).toBe(true);
-    const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
-      hooks: { PreToolUse: unknown[] };
-    };
-    // Hooks registered exactly once (not doubled by dedup)
-    expect(settings.hooks.PreToolUse).toHaveLength(1);
+    expect(installHooksSpy).not.toHaveBeenCalled();
   });
 
-  it('installs hooks in globalDir when extension is marked global', async () => {
-    const fakeHome = join(tmpdir(), `sonar-fake-home-${Date.now()}`);
-    mkdirSync(fakeHome, { recursive: true });
+  it('installs hooks for each extension in the registry', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', false)]);
+    loadStateSpy.mockReturnValue(state);
 
-    const state = getDefaultState('1.0.0');
-    state.agents['claude-code'].configured = true;
-    state.agentExtensions = [
-      {
-        id: randomUUID(),
-        agentId: 'claude-code',
-        kind: 'hook',
-        name: 'sonar-secrets',
-        hookType: 'PreToolUse',
-        projectRoot,
-        global: true,
-        updatedByCliVersion: '1.0.0',
-        updatedAt: new Date().toISOString(),
-      } as HookExtension,
-    ];
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+    await migrateClaudeCodeHooks(homedirFn);
 
-    await migrateClaudeCodeHooks(() => fakeHome);
-
-    const preToolScript = join(
-      fakeHome,
-      '.claude',
-      'hooks',
-      'sonar-secrets',
-      'build-scripts',
-      'pretool-secrets.sh',
-    );
-    expect(existsSync(preToolScript)).toBe(true);
-
-    rmSync(fakeHome, { recursive: true, force: true });
+    expect(installHooksSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('falls back to global homedir migration when registry is empty but old global hooks exist', async () => {
-    const fakeHome = join(tmpdir(), `sonar-fake-home-${Date.now()}`);
-    const oldHooksDir = join(fakeHome, '.claude', 'hooks', 'sonar-secrets');
-    mkdirSync(oldHooksDir, { recursive: true });
+  it('passes projectRoot and undefined globalDir for non-global extensions', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', false)]);
+    loadStateSpy.mockReturnValue(state);
 
-    const state = getDefaultState('1.0.0');
-    state.agents['claude-code'].configured = true;
-    // No agentExtensions — pre-registry format
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+    await migrateClaudeCodeHooks(homedirFn);
 
-    await migrateClaudeCodeHooks(() => fakeHome);
-
-    // installHooks should have written settings.json under fakeHome/.claude
-    const settingsPath = join(fakeHome, '.claude', 'settings.json');
-    expect(existsSync(settingsPath)).toBe(true);
-
-    rmSync(fakeHome, { recursive: true, force: true });
+    expect(installHooksSpy).toHaveBeenCalledWith('/proj/root', undefined, false);
   });
 
-  it('skips migration when registry is empty and no global hooks exist', async () => {
-    const state = getDefaultState('1.0.0');
-    state.agents['claude-code'].configured = true;
-    // No agentExtensions, no global hooks dir
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+  it('passes projectRoot and homedirFn() as globalDir for global extensions', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', true)]);
+    loadStateSpy.mockReturnValue(state);
 
-    await runPostUpdateActions();
+    await migrateClaudeCodeHooks(homedirFn);
 
-    // No hooks installed in projectRoot (we never told it where to install)
-    expect(existsSync(join(projectRoot, '.claude'))).toBe(false);
+    expect(installHooksSpy).toHaveBeenCalledWith('/proj/root', FAKE_HOME, false);
   });
 
-  it('skips migration when agent is not configured', async () => {
-    const state = getDefaultState('1.0.0');
-    // configured = false (default)
-    writeFileSync(testStateFile, JSON.stringify(state), 'utf-8');
+  it('migrates hook scripts for each location before installing hooks', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', false)]);
+    loadStateSpy.mockReturnValue(state);
 
-    await runPostUpdateActions();
+    await migrateClaudeCodeHooks(homedirFn);
 
-    expect(existsSync(join(projectRoot, '.claude'))).toBe(false);
+    expect(migrateHookScriptsSpy).toHaveBeenCalledTimes(1);
+    expect(migrateHookScriptsSpy).toHaveBeenCalledWith('/proj/root', undefined);
+  });
+
+  it('deduplicates locations - installs hooks once for repeated (projectRoot, globalDir)', async () => {
+    const state = makeStateWithExtensions([
+      makeExtension('/proj/root', false),
+      makeExtension('/proj/root', false),
+    ]);
+    loadStateSpy.mockReturnValue(state);
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('installs hooks for multiple distinct locations', async () => {
+    const state = makeStateWithExtensions([
+      makeExtension('/proj/alpha', false),
+      makeExtension('/proj/beta', false),
+    ]);
+    loadStateSpy.mockReturnValue(state);
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to global migration when registry is empty, agent is configured, and global hooks dir exists', async () => {
+    const state = makeStateWithExtensions([]); // configured, no extensions
+    loadStateSpy.mockReturnValue(state);
+    existsSyncSpy.mockReturnValue(true); // globalHooksDir exists
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses homedirFn() as both projectRoot and globalDir in the pre-registry fallback', async () => {
+    const state = makeStateWithExtensions([]);
+    loadStateSpy.mockReturnValue(state);
+    existsSyncSpy.mockReturnValue(true);
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).toHaveBeenCalledWith(FAKE_HOME, FAKE_HOME, false);
+  });
+
+  it('does not fall back when agent is not configured', async () => {
+    const state = makeStateWithExtensions([], false); // configured = false
+    loadStateSpy.mockReturnValue(state);
+    existsSyncSpy.mockReturnValue(true); // hooks dir exists, but shouldn't matter
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).not.toHaveBeenCalled();
+  });
+
+  it('continues installing remaining locations when one throws', async () => {
+    const state = makeStateWithExtensions([
+      makeExtension('/proj/alpha', false),
+      makeExtension('/proj/beta', false),
+    ]);
+    loadStateSpy.mockReturnValue(state);
+    migrateHookScriptsSpy.mockImplementationOnce(() => {
+      throw new Error('migrate failed');
+    });
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    // First location failed, but second location still ran
+    expect(installHooksSpy).toHaveBeenCalledTimes(1);
+    expect(installHooksSpy).toHaveBeenCalledWith('/proj/beta', undefined, false);
+  });
+
+  it('does not throw when a location migration fails', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', false)]);
+    loadStateSpy.mockReturnValue(state);
+    installHooksSpy.mockRejectedValue(new Error('hook install failed'));
+
+    const actual = await migrateClaudeCodeHooks(homedirFn);
+
+    expect(actual).toBeUndefined();
   });
 });

--- a/tests/unit/repair.test.ts
+++ b/tests/unit/repair.test.ts
@@ -18,141 +18,133 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Tests for repair orchestrator
+import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
+import { repairToken } from '../../src/cli/commands/integrate/claude/repair';
+import * as token from '../../src/cli/commands/_common/token';
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../src/ui';
 
-import { describe, it, beforeEach, afterEach, expect, spyOn } from 'bun:test';
-import { mkdirSync, rmSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { runRepair } from '../../src/cli/commands/integrate/claude/repair';
-import * as auth from '../../src/cli/commands/_common/token';
-import type { HealthCheckResult } from '../../src/cli/commands/integrate/claude/health';
-import { setMockUi } from '../../src/ui';
+const SERVER_URL = 'https://sonarqube.example.com';
+const NEW_TOKEN = 'new-generated-token';
 
-const healthAllGood: HealthCheckResult = {
-  tokenValid: true,
-  serverAvailable: true,
-  projectAccessible: true,
-  organizationAccessible: true,
-  qualityProfilesAccessible: true,
-  hooksInstalled: true,
-  errors: [],
-};
-
-const healthNeedsHooks: HealthCheckResult = {
-  ...healthAllGood,
-  hooksInstalled: false,
-};
-
-describe('Repair Orchestrator', () => {
-  let testDir: string;
+describe('repairToken', () => {
+  let generateTokenSpy: Mock<
+    Extract<(typeof token)['generateTokenViaBrowser'], (...args: any[]) => any>
+  >;
+  let validateTokenSpy: Mock<Extract<(typeof token)['validateToken'], (...args: any[]) => any>>;
+  let saveTokenSpy: Mock<Extract<(typeof token)['saveToken'], (...args: any[]) => any>>;
+  let deleteTokenSpy: Mock<Extract<(typeof token)['deleteToken'], (...args: any[]) => any>>;
 
   beforeEach(() => {
     setMockUi(true);
-    testDir = join(tmpdir(), `test-repair-${Date.now()}`);
-    mkdirSync(testDir, { recursive: true });
+    generateTokenSpy = spyOn(token, 'generateTokenViaBrowser').mockResolvedValue(NEW_TOKEN);
+    validateTokenSpy = spyOn(token, 'validateToken').mockResolvedValue(true);
+    saveTokenSpy = spyOn(token, 'saveToken').mockResolvedValue(undefined);
+    deleteTokenSpy = spyOn(token, 'deleteToken').mockResolvedValue(undefined);
   });
 
   afterEach(() => {
-    setMockUi(false);
-    if (existsSync(testDir)) {
-      rmSync(testDir, { recursive: true, force: true });
-    }
-  });
-
-  it('creates .claude directory when repair runs', async () => {
-    await runRepair('https://sonarcloud.io', testDir, healthNeedsHooks, 'test_key', 'test-org');
-
-    expect(existsSync(join(testDir, '.claude'))).toBe(true);
-  });
-
-  it('creates hooks directory structure', async () => {
-    await runRepair('https://sonarcloud.io', testDir, healthNeedsHooks, 'test_key', 'test-org');
-
-    expect(existsSync(join(testDir, '.claude', 'hooks'))).toBe(true);
-  });
-
-  it('creates sonar-secrets hooks directory', async () => {
-    await runRepair('https://sonarcloud.io', testDir, healthNeedsHooks, 'test_key', 'test-org');
-
-    expect(existsSync(join(testDir, '.claude', 'hooks', 'sonar-secrets', 'build-scripts'))).toBe(
-      true,
-    );
-  });
-
-  it('does not create old sonar-prompt.sh verify hook', async () => {
-    await runRepair('https://sonarcloud.io', testDir, healthNeedsHooks, 'key', 'org');
-
-    expect(existsSync(join(testDir, '.claude', 'hooks', 'sonar-prompt.sh'))).toBe(false);
-  });
-});
-
-// ─── token invalid path ───────────────────────────────────────────────────────
-
-describe('Repair Orchestrator: token repair', () => {
-  let testDir: string;
-  let generateTokenSpy: ReturnType<typeof spyOn>;
-  let validateTokenSpy: ReturnType<typeof spyOn>;
-  let saveTokenSpy: ReturnType<typeof spyOn>;
-  let deleteTokenSpy: ReturnType<typeof spyOn>;
-
-  const healthTokenInvalid: HealthCheckResult = {
-    tokenValid: false,
-    serverAvailable: true,
-    projectAccessible: true,
-    organizationAccessible: true,
-    qualityProfilesAccessible: true,
-    hooksInstalled: true,
-    errors: [],
-  };
-
-  beforeEach(() => {
-    setMockUi(true);
-    testDir = join(tmpdir(), `test-repair-token-${Date.now()}`);
-    mkdirSync(testDir, { recursive: true });
-    generateTokenSpy = spyOn(auth, 'generateTokenViaBrowser').mockResolvedValue('new-token');
-    validateTokenSpy = spyOn(auth, 'validateToken').mockResolvedValue(true);
-    saveTokenSpy = spyOn(auth, 'saveToken').mockResolvedValue(undefined);
-    deleteTokenSpy = spyOn(auth, 'deleteToken').mockResolvedValue(undefined);
-  });
-
-  afterEach(() => {
+    clearMockUiCalls();
     setMockUi(false);
     generateTokenSpy.mockRestore();
     validateTokenSpy.mockRestore();
     saveTokenSpy.mockRestore();
     deleteTokenSpy.mockRestore();
-    if (existsSync(testDir)) {
-      rmSync(testDir, { recursive: true, force: true });
-    }
   });
 
-  it('generates a new token when tokenValid is false', async () => {
-    await runRepair('https://sonarcloud.io', testDir, healthTokenInvalid);
-    expect(generateTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io');
-  });
+  it('shows "Obtaining access token..." text message', async () => {
+    await repairToken(SERVER_URL);
 
-  it('deletes old token before generating a new one', async () => {
-    await runRepair('https://sonarcloud.io', testDir, healthTokenInvalid, 'proj', 'my-org');
-    expect(deleteTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'my-org');
-  });
-
-  it('validates generated token and saves it when valid', async () => {
-    await runRepair('https://sonarcloud.io', testDir, healthTokenInvalid, 'proj', 'my-org');
-    expect(validateTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'new-token');
-    expect(saveTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'new-token', 'my-org');
-  });
-
-  it('throws when generated token fails validation', () => {
-    validateTokenSpy.mockResolvedValue(false);
-    expect(runRepair('https://sonarcloud.io', testDir, healthTokenInvalid)).rejects.toThrow(
-      'Generated token is invalid',
+    const msg = getMockUiCalls().find(
+      (c) => c.method === 'text' && String(c.args[0]) === 'Obtaining access token...',
     );
+    expect(msg).toBeDefined();
   });
 
-  it('continues if deleteToken throws (non-fatal)', async () => {
+  it('shows "Token saved to keychain" success message', async () => {
+    await repairToken(SERVER_URL);
+
+    const msg = getMockUiCalls().find(
+      (c) => c.method === 'success' && String(c.args[0]) === 'Token saved to keychain',
+    );
+    expect(msg).toBeDefined();
+  });
+
+  it('generates a new token via browser using the provided server URL', async () => {
+    await repairToken(SERVER_URL);
+
+    expect(generateTokenSpy).toHaveBeenCalledTimes(1);
+    expect(generateTokenSpy).toHaveBeenCalledWith(SERVER_URL);
+  });
+
+  it('returns the newly generated token', async () => {
+    const actual = await repairToken(SERVER_URL);
+
+    expect(actual).toBe(NEW_TOKEN);
+  });
+
+  it('validates the generated token against the server', async () => {
+    await repairToken(SERVER_URL);
+
+    expect(validateTokenSpy).toHaveBeenCalledTimes(1);
+    expect(validateTokenSpy).toHaveBeenCalledWith(SERVER_URL, NEW_TOKEN);
+  });
+
+  it('throws when the generated token fails validation', () => {
+    validateTokenSpy.mockResolvedValue(false);
+
+    const actual = repairToken(SERVER_URL);
+
+    expect(actual).rejects.toThrow('Generated token is invalid');
+  });
+
+  it('does not save the token when validation fails', async () => {
+    validateTokenSpy.mockResolvedValue(false);
+
+    const actual = repairToken(SERVER_URL);
+
+    await actual.catch(() => {});
+    expect(saveTokenSpy).not.toHaveBeenCalled();
+  });
+
+  it('deletes the old token with the provided organization', async () => {
+    await repairToken(SERVER_URL, 'my-org');
+
+    expect(deleteTokenSpy).toHaveBeenCalledTimes(1);
+    expect(deleteTokenSpy).toHaveBeenCalledWith(SERVER_URL, 'my-org');
+  });
+
+  it('deletes the old token without organization when none is provided', async () => {
+    await repairToken(SERVER_URL);
+
+    expect(deleteTokenSpy).toHaveBeenCalledWith(SERVER_URL, undefined);
+  });
+
+  it('continues and saves the new token even when deleteToken throws', async () => {
     deleteTokenSpy.mockRejectedValue(new Error('keychain unavailable'));
-    await runRepair('https://sonarcloud.io', testDir, healthTokenInvalid);
-    expect(generateTokenSpy).toHaveBeenCalled();
+
+    await repairToken(SERVER_URL);
+
+    expect(saveTokenSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when deleteToken fails', async () => {
+    deleteTokenSpy.mockRejectedValue(new Error('keychain locked'));
+
+    const actual = await repairToken(SERVER_URL);
+
+    expect(actual).toBe(NEW_TOKEN);
+  });
+
+  it('saves the new token to the keychain with the provided organization', async () => {
+    await repairToken(SERVER_URL, 'my-org');
+
+    expect(saveTokenSpy).toHaveBeenCalledTimes(1);
+    expect(saveTokenSpy).toHaveBeenCalledWith(SERVER_URL, NEW_TOKEN, 'my-org');
+  });
+
+  it('saves the new token to the keychain without organization when none is provided', async () => {
+    await repairToken(SERVER_URL);
+
+    expect(saveTokenSpy).toHaveBeenCalledWith(SERVER_URL, NEW_TOKEN, undefined);
   });
 });


### PR DESCRIPTION
# Behavior changes
1. `sonar integrate claude` now relies on the authentication flow (via `resolveAuth`)
2. the resolution of the organization follows
    * `-o --org` option
    * fallback to `auth login` configuration
    * fallback to local project discovery (`sonar-project.properties` and `connectecMode.json`)
3. similar flow for `serverUrl` and `projectKey`

# Expect
1. no other change in behavior
2. cleanup on the `integrate/` code (removed duplicated code)
3. extensive unit tests
4. refactoring for testability
5. extraction of reusable functions