### PR TITLE
Add linux-arm64 build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,10 @@ jobs:
             runner: github-ubuntu-latest-m
             target: bun-linux-x64
             platform: linux-x86-64
+          - os: linux-arm64
+            runner: github-ubuntu-latest-arm64-m
+            target: bun-linux-arm64
+            platform: linux-arm64
           - os: macos
             runner: macos-latest-xlarge
             target: bun-darwin-arm64
@@ -237,6 +241,12 @@ jobs:
           name: binary-linux
           path: dist/
 
+      - name: Download linux-arm64 binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          name: binary-linux-arm64
+          path: dist/
+
       - name: Download macos binary
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
@@ -265,7 +275,7 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           PROJECT: ${{ github.event.repository.name }}
           BUILD_NUMBER: ${{ needs.prepare.outputs.BUILD_NUMBER }}
-          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64,org.sonarsource.cli:sonarqube-cli:exe:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
+          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64,org.sonarsource.cli:sonarqube-cli:exe:linux-arm64,org.sonarsource.cli:sonarqube-cli:exe:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
         run: |
           jf config add repox \
             --artifactory-url="${ARTIFACTORY_URL}" \

--- a/user-scripts/install-prerelease.sh
+++ b/user-scripts/install-prerelease.sh
@@ -12,21 +12,34 @@ trap cleanup EXIT
 
 BASE_URL="https://repox.jfrog.io/artifactory/sonarsource-public-builds/org/sonarsource/cli/sonarqube-cli"
 
-detect_platform() {
+detect_os() {
   local os
   os="$(uname -s)"
   case "$os" in
-    Linux*)
-      echo "linux-x86-64"
-      ;;
-    Darwin*)
-      echo "macos-arm64"
-      ;;
+    Linux*)  echo "linux" ;;
+    Darwin*) echo "macos" ;;
     *)
       echo "Unsupported operating system: $os" >&2
       exit 1
       ;;
   esac
+}
+
+detect_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) echo "x86-64" ;;
+    aarch64|arm64) echo "arm64" ;;
+    *)
+      echo "Unsupported architecture: $machine" >&2
+      exit 1
+      ;;
+  esac
+}
+
+detect_platform() {
+  echo "$(detect_os)-$(detect_arch)"
 }
 
 fetch_with_auth() {

--- a/user-scripts/install.sh
+++ b/user-scripts/install.sh
@@ -25,11 +25,21 @@ detect_os() {
   esac
 }
 
-detect_platform() {
-  case "$(detect_os)" in
-    linux) echo "linux-x86-64" ;;
-    macos)   echo "macos-arm64" ;;
+detect_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) echo "x86-64" ;;
+    aarch64|arm64) echo "arm64" ;;
+    *)
+      echo "Unsupported architecture: $machine" >&2
+      exit 1
+      ;;
   esac
+}
+
+detect_platform() {
+  echo "$(detect_os)-$(detect_arch)"
 }
 
 resolve_latest_version() {


### PR DESCRIPTION
## Summary
- Add architecture detection (`uname -m`) to `install.sh` and `install-prerelease.sh` so they resolve `linux-arm64` on ARM hosts and `linux-x86-64` on x86 hosts
- Add `linux-arm64` matrix entry to the CI build pipeline (`build.yml`) with `bun-linux-arm64` compile target
- Add artifact download step and publish entry for the new `linux-arm64` binary

## Test plan
- [ ] Verify the `github-ubuntu-latest-arm64-m` runner is available in CI
- [ ] Confirm the `bun-linux-arm64` compile target produces a working binary
- [ ] Run `install.sh` on a linux-arm64 host and verify correct platform detection
- [ ] Run `install.sh` on a linux-x86-64 host and verify no regression
- [ ] Run `install.sh` on macOS and verify no regression