### PR TITLE
feat: a musl linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
       PACKAGE_VERSION: ${{ steps.project_version.outputs.PACKAGE_VERSION }}
       ARTIFACT_LINUX: ${{ steps.project_version.outputs.ARTIFACT_LINUX }}
       ARTIFACT_LINUX_ARM64: ${{ steps.project_version.outputs.ARTIFACT_LINUX_ARM64 }}
+      ARTIFACT_LINUX_MUSL: ${{ steps.project_version.outputs.ARTIFACT_LINUX_MUSL }}
+      ARTIFACT_LINUX_ARM64_MUSL: ${{ steps.project_version.outputs.ARTIFACT_LINUX_ARM64_MUSL }}
       ARTIFACT_MACOS: ${{ steps.project_version.outputs.ARTIFACT_MACOS }}
       ARTIFACT_WINDOWS: ${{ steps.project_version.outputs.ARTIFACT_WINDOWS }}
     steps:
@@ -54,6 +56,8 @@ jobs:
           echo "PROJECT_VERSION=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
           echo "ARTIFACT_LINUX=sonarqube-cli-${PACKAGE_VERSION}-linux-x86-64.exe" >> $GITHUB_OUTPUT
           echo "ARTIFACT_LINUX_ARM64=sonarqube-cli-${PACKAGE_VERSION}-linux-arm64.exe" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_LINUX_MUSL=sonarqube-cli-${PACKAGE_VERSION}-linux-x86-64-musl.exe" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_LINUX_ARM64_MUSL=sonarqube-cli-${PACKAGE_VERSION}-linux-arm64-musl.exe" >> $GITHUB_OUTPUT
           echo "ARTIFACT_MACOS=sonarqube-cli-${PACKAGE_VERSION}-macos-arm64.exe" >> $GITHUB_OUTPUT
           echo "ARTIFACT_WINDOWS=sonarqube-cli-${PACKAGE_VERSION}-windows-x86-64.exe" >> $GITHUB_OUTPUT
 
@@ -89,6 +93,8 @@ jobs:
         run: |
           bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_LINUX }} --target bun-linux-x64
           bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_ARM64 }} --target bun-linux-arm64
+          bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_MUSL }} --target bun-linux-x64-musl
+          bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_ARM64_MUSL }} --target bun-linux-arm64-musl
           bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }} --target bun-darwin-arm64
           bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_WINDOWS }} --target bun-windows-x64
 
@@ -99,6 +105,8 @@ jobs:
         run: |
           bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_LINUX }}
           bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_ARM64 }}
+          bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_MUSL }}
+          bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_ARM64_MUSL }}
           bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}
           bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_WINDOWS }}
 
@@ -259,7 +267,7 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           PROJECT: ${{ github.event.repository.name }}
           BUILD_NUMBER: ${{ needs.prepare.outputs.BUILD_NUMBER }}
-          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64,org.sonarsource.cli:sonarqube-cli:exe:linux-arm64,org.sonarsource.cli:sonarqube-cli:exe:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
+          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64,org.sonarsource.cli:sonarqube-cli:exe:linux-arm64,org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64-musl,org.sonarsource.cli:sonarqube-cli:exe:linux-arm64-musl,org.sonarsource.cli:sonarqube-cli:exe:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
         run: |
           jf config add repox \
             --artifactory-url="${ARTIFACTORY_URL}" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 A CLI tool (`sonar`) that integrates SonarQube Server and Cloud into developer workflows.
 
-Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `macos-arm64`, and `windows-x86-64`. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`).
+Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `linux-x86-64-musl`, `linux-arm64-musl`, `macos-arm64`, and `windows-x86-64`. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`) and append `-musl` when the system uses musl libc.
 
 # Running checks
 

--- a/tests/integration/specs/user-scripts/detect-platform.test.ts
+++ b/tests/integration/specs/user-scripts/detect-platform.test.ts
@@ -1,0 +1,173 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+const scriptPath = join(import.meta.dir, '../../../../user-scripts/install.sh');
+const prereleaseScriptPath = join(
+  import.meta.dir,
+  '../../../../user-scripts/install-prerelease.sh',
+);
+const isWindows = process.platform === 'win32';
+
+function writeExecutable(path: string, content: string) {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+function extract(path: string, fn: string): string {
+  const proc = Bun.spawnSync(['sed', '-n', `/^${fn}()/,/^}/p`, path]);
+  return new TextDecoder().decode(proc.stdout).trim();
+}
+
+function runDetectPlatform(opts: {
+  os?: string;
+  arch: string;
+  lddOutput?: string;
+  lddExitCode?: number;
+  script?: string;
+}): { stdout: string; stderr: string; exitCode: number } {
+  const binDir = mkdtempSync(join(tmpdir(), 'sonar-platform-bin-'));
+  const script = opts.script ?? scriptPath;
+
+  try {
+    writeExecutable(
+      join(binDir, 'uname'),
+      `#!/usr/bin/env bash
+case "$1" in
+  -s) echo "${opts.os ?? 'Linux'}" ;;
+  -m) echo "${opts.arch}" ;;
+  *) exit 1 ;;
+esac
+`,
+    );
+    writeExecutable(
+      join(binDir, 'ldd'),
+      `#!/usr/bin/env bash
+if [[ "$1" == "--version" ]]; then
+  cat <<'EOF'
+${opts.lddOutput ?? 'ldd (GNU libc) 2.39'}
+EOF
+  exit ${opts.lddExitCode ?? 0}
+fi
+exit 1
+`,
+    );
+
+    const bashSnippet = `
+set -euo pipefail
+eval "$(sed -n '/^detect_os()/,/^}/p' "${script}")"
+eval "$(sed -n '/^is_musl_linux()/,/^}/p' "${script}")"
+eval "$(sed -n '/^detect_platform()/,/^}/p' "${script}")"
+detect_platform
+`;
+    const proc = Bun.spawnSync(['bash', '-c', bashSnippet], {
+      env: { PATH: `${binDir}:${process.env.PATH!}` },
+    });
+    return {
+      stdout: new TextDecoder().decode(proc.stdout).trim(),
+      stderr: new TextDecoder().decode(proc.stderr).trim(),
+      exitCode: proc.exitCode,
+    };
+  } finally {
+    rmSync(binDir, { recursive: true, force: true });
+  }
+}
+
+describe.if(!isWindows)('install.sh platform detection', () => {
+  const cases = [
+    {
+      name: 'detects glibc x86_64',
+      arch: 'x86_64',
+      lddOutput: 'ldd (GNU libc) 2.39',
+      expected: 'linux-x86-64',
+    },
+    {
+      name: 'detects musl x86_64',
+      arch: 'x86_64',
+      lddOutput: 'musl libc (x86_64)\nVersion 1.2.5',
+      expected: 'linux-x86-64-musl',
+    },
+    {
+      name: 'detects glibc arm64',
+      arch: 'aarch64',
+      lddOutput: 'ldd (GNU libc) 2.39',
+      expected: 'linux-arm64',
+    },
+    {
+      name: 'detects musl arm64',
+      arch: 'arm64',
+      lddOutput: 'musl libc (aarch64)\nVersion 1.2.5',
+      expected: 'linux-arm64-musl',
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.name, () => {
+      const result = runDetectPlatform(testCase);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(result.stdout).toBe(testCase.expected);
+    });
+  }
+
+  it('keeps macOS arm64 unchanged', () => {
+    const result = runDetectPlatform({ os: 'Darwin', arch: 'arm64' });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('macos-arm64');
+  });
+
+  it('detects musl even when ldd exits nonzero', () => {
+    const result = runDetectPlatform({
+      arch: 'x86_64',
+      lddOutput: 'musl libc (x86_64)\nVersion 1.2.5',
+      lddExitCode: 1,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('linux-x86-64-musl');
+  });
+
+  it('fails on unsupported Linux architecture', () => {
+    const result = runDetectPlatform({ arch: 'riscv64' });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stderr).toContain('Unsupported Linux architecture: riscv64');
+  });
+
+  describe('sync check between install scripts', () => {
+    it('install.sh and install-prerelease.sh define the same platform detection', () => {
+      expect(extract(scriptPath, 'detect_os')).toBe(extract(prereleaseScriptPath, 'detect_os'));
+      expect(extract(scriptPath, 'is_musl_linux')).toBe(
+        extract(prereleaseScriptPath, 'is_musl_linux'),
+      );
+      expect(extract(scriptPath, 'detect_platform')).toBe(
+        extract(prereleaseScriptPath, 'detect_platform'),
+      );
+    });
+  });
+});

--- a/user-scripts/install-prerelease.sh
+++ b/user-scripts/install-prerelease.sh
@@ -25,12 +25,26 @@ detect_os() {
   esac
 }
 
+is_musl_linux() {
+  if command -v ldd &>/dev/null && { ldd --version 2>&1 || true; } | grep -qi musl; then
+    return 0
+  fi
+  if ls /lib/ld-musl-*.so.1 /usr/lib/ld-musl-*.so.1 &>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
 detect_platform() {
   case "$(detect_os)" in
     linux)
+      local libc_suffix=""
+      if is_musl_linux; then
+        libc_suffix="-musl"
+      fi
       case "$(uname -m)" in
-        aarch64 | arm64) echo "linux-arm64" ;;
-        x86_64 | amd64) echo "linux-x86-64" ;;
+        aarch64 | arm64) echo "linux-arm64${libc_suffix}" ;;
+        x86_64 | amd64) echo "linux-x86-64${libc_suffix}" ;;
         *)
           echo "Unsupported Linux architecture: $(uname -m)" >&2
           exit 1

--- a/user-scripts/install.sh
+++ b/user-scripts/install.sh
@@ -25,12 +25,26 @@ detect_os() {
   esac
 }
 
+is_musl_linux() {
+  if command -v ldd &>/dev/null && { ldd --version 2>&1 || true; } | grep -qi musl; then
+    return 0
+  fi
+  if ls /lib/ld-musl-*.so.1 /usr/lib/ld-musl-*.so.1 &>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
 detect_platform() {
   case "$(detect_os)" in
     linux)
+      local libc_suffix=""
+      if is_musl_linux; then
+        libc_suffix="-musl"
+      fi
       case "$(uname -m)" in
-        aarch64 | arm64) echo "linux-arm64" ;;
-        x86_64 | amd64) echo "linux-x86-64" ;;
+        aarch64 | arm64) echo "linux-arm64${libc_suffix}" ;;
+        x86_64 | amd64) echo "linux-x86-64${libc_suffix}" ;;
         *)
           echo "Unsupported Linux architecture: $(uname -m)" >&2
           exit 1


### PR DESCRIPTION
Adds builds for musl based linux (i.e. Alpine Linux)

its pretty simple as bun supports it as just another target, so just add those extra targets and a simple check in the install script to pull the correct build

Currently on alpine a build is downloaded but the executable wont run, this should solve that

this will be super helpful, my previous PR didnt fully fix my issue,https://github.com/SonarSource/sonarqube-cli/pull/177 - I'm using an alpine based docker container to run all my agents and want to give them access to sonar
