### PR TITLE
CLI-158 Replace legacy pre-commit configuration when encountered.

### DIFF
--- a/src/cli/commands/integrate/git/git-precommit-framework.ts
+++ b/src/cli/commands/integrate/git/git-precommit-framework.ts
@@ -26,12 +26,13 @@ import { join } from 'node:path';
 import yaml from 'js-yaml';
 
 import { spawnProcess } from '../../../../lib/process';
-import { success } from '../../../../ui';
+import { success, text } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 import type { GitHookType } from '.';
 
 export const PRE_COMMIT_CONFIG_FILE = '.pre-commit-config.yaml';
 const PRE_COMMIT_SONAR_HOOK_ID = 'sonar-secrets';
+export const PRE_COMMIT_LEGACY_REPO = 'https://github.com/SonarSource/sonar-secrets-pre-commit';
 
 interface PreCommitHookEntry {
   id: string;
@@ -48,13 +49,13 @@ interface PreCommitRepo {
   hooks: PreCommitHookEntry[];
 }
 
-interface PreCommitConfig {
+export interface PreCommitConfig {
   repos: PreCommitRepo[];
   [key: string]: unknown;
 }
 
 function buildSonarPreCommitHook(stage: GitHookType): PreCommitHookEntry {
-  const base: PreCommitHookEntry = {
+  return {
     id: PRE_COMMIT_SONAR_HOOK_ID,
     name: 'Sonar secrets scan',
     entry: 'sonar analyze secrets --',
@@ -62,7 +63,6 @@ function buildSonarPreCommitHook(stage: GitHookType): PreCommitHookEntry {
     pass_filenames: true,
     stages: [stage],
   };
-  return base;
 }
 
 function parsePreCommitConfig(raw: unknown): PreCommitConfig {
@@ -83,35 +83,50 @@ function isSonarHookEntry(hookEntry: unknown): hookEntry is PreCommitHookEntry {
   );
 }
 
-function findExistingSonarHook(configPath: string): {
-  config: PreCommitConfig;
-  repo: { hooks: unknown[] } | undefined;
-  index: number;
-} {
-  let config: PreCommitConfig;
+function readPreCommitConfig(root: string): PreCommitConfig {
   try {
-    config = parsePreCommitConfig(yaml.load(readFileSync(configPath, 'utf-8')));
+    return parsePreCommitConfig(
+      yaml.load(readFileSync(join(root, PRE_COMMIT_CONFIG_FILE), 'utf-8')),
+    );
   } catch {
-    config = { repos: [] };
+    return { repos: [] };
   }
-  const repo = config.repos.find((r) => r.repo === 'local' && Array.isArray(r.hooks)) as
-    | { hooks: unknown[] }
-    | undefined;
-  return { config, repo, index: repo ? repo.hooks.findIndex(isSonarHookEntry) : -1 };
 }
 
-/** Upsert the sonar-secrets hook into .pre-commit-config.yaml. */
-export function upsertPreCommitConfig(root: string, stage: GitHookType): void {
-  const configPath = join(root, PRE_COMMIT_CONFIG_FILE);
+function writePreCommitConfig(root: string, config: PreCommitConfig): void {
+  writeFileSync(join(root, PRE_COMMIT_CONFIG_FILE), yaml.dump(config, { lineWidth: -1 }), 'utf-8');
+}
+
+function findLocalRepo(config: PreCommitConfig): PreCommitRepo | undefined {
+  return config.repos.find((r) => r.repo === 'local' && Array.isArray(r.hooks));
+}
+
+/** Removes the legacy sonar-secrets-pre-commit repo entry. Returns true if anything was removed. */
+export function removeLegacyHook(config: PreCommitConfig): boolean {
+  const before = config.repos.length;
+  config.repos = config.repos.filter((r) => r.repo !== PRE_COMMIT_LEGACY_REPO);
+  return config.repos.length < before;
+}
+
+/** Upserts the sonar-secrets hook into the local repo entry of a config object. */
+export function upsertSonarHook(config: PreCommitConfig, stage: GitHookType): void {
   const sonarHook = buildSonarPreCommitHook(stage);
-  const { config, repo, index } = findExistingSonarHook(configPath);
-  if (repo) {
-    const idx = index >= 0 ? index : repo.hooks.length;
-    repo.hooks[idx] = sonarHook;
+  const localRepo = findLocalRepo(config);
+  if (localRepo) {
+    const index = localRepo.hooks.findIndex(isSonarHookEntry);
+    const idx = index >= 0 ? index : localRepo.hooks.length;
+    localRepo.hooks[idx] = sonarHook;
   } else {
     config.repos.push({ repo: 'local', hooks: [sonarHook] });
   }
-  writeFileSync(configPath, yaml.dump(config, { lineWidth: -1 }), 'utf-8');
+}
+
+/** Return true if .pre-commit-config.yaml already contains the sonar-secrets local hook. */
+export function hasSonarHookInPreCommitConfig(root: string): boolean {
+  if (!existsSync(join(root, PRE_COMMIT_CONFIG_FILE))) {
+    return false;
+  }
+  return findLocalRepo(readPreCommitConfig(root))?.hooks.some(isSonarHookEntry) ?? false;
 }
 
 async function runPreCommitCommand(args: string[], cwd: string): Promise<void> {
@@ -140,16 +155,14 @@ export async function runPreCommitInstall(root: string, hook: GitHookType): Prom
   }
 }
 
-/** Return true if .pre-commit-config.yaml already contains the sonar-secrets local hook. */
-export function hasSonarHookInPreCommitConfig(root: string): boolean {
-  const configPath = join(root, PRE_COMMIT_CONFIG_FILE);
-  if (!existsSync(configPath)) return false;
-  const { repo, index } = findExistingSonarHook(configPath);
-  return repo !== undefined && index >= 0;
-}
-
 export async function installViaPreCommitFramework(root: string, hook: GitHookType): Promise<void> {
-  upsertPreCommitConfig(root, hook);
+  const config = readPreCommitConfig(root);
+  const isLegacyHookRemoved = removeLegacyHook(config);
+  upsertSonarHook(config, hook);
+  writePreCommitConfig(root, config);
+  if (isLegacyHookRemoved) {
+    text(`Removed legacy ${PRE_COMMIT_LEGACY_REPO} hook from ${PRE_COMMIT_CONFIG_FILE}.`);
+  }
   try {
     await runPreCommitInstall(root, hook);
   } catch {

--- a/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
@@ -29,8 +29,11 @@ import {
   hasSonarHookInPreCommitConfig,
   installViaPreCommitFramework,
   PRE_COMMIT_CONFIG_FILE,
+  PRE_COMMIT_LEGACY_REPO,
+  type PreCommitConfig,
+  removeLegacyHook,
   runPreCommitInstall,
-  upsertPreCommitConfig,
+  upsertSonarHook,
 } from '../../../../../../src/cli/commands/integrate/git/git-precommit-framework';
 import * as processLib from '../../../../../../src/lib/process.js';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../../src/ui/mock';
@@ -40,12 +43,118 @@ const TEMP_DIR = join(process.cwd(), 'tests', 'unit', '.git-precommit-framework-
 const PRE_COMMIT_OK = { exitCode: 0, stdout: '', stderr: '' };
 const PRE_COMMIT_FAIL = { exitCode: 1, stdout: '', stderr: 'something went wrong' };
 
-function readConfig(): Record<string, unknown> {
-  return yaml.load(readFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), 'utf-8')) as Record<
-    string,
-    unknown
-  >;
-}
+describe('removeLegacyHook', () => {
+  it('removes the legacy repo entry and returns true', () => {
+    const config: PreCommitConfig = {
+      repos: [
+        {
+          repo: PRE_COMMIT_LEGACY_REPO,
+          hooks: [{ id: 'sonar-secrets', name: 'x', entry: 'e', language: 'system' }],
+        },
+      ],
+    };
+    expect(removeLegacyHook(config)).toBe(true);
+    expect(config.repos).toHaveLength(0);
+  });
+
+  it('returns false when no legacy repo is present', () => {
+    const config: PreCommitConfig = { repos: [] };
+    expect(removeLegacyHook(config)).toBe(false);
+  });
+
+  it('preserves unrelated repos', () => {
+    const config: PreCommitConfig = {
+      repos: [
+        { repo: PRE_COMMIT_LEGACY_REPO, hooks: [] },
+        { repo: 'https://github.com/pre-commit/pre-commit-hooks', hooks: [] },
+      ],
+    };
+    removeLegacyHook(config);
+    expect(config.repos).toHaveLength(1);
+    expect(config.repos[0].repo).toBe('https://github.com/pre-commit/pre-commit-hooks');
+  });
+});
+
+describe('upsertSonarHook', () => {
+  it('creates a local repo with the sonar-secrets hook when no repos exist', () => {
+    const config: PreCommitConfig = { repos: [] };
+    upsertSonarHook(config, 'pre-commit');
+    const localRepo = config.repos.find((r) => r.repo === 'local');
+    expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
+  });
+
+  it('sets stage to pre-commit', () => {
+    const config: PreCommitConfig = { repos: [] };
+    upsertSonarHook(config, 'pre-commit');
+    const hook = config.repos
+      .find((r) => r.repo === 'local')
+      ?.hooks.find((h) => h.id === 'sonar-secrets');
+    expect(hook?.stages).toEqual(['pre-commit']);
+  });
+
+  it('sets stage to pre-push', () => {
+    const config: PreCommitConfig = { repos: [] };
+    upsertSonarHook(config, 'pre-push');
+    const hook = config.repos
+      .find((r) => r.repo === 'local')
+      ?.hooks.find((h) => h.id === 'sonar-secrets');
+    expect(hook?.stages).toEqual(['pre-push']);
+  });
+
+  it('appends a local repo when only unrelated repos exist', () => {
+    const config: PreCommitConfig = {
+      repos: [{ repo: 'https://github.com/pre-commit/pre-commit-hooks', hooks: [] }],
+    };
+    upsertSonarHook(config, 'pre-commit');
+    expect(config.repos).toHaveLength(2);
+    expect(
+      config.repos.find((r) => r.repo === 'local')?.hooks.some((h) => h.id === 'sonar-secrets'),
+    ).toBe(true);
+  });
+
+  it('adds the hook to an existing local repo that has no sonar-secrets hook yet', () => {
+    const config: PreCommitConfig = {
+      repos: [
+        { repo: 'local', hooks: [{ id: 'other-hook', name: 'x', entry: 'e', language: 'system' }] },
+      ],
+    };
+    upsertSonarHook(config, 'pre-commit');
+    const localRepo = config.repos.find((r) => r.repo === 'local');
+    expect(localRepo?.hooks).toHaveLength(2);
+    expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
+    expect(localRepo?.hooks.some((h) => h.id === 'other-hook')).toBe(true);
+  });
+
+  it('replaces the existing sonar-secrets hook in place without duplicating it', () => {
+    const config: PreCommitConfig = {
+      repos: [
+        {
+          repo: 'local',
+          hooks: [
+            {
+              id: 'sonar-secrets',
+              name: 'old',
+              entry: 'old',
+              language: 'system',
+              stages: ['pre-push'],
+            },
+          ],
+        },
+      ],
+    };
+    upsertSonarHook(config, 'pre-commit');
+    const localRepo = config.repos.find((r) => r.repo === 'local');
+    const sonarHooks = localRepo?.hooks.filter((h) => h.id === 'sonar-secrets');
+    expect(sonarHooks).toHaveLength(1);
+    expect(sonarHooks?.[0].stages).toEqual(['pre-commit']);
+  });
+
+  it('preserves top-level keys that are not repos', () => {
+    const config: PreCommitConfig = { default_install_hook_types: ['pre-commit'], repos: [] };
+    upsertSonarHook(config, 'pre-commit');
+    expect(config.default_install_hook_types).toEqual(['pre-commit']);
+  });
+});
 
 describe('hasSonarHookInPreCommitConfig', () => {
   beforeEach(() => mkdirSync(TEMP_DIR, { recursive: true }));
@@ -106,176 +215,6 @@ describe('hasSonarHookInPreCommitConfig', () => {
       }),
     );
     expect(hasSonarHookInPreCommitConfig(TEMP_DIR)).toBe(false);
-  });
-});
-
-describe('upsertPreCommitConfig — parsing', () => {
-  beforeEach(() => mkdirSync(TEMP_DIR, { recursive: true }));
-  afterEach(() => rmSync(TEMP_DIR, { recursive: true, force: true }));
-
-  it('creates a new config file with a local repo and the sonar-secrets hook', () => {
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    expect(Array.isArray(config.repos)).toBe(true);
-    const repos = config.repos as Array<{ repo: string; hooks: Array<{ id: string }> }>;
-    const localRepo = repos.find((r) => r.repo === 'local');
-    expect(localRepo).toBeDefined();
-    expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
-  });
-
-  it('sets the stage to pre-commit when called with pre-commit', () => {
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{
-      repo: string;
-      hooks: Array<{ id: string; stages: string[] }>;
-    }>;
-    const hook = repos.find((r) => r.repo === 'local')?.hooks.find((h) => h.id === 'sonar-secrets');
-    expect(hook?.stages).toEqual(['pre-commit']);
-  });
-
-  it('sets the stage to pre-push when called with pre-push', () => {
-    upsertPreCommitConfig(TEMP_DIR, 'pre-push');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{
-      repo: string;
-      hooks: Array<{ id: string; stages: string[] }>;
-    }>;
-    const hook = repos.find((r) => r.repo === 'local')?.hooks.find((h) => h.id === 'sonar-secrets');
-    expect(hook?.stages).toEqual(['pre-push']);
-  });
-
-  it('appends a local repo with the hook to a config that already has unrelated repos', () => {
-    writeFileSync(
-      join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
-      yaml.dump({
-        repos: [
-          {
-            repo: 'https://github.com/pre-commit/pre-commit-hooks',
-            rev: 'v4.5.0',
-            hooks: [{ id: 'trailing-whitespace' }],
-          },
-        ],
-      }),
-    );
-
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{ repo: string; hooks: Array<{ id: string }> }>;
-    expect(repos).toHaveLength(2);
-    expect(repos.some((r) => r.repo === 'https://github.com/pre-commit/pre-commit-hooks')).toBe(
-      true,
-    );
-    const localRepo = repos.find((r) => r.repo === 'local');
-    expect(localRepo).toBeDefined();
-    expect(localRepo?.hooks).toHaveLength(1);
-    expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
-  });
-
-  it('adds the hook to an existing local repo that has no sonar-secrets hook yet', () => {
-    writeFileSync(
-      join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
-      yaml.dump({
-        repos: [
-          {
-            repo: 'local',
-            hooks: [{ id: 'other-hook', name: 'x', entry: 'e', language: 'system' }],
-          },
-        ],
-      }),
-    );
-
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{ repo: string; hooks: Array<{ id: string }> }>;
-    const localRepo = repos.find((r) => r.repo === 'local');
-    expect(localRepo?.hooks).toHaveLength(2);
-    expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
-    expect(localRepo?.hooks.some((h) => h.id === 'other-hook')).toBe(true);
-  });
-
-  it('replaces the existing sonar-secrets hook in place without duplicating it', () => {
-    writeFileSync(
-      join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
-      yaml.dump({
-        repos: [
-          {
-            repo: 'local',
-            hooks: [
-              {
-                id: 'sonar-secrets',
-                name: 'old name',
-                entry: 'old entry',
-                language: 'system',
-                stages: ['pre-push'],
-              },
-            ],
-          },
-        ],
-      }),
-    );
-
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{
-      repo: string;
-      hooks: Array<{ id: string; stages: string[] }>;
-    }>;
-    const localRepo = repos.find((r) => r.repo === 'local');
-    const sonarHooks = localRepo?.hooks.filter((h) => h.id === 'sonar-secrets');
-    expect(sonarHooks).toHaveLength(1);
-    expect(sonarHooks?.[0].stages).toEqual(['pre-commit']);
-  });
-
-  it('falls back to an empty repos list when the file contains invalid YAML', () => {
-    writeFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), '{ invalid yaml :::');
-
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{ repo: string }>;
-    expect(repos.some((r) => r.repo === 'local')).toBe(true);
-  });
-
-  it('falls back to an empty repos list when the file is empty', () => {
-    writeFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), '');
-
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{ repo: string }>;
-    expect(repos.some((r) => r.repo === 'local')).toBe(true);
-  });
-
-  it('treats a repos value that is not an array as an empty list', () => {
-    writeFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), yaml.dump({ repos: 'not-an-array' }));
-
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    const repos = config.repos as Array<{ repo: string; hooks: Array<{ id: string }> }>;
-    const localRepo = repos.find((r) => r.repo === 'local');
-    expect(localRepo).toBeDefined();
-    expect(localRepo?.hooks).toHaveLength(1);
-    expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
-  });
-
-  it('preserves top-level keys that are not repos', () => {
-    writeFileSync(
-      join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
-      yaml.dump({ default_install_hook_types: ['pre-commit'], repos: [] }),
-    );
-
-    upsertPreCommitConfig(TEMP_DIR, 'pre-commit');
-
-    const config = readConfig();
-    expect(config.default_install_hook_types).toEqual(['pre-commit']);
   });
 });
 
@@ -370,6 +309,127 @@ describe('installViaPreCommitFramework', () => {
     try {
       await installViaPreCommitFramework(TEMP_DIR, 'pre-commit').catch(() => {});
       expect(hasSonarHookInPreCommitConfig(TEMP_DIR)).toBe(true);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('installs the hook even when the existing file contains invalid YAML', async () => {
+    writeFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), '{ invalid yaml :::');
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await installViaPreCommitFramework(TEMP_DIR, 'pre-commit');
+      expect(hasSonarHookInPreCommitConfig(TEMP_DIR)).toBe(true);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('installs the hook even when the existing file is empty', async () => {
+    writeFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), '');
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await installViaPreCommitFramework(TEMP_DIR, 'pre-commit');
+      expect(hasSonarHookInPreCommitConfig(TEMP_DIR)).toBe(true);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('installs the hook when the existing file has a non-array repos value', async () => {
+    writeFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), yaml.dump({ repos: 'not-an-array' }));
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await installViaPreCommitFramework(TEMP_DIR, 'pre-commit');
+      expect(hasSonarHookInPreCommitConfig(TEMP_DIR)).toBe(true);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('removes legacy repo, adds local hook, and prints a text message', async () => {
+    writeFileSync(
+      join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
+      yaml.dump({
+        repos: [
+          {
+            repo: PRE_COMMIT_LEGACY_REPO,
+            rev: 'v2.41.0.10709',
+            hooks: [{ id: 'sonar-secrets', stages: ['pre-commit'] }],
+          },
+        ],
+      }),
+    );
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await installViaPreCommitFramework(TEMP_DIR, 'pre-commit');
+
+      const textCalls = getMockUiCalls().filter((c) => c.method === 'text');
+      expect(textCalls).toHaveLength(1);
+      expect(textCalls[0].args[0]).toBe(
+        `Removed legacy ${PRE_COMMIT_LEGACY_REPO} hook from ${PRE_COMMIT_CONFIG_FILE}.`,
+      );
+      const written = yaml.load(readFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), 'utf-8')) as {
+        repos: Array<{ repo: string; hooks: Array<{ id: string }> }>;
+      };
+      expect(written.repos.some((r) => r.repo === PRE_COMMIT_LEGACY_REPO)).toBe(false);
+      expect(hasSonarHookInPreCommitConfig(TEMP_DIR)).toBe(true);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('removes legacy repo and installs hook alongside existing local hooks', async () => {
+    writeFileSync(
+      join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
+      yaml.dump({
+        repos: [
+          {
+            repo: PRE_COMMIT_LEGACY_REPO,
+            rev: 'v2.41.0.10709',
+            hooks: [{ id: 'sonar-secrets', stages: ['pre-commit'] }],
+          },
+          {
+            repo: 'local',
+            hooks: [{ id: 'other-local-hook', name: 'x', entry: 'e', language: 'system' }],
+          },
+        ],
+      }),
+    );
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await installViaPreCommitFramework(TEMP_DIR, 'pre-commit');
+
+      const textCalls = getMockUiCalls().filter((c) => c.method === 'text');
+      expect(textCalls).toHaveLength(1);
+      expect(textCalls[0].args[0]).toBe(
+        `Removed legacy ${PRE_COMMIT_LEGACY_REPO} hook from ${PRE_COMMIT_CONFIG_FILE}.`,
+      );
+      const written = yaml.load(readFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), 'utf-8')) as {
+        repos: Array<{ repo: string; hooks: Array<{ id: string }> }>;
+      };
+      expect(written.repos.some((r) => r.repo === PRE_COMMIT_LEGACY_REPO)).toBe(false);
+      const localRepo = written.repos.find((r) => r.repo === 'local');
+      expect(localRepo?.hooks).toHaveLength(2);
+      expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
+      expect(localRepo?.hooks.some((h) => h.id === 'other-local-hook')).toBe(true);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('prints no text message when there is no legacy repo', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await installViaPreCommitFramework(TEMP_DIR, 'pre-commit');
+
+      expect(getMockUiCalls().some((c) => c.method === 'text')).toBe(false);
     } finally {
       spawnSpy.mockRestore();
     }


### PR DESCRIPTION
I split `.pre-commit-config.yaml` update into separate `read`->`checkLegacy`->`addHook`->`write` so that it's easier to separate UI from actions. We needed to notify the user that the old hook was deleted and I didn't want to neither do it deep inside logic methods nor read-write twice.
That led to quite a shake up on tests so now they mostly test without the file outside of few high level scenarios.