### PR TITLE
Add macos-x86-64 build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,13 +64,17 @@ jobs:
             runner: macos-latest-xlarge
             target: bun-darwin-arm64
             platform: macos-arm64
+          - os: macos-x86-64
+            runner: macos-13
+            target: bun-darwin-x64
+            platform: macos-x86-64
           - os: windows
             runner: warp-custom-windows-2022-s
             target: bun-windows-x64
             platform: windows-x86-64
     steps:
       - name: Setup Cloudflare WARP (macOS only)
-        if: matrix.os == 'macos'
+        if: startsWith(matrix.os, 'macos')
         uses: SonarSource/gh-action_setup-cloudflare-warp@v1
 
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -126,7 +130,7 @@ jobs:
 
       - name: Fetch Apple Developer Certificate secrets (macOS only)
         id: apple-secrets
-        if: matrix.os == 'macos' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))
+        if: startsWith(matrix.os, 'macos') && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))
         uses: SonarSource/vault-action-wrapper@320bd31b03e5dacaac6be51bbbb15adf7caccc32 # 3.1.0
         with:
           secrets: |
@@ -137,7 +141,7 @@ jobs:
             development/kv/data/sign/sonarqube-cli APPLE_APP_SPECIFIC_PASSWORD | APPLE_APP_SPECIFIC_PASSWORD;
 
       - name: Code-sign and notarize binary (macOS only)
-        if: matrix.os == 'macos' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))
+        if: startsWith(matrix.os, 'macos') && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))
         env:
           CERTIFICATE: ${{ fromJSON(steps.apple-secrets.outputs.vault || '{}').CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ fromJSON(steps.apple-secrets.outputs.vault || '{}').CSC_KEY_PASSWORD }}
@@ -170,7 +174,7 @@ jobs:
           rm /tmp/notarize.zip
 
       - name: Clean up build keychain
-        if: always() && matrix.os == 'macos' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))
+        if: always() && startsWith(matrix.os, 'macos') && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))
         run: |
           security default-keychain -s ~/Library/Keychains/login.keychain-db 2>/dev/null || true
           security delete-keychain build.keychain 2>/dev/null || true
@@ -243,6 +247,12 @@ jobs:
           name: binary-macos
           path: dist/
 
+      - name: Download macos-x86-64 binary
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
+        with:
+          name: binary-macos-x86-64
+          path: dist/
+
       - name: Download windows binary
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
@@ -265,7 +275,7 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           PROJECT: ${{ github.event.repository.name }}
           BUILD_NUMBER: ${{ needs.prepare.outputs.BUILD_NUMBER }}
-          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64,org.sonarsource.cli:sonarqube-cli:exe:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
+          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64,org.sonarsource.cli:sonarqube-cli:exe:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:macos-x86-64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
         run: |
           jf config add repox \
             --artifactory-url="${ARTIFACTORY_URL}" \

--- a/user-scripts/install-prerelease.sh
+++ b/user-scripts/install-prerelease.sh
@@ -12,21 +12,34 @@ trap cleanup EXIT
 
 BASE_URL="https://repox.jfrog.io/artifactory/sonarsource-public-builds/org/sonarsource/cli/sonarqube-cli"
 
-detect_platform() {
+detect_os() {
   local os
   os="$(uname -s)"
   case "$os" in
-    Linux*)
-      echo "linux-x86-64"
-      ;;
-    Darwin*)
-      echo "macos-arm64"
-      ;;
+    Linux*)  echo "linux" ;;
+    Darwin*) echo "macos" ;;
     *)
       echo "Unsupported operating system: $os" >&2
       exit 1
       ;;
   esac
+}
+
+detect_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) echo "x86-64" ;;
+    aarch64|arm64) echo "arm64" ;;
+    *)
+      echo "Unsupported architecture: $machine" >&2
+      exit 1
+      ;;
+  esac
+}
+
+detect_platform() {
+  echo "$(detect_os)-$(detect_arch)"
 }
 
 fetch_with_auth() {

--- a/user-scripts/install.sh
+++ b/user-scripts/install.sh
@@ -25,11 +25,21 @@ detect_os() {
   esac
 }
 
-detect_platform() {
-  case "$(detect_os)" in
-    linux) echo "linux-x86-64" ;;
-    macos)   echo "macos-arm64" ;;
+detect_arch() {
+  local machine
+  machine="$(uname -m)"
+  case "$machine" in
+    x86_64|amd64) echo "x86-64" ;;
+    aarch64|arm64) echo "arm64" ;;
+    *)
+      echo "Unsupported architecture: $machine" >&2
+      exit 1
+      ;;
   esac
+}
+
+detect_platform() {
+  echo "$(detect_os)-$(detect_arch)"
 }
 
 resolve_latest_version() {


### PR DESCRIPTION
## Summary
- Add architecture detection (`uname -m`) to `install.sh` and `install-prerelease.sh` so they resolve `macos-x86-64` on Intel hosts and `macos-arm64` on Apple Silicon hosts
- Add `macos-x86-64` matrix entry to the CI build pipeline (`build.yml`) with `bun-darwin-x64` compile target
- Add artifact download step and publish entry for the new `macos-x86-64` binary
- Update macOS-specific CI conditions to use `startsWith(matrix.os, 'macos')` so code-signing and notarization apply to both macOS variants

## Test plan
- [x] Verify `detect_arch` returns `x86-64` on an Intel Mac (`uname -m` → `x86_64`)
- [x] Verify `detect_platform` returns `macos-x86-64` on an Intel Mac
- [x] Build binary locally with `bun run build:binary` on Intel Mac — produces `Mach-O 64-bit executable x86_64`
- [x] Install and run `sonar --version` / `sonar --help` on Intel Mac — works correctly
- [ ] Confirm the `macos-13` runner produces a working binary in CI
- [ ] Run `install.sh` on macOS ARM64 and verify no regression
- [ ] Run `install.sh` on Linux x86-64 and verify no regression