### PR TITLE
CLI-95 Correct SQC US auth and add mentions of US in help and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,26 @@ irm https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/maste
 ```
 
 ## Setup steps for Claude Code integration
-Below is an example of a setup which will work for SonarQube Cloud.
+
+Below is an example of a setup which will work for SonarQube Cloud EU (default).
 The authentication step is optional. With authentication, more types of secrets can be detected.
 
 ```
 sonar auth login
+sonar integrate claude -g
+```
+
+For SonarQube Cloud US, pass the server URL explicitly:
+
+```
+sonar auth login --server https://sonarqube.us
+sonar integrate claude -g
+```
+
+For SonarQube Server, pass your instance URL:
+
+```
+sonar auth login --server https://sonarqube.mycompany.com
 sonar integrate claude -g
 ```
 
@@ -36,10 +51,10 @@ The full list of commands is available at https://cli.sonarqube.com
 
 ## Exit Codes
 
-| Code | Meaning                           |
-|------|-----------------------------------|
-| 0    | Success                           |
-| 1    | Error (validation, execution, etc.) |
+| Code | Meaning                              |
+|------|--------------------------------------|
+| 0    | Success                              |
+| 1    | Error (validation, execution, etc.)  |
 
 ---
 

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -177,7 +177,7 @@ auth
   .description('Save authentication token to keychain')
   .option(
     '-s, --server <server>',
-    'SonarQube URL (default is SonarQube Cloud https://sonarcloud.io)',
+    'SonarQube Server URL, SonarQube Cloud EU (https://sonarcloud.io), or SonarQube Cloud US (https://sonarqube.us). Defaults to SonarQube Cloud EU.',
   )
   .option('-o, --org <org>', 'SonarQube Cloud organization key (required for SonarQube Cloud)')
   .option('-t, --with-token <with-token>', 'Token value (skips browser, non-interactive mode)')

--- a/src/cli/commands/auth/login.ts
+++ b/src/cli/commands/auth/login.ts
@@ -19,7 +19,8 @@
  */
 
 import { generateTokenViaBrowser } from '../../../cli/commands/_common/token';
-import { SONARCLOUD_HOSTNAME, SONARCLOUD_URL } from '../../../lib/config-constants';
+import { cloudRegionFromUrl, isSonarQubeCloud } from '../../../lib/auth-resolver';
+import { SONARCLOUD_URL } from '../../../lib/config-constants';
 import { deleteStaleTokens, getToken as getKeystoreToken, saveToken } from '../../../lib/keychain';
 import { discoverOrganization, discoverServer } from '../../../lib/project-workspace';
 import { addOrUpdateConnection, loadState, saveState } from '../../../lib/state-manager';
@@ -33,8 +34,7 @@ import { CommandFailedError, InvalidOptionError } from '../_common/error';
 export async function authLogin(options: AuthLoginOptions): Promise<void> {
   const server = await validateLoginOptions(options);
 
-  const isCloud = isSonarCloud(server);
-  const region = (options.region || 'eu') as 'eu' | 'us';
+  const isCloud = isSonarQubeCloud(server);
   const isNonInteractive = !!options.withToken;
 
   const token = await getOrGenerateToken(server, options.org, isNonInteractive, options.withToken);
@@ -55,7 +55,7 @@ export async function authLogin(options: AuthLoginOptions): Promise<void> {
 
   const connection = addOrUpdateConnection(state, server, isCloud ? 'cloud' : 'on-premise', {
     orgKey: org,
-    region: isCloud ? region : undefined,
+    region: cloudRegionFromUrl(server),
   });
 
   // Fetch server-side IDs for telemetry enrichment (best effort, non-blocking on error).
@@ -73,25 +73,13 @@ export async function authLogin(options: AuthLoginOptions): Promise<void> {
 
   saveState(state);
 
-  const displayServer = isSonarCloud(server) ? `${server} (${org})` : server;
+  const displayServer = isSonarQubeCloud(server) ? `${server} (${org})` : server;
   success(`Authentication successful for: ${displayServer}`);
 
   // When org came from config we never ran the org selection prompts, so stdin is still
   // resumed from the token step (for Windows). Pause it so the process can exit.
   if (process.stdin.isTTY) {
     process.stdin.pause();
-  }
-}
-
-/**
- * Check if server is SonarCloud
- */
-function isSonarCloud(serverURL: string): boolean {
-  try {
-    const url = new URL(serverURL);
-    return url.hostname === SONARCLOUD_HOSTNAME;
-  } catch {
-    return false;
   }
 }
 
@@ -128,7 +116,7 @@ async function getOrGenerateToken(
 
   const existingToken = await getKeystoreToken(server, org);
   if (existingToken) {
-    const displayServer = isSonarCloud(server) ? `${server} (${org})` : server;
+    const displayServer = isSonarQubeCloud(server) ? `${server} (${org})` : server;
     print(`Token already exists for: ${displayServer}`);
     print('You are already authenticated');
     return existingToken;
@@ -232,7 +220,6 @@ async function validateLoginOptions(options: {
   server?: string;
   org?: string;
   withToken?: string;
-  region?: string;
 }) {
   if (options.org !== undefined && !options.org.trim()) {
     throw new InvalidOptionError(
@@ -274,5 +261,4 @@ export interface AuthLoginOptions {
   server?: string;
   org?: string;
   withToken?: string;
-  region?: string;
 }

--- a/src/lib/auth-resolver.ts
+++ b/src/lib/auth-resolver.ts
@@ -31,6 +31,7 @@ import {
 } from './config-constants';
 import { getToken } from './keychain.js';
 import logger from './logger.js';
+import type { CloudRegion } from './state.js';
 import { getActiveConnection, loadState } from './state-manager.js';
 
 export const ENV_TOKEN = 'SONARQUBE_CLI_TOKEN';
@@ -143,8 +144,9 @@ export async function resolveFromState(): Promise<ResolvedAuth | null> {
  */
 export function resolveFromEndpoint(serverUrl: string, endpoint: string): string {
   const normalized = serverUrl.replace(/\/$/, '');
-  if (isSonarQubeCloud(serverUrl)) {
-    const isUS = new URL(serverUrl).hostname === SONARCLOUD_US_HOSTNAME;
+  const region = cloudRegionFromUrl(serverUrl);
+  if (region !== undefined) {
+    const isUS = region === 'us';
 
     if (endpoint.startsWith('/api')) {
       return isUS ? SONARCLOUD_US_URL : SONARCLOUD_URL;
@@ -155,11 +157,17 @@ export function resolveFromEndpoint(serverUrl: string, endpoint: string): string
   return normalized;
 }
 
-export function isSonarQubeCloud(serverUrl: string): boolean {
+export function cloudRegionFromUrl(serverUrl: string): CloudRegion | undefined {
   try {
-    const url = new URL(serverUrl);
-    return url.hostname === SONARCLOUD_HOSTNAME || url.hostname === SONARCLOUD_US_HOSTNAME;
+    const { hostname } = new URL(serverUrl);
+    if (hostname === SONARCLOUD_US_HOSTNAME) return 'us';
+    if (hostname === SONARCLOUD_HOSTNAME) return 'eu';
+    return undefined;
   } catch {
-    return false;
+    return undefined;
   }
+}
+
+export function isSonarQubeCloud(serverUrl: string): boolean {
+  return cloudRegionFromUrl(serverUrl) !== undefined;
 }

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -22,7 +22,6 @@
 
 import { version as VERSION } from '../../package.json';
 import { isSonarQubeCloud, resolveFromEndpoint } from '../lib/auth-resolver';
-import { SONARCLOUD_URL, SONARCLOUD_US_URL } from '../lib/config-constants.js';
 import { print } from '../ui';
 
 const GET_REQUEST_TIMEOUT_MS = 30000; // 30 seconds
@@ -42,7 +41,7 @@ export class SonarQubeClient {
   constructor(serverURL: string, token: string) {
     this.serverURL = serverURL.replace(/\/$/, ''); // Remove trailing slash
     this.token = token;
-    this.isCloud = serverURL.includes(SONARCLOUD_URL) || serverURL.includes(SONARCLOUD_US_URL);
+    this.isCloud = isSonarQubeCloud(serverURL);
   }
 
   private commonHeaders(contentType?: 'json' | 'form'): Record<string, string> {

--- a/tests/integration/specs/auth/auth.test.ts
+++ b/tests/integration/specs/auth/auth.test.ts
@@ -102,6 +102,38 @@ describe('auth login', () => {
     },
     { timeout: 15000 },
   );
+
+  it(
+    'saves token and org when logging in to SonarCloud US',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('my-token')
+        .withOrganizations([{ key: 'us-org', name: 'US Org' }])
+        .start();
+
+      const result = await harness.run(
+        `auth login --with-token my-token --server ${server.baseUrl()}`,
+        {
+          extraEnv: {
+            SONARQUBE_CLI_SONARCLOUD_US_URL: server.baseUrl(),
+            SONARQUBE_CLI_SONARCLOUD_US_API_URL: server.baseUrl(),
+          },
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Authentication successful');
+
+      const state = harness.stateJsonFile.asJson() as {
+        auth: { connections: Array<{ type: string; orgKey: string; region: string }> };
+      };
+      expect(state.auth.connections[0].type).toBe('cloud');
+      expect(state.auth.connections[0].orgKey).toBe('us-org');
+      expect(state.auth.connections[0].region).toBe('us');
+    },
+    { timeout: 15000 },
+  );
 });
 
 const LARGE_ORG_TOTAL = 200;

--- a/tests/unit/cli/commands/auth/auth-resolver.test.ts
+++ b/tests/unit/cli/commands/auth/auth-resolver.test.ts
@@ -23,6 +23,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import {
+  cloudRegionFromUrl,
   ENV_SERVER,
   ENV_TOKEN,
   resolveAuth,
@@ -244,5 +245,29 @@ describe('resolveBaseUrl', () => {
   it('returns the input as-is when the URL is not parseable', () => {
     const result = resolveFromEndpoint('not-a-valid-url', '/api/system/status');
     expect(result).toBe('not-a-valid-url');
+  });
+
+  it('returns the SonarCloud US URL for /api endpoints', () => {
+    const result = resolveFromEndpoint('https://sonarqube.us', '/api/system/status');
+    expect(result).toBe('https://sonarqube.us');
+  });
+
+  it('returns the SonarCloud US API URL for non-/api endpoints', () => {
+    const result = resolveFromEndpoint('https://sonarqube.us', '/organizations/search');
+    expect(result).toBe('https://api.sonarqube.us');
+  });
+});
+
+describe('cloudRegionFromUrl', () => {
+  it("returns 'eu' for SonarCloud EU", () => {
+    expect(cloudRegionFromUrl('https://sonarcloud.io')).toBe('eu');
+  });
+
+  it("returns 'us' for SonarCloud US", () => {
+    expect(cloudRegionFromUrl('https://sonarqube.us')).toBe('us');
+  });
+
+  it('returns undefined for a self-hosted SonarQube Server', () => {
+    expect(cloudRegionFromUrl('https://sonar.mycompany.com')).toBeUndefined();
   });
 });


### PR DESCRIPTION
The issue with the auth was mentioned here: https://sonarsource.atlassian.net/browse/DOC-3292?focusedCommentId=896293
It was saving SQC US as 'on-prem'. Also, there was a not-exposed parameter `region` that always defaulted to 'eu'. Now SQC US   saved correcly as:
```
        "type": "cloud",
        "serverUrl": "https://sonarqube.us",
        "region": "us",
```