### PR TITLE
CLI-475 Add no-JS fallback to commands.html pointing to llms.txt

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -16,6 +16,7 @@
   <meta name="twitter:title" content="Commands — SonarQube CLI">
   <meta name="twitter:description" content="Full command reference for the SonarQube CLI. Browse all commands, options, and examples. Machine-readable schema available at /data/commands.json.">
   <link rel="alternate" type="application/json" href="data/commands.json" title="Command Reference (JSON)">
+  <link rel="alternate" type="text/plain" href="llms.txt" title="Command Reference (Markdown)">
   <link rel="stylesheet" href="assets/style.css">
   <script>if(localStorage.getItem('clidoc-theme')==='light')document.documentElement.setAttribute('data-theme','light');</script>
 </head>
@@ -57,7 +58,17 @@
 
   <!-- Main panel -->
   <main class="main-panel" id="detail">
-    <div class="empty-state">Loading…</div>
+    <noscript>
+      <div class="empty-state">
+        <p>This interactive command browser requires JavaScript.</p>
+        <p>For the full command reference without JavaScript, see:</p>
+        <ul>
+          <li><a href="llms.txt">llms.txt</a> — full reference in Markdown</li>
+          <li><a href="data/commands.json">commands.json</a> — structured JSON schema</li>
+        </ul>
+      </div>
+    </noscript>
+    <div class="empty-state" id="js-loading">Loading…</div>
   </main>
 </div>
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -68,7 +68,7 @@
         </ul>
       </div>
     </noscript>
-    <div class="empty-state" id="js-loading">Loading…</div>
+    <div class="empty-state">Loading…</div>
   </main>
 </div>
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -16,7 +16,7 @@
   <meta name="twitter:title" content="Commands — SonarQube CLI">
   <meta name="twitter:description" content="Full command reference for the SonarQube CLI. Browse all commands, options, and examples. Machine-readable schema available at /data/commands.json.">
   <link rel="alternate" type="application/json" href="data/commands.json" title="Command Reference (JSON)">
-  <link rel="alternate" type="text/plain" href="llms.txt" title="Command Reference (Markdown)">
+  <link rel="alternate" type="text/markdown" href="llms.txt" title="Command Reference (Markdown)">
   <link rel="stylesheet" href="assets/style.css">
   <script>if(localStorage.getItem('clidoc-theme')==='light')document.documentElement.setAttribute('data-theme','light');</script>
 </head>


### PR DESCRIPTION
The commands reference is entirely client-side rendered from commands.json, so agents and crawlers without JavaScript see only a "Loading…" placeholder. Add a <noscript> block linking to llms.txt and commands.json, plus a text/plain alternate link in <head>, so the full command reference is discoverable without executing JavaScript.