### PR TITLE
CLI-446 Migrate Copilot integration to declarative installer

### DIFF
--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -1,0 +1,280 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { join, relative } from 'node:path';
+
+import { CLI_COMMAND } from '../../../../lib/config-constants';
+import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { CommandFailedError } from '../../_common/error';
+import {
+  type IntegrationContext,
+  type IntegrationDeclaration,
+  jsonPatch,
+  SonarSourceBinary,
+  sonarSourceBinary,
+  supportedIntegrations,
+  wholeFile,
+} from '../_common/registry';
+import type { IntegrateAgentOptions } from '../_common/types';
+import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
+import {
+  entryReferencesSonarSecrets,
+  HOOK_TIMEOUT_SEC,
+  type HookCommandEntry,
+  HOOKS_JSON,
+  hookScriptName,
+  type HooksJson,
+  PROJECT_HOOKS_REL_DIR,
+  SCRIPT_REL_DIR,
+} from './hooks';
+import {
+  buildInstructionsBody,
+  buildSqaaInstructionsBody,
+  INSTRUCTIONS_FILENAME,
+  PROJECT_INSTRUCTIONS_REL_DIR,
+} from './instructions';
+
+export const COPILOT_INTEGRATION_ID = 'copilot-cli';
+
+export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
+  projectRoot?: string;
+  installBinary?: boolean;
+  installHook?: boolean;
+  installInstructions?: boolean;
+  installSqaaInstructions?: boolean;
+  installMcp?: boolean;
+}
+
+export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOptions> = {
+  id: COPILOT_INTEGRATION_ID,
+  displayName: 'Copilot',
+  features: [
+    {
+      id: 'sonar-secrets-binary',
+      displayName: 'sonar-secrets binary',
+      when: ({ options }) => options.installBinary === true,
+      resources: [
+        sonarSourceBinary({
+          id: 'sonar-secrets',
+          displayName: 'sonar-secrets binary',
+          binary: SonarSourceBinary.SonarSecrets,
+        }),
+      ],
+    },
+    {
+      id: 'pre-tool-use-hook',
+      displayName: 'pre-tool-use hook',
+      when: ({ options }) => options.installHook === true,
+      resources: [
+        wholeFile({
+          id: 'pretool-secrets-script',
+          displayName: 'Copilot pre-tool-use hook script',
+          targetPath: resolveCopilotHookScriptPath,
+          content: {
+            unix: getSecretPreToolTemplateUnix(),
+            windows: getSecretPreToolTemplateWindows(),
+          },
+          executable: true,
+        }),
+        jsonPatch({
+          id: 'copilot-hooks-config',
+          displayName: 'Copilot hooks configuration',
+          targetPath: resolveHooksJsonPath,
+          defaultValue: { version: 1, hooks: {} },
+          patch: (document, context) => upsertHookConfig(document, context),
+        }),
+      ],
+    },
+    {
+      id: 'prompt-secrets-instructions',
+      displayName: 'prompt-secrets instructions',
+      when: ({ options }) => options.installInstructions === true,
+      resources: [
+        wholeFile({
+          id: 'prompt-secrets-instructions-file',
+          displayName: 'Copilot prompt-secrets instructions',
+          targetPath: resolveInstructionsPath,
+          content: (context) =>
+            context.scope === 'project' && getBooleanAttr(context, 'sqaaEnabled')
+              ? buildInstructionsBody(getRequiredStringAttr(context, 'projectKey'))
+              : buildInstructionsBody(),
+        }),
+      ],
+    },
+    {
+      id: 'sqaa-instructions',
+      displayName: 'SonarQube Agentic Analysis instructions',
+      when: ({ options, scope }) => scope === 'global' && options.installSqaaInstructions === true,
+      targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
+      scope: 'project',
+      resources: [
+        wholeFile({
+          id: 'sqaa-instructions-file',
+          displayName: 'Copilot SQAA instructions',
+          targetPath: resolveInstructionsPath,
+          content: (context) =>
+            buildSqaaInstructionsBody(getRequiredStringAttr(context, 'projectKey')),
+        }),
+      ],
+    },
+    {
+      id: 'mcp-server',
+      displayName: 'MCP server',
+      when: ({ options }) => options.installMcp === true,
+      resources: [
+        jsonPatch({
+          id: 'copilot-mcp-config',
+          displayName: 'Copilot MCP configuration',
+          targetPath: resolveCopilotMcpConfigPath,
+          defaultValue: {},
+          patch: (document, context) =>
+            upsertCopilotMcpServer(document, getDesiredCopilotMcpConfig(context)),
+        }),
+      ],
+    },
+  ],
+};
+
+let copilotIntegrationRegistered = false;
+
+export function registerCopilotIntegration(): void {
+  if (copilotIntegrationRegistered) {
+    return;
+  }
+
+  supportedIntegrations.register(copilotIntegration);
+  copilotIntegrationRegistered = true;
+}
+
+function resolveCopilotHookScriptPath(context: IntegrationContext): string {
+  return join(resolveHooksDir(context), SCRIPT_REL_DIR, hookScriptName());
+}
+
+function resolveHooksJsonPath(context: IntegrationContext): string {
+  return join(resolveHooksDir(context), HOOKS_JSON);
+}
+
+function resolveCopilotMcpConfigPath(context: IntegrationContext): string {
+  return getMcpConfigFilePath('copilot', context.scope === 'global', context.targetRoot);
+}
+
+function resolveInstructionsPath(context: IntegrationContext): string {
+  return context.scope === 'global'
+    ? join(context.targetRoot, '.copilot', 'instructions', INSTRUCTIONS_FILENAME)
+    : join(context.targetRoot, PROJECT_INSTRUCTIONS_REL_DIR, INSTRUCTIONS_FILENAME);
+}
+
+function resolveHooksDir(context: IntegrationContext): string {
+  return context.scope === 'global'
+    ? join(context.targetRoot, '.copilot', 'hooks')
+    : join(context.targetRoot, PROJECT_HOOKS_REL_DIR);
+}
+
+function upsertHookConfig(document: unknown, context: IntegrationContext): HooksJson {
+  const hooksJson = toHooksJson(document);
+  hooksJson.hooks ??= {};
+
+  const existing = hooksJson.hooks.preToolUse ?? [];
+  hooksJson.hooks.preToolUse = [
+    ...existing.filter((entry) => !entryReferencesSonarSecrets(entry)),
+    createHookCommandEntry(context),
+  ];
+
+  return hooksJson;
+}
+
+function toHooksJson(document: unknown): HooksJson {
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    return { version: 1, hooks: {} };
+  }
+
+  const json = document as Partial<HooksJson>;
+  return {
+    version: typeof json.version === 'number' ? json.version : 1,
+    hooks: json.hooks ? { ...json.hooks } : {},
+  };
+}
+
+function createHookCommandEntry(context: IntegrationContext): HookCommandEntry {
+  const scriptPath = resolveCopilotHookScriptPath(context);
+  const commandPath =
+    context.scope === 'global' ? scriptPath : relative(context.targetRoot, scriptPath);
+
+  return process.platform === 'win32'
+    ? {
+        type: 'command',
+        timeoutSec: HOOK_TIMEOUT_SEC,
+        powershell: commandPath.replaceAll('\\', '/'),
+      }
+    : {
+        type: 'command',
+        timeoutSec: HOOK_TIMEOUT_SEC,
+        bash: commandPath,
+      };
+}
+
+function upsertCopilotMcpServer(document: unknown, serverConfig: object): Record<string, unknown> {
+  const existing = toJsonObject(document);
+  const mcpServers = toJsonObject(existing.mcpServers);
+  return {
+    ...existing,
+    mcpServers: {
+      ...mcpServers,
+      sonarqube: serverConfig,
+    },
+  };
+}
+
+function getDesiredCopilotMcpConfig(context: IntegrationContext) {
+  return getMcpConfig(
+    CLI_COMMAND,
+    context.scope === 'global'
+      ? { withFsMount: false }
+      : {
+          withFsMount: true,
+          projectRoot: context.targetRoot,
+          projectKey: getOptionalProjectKey(context),
+        },
+  );
+}
+
+function getOptionalProjectKey(context: IntegrationContext): string | undefined {
+  const value = context.attrs?.projectKey;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getRequiredStringAttr(context: IntegrationContext, key: string): string {
+  const value = context.attrs?.[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new CommandFailedError(`Missing required integration attribute: ${key}`);
+  }
+  return value;
+}
+
+function getBooleanAttr(context: IntegrationContext, key: string): boolean {
+  return context.attrs?.[key] === true;
+}
+
+function toJsonObject(document: unknown): Record<string, unknown> {
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    return {};
+  }
+  return { ...(document as Record<string, unknown>) };
+}

--- a/src/cli/commands/integrate/copilot/hooks.ts
+++ b/src/cli/commands/integrate/copilot/hooks.ts
@@ -18,42 +18,29 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Copilot CLI hook installation.
-// Writes a single OS-specific script and registers it in
-// the Copilot `hooks.json` config.
-
 import { existsSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { join, relative } from 'node:path';
+import { join } from 'node:path';
 
-import { info, success, warn } from '../../../../ui';
-import { installSecretsBinary } from '../../_common/install/secrets';
-import { readOrInitJson, SONAR_SECRETS_MARKER, writeHookScript } from '../_common/hooks';
-import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
+import { info, warn } from '../../../../ui';
+import { readOrInitJson, SONAR_SECRETS_MARKER } from '../_common/hooks';
 
-export interface HookInstallResult {
-  /* Absolute path of the active sonar-secrets hook script. `undefined` when installation failed. */
-  hookPath?: string;
-  hookInstalled: boolean;
-}
+export const SCRIPT_REL_DIR = join(SONAR_SECRETS_MARKER, 'build-scripts');
+export const SCRIPT_BASENAME = 'pretool-secrets';
+export const HOOKS_JSON = 'hooks.json';
+export const HOOK_TIMEOUT_SEC = 60;
 
-const SCRIPT_REL_DIR = join(SONAR_SECRETS_MARKER, 'build-scripts');
-const SCRIPT_BASENAME = 'pretool-secrets';
-const HOOKS_JSON = 'hooks.json';
-const HOOK_TIMEOUT_SEC = 60;
+export const PROJECT_HOOKS_REL_DIR = join('.github', 'hooks');
+export const GLOBAL_HOOKS_DIR = join(homedir(), '.copilot', 'hooks');
 
-const PROJECT_HOOKS_REL_DIR = join('.github', 'hooks');
-const GLOBAL_HOOKS_DIR = join(homedir(), '.copilot', 'hooks');
-
-interface HookCommandEntry {
+export interface HookCommandEntry {
   type: 'command';
   bash?: string;
   powershell?: string;
   timeoutSec?: number;
 }
 
-interface HooksJson {
+export interface HooksJson {
   version: number;
   hooks?: {
     // Optional because a user-authored hooks.json may be a bare `{}` with no top-level `hooks` key
@@ -73,7 +60,7 @@ interface HooksJson {
  *    script is missing) → `warn(...)` and return `undefined`.
  *  - No global install → silent, return `undefined`.
  */
-async function detectGlobalSecretsHook(): Promise<string | undefined> {
+export async function detectGlobalSecretsHook(): Promise<string | undefined> {
   const hooksJsonPath = join(GLOBAL_HOOKS_DIR, HOOKS_JSON);
   if (!existsSync(hooksJsonPath)) return undefined;
   const parsed = await readOrInitJson<HooksJson>(hooksJsonPath, { version: 1, hooks: {} });
@@ -97,88 +84,12 @@ async function detectGlobalSecretsHook(): Promise<string | undefined> {
   return scriptPath;
 }
 
-/**
- * Write the secrets pre-tool-use script for the current platform and upsert a
- * matching entry in the Copilot `hooks.json`. The hooks directory is derived
- * from `projectRoot` and `isGlobal` so callers don't have to know about it.
- *
- * Emits user-facing progress messages directly.
- */
-async function installPreToolUseHook(projectRoot: string, isGlobal: boolean): Promise<string> {
-  info('Installing pre-tool-use secrets hook...');
-
-  const hooksDir = isGlobal ? GLOBAL_HOOKS_DIR : join(projectRoot, PROJECT_HOOKS_REL_DIR);
-  const isWindows = process.platform === 'win32';
-
-  const scriptDir = join(hooksDir, SCRIPT_REL_DIR);
-  const scriptPath = await writeHookScript(
-    scriptDir,
-    SCRIPT_BASENAME,
-    getSecretPreToolTemplateUnix(),
-    getSecretPreToolTemplateWindows(),
-  );
-
-  const hooksJsonPath = join(hooksDir, HOOKS_JSON);
-  const hooksJson = await readOrInitJson<HooksJson>(hooksJsonPath, { version: 1, hooks: {} });
-  hooksJson.hooks ??= {};
-
-  // Project scope uses paths relative to the project root so the config remains
-  // portable when the project is moved or shared via version control. Copilot
-  // CLI resolves relative `powershell`/`bash` entries against the session's
-  // working directory (the project root), not the hooks dir, so paths relative
-  // to the hooks dir silently fail to find the script on Windows.
-  // Global scope uses absolute paths because `~/.copilot/hooks` is fixed.
-  const commandPath = isGlobal ? scriptPath : relative(projectRoot, scriptPath);
-
-  const newEntry: HookCommandEntry = {
-    type: 'command',
-    timeoutSec: HOOK_TIMEOUT_SEC,
-  };
-  if (isWindows) {
-    // Normalize Windows backslashes so the JSON entry stays clean and matches
-    // the convention used by the Claude integration.
-    newEntry.powershell = commandPath.replaceAll('\\', '/');
-  } else {
-    newEntry.bash = commandPath;
-  }
-
-  const existing = hooksJson.hooks.preToolUse ?? [];
-  hooksJson.hooks.preToolUse = [
-    ...existing.filter((e) => !entryReferencesSonarSecrets(e)),
-    newEntry,
-  ];
-
-  await writeFile(hooksJsonPath, JSON.stringify(hooksJson, null, 2) + '\n', 'utf-8');
-
-  success(`Pre-tool-use hook installed (${hooksJsonPath})`);
-  return scriptPath;
-}
-
-export async function installHooks(
-  projectRoot: string,
-  isGlobal: boolean,
-): Promise<HookInstallResult> {
-  try {
-    await installSecretsBinary();
-    if (!isGlobal) {
-      const existingGlobalHookPath = await detectGlobalSecretsHook();
-      if (existingGlobalHookPath) {
-        return { hookPath: existingGlobalHookPath, hookInstalled: false };
-      }
-    }
-    const hookPath = await installPreToolUseHook(projectRoot, isGlobal);
-    return { hookPath, hookInstalled: true };
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    warn(
-      `Failed to set up the pre-tool-use secrets hook: ${detail}. Secrets scanning will not run.`,
-    );
-    return { hookInstalled: false };
-  }
-}
-
-function entryReferencesSonarSecrets(entry: HookCommandEntry): boolean {
+export function entryReferencesSonarSecrets(entry: HookCommandEntry): boolean {
   return Boolean(
     entry.bash?.includes(SONAR_SECRETS_MARKER) || entry.powershell?.includes(SONAR_SECRETS_MARKER),
   );
+}
+
+export function hookScriptName(): string {
+  return `${SCRIPT_BASENAME}${process.platform === 'win32' ? '.ps1' : '.sh'}`;
 }

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -17,18 +17,38 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
+import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
 import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
+import { installIntegration } from '../_common/registry';
 import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
-import { installHooks } from './hooks';
-import type { InstructionsInstallResult } from './instructions';
-import { installInstructions } from './instructions';
-import { setupMcpServer } from './mcp';
+import {
+  COPILOT_INTEGRATION_ID,
+  type CopilotIntegrationOptions,
+  registerCopilotIntegration,
+} from './declaration';
+import {
+  detectGlobalSecretsHook,
+  hookScriptName,
+  PROJECT_HOOKS_REL_DIR,
+  SCRIPT_REL_DIR,
+} from './hooks';
+import {
+  INSTRUCTIONS_FILENAME,
+  PROJECT_INSTRUCTIONS_REL_DIR,
+  warnIfProjectInstructionsShadowGlobal,
+} from './instructions';
 import { updateCopilotState } from './state';
+
+registerCopilotIntegration();
 
 export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAgentOptions) {
   if (options.global && options.project) {
@@ -39,11 +59,6 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
 
   intro('SonarQube integration for Copilot');
 
-  // =========
-  // Discovery
-  // =========
-
-  // Discover project
   const project = await discoverProject(process.cwd());
   const isGlobal = options.global ?? false;
   const projectKey = options.project || project.projectKey;
@@ -56,22 +71,40 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
   const entitled = await resolveSqaaEntitlement(auth.serverUrl, auth.token, auth.orgKey);
   const sqaaProjectKey = entitled && projectKey ? projectKey : undefined;
 
-  // ============
-  // Installation
-  // ============
-  const { hookPath, hookInstalled } = await installHooks(project.rootDir, isGlobal);
-  const instructions = await installInstructions(project.rootDir, isGlobal, sqaaProjectKey);
+  const targetRoot = isGlobal ? homedir() : project.rootDir;
+  const scope: IntegrationScope = isGlobal ? 'global' : 'project';
+  const existingGlobalHookPath = isGlobal ? undefined : await detectGlobalSecretsHook();
+  const installHook = existingGlobalHookPath === undefined;
+  if (!isGlobal) {
+    warnIfProjectInstructionsShadowGlobal();
+  }
 
-  await updateCopilotState(project.rootDir, isGlobal, {
-    hookInstalled,
-    promptSecretsInstructionsInstalled: instructions.promptSecrets.installed,
-    sqaaInstructionsInstalled: instructions.sqaa.installed,
-    projectKey: instructions.sqaa.installed ? sqaaProjectKey : undefined,
-    orgKey: instructions.sqaa.installed ? auth.orgKey : undefined,
-    serverUrl: instructions.sqaa.installed ? auth.serverUrl : undefined,
+  const integrationOptions: CopilotIntegrationOptions = {
+    ...options,
+    projectRoot: project.rootDir,
+    installBinary: true,
+    installHook,
+    installInstructions: true,
+    installSqaaInstructions: sqaaProjectKey !== undefined,
+    installMcp: true,
+  };
+
+  await installIntegration({
+    integrationId: COPILOT_INTEGRATION_ID,
+    options: integrationOptions,
+    targetRoot,
+    scope,
+    attrs: buildIntegrationAttrs(projectKey, sqaaProjectKey !== undefined),
   });
 
-  await setupMcpServer(project, isGlobal, projectKey);
+  await updateCopilotState(project.rootDir, isGlobal, {
+    hookInstalled: installHook,
+    promptSecretsInstructionsInstalled: true,
+    sqaaInstructionsInstalled: sqaaProjectKey !== undefined,
+    projectKey: sqaaProjectKey,
+    orgKey: sqaaProjectKey ? auth.orgKey : undefined,
+    serverUrl: sqaaProjectKey ? auth.serverUrl : undefined,
+  });
 
   if (!options.skipContext) {
     await setupContextAugmentation({
@@ -83,36 +116,75 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     });
   }
 
-  reportInstallationOutcome(isGlobal, hookPath, instructions);
+  reportInstallationOutcome({
+    isGlobal,
+    hookPath: existingGlobalHookPath ?? expectedHookPath(targetRoot, scope),
+    promptInstructionsPath: expectedPromptInstructionsPath(targetRoot, scope),
+    sqaaInstructionsPath:
+      sqaaProjectKey === undefined ? undefined : expectedSqaaInstructionsPath(project.rootDir),
+  });
 }
 
-function reportInstallationOutcome(
-  isGlobal: boolean,
-  hookPath: string | undefined,
-  instructions: InstructionsInstallResult,
-): void {
+interface InstallationOutcome {
+  isGlobal: boolean;
+  hookPath: string;
+  promptInstructionsPath: string;
+  sqaaInstructionsPath?: string;
+}
+
+function reportInstallationOutcome({
+  isGlobal,
+  hookPath,
+  promptInstructionsPath,
+  sqaaInstructionsPath,
+}: InstallationOutcome): void {
   const scope = isGlobal
     ? 'Copilot integration successfully configured globally'
     : 'Copilot integration successfully configured at the project level';
-  const hookLine = hookPath ? `Hook: ${hookPath}` : 'Hook: not installed (see warning above)';
-  const instructionsLines = formatInstructionsLines(instructions);
+  const instructionsLines = formatInstructionsLines(promptInstructionsPath, sqaaInstructionsPath);
+  const hookLine = `Hook: ${hookPath}`;
   success([scope, hookLine, ...instructionsLines].join('\n'));
 }
 
-function formatInstructionsLines(instructions: InstructionsInstallResult): string[] {
-  const { promptSecrets, sqaa } = instructions;
-  const lines: string[] = [];
-  if (!promptSecrets.installed || !promptSecrets.path) {
-    lines.push('Instructions (secrets scanning for prompts): not installed (see warning above)');
-  } else if (sqaa.installed && sqaa.path === promptSecrets.path) {
-    lines.push(
-      `Instructions (secrets scanning for prompts, SonarQube Agentic Analysis): ${promptSecrets.path}`,
-    );
-  } else {
-    lines.push(`Instructions (secrets scanning for prompts): ${promptSecrets.path}`);
+function formatInstructionsLines(
+  promptInstructionsPath: string,
+  sqaaInstructionsPath?: string,
+): string[] {
+  if (sqaaInstructionsPath && sqaaInstructionsPath === promptInstructionsPath) {
+    return [
+      `Instructions (secrets scanning for prompts, SonarQube Agentic Analysis): ${promptInstructionsPath}`,
+    ];
   }
-  if (sqaa.installed && sqaa.path && sqaa.path !== promptSecrets.path) {
-    lines.push(`Instructions (SonarQube Agentic Analysis): ${sqaa.path}`);
+
+  const lines = [`Instructions (secrets scanning for prompts): ${promptInstructionsPath}`];
+  if (sqaaInstructionsPath) {
+    lines.push(`Instructions (SonarQube Agentic Analysis): ${sqaaInstructionsPath}`);
   }
   return lines;
+}
+
+function expectedHookPath(targetRoot: string, scope: IntegrationScope): string {
+  return scope === 'global'
+    ? join(targetRoot, '.copilot', 'hooks', SCRIPT_REL_DIR, hookScriptName())
+    : join(targetRoot, PROJECT_HOOKS_REL_DIR, SCRIPT_REL_DIR, hookScriptName());
+}
+
+function expectedPromptInstructionsPath(targetRoot: string, scope: IntegrationScope): string {
+  return scope === 'global'
+    ? join(targetRoot, '.copilot', 'instructions', INSTRUCTIONS_FILENAME)
+    : expectedSqaaInstructionsPath(targetRoot);
+}
+
+function buildIntegrationAttrs(
+  projectKey: string | undefined,
+  sqaaEnabled: boolean,
+): Record<string, IntegrationStateAttribute> {
+  return {
+    projectKey: projectKey ?? null,
+    sqaaEnabled,
+  };
+}
+
+function expectedSqaaInstructionsPath(projectRoot: string): string {
+  return join(projectRoot, PROJECT_INSTRUCTIONS_REL_DIR, INSTRUCTIONS_FILENAME);
 }

--- a/src/cli/commands/integrate/copilot/instructions.ts
+++ b/src/cli/commands/integrate/copilot/instructions.ts
@@ -26,32 +26,17 @@
 // (a) ask the agent to warn the user when a prompt appears to contain a
 // secret, and (b) direct the agent to run `sonar analyze agentic` at
 // end-of-turn for files modified in that turn.
-//
-// The instructions file is CLI-owned, so each run computes the full intended
-// contents and overwrites whatever is there.
 
-import { existsSync, mkdirSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
-import { info, warn } from '../../../../ui';
+import { warn } from '../../../../ui';
 import { buildSqaaSection, withSonarMarkers } from '../_common/instructions-templates';
 
-const INSTRUCTIONS_FILENAME = 'sonarqube.instructions.md';
-const PROJECT_INSTRUCTIONS_REL_DIR = join('.github', 'instructions');
-const GLOBAL_INSTRUCTIONS_DIR = join(homedir(), '.copilot', 'instructions');
-
-export interface SectionInstallResult {
-  /** Absolute path of the file the section was written to. `undefined` when the section was skipped or failed. */
-  path?: string;
-  installed: boolean;
-}
-
-export interface InstructionsInstallResult {
-  promptSecrets: SectionInstallResult;
-  sqaa: SectionInstallResult;
-}
+export const INSTRUCTIONS_FILENAME = 'sonarqube.instructions.md';
+export const PROJECT_INSTRUCTIONS_REL_DIR = join('.github', 'instructions');
+export const GLOBAL_INSTRUCTIONS_DIR = join(homedir(), '.copilot', 'instructions');
 
 const PROMPT_SECRETS_SECTION = withSonarMarkers(
   'copilot-prompt-secrets',
@@ -79,66 +64,23 @@ If the prompt appears to contain any such secret (either by your judgement or th
 `,
 );
 
-export async function installInstructions(
-  projectRoot: string,
-  isGlobal: boolean,
-  sqaaProjectKey?: string,
-): Promise<InstructionsInstallResult> {
-  const projectPath = join(projectRoot, PROJECT_INSTRUCTIONS_REL_DIR, INSTRUCTIONS_FILENAME);
-  const globalPath = join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME);
-
-  const result: InstructionsInstallResult = {
-    promptSecrets: { installed: false },
-    sqaa: { installed: false },
-  };
-
-  if (isGlobal) {
-    // Global install: prompt-secrets goes to the global file. SQAA, when
-    // entitled, additionally goes to the project file (SQAA is always
-    // project-scoped, even on a --global install).
-    const promptSecretsInstalled = await writeInstructionsFile(globalPath, PROMPT_SECRETS_SECTION);
-    if (promptSecretsInstalled) {
-      result.promptSecrets = { installed: true, path: globalPath };
-    }
-    if (sqaaProjectKey) {
-      const sqaaInstalled = await writeInstructionsFile(
-        projectPath,
-        buildSqaaSection(sqaaProjectKey),
-      );
-      if (sqaaInstalled) {
-        result.sqaa = { installed: true, path: projectPath };
-      }
-    }
-    return result;
+export function buildInstructionsBody(projectKey?: string): string {
+  const sections = [PROMPT_SECRETS_SECTION];
+  if (projectKey) {
+    sections.push(buildSqaaSection(projectKey));
   }
-
-  // Project install: prompt-secrets + (optional) SQAA both go to the project file.
-  if (existsSync(globalPath)) warnOrphan(globalPath);
-  const sections = sqaaProjectKey
-    ? [PROMPT_SECRETS_SECTION, buildSqaaSection(sqaaProjectKey)]
-    : [PROMPT_SECRETS_SECTION];
-  const projectInstalled = await writeInstructionsFile(projectPath, sections.join('\n\n'));
-  if (projectInstalled) {
-    result.promptSecrets = { installed: true, path: projectPath };
-    if (sqaaProjectKey) result.sqaa = { installed: true, path: projectPath };
-  }
-  return result;
+  return `${sections.join('\n\n').trimEnd()}\n`;
 }
 
-async function writeInstructionsFile(filePath: string, content: string): Promise<boolean> {
-  try {
-    info(`Installing Copilot instructions...`);
-    mkdirSync(dirname(filePath), { recursive: true });
-    await writeFile(filePath, `${content.trimEnd()}\n`, 'utf-8');
-    return true;
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    warn(`Failed to install Copilot instructions at ${filePath}: ${detail}.`);
-    return false;
-  }
+export function buildSqaaInstructionsBody(projectKey: string): string {
+  return `${buildSqaaSection(projectKey).trimEnd()}\n`;
 }
 
-function warnOrphan(filePath: string): void {
+export function warnIfProjectInstructionsShadowGlobal(): void {
+  const filePath = join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME);
+  if (!existsSync(filePath)) {
+    return;
+  }
   warn(
     `Found existing Copilot instructions at '${filePath}'; this run only updates the project-level file. Remove the existing one if it is no longer needed.`,
   );

--- a/tests/integration/specs/integrate/copilot-test-helpers.ts
+++ b/tests/integration/specs/integrate/copilot-test-helpers.ts
@@ -150,9 +150,8 @@ export function writeExistingGlobalInstructions(harness: TestHarness): void {
 }
 
 /**
- * Force the project-level hook write to fail by pre-creating `hooks.json` as a
- * directory. The integration's `readOrInitJson` then fails with `EISDIR`,
- * exercising the try/catch fallback in `installHooks`.
+ * Force the project-level hook configuration update to fail by pre-creating
+ * `hooks.json` as a directory.
  */
 export function obstructHooksJson(harness: TestHarness): void {
   mkdirSync(harness.cwd.file('.github', 'hooks').path, { recursive: true });
@@ -161,8 +160,7 @@ export function obstructHooksJson(harness: TestHarness): void {
 
 /**
  * Force the project-level instructions write to fail by pre-creating the
- * target file path as a directory. The integration's `writeFile` then fails
- * with `EISDIR`, exercising the try/catch fallback in `installInstructions`.
+ * target file path as a directory.
  */
 export function obstructInstructionsFile(harness: TestHarness): void {
   mkdirSync(harness.cwd.file('.github', 'instructions').path, { recursive: true });

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -144,6 +144,41 @@ describe('integrate copilot', () => {
     );
 
     it(
+      'records declarative Copilot features in integrations.installed for project installs',
+      async () => {
+        await harness.run('integrate copilot --project my-project');
+
+        const state = harness.stateJsonFile.asJson();
+        const copilotIntegration = state.integrations.installed.find(
+          (integration: { integrationId: string }) => integration.integrationId === 'copilot-cli',
+        );
+
+        expect(copilotIntegration).toBeDefined();
+        expect(
+          copilotIntegration.features
+            .map((feature: { featureId: string }) => feature.featureId)
+            .sort(),
+        ).toEqual([
+          'mcp-server',
+          'pre-tool-use-hook',
+          'prompt-secrets-instructions',
+          'sonar-secrets-binary',
+        ]);
+
+        const hookFeature = copilotIntegration.features.find(
+          (feature: { featureId: string }) => feature.featureId === 'pre-tool-use-hook',
+        );
+        expect(hookFeature).toMatchObject({
+          scope: 'project',
+          attrs: {
+            projectKey: 'my-project',
+          },
+        });
+      },
+      { timeout: 30000 },
+    );
+
+    it(
       'running twice yields exactly one preToolUse entry in hooks.json',
       async () => {
         await harness.run('integrate copilot');
@@ -537,6 +572,16 @@ describe('integrate copilot', () => {
         expect(
           normalizePath(outcomeLine(result.stdout, 'Instructions (secrets scanning for prompts):')),
         ).toContain('.github/instructions/sonarqube.instructions.md');
+
+        const copilotIntegration = state.integrations.installed.find(
+          (integration: { integrationId: string }) => integration.integrationId === 'copilot-cli',
+        );
+        expect(copilotIntegration).toBeDefined();
+        expect(
+          copilotIntegration.features
+            .map((feature: { featureId: string }) => feature.featureId)
+            .sort(),
+        ).toEqual(['mcp-server', 'prompt-secrets-instructions', 'sonar-secrets-binary']);
       },
       { timeout: 30000 },
     );
@@ -544,69 +589,64 @@ describe('integrate copilot', () => {
 
   // ─── Installation failure handling ──────────────────────────────────────────
 
-  // We force file-system failures by pre-creating the would-be artifact paths
-  // as directories. The integration's `writeFile`/`readFile` calls then fail,
-  // exercising the try/catch fallbacks.
+  // We force file-system failures by pre-creating artifact paths as
+  // directories or by writing invalid JSON. The declarative installer now
+  // fails fast, so later features are not applied and the Copilot agent state
+  // is not recorded.
 
   describe('installation failure handling', () => {
     it(
-      'warns and continues with MCP + instructions when the hook write fails',
+      'fails and stops before instructions + MCP when the hook configuration write fails',
       async () => {
         obstructHooksJson(harness);
 
         const result = await harness.run('integrate copilot');
 
-        expect(result.exitCode).toBe(0);
-        expect(result.stderr + result.stdout).toContain(
-          'Failed to set up the pre-tool-use secrets hook',
-        );
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout + result.stderr).toContain('contains invalid JSON');
+        expect(result.stdout).not.toContain('Copilot integration successfully configured');
 
-        // Hook artifact was not finalized; the registry must not claim it was.
+        // The hook feature fails before later features run.
+        expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(false);
+        expect(harness.cwd.exists('.mcp.json')).toBe(false);
+
+        // Agent state is not updated because the integration did not complete.
         expect(findSonarHookExt(harness)).toBeUndefined();
-        // Outcome line reflects the failure rather than printing a misleading path.
-        expect(outcomeLine(result.stdout, 'Hook:')).toContain('not installed (see warning above)');
-
-        // Instructions still installed.
-        const instructionsFile = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH);
-        expect(instructionsFile.exists()).toBe(true);
-        expect(instructionsFile.asText()).toContain(
-          '# SonarQube secrets scanning for prompts protocol',
-        );
-        expect(findSonarInstructionsExt(harness)).toBeDefined();
-        expect(
-          outcomeLine(result.stdout, 'Instructions (secrets scanning for prompts):'),
-        ).not.toContain('not installed');
-
-        // MCP still configured.
-        expect(harness.cwd.exists('.mcp.json')).toBe(true);
+        expect(findSonarInstructionsExt(harness)).toBeUndefined();
       },
       { timeout: 30000 },
     );
 
     it(
-      'warns and continues with MCP + hook when the instructions write fails',
+      'fails and stops before MCP when the instructions write fails',
       async () => {
         obstructInstructionsFile(harness);
 
         const result = await harness.run('integrate copilot');
 
-        expect(result.exitCode).toBe(0);
-        expect(result.stderr + result.stdout).toContain('Failed to install Copilot instructions');
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).not.toContain('Copilot integration successfully configured');
+        expect(harness.cwd.exists('.mcp.json')).toBe(false);
 
-        // Instructions registry entry must not be recorded.
+        // Agent state is not updated because the integration did not complete.
+        expect(findSonarHookExt(harness)).toBeUndefined();
         expect(findSonarInstructionsExt(harness)).toBeUndefined();
-        expect(
-          outcomeLine(result.stdout, 'Instructions (secrets scanning for prompts):'),
-        ).toContain('not installed (see warning above)');
+      },
+      { timeout: 30000 },
+    );
 
-        // Hook still installed.
-        const scriptFile = harness.cwd.file(...PROJECT_HOOK_SCRIPT_PATH);
-        expect(scriptFile.exists()).toBe(true);
-        expect(findSonarHookExt(harness)).toBeDefined();
-        expect(outcomeLine(result.stdout, 'Hook:')).not.toContain('not installed');
+    it(
+      'fails when the existing MCP config contains invalid JSON',
+      async () => {
+        harness.cwd.writeFile('.mcp.json', '{ invalid json\n');
 
-        // MCP still configured.
-        expect(harness.cwd.exists('.mcp.json')).toBe(true);
+        const result = await harness.run('integrate copilot');
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout + result.stderr).toContain('.mcp.json contains invalid JSON');
+        expect(result.stdout).not.toContain('Copilot integration successfully configured');
+        expect(findSonarHookExt(harness)).toBeUndefined();
+        expect(findSonarInstructionsExt(harness)).toBeUndefined();
       },
       { timeout: 30000 },
     );


### PR DESCRIPTION
----
## Summary by Gitar

- **Declarative installer migration:**
  - Migrated Copilot integration from imperative hooks/instructions/MCP setup to declarative `IntegrationDeclaration` in new `declaration.ts`
  - Features: sonar-secrets binary, pre-tool-use hook, prompt-secrets instructions, SQAA instructions, MCP server configuration
- **Integration refactoring:**
  - Moved file I/O and patching logic into declarative resource handlers; `index.ts` now orchestrates via `installIntegration()`
  - Consolidated hook/instructions/MCP state updates into unified integration registry
- **Error handling change:**
  - Declarative installer now fails fast on any resource error (e.g., invalid JSON); previously warned and continued
- **Tests updated:**
  - Added test for recorded Copilot features in integration state; updated failure-handling tests to expect early exit

<sub>This will update automatically on new commits.</sub>