### PR TITLE
CLI-480 Link docs.sonarsource.com from cli.sonarqube.com site

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -635,6 +635,14 @@ pre code {
   display: none;
 }
 .jtbd-recipe.visible { display: block; }
+.jtbd-docs-link {
+  display: inline-block;
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--text-muted, #888);
+  text-decoration: none;
+}
+.jtbd-docs-link:hover { color: var(--accent); text-decoration: underline; }
 
 /* ─── Feature cards ─────────────────────────────────────────── */
 .features-grid {

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -33,6 +33,7 @@
   <div class="nav-links">
     <a href="index.html" class="nav-link">Home</a>
     <a href="commands.html" class="nav-link active">Commands</a>
+    <a href="https://docs.sonarsource.com/sonarqube-cli" class="nav-link" target="_blank" rel="noopener">Docs</a>
     <a href="https://github.com/SonarSource/sonarqube-cli" class="nav-link" target="_blank" rel="noopener">GitHub</a>
     <a href="llms.txt" class="nav-link">llms.txt</a>
     <a href="https://forms.gle/zuNTSBFq2EKsum3E6" class="nav-link" target="_blank" rel="noopener">Feedback</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -48,6 +48,7 @@
   <div class="nav-links">
     <a href="index.html" class="nav-link active">Home</a>
     <a href="commands.html" class="nav-link">Commands</a>
+    <a href="https://docs.sonarsource.com/sonarqube-cli" class="nav-link" target="_blank" rel="noopener">Docs</a>
     <a href="https://github.com/SonarSource/sonarqube-cli" class="nav-link" target="_blank" rel="noopener">GitHub</a>
     <a href="llms.txt" class="nav-link">llms.txt</a>
     <a href="https://forms.gle/zuNTSBFq2EKsum3E6" class="nav-link" target="_blank" rel="noopener">Feedback</a>
@@ -106,6 +107,7 @@
 
   <div class="hero-ctas">
     <a href="commands.html" class="btn btn-primary">Browse Commands</a>
+    <a href="https://docs.sonarsource.com/sonarqube-cli" class="btn" target="_blank" rel="noopener">Read the Docs ↗</a>
   </div>
 </section>
 
@@ -525,10 +527,12 @@
   };
 
   function buildStepsHtml(steps) {
-    return '<div class="steps">' + steps.map((s, i) => {
+    const stepsHtml = '<div class="steps">' + steps.map((s, i) => {
       const arrow = i < steps.length - 1 ? '<div class="steps-arrow">→</div>' : '';
       return `<div class="step"><div class="step-num">${i + 1}</div><h3>${s.title}</h3><code>${s.cmd}</code><p>${s.desc}</p></div>${arrow}`;
     }).join('') + '</div>';
+    const docsLink = '<a href="https://docs.sonarsource.com/sonarqube-cli" class="jtbd-docs-link" target="_blank" rel="noopener">Full reference on docs.sonarsource.com ↗</a>';
+    return stepsHtml + docsLink;
   }
 
   let activeJtbd = null;


### PR DESCRIPTION
## Summary

  Make the official documentation at https://docs.sonarsource.com/sonarqube-cli discoverable from the GitHub Pages site
  (`cli.sonarqube.com`). The page already links to it from the footer; this surfaces it above the fold and contextually inside each Quick Start recipe.

  ## Changes

  - **Top nav** (`docs/index.html`, `docs/commands.html`) — new "Docs" link between "Commands" and "GitHub", opens in a new tab.
  - **Hero CTAs** (`docs/index.html`) — secondary "Read the Docs ↗" button next to "Browse Commands".
  - **Quick Start recipes** (`docs/index.html` + `.jtbd-docs-link` in `docs/assets/style.css`) — every JTBD recipe now ends with a "Full reference on docs.sonarsource.com ↗" link.

  The pre-existing footer link is unchanged.