### PR TITLE
CLI-456 Add SCA eligibility SQ Server version check

### DIFF
--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -166,7 +166,7 @@ async function assertServerSupportsLocalSca(
       'Software Composition Analysis is not available for the current server connection.',
       {
         remediationHint:
-          'Software Composition Analysis requires SonarQube Server Enterprise Edition or SonarQube Cloud Team plan or higher, and must be enabled by an administrator. Learn more: https://docs.sonarsource.com/sonarqube-server/latdontest/advanced-security/sca-overview/',
+          'Software Composition Analysis must be enabled by an administrator and requires an eligible SonarQube plan. Learn more: https://www.sonarsource.com/products/sonarqube/advanced-security/',
       },
     );
   }

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 import { type ResolvedAuth } from '../../../lib/auth-resolver';
 import { CLI_DIR } from '../../../lib/config-constants';
 import logger, { getLogLevelConfig } from '../../../lib/logger';
+import { fetchServerVersion, isAtLeast } from '../../../lib/server-info';
 import { SonarQubeClient } from '../../../sonarqube/client';
 import { error, print, warn } from '../../../ui';
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
@@ -47,6 +48,8 @@ const EXIT_CODE_OK = 0;
 const EXIT_CODE_ERRORS_ONLY = 1;
 const EXIT_CODE_UNRESOLVED_RISKS = 51;
 
+const MIN_SCA_SQS_VERSION = '26.4';
+
 export interface AnalyzeDependencyRisksOptions {
   project: string;
   format: string;
@@ -63,6 +66,7 @@ export async function analyzeDependencyRisks(
   }
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
+  await assertServerSupportsSca(auth);
   const enabled = await client.checkScaEnabled(auth.connectionType, auth.orgKey);
   if (!enabled) {
     throw new CommandFailedError(
@@ -145,4 +149,21 @@ export function countUnresolvedIssues(vm: DependencyRisksViewModel): number {
     }
   }
   return count;
+}
+
+async function assertServerSupportsSca(auth: ResolvedAuth): Promise<void> {
+  if (auth.connectionType === 'cloud') return;
+  let serverVersion: string;
+  try {
+    serverVersion = await fetchServerVersion(auth.serverUrl);
+  } catch {
+    throw new CommandFailedError(
+      `Could not determine SonarQube Server version. Software Composition Analysis requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
+    );
+  }
+  if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
+    throw new CommandFailedError(
+      `Software Composition Analysis requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
+    );
+  }
 }

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -48,7 +48,7 @@ const EXIT_CODE_OK = 0;
 const EXIT_CODE_ERRORS_ONLY = 1;
 const EXIT_CODE_UNRESOLVED_RISKS = 51;
 
-const MIN_SCA_SQS_VERSION = '26.4';
+const MIN_SCA_SQS_VERSION = '2026.4';
 
 export interface AnalyzeDependencyRisksOptions {
   project: string;
@@ -166,7 +166,7 @@ async function assertServerSupportsLocalSca(
       'Software Composition Analysis is not available for the current server connection.',
       {
         remediationHint:
-          'Use a connection where SCA is enabled, or verify your server edition, plan, and organization entitlements.',
+          'Software Composition Analysis requires SonarQube Server Enterprise Edition or SonarQube Cloud Team plan or higher, and must be enabled by an administrator. Learn more: https://docs.sonarsource.com/sonarqube-server/latdontest/advanced-security/sca-overview/',
       },
     );
   }

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -66,17 +66,7 @@ export async function analyzeDependencyRisks(
   }
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
-  await assertServerSupportsSca(auth);
-  const enabled = await client.checkScaEnabled(auth.connectionType, auth.orgKey);
-  if (!enabled) {
-    throw new CommandFailedError(
-      'Software Composition Analysis is not available for the current server connection.',
-      {
-        remediationHint:
-          'Use a connection where SCA is enabled, or verify your server edition, plan, and organization entitlements.',
-      },
-    );
-  }
+  await assertServerSupportsLocalSca(auth, client);
 
   const settings = await client.getProjectSettings(options.project);
   const properties = parseAnalysisProperties(settings);
@@ -151,19 +141,33 @@ export function countUnresolvedIssues(vm: DependencyRisksViewModel): number {
   return count;
 }
 
-async function assertServerSupportsSca(auth: ResolvedAuth): Promise<void> {
-  if (auth.connectionType === 'cloud') return;
-  let serverVersion: string;
-  try {
-    serverVersion = await fetchServerVersion(auth.serverUrl);
-  } catch {
-    throw new CommandFailedError(
-      `Could not determine SonarQube Server version. Software Composition Analysis requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
-    );
+async function assertServerSupportsLocalSca(
+  auth: ResolvedAuth,
+  client: SonarQubeClient,
+): Promise<void> {
+  if (auth.connectionType !== 'cloud') {
+    let serverVersion: string;
+    try {
+      serverVersion = await fetchServerVersion(auth.serverUrl);
+    } catch {
+      throw new CommandFailedError(
+        `Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
+      );
+    }
+    if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
+      throw new CommandFailedError(
+        `Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
+      );
+    }
   }
-  if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
+  const enabled = await client.checkScaEnabled(auth.connectionType, auth.orgKey);
+  if (!enabled) {
     throw new CommandFailedError(
-      `Software Composition Analysis requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
+      'Software Composition Analysis is not available for the current server connection.',
+      {
+        remediationHint:
+          'Use a connection where SCA is enabled, or verify your server edition, plan, and organization entitlements.',
+      },
     );
   }
 }

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -187,7 +187,7 @@ describe('analyze dependency-risks', () => {
     );
   });
 
-  it('exits with code 1 when the on-premise server version is below 26.4', async () => {
+  it('exits with code 1 when the on-premise server version is below 2026.4', async () => {
     const server = await harness
       .newFakeServer()
       .withAuthToken(VALID_TOKEN)
@@ -200,7 +200,7 @@ describe('analyze dependency-risks', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout + result.stderr).toContain(
-      'Running Software Composition Analysis from this CLI requires SonarQube Server 26.4 or later (server is 26.3)',
+      'Running Software Composition Analysis from this CLI requires SonarQube Server 2026.4 or later (server is 26.3)',
     );
     // Version check runs before the SCA feature-enabled probe.
     expect(server.getRecordedRequests().some((r) => r.path.endsWith('/sca/feature-enabled'))).toBe(
@@ -208,7 +208,7 @@ describe('analyze dependency-risks', () => {
     );
   });
 
-  it('proceeds past the version check when the on-premise server version is 26.4 or newer', async () => {
+  it('proceeds past the version check when the on-premise server version is 2026.4 or newer', async () => {
     const server = await harness
       .newFakeServer()
       .withAuthToken(VALID_TOKEN)
@@ -239,7 +239,7 @@ describe('analyze dependency-risks', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout + result.stderr).toContain(
-      'Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server 26.4 or later.',
+      'Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server 2026.4 or later.',
     );
   });
 

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -172,7 +172,11 @@ describe('analyze dependency-risks', () => {
   });
 
   it('exits with code 1 when the SCA endpoint is absent (404)', async () => {
-    const server = await harness.newFakeServer().withAuthToken(VALID_TOKEN).start();
+    const server = await harness
+      .newFakeServer()
+      .withAuthToken(VALID_TOKEN)
+      .withVersion('26.4')
+      .start();
     harness.withAuth(server.baseUrl(), VALID_TOKEN);
 
     const result = await harness.run('analyze dependency-risks --project demo');
@@ -181,5 +185,81 @@ describe('analyze dependency-risks', () => {
     expect(result.stdout + result.stderr).toContain(
       'Software Composition Analysis is not available for the current server connection',
     );
+  });
+
+  it('exits with code 1 when the on-premise server version is below 26.4', async () => {
+    const server = await harness
+      .newFakeServer()
+      .withAuthToken(VALID_TOKEN)
+      .withVersion('26.3')
+      .withScaEnabled(true)
+      .start();
+    harness.withAuth(server.baseUrl(), VALID_TOKEN);
+
+    const result = await harness.run('analyze dependency-risks --project demo');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      'Software Composition Analysis requires SonarQube Server 26.4 or later (server is 26.3)',
+    );
+    // Version check runs before the SCA feature-enabled probe.
+    expect(server.getRecordedRequests().some((r) => r.path.endsWith('/sca/feature-enabled'))).toBe(
+      false,
+    );
+  });
+
+  it('proceeds past the version check when the on-premise server version is 26.4 or newer', async () => {
+    const server = await harness
+      .newFakeServer()
+      .withAuthToken(VALID_TOKEN)
+      .withVersion('2026.4.0.12345')
+      .withScaEnabled(false)
+      .start();
+    harness.withAuth(server.baseUrl(), VALID_TOKEN);
+
+    const result = await harness.run('analyze dependency-risks --project demo');
+
+    // Version check passes — failure now comes from the SCA availability check.
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      'Software Composition Analysis is not available for the current server connection',
+    );
+  });
+
+  it('exits with code 1 when the on-premise server version cannot be determined', async () => {
+    const server = await harness
+      .newFakeServer()
+      .withAuthToken(VALID_TOKEN)
+      .withSystemStatusCode(503)
+      .withScaEnabled(true)
+      .start();
+    harness.withAuth(server.baseUrl(), VALID_TOKEN);
+
+    const result = await harness.run('analyze dependency-risks --project demo');
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      'Could not determine SonarQube Server version. Software Composition Analysis requires SonarQube Server 26.4 or later.',
+    );
+  });
+
+  it('skips the server version check for cloud connections', async () => {
+    const server = await harness
+      .newFakeServer()
+      .withAuthToken(VALID_TOKEN)
+      .withVersion('1.0')
+      .withScaEnabled(false)
+      .start();
+    harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+    const result = await harness.run('analyze dependency-risks --project demo');
+
+    // Despite the absurdly old "version", the cloud path bypasses the check
+    // and proceeds to the SCA availability probe.
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout + result.stderr).toContain(
+      'Software Composition Analysis is not available for the current server connection',
+    );
+    expect(server.getRecordedRequests().some((r) => r.path === '/api/system/status')).toBe(false);
   });
 });

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -200,7 +200,7 @@ describe('analyze dependency-risks', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout + result.stderr).toContain(
-      'Software Composition Analysis requires SonarQube Server 26.4 or later (server is 26.3)',
+      'Running Software Composition Analysis from this CLI requires SonarQube Server 26.4 or later (server is 26.3)',
     );
     // Version check runs before the SCA feature-enabled probe.
     expect(server.getRecordedRequests().some((r) => r.path.endsWith('/sca/feature-enabled'))).toBe(
@@ -239,7 +239,7 @@ describe('analyze dependency-risks', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.stdout + result.stderr).toContain(
-      'Could not determine SonarQube Server version. Software Composition Analysis requires SonarQube Server 26.4 or later.',
+      'Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server 26.4 or later.',
     );
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **SCA eligibility:**
  - Added a requirement for SonarQube Server version `2026.4` or later when running SCA analysis.
  - Implemented `assertServerSupportsLocalSca` to enforce the version check before performing SCA probes.
- **Compatibility improvements:**
  - Added logic to skip the server version check for `cloud` connections.
  - Added integration tests to verify version enforcement, error handling for unknown versions, and cloud-specific bypassing.
- **Documentation:**
  - Updated the remediation hint for SCA compatibility to provide clearer guidance on edition, plan, and documentation links.

<sub>This will update automatically on new commits.</sub>