### PR TITLE
CLI-499 skip sqaa during global integration

### DIFF
--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -28,19 +28,27 @@
 // instructions file (i.e. without clobbering anything the user appended
 // around it).
 
+export const SQAA_SECTION_ID = 'sonarqube-agentic-analysis';
+
+export function sonarBeginMarker(id: string): string {
+  return `<!-- sonar:begin:${id} -->`;
+}
+
+export function sonarEndMarker(id: string): string {
+  return `<!-- sonar:end:${id} -->`;
+}
+
 /**
  * Wrap a markdown body in stable HTML-comment markers. The `id` must remain
  * unique and stable across CLI versions — it is the only identifier we have
  * for finding and replacing the managed region later.
  */
 export function withSonarMarkers(id: string, body: string): string {
-  return `<!-- sonar:begin:${id} -->\n${body.trimEnd()}\n<!-- sonar:end:${id} -->\n`;
+  return `${sonarBeginMarker(id)}\n${body.trimEnd()}\n${sonarEndMarker(id)}\n`;
 }
 
-export function buildSqaaSection(projectKey: string): string {
-  return withSonarMarkers(
-    'sqaa-protocol',
-    `# SonarQube Agentic Analysis protocol
+export function buildSqaaSectionBody(projectKey: string): string {
+  return `# SonarQube Agentic Analysis protocol
 
 SonarQube Agentic Analysis is the final confirmation layer at the end of every turn in which you wrote to one or more files in the workspace (create, edit, patch, format — any tool call that changed file contents on disk).
 
@@ -62,6 +70,9 @@ Non-negotiable rules:
 3. If SonarQube Agentic Analysis reports issues on lines you touched in this turn, fix them, then re-run SonarQube Agentic Analysis on that file. Repeat until the file is clean (or only pre-existing findings on lines you did not touch remain). Pre-existing findings on untouched lines are out of scope — do not "fix" them unless the user asked.
 4. If SonarQube Agentic Analysis is skipped (no SonarQube Cloud connection, or no project configured), state the skip reason to the user once and continue — do not retry.
 5. Do not suppress, summarize away, or omit SonarQube Agentic Analysis findings from your reply. Surface them verbatim.
-`,
-  );
+`;
+}
+
+export function buildSqaaSection(projectKey: string): string {
+  return withSonarMarkers(SQAA_SECTION_ID, buildSqaaSectionBody(projectKey));
 }

--- a/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { AppliedResource, IntegrationContext } from '../types';
+import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
   type BaseResourceOptions,
   type PathResolver,
@@ -28,9 +28,11 @@ import {
   writeFileIfChanged,
 } from './common';
 
+export type TextSnippetContent = string | ((context: IntegrationContext) => MaybePromise<string>);
+
 export interface TextSnippetResourceOptions extends BaseResourceOptions {
   targetPath: PathResolver;
-  content: string;
+  content: TextSnippetContent;
   executable?: boolean;
   startMarker: string;
   endMarker?: string;
@@ -54,7 +56,8 @@ export class TextSnippet implements ResourceDeclaration {
 
   async apply(context: IntegrationContext): Promise<AppliedResource> {
     const path = await resolvePath(context, this.options.targetPath);
-    await writeFileIfChanged(path, await this.renderContent(path), this.options.executable);
+    const body = await this.resolveBody(context);
+    await writeFileIfChanged(path, await this.renderFile(path, body), this.options.executable);
     return { id: this.id, resourceType: this.resourceType, version: this.version, path };
   }
 
@@ -64,12 +67,17 @@ export class TextSnippet implements ResourceDeclaration {
     if (existing === undefined) {
       return false;
     }
-    return existing.includes(this.renderManagedBlock());
+    return existing.includes(this.renderManagedBlock(await this.resolveBody(context)));
   }
 
-  private async renderContent(path: string): Promise<string> {
+  private async resolveBody(context: IntegrationContext): Promise<string> {
+    const { content } = this.options;
+    return typeof content === 'function' ? content(context) : content;
+  }
+
+  private async renderFile(path: string, body: string): Promise<string> {
     const existing = (await readTextFile(path)) ?? '';
-    const managedBlock = this.renderManagedBlock();
+    const managedBlock = this.renderManagedBlock(body);
     const pattern = new RegExp(
       String.raw`${escapeRegExp(this.startMarker)}[\s\S]*?${escapeRegExp(this.endMarker)}`,
     );
@@ -85,8 +93,8 @@ export class TextSnippet implements ResourceDeclaration {
     return appendBlock(existing, managedBlock);
   }
 
-  private renderManagedBlock(): string {
-    return `${this.startMarker}\n${this.options.content.trimEnd()}\n${this.endMarker}`;
+  private renderManagedBlock(body: string): string {
+    return `${this.startMarker}\n${body.trimEnd()}\n${this.endMarker}`;
   }
 
   private get startMarker(): string {
@@ -106,5 +114,5 @@ function appendBlock(existing: string, block: string): string {
 }
 
 function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  return value.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
 }

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -43,3 +43,27 @@ export async function resolveSqaaEntitlement(
     return false;
   }
 }
+
+/**
+ * Emit the standard "SQAA is project-scoped" warning when an entitled org runs
+ * an integration globally. SQAA hooks and instructions are only installed by
+ * per-project integrate runs, so global users need to be steered to re-run.
+ *
+ * No-op unless both `isGlobal` and `sqaaEntitled` are true — keeps call sites
+ * free of nested conditionals.
+ *
+ * `agentCommand` is the subcommand name (e.g. `claude`, `codex`, `copilot`)
+ * that gets baked into the suggested `sonar integrate <agent> --project <key>`.
+ */
+export function warnSqaaSkippedOnGlobal(
+  agentCommand: string,
+  isGlobal: boolean,
+  sqaaEntitled: boolean,
+): void {
+  if (!isGlobal || !sqaaEntitled) {
+    return;
+  }
+  warn(
+    `SonarQube Agentic Analysis is project-scoped and is not enabled by this global install. Run \`sonar integrate ${agentCommand} --project <key>\` from a project directory to enable it for that project.`,
+  );
+}

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -52,18 +52,12 @@ export async function resolveSqaaEntitlement(
  * No-op unless both `isGlobal` and `sqaaEntitled` are true — keeps call sites
  * free of nested conditionals.
  *
- * `agentCommand` is the subcommand name (e.g. `claude`, `codex`, `copilot`)
- * that gets baked into the suggested `sonar integrate <agent> --project <key>`.
  */
-export function warnSqaaSkippedOnGlobal(
-  agentCommand: string,
-  isGlobal: boolean,
-  sqaaEntitled: boolean,
-): void {
+export function warnSqaaSkippedOnGlobal(isGlobal: boolean, sqaaEntitled: boolean): void {
   if (!isGlobal || !sqaaEntitled) {
     return;
   }
   warn(
-    `SonarQube Agentic Analysis is project-scoped and is not enabled by this global install. Run \`sonar integrate ${agentCommand} --project <key>\` from a project directory to enable it for that project.`,
+    `Skipping SonarQube Agentic Analysis: not supported with --global. Re-run without --global from a project directory to install it there.`,
   );
 }

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -260,7 +260,7 @@ function reportHookInstallationOutcome(
   }
   if (isGlobal) {
     success('Claude Code integration successfully configured globally');
-    warnSqaaSkippedOnGlobal('claude', isGlobal, sqaaEntitled);
+    warnSqaaSkippedOnGlobal(isGlobal, sqaaEntitled);
   } else {
     success('Claude Code integration successfully configured at the project level');
   }

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -35,7 +35,7 @@ import { blank, info, intro, note, outro, success, text, warn } from '../../../.
 import { CommandFailedError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
+import { resolveSqaaEntitlement, warnSqaaSkippedOnGlobal } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { CLAUDE_INTEGRATION_ID } from './declaration';
 import { runHealthChecks } from './health';
@@ -77,41 +77,19 @@ export async function integrateClaude(
   const hooksRoot = isGlobal || skipSecretsHooks ? homedir() : project.rootDir;
   const globalDir = isGlobal ? homedir() : undefined;
 
-  let token = config.token;
-
   blank();
   text('Phase 2/3: Health Check & Repair');
   blank();
 
-  const healthResult = await runHealthChecks(
-    config.serverURL,
-    token,
-    config.projectKey,
-    hooksRoot,
-    config.organization,
-  );
+  const token = await runHealthCheckAndRepair(config, hooksRoot, options);
 
-  if (healthResult.errors.length === 0) {
-    success('All checks passed! Configuration is healthy.');
-  } else {
-    warn(`Found ${healthResult.errors.length} issue(s):`);
-    for (const msg of healthResult.errors) {
-      text(`  - ${msg}`);
-    }
+  const sqaaEntitled = await resolveSqaaEntitlement(config.serverURL, token, config.organization);
+  // SQAA is project-scoped; never install it (hooks, state, or migrations)
+  // during a global install. We still surface the entitlement check so we can
+  // hint the user to re-run per-project.
+  const installSqaa = !isGlobal && sqaaEntitled;
 
-    const isNonInteractive = !!options.nonInteractive || isEnvBasedAuth();
-
-    if (!isNonInteractive && !healthResult.tokenValid) {
-      blank();
-      text('Running token repair...');
-
-      token = await repairToken(config.serverURL, config.organization);
-    }
-  }
-
-  const sqaaEnabled = await resolveSqaaEntitlement(config.serverURL, token, config.organization);
-
-  await runMigrations(project.rootDir, globalDir, sqaaEnabled, config.projectKey, {
+  await runMigrations(project.rootDir, globalDir, installSqaa, config.projectKey, {
     skipSecretsHooks,
   });
 
@@ -124,7 +102,7 @@ export async function integrateClaude(
       ...options,
       projectRoot: project.rootDir,
       installSecretsHooks: !skipSecretsHooks,
-      installSqaaHook: sqaaEnabled && config.projectKey !== undefined,
+      installSqaaHook: installSqaa && config.projectKey !== undefined,
       installMcp: true,
     },
     targetRoot: installRoot,
@@ -132,10 +110,10 @@ export async function integrateClaude(
     attrs: featureAttrs,
   });
   await removeObsoleteHookArtifacts(project.rootDir, OBSOLETE_A3S_MARKER);
-  await updateStateAfterConfiguration(config, project.rootDir, isGlobal, sqaaEnabled, {
+  await updateStateAfterConfiguration(config, project.rootDir, isGlobal, installSqaa, {
     skipSecretsHooks,
   });
-  reportHookInstallationOutcome(isGlobal, existingGlobalHookPath);
+  reportHookInstallationOutcome(isGlobal, existingGlobalHookPath, sqaaEntitled);
 
   if (!options.skipContext) {
     await setupContextAugmentation({
@@ -225,14 +203,54 @@ function validateConfiguration(
 }
 
 /**
+ * Run health checks and, if interactively recoverable, repair the token.
+ * Returns the (possibly refreshed) token to use for the rest of the install.
+ */
+async function runHealthCheckAndRepair(
+  config: ConfigurationData,
+  hooksRoot: string,
+  options: IntegrateAgentOptions,
+): Promise<string> {
+  const healthResult = await runHealthChecks(
+    config.serverURL,
+    config.token,
+    config.projectKey,
+    hooksRoot,
+    config.organization,
+  );
+
+  if (healthResult.errors.length === 0) {
+    success('All checks passed! Configuration is healthy.');
+    return config.token;
+  }
+
+  warn(`Found ${healthResult.errors.length} issue(s):`);
+  for (const msg of healthResult.errors) {
+    text(`  - ${msg}`);
+  }
+
+  const isNonInteractive = !!options.nonInteractive || isEnvBasedAuth();
+  if (isNonInteractive || healthResult.tokenValid) {
+    return config.token;
+  }
+
+  blank();
+  text('Running token repair...');
+  return repairToken(config.serverURL, config.organization);
+}
+
+/**
  * Print the scope-aware outcome after hook installation completes.
  * When project-level setup was skipped because a global hook already owns the
  * sonar-secrets scope, surface the existing hook path so the user knows where
  * the active secrets scanning hook lives.
+ * When the install is global and the org is SQAA-entitled, hint the user to
+ * re-run per-project so the project-scoped SQAA hook gets installed.
  */
 function reportHookInstallationOutcome(
   isGlobal: boolean,
   existingGlobalHookPath: string | undefined,
+  sqaaEntitled: boolean,
 ): void {
   if (existingGlobalHookPath) {
     success(
@@ -242,6 +260,7 @@ function reportHookInstallationOutcome(
   }
   if (isGlobal) {
     success('Claude Code integration successfully configured globally');
+    warnSqaaSkippedOnGlobal('claude', isGlobal, sqaaEntitled);
   } else {
     success('Claude Code integration successfully configured at the project level');
   }

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -29,7 +29,7 @@ import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
+import { resolveSqaaEntitlement, warnSqaaSkippedOnGlobal } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { CODEX_INTEGRATION_ID } from './declaration';
 
@@ -97,11 +97,7 @@ export async function integrateCodex(
 
   if (isGlobal) {
     success('Codex integration successfully configured globally');
-    if (sqaaEligible) {
-      warn(
-        'SonarQube Agentic Analysis is project-scoped and is not enabled by this global install. Run `sonar integrate codex --project <key>` from a project directory to enable it for that project.',
-      );
-    }
+    warnSqaaSkippedOnGlobal('codex', isGlobal, sqaaEligible);
   } else {
     success('Codex integration successfully configured at the project level');
   }

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -97,7 +97,7 @@ export async function integrateCodex(
 
   if (isGlobal) {
     success('Codex integration successfully configured globally');
-    warnSqaaSkippedOnGlobal('codex', isGlobal, sqaaEligible);
+    warnSqaaSkippedOnGlobal(isGlobal, sqaaEligible);
   } else {
     success('Codex integration successfully configured at the project level');
   }

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -40,7 +40,6 @@ import {
 } from './hooks';
 import {
   buildInstructionsBody,
-  buildSqaaInstructionsBody,
   INSTRUCTIONS_FILENAME,
   PROJECT_INSTRUCTIONS_REL_DIR,
 } from './instructions';
@@ -51,7 +50,6 @@ export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
   installHook?: boolean;
   installInstructions?: boolean;
-  installSqaaInstructions?: boolean;
   installMcp?: boolean;
 }
 
@@ -97,22 +95,6 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
             context.scope === 'project' && getBooleanAttr(context, 'sqaaEnabled')
               ? buildInstructionsBody(getRequiredStringAttr(context, 'projectKey'))
               : buildInstructionsBody(),
-        }),
-      ],
-    },
-    {
-      id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis instructions',
-      when: ({ options, scope }) => scope === 'global' && options.installSqaaInstructions === true,
-      targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
-      scope: 'project',
-      resources: [
-        wholeFile({
-          id: 'sqaa-instructions-file',
-          displayName: 'Copilot SQAA instructions',
-          targetPath: resolveInstructionsPath,
-          content: (context) =>
-            buildSqaaInstructionsBody(getRequiredStringAttr(context, 'projectKey')),
         }),
       ],
     },

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -23,8 +23,14 @@ import { join, relative } from 'node:path';
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { CommandFailedError } from '../../_common/error';
+import {
+  buildSqaaSectionBody,
+  sonarBeginMarker,
+  sonarEndMarker,
+  SQAA_SECTION_ID,
+} from '../_common/instructions-templates';
 import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
-import { jsonPatch, wholeFile } from '../_common/registry/resources';
+import { jsonPatch, textSnippet, wholeFile } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
@@ -39,9 +45,10 @@ import {
   SCRIPT_REL_DIR,
 } from './hooks';
 import {
-  buildInstructionsBody,
   INSTRUCTIONS_FILENAME,
   PROJECT_INSTRUCTIONS_REL_DIR,
+  PROMPT_SECRETS_SECTION_BODY,
+  PROMPT_SECRETS_SECTION_ID,
 } from './instructions';
 
 export const COPILOT_INTEGRATION_ID = 'copilot-cli';
@@ -49,7 +56,8 @@ export const COPILOT_INTEGRATION_ID = 'copilot-cli';
 export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
   installHook?: boolean;
-  installInstructions?: boolean;
+  installPromptSecretsInstructions?: boolean;
+  installSqaaInstructions?: boolean;
   installMcp?: boolean;
 }
 
@@ -85,16 +93,30 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'prompt-secrets-instructions',
       displayName: 'prompt-secrets instructions',
-      when: ({ options }) => options.installInstructions === true,
+      when: ({ options }) => options.installPromptSecretsInstructions === true,
       resources: [
-        wholeFile({
-          id: 'prompt-secrets-instructions-file',
-          displayName: 'Copilot prompt-secrets instructions',
+        textSnippet({
+          id: 'prompt-secrets-instructions-section',
+          displayName: 'Copilot prompt-secrets instructions section',
           targetPath: resolveInstructionsPath,
-          content: (context) =>
-            context.scope === 'project' && getBooleanAttr(context, 'sqaaEnabled')
-              ? buildInstructionsBody(getRequiredStringAttr(context, 'projectKey'))
-              : buildInstructionsBody(),
+          content: PROMPT_SECRETS_SECTION_BODY,
+          startMarker: sonarBeginMarker(PROMPT_SECRETS_SECTION_ID),
+          endMarker: sonarEndMarker(PROMPT_SECRETS_SECTION_ID),
+        }),
+      ],
+    },
+    {
+      id: 'sqaa-instructions',
+      displayName: 'SonarQube Agentic Analysis instructions',
+      when: ({ options }) => options.installSqaaInstructions === true,
+      resources: [
+        textSnippet({
+          id: 'sqaa-instructions-section',
+          displayName: 'Copilot SQAA instructions section',
+          targetPath: resolveInstructionsPath,
+          content: (context) => buildSqaaSectionBody(getRequiredStringAttr(context, 'projectKey')),
+          startMarker: sonarBeginMarker(SQAA_SECTION_ID),
+          endMarker: sonarEndMarker(SQAA_SECTION_ID),
         }),
       ],
     },
@@ -219,10 +241,6 @@ function getRequiredStringAttr(context: IntegrationContext, key: string): string
     throw new CommandFailedError(`Missing required integration attribute: ${key}`);
   }
   return value;
-}
-
-function getBooleanAttr(context: IntegrationContext, key: string): boolean {
-  return context.attrs?.[key] === true;
 }
 
 function toJsonObject(document: unknown): Record<string, unknown> {

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -78,7 +78,8 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     ...options,
     projectRoot: project.rootDir,
     installHook,
-    installInstructions: true,
+    installPromptSecretsInstructions: true,
+    installSqaaInstructions: installSqaa,
     installMcp: true,
   };
 
@@ -151,10 +152,10 @@ function expectedInstructionsPath(targetRoot: string, scope: IntegrationScope): 
 
 function buildIntegrationAttrs(
   projectKey: string | undefined,
-  sqaaEnabled: boolean,
+  sqaaEntitled: boolean,
 ): Record<string, IntegrationStateAttribute> {
   return {
     projectKey: projectKey ?? null,
-    sqaaEnabled,
+    sqaaEntitled,
   };
 }

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -28,7 +28,7 @@ import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
+import { resolveSqaaEntitlement, warnSqaaSkippedOnGlobal } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { COPILOT_INTEGRATION_ID, type CopilotIntegrationOptions } from './declaration';
 import {
@@ -61,8 +61,10 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     );
   }
 
-  const entitled = await resolveSqaaEntitlement(auth.serverUrl, auth.token, auth.orgKey);
-  const sqaaProjectKey = entitled && projectKey ? projectKey : undefined;
+  const sqaaEntitled = await resolveSqaaEntitlement(auth.serverUrl, auth.token, auth.orgKey);
+  // SQAA is project-scoped; never install it during a global install. We still
+  // surface the entitlement check so we can hint the user to re-run per-project.
+  const installSqaa = !isGlobal && sqaaEntitled && projectKey !== undefined;
 
   const targetRoot = isGlobal ? homedir() : project.rootDir;
   const scope: IntegrationScope = isGlobal ? 'global' : 'project';
@@ -77,7 +79,6 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     projectRoot: project.rootDir,
     installHook,
     installInstructions: true,
-    installSqaaInstructions: sqaaProjectKey !== undefined,
     installMcp: true,
   };
 
@@ -86,7 +87,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     options: integrationOptions,
     targetRoot,
     scope,
-    attrs: buildIntegrationAttrs(projectKey, sqaaProjectKey !== undefined),
+    attrs: buildIntegrationAttrs(projectKey, installSqaa),
   });
 
   if (!options.skipContext) {
@@ -102,48 +103,38 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
   reportInstallationOutcome({
     isGlobal,
     hookPath: existingGlobalHookPath ?? expectedHookPath(targetRoot, scope),
-    promptInstructionsPath: expectedPromptInstructionsPath(targetRoot, scope),
-    sqaaInstructionsPath:
-      sqaaProjectKey === undefined ? undefined : expectedSqaaInstructionsPath(project.rootDir),
+    instructionsPath: expectedInstructionsPath(targetRoot, scope),
+    sqaaInstalled: installSqaa,
   });
+  warnSqaaSkippedOnGlobal('copilot', isGlobal, sqaaEntitled);
 }
 
 interface InstallationOutcome {
   isGlobal: boolean;
   hookPath: string;
-  promptInstructionsPath: string;
-  sqaaInstructionsPath?: string;
+  instructionsPath: string;
+  sqaaInstalled: boolean;
 }
 
-function reportInstallationOutcome({
-  isGlobal,
-  hookPath,
-  promptInstructionsPath,
-  sqaaInstructionsPath,
-}: InstallationOutcome): void {
-  const scope = isGlobal
+function reportInstallationOutcome(outcome: InstallationOutcome): void {
+  const scope = outcome.isGlobal
     ? 'Copilot integration successfully configured globally'
     : 'Copilot integration successfully configured at the project level';
-  const instructionsLines = formatInstructionsLines(promptInstructionsPath, sqaaInstructionsPath);
-  const hookLine = `Hook: ${hookPath}`;
+  const instructionsLines = formatInstructionsLines(outcome);
+  const hookLine = `Hook: ${outcome.hookPath}`;
   success([scope, hookLine, ...instructionsLines].join('\n'));
 }
 
-function formatInstructionsLines(
-  promptInstructionsPath: string,
-  sqaaInstructionsPath?: string,
-): string[] {
-  if (sqaaInstructionsPath && sqaaInstructionsPath === promptInstructionsPath) {
+function formatInstructionsLines({
+  instructionsPath,
+  sqaaInstalled,
+}: InstallationOutcome): string[] {
+  if (sqaaInstalled) {
     return [
-      `Instructions (secrets scanning for prompts, SonarQube Agentic Analysis): ${promptInstructionsPath}`,
+      `Instructions (secrets scanning for prompts, SonarQube Agentic Analysis): ${instructionsPath}`,
     ];
   }
-
-  const lines = [`Instructions (secrets scanning for prompts): ${promptInstructionsPath}`];
-  if (sqaaInstructionsPath) {
-    lines.push(`Instructions (SonarQube Agentic Analysis): ${sqaaInstructionsPath}`);
-  }
-  return lines;
+  return [`Instructions (secrets scanning for prompts): ${instructionsPath}`];
 }
 
 function expectedHookPath(targetRoot: string, scope: IntegrationScope): string {
@@ -152,10 +143,10 @@ function expectedHookPath(targetRoot: string, scope: IntegrationScope): string {
     : join(targetRoot, PROJECT_HOOKS_REL_DIR, SCRIPT_REL_DIR, hookScriptName());
 }
 
-function expectedPromptInstructionsPath(targetRoot: string, scope: IntegrationScope): string {
+function expectedInstructionsPath(targetRoot: string, scope: IntegrationScope): string {
   return scope === 'global'
     ? join(targetRoot, '.copilot', 'instructions', INSTRUCTIONS_FILENAME)
-    : expectedSqaaInstructionsPath(targetRoot);
+    : join(targetRoot, PROJECT_INSTRUCTIONS_REL_DIR, INSTRUCTIONS_FILENAME);
 }
 
 function buildIntegrationAttrs(
@@ -166,8 +157,4 @@ function buildIntegrationAttrs(
     projectKey: projectKey ?? null,
     sqaaEnabled,
   };
-}
-
-function expectedSqaaInstructionsPath(projectRoot: string): string {
-  return join(projectRoot, PROJECT_INSTRUCTIONS_REL_DIR, INSTRUCTIONS_FILENAME);
 }

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -23,7 +23,7 @@ import { join } from 'node:path';
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
-import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
+import type { IntegrationScope } from '../../../../lib/state';
 import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
@@ -88,7 +88,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     options: integrationOptions,
     targetRoot,
     scope,
-    attrs: buildIntegrationAttrs(projectKey, installSqaa),
+    attrs: { projectKey: projectKey ?? null },
   });
 
   if (!options.skipContext) {
@@ -107,7 +107,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     instructionsPath: expectedInstructionsPath(targetRoot, scope),
     sqaaInstalled: installSqaa,
   });
-  warnSqaaSkippedOnGlobal('copilot', isGlobal, sqaaEntitled);
+  warnSqaaSkippedOnGlobal(isGlobal, sqaaEntitled);
 }
 
 interface InstallationOutcome {
@@ -148,14 +148,4 @@ function expectedInstructionsPath(targetRoot: string, scope: IntegrationScope): 
   return scope === 'global'
     ? join(targetRoot, '.copilot', 'instructions', INSTRUCTIONS_FILENAME)
     : join(targetRoot, PROJECT_INSTRUCTIONS_REL_DIR, INSTRUCTIONS_FILENAME);
-}
-
-function buildIntegrationAttrs(
-  projectKey: string | undefined,
-  sqaaEntitled: boolean,
-): Record<string, IntegrationStateAttribute> {
-  return {
-    projectKey: projectKey ?? null,
-    sqaaEntitled,
-  };
 }

--- a/src/cli/commands/integrate/copilot/instructions.ts
+++ b/src/cli/commands/integrate/copilot/instructions.ts
@@ -72,10 +72,6 @@ export function buildInstructionsBody(projectKey?: string): string {
   return `${sections.join('\n\n').trimEnd()}\n`;
 }
 
-export function buildSqaaInstructionsBody(projectKey: string): string {
-  return `${buildSqaaSection(projectKey).trimEnd()}\n`;
-}
-
 export function warnIfProjectInstructionsShadowGlobal(): void {
   const filePath = join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME);
   if (!existsSync(filePath)) {

--- a/src/cli/commands/integrate/copilot/instructions.ts
+++ b/src/cli/commands/integrate/copilot/instructions.ts
@@ -32,15 +32,14 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { warn } from '../../../../ui';
-import { buildSqaaSection, withSonarMarkers } from '../_common/instructions-templates';
 
 export const INSTRUCTIONS_FILENAME = 'sonarqube.instructions.md';
 export const PROJECT_INSTRUCTIONS_REL_DIR = join('.github', 'instructions');
 export const GLOBAL_INSTRUCTIONS_DIR = join(homedir(), '.copilot', 'instructions');
 
-const PROMPT_SECRETS_SECTION = withSonarMarkers(
-  'copilot-prompt-secrets',
-  `# SonarQube secrets scanning for prompts protocol
+export const PROMPT_SECRETS_SECTION_ID = 'copilot-prompt-secrets';
+
+export const PROMPT_SECRETS_SECTION_BODY = `# SonarQube secrets scanning for prompts protocol
 
 Before acting on any user prompt, scan the prompt text for secrets or credentials. Treat the following as secrets (non-exhaustive):
 
@@ -61,16 +60,7 @@ If the prompt appears to contain any such secret (either by your judgement or th
 
 1. Inform the user that their prompt appears to contain a secret or credential and that it may now be exposed in chat history, logs, and any downstream telemetry.
 2. Advise them to rotate the leaked credential immediately at its source of truth.
-`,
-);
-
-export function buildInstructionsBody(projectKey?: string): string {
-  const sections = [PROMPT_SECRETS_SECTION];
-  if (projectKey) {
-    sections.push(buildSqaaSection(projectKey));
-  }
-  return `${sections.join('\n\n').trimEnd()}\n`;
-}
+`;
 
 export function warnIfProjectInstructionsShadowGlobal(): void {
   const filePath = join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME);

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -718,8 +718,11 @@ describe('integrate claude — SQAA entitlement guard', () => {
   );
 
   it(
-    'sonar-sqaa agentExtension is always project-level even when -g flag is used',
+    'on global install, does not install SQAA but warns to run per-project when the org is entitled',
     async () => {
+      // SQAA is project-scoped: a global install must not install the hook,
+      // record SQAA state, or write any project-level SQAA artifact, even when
+      // a project key is supplied. The user is steered to re-run per-project.
       const server = await harness
         .newFakeServer()
         .withAuthToken('cloud-token')
@@ -743,12 +746,10 @@ describe('integrate claude — SQAA entitlement guard', () => {
       expect(result.exitCode).toBe(0);
 
       const state = harness.stateJsonFile.asJson();
-      const sqaaExt = (state.agentExtensions as Array<{ name: string; global: boolean }>).find(
+      const sqaaExt = (state.agentExtensions as Array<{ name: string }>).find(
         (e) => e.name === 'sonar-sqaa',
       );
-
-      expect(sqaaExt).toBeDefined();
-      expect(sqaaExt?.global).toBe(false);
+      expect(sqaaExt).toBeUndefined();
 
       const claudeIntegration = state.integrations.installed.find(
         (integration: { integrationId: string }) => integration.integrationId === 'claude-code',
@@ -756,16 +757,12 @@ describe('integrate claude — SQAA entitlement guard', () => {
       const sqaaFeature = claudeIntegration?.features.find(
         (feature: { featureId: string }) => feature.featureId === 'sonar-sqaa-hook',
       );
+      expect(sqaaFeature).toBeUndefined();
 
-      expect(sqaaFeature).toBeDefined();
-      expect(sqaaFeature).toMatchObject({
-        scope: 'project',
-        attrs: {
-          orgKey: 'my-org',
-          projectKey: 'my-project',
-          serverUrl,
-        },
-      });
+      // The user gets a hint pointing them at the per-project command.
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(output).toContain('SonarQube Agentic Analysis');
+      expect(output).toContain('sonar integrate claude --project');
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -131,7 +131,7 @@ describe('integrate claude', () => {
           {
             id: 'claude-mcp-config',
             resourceType: 'json-patch',
-            path: harness.cwd.file('.mcp.json').path,
+            path: realpathSync(harness.cwd.file('.mcp.json').path),
           },
         ],
         operations: [],
@@ -762,7 +762,7 @@ describe('integrate claude — SQAA entitlement guard', () => {
       // The user gets a hint pointing them at the per-project command.
       const output = `${result.stdout}\n${result.stderr}`;
       expect(output).toContain('SonarQube Agentic Analysis');
-      expect(output).toContain('sonar integrate claude --project');
+      expect(output).toContain('Re-run without --global from a project directory');
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -391,8 +391,8 @@ describe('integrate codex', () => {
         expect(body).toContain('<!-- sonar:begin:codex-secrets-on-read -->');
         expect(body).toContain('<!-- sonar:end:codex-secrets-on-read -->');
         expect(body).toContain(SECRETS_HEADING);
-        expect(body).toContain('<!-- sonar:begin:sqaa-protocol -->');
-        expect(body).toContain('<!-- sonar:end:sqaa-protocol -->');
+        expect(body).toContain('<!-- sonar:begin:sonarqube-agentic-analysis -->');
+        expect(body).toContain('<!-- sonar:end:sonarqube-agentic-analysis -->');
         expect(body).toContain(SQAA_HEADING);
         expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
       },

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -23,6 +23,7 @@
 // hook-agent-prompt-submit.test.ts; this spec only exercises the integrate
 // command — script + hooks.json layout, scope semantics, and idempotency.
 
+import { realpathSync } from 'node:fs';
 import { isAbsolute } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
@@ -199,7 +200,7 @@ describe('integrate codex', () => {
             {
               id: 'codex-mcp-config',
               resourceType: 'toml-patch',
-              path: harness.cwd.file(...CONFIG_TOML_DIRS).path,
+              path: realpathSync(harness.cwd.file(...CONFIG_TOML_DIRS).path),
             },
           ],
         });
@@ -410,7 +411,7 @@ describe('integrate codex', () => {
         expect(body).toContain(SECRETS_HEADING);
         expect(body).not.toContain(SQAA_HEADING);
         const output = `${result.stdout}\n${result.stderr}`;
-        expect(output).not.toContain('sonar integrate codex --project');
+        expect(output).not.toContain('Skipping SonarQube Agentic Analysis');
       },
       { timeout: 30000 },
     );
@@ -445,7 +446,7 @@ describe('integrate codex', () => {
 
         const output = `${result.stdout}\n${result.stderr}`;
         expect(output).toContain('SonarQube Agentic Analysis');
-        expect(output).toContain('sonar integrate codex --project');
+        expect(output).toContain('Re-run without --global from a project directory');
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -342,10 +342,11 @@ describe('integrate copilot', () => {
     );
 
     it(
-      'overwrites pre-existing global instructions (CLI-owned file)',
+      'preserves pre-existing global instructions and appends the managed prompt-secrets section',
       async () => {
-        // sonarqube.instructions.md is CLI-owned, so any pre-existing content
-        // is replaced with the freshly rendered prompt-secrets section.
+        // sonarqube.instructions.md is patched in-place: any pre-existing
+        // content outside our managed markers is preserved, and our section
+        // is appended (or replaced in-place on re-runs).
         harness.userHome.writeFile(
           '.copilot/instructions/sonarqube.instructions.md',
           '# pre-existing\n',
@@ -355,7 +356,7 @@ describe('integrate copilot', () => {
 
         expect(result.exitCode).toBe(0);
         const body = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
-        expect(body).not.toContain('# pre-existing');
+        expect(body).toContain('# pre-existing');
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
       },
       { timeout: 30000 },
@@ -725,14 +726,28 @@ describe('integrate copilot', () => {
         // Project key is baked into the example command.
         expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
 
-        // Project-scope installs keep SQAA in the prompt instructions feature.
+        // Both sections recorded in state with the SQAA entry carrying the cloud attrs.
         const promptSecrets = findCopilotFeature(harness, 'prompt-secrets-instructions');
         expect(promptSecrets?.scope).toBe('project');
-        expect(promptSecrets?.attrs).toMatchObject({
-          projectKey: TEST_PROJECT,
-          sqaaEnabled: true,
-        });
-        expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
+        const sqaa = findCopilotFeature(harness, 'sqaa-instructions');
+        expect(sqaa?.scope).toBe('project');
+
+        // Both instruction features are recorded as installed.
+        const state = harness.stateJsonFile.asJson();
+        const copilotIntegration = state.integrations.installed.find(
+          (integration: { integrationId: string }) => integration.integrationId === 'copilot-cli',
+        );
+        expect(
+          copilotIntegration.features
+            .map((feature: { featureId: string }) => feature.featureId)
+            .sort(),
+        ).toEqual([
+          'mcp-server',
+          'pre-tool-use-hook',
+          'prompt-secrets-instructions',
+          'sonar-secrets-binary',
+          'sqaa-instructions',
+        ]);
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -745,7 +745,6 @@ describe('integrate copilot', () => {
           'mcp-server',
           'pre-tool-use-hook',
           'prompt-secrets-instructions',
-          'sonar-secrets-binary',
           'sqaa-instructions',
         ]);
       },
@@ -776,10 +775,10 @@ describe('integrate copilot', () => {
         expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('global');
         expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
 
-        // The user gets a hint pointing them at the per-project command.
+        // The user gets a hint pointing them at the per-project re-run.
         const output = `${result.stdout}\n${result.stderr}`;
         expect(output).toContain('SonarQube Agentic Analysis');
-        expect(output).toContain('sonar integrate copilot --project');
+        expect(output).toContain('Re-run without --global from a project directory');
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -738,10 +738,10 @@ describe('integrate copilot', () => {
     );
 
     it(
-      'writes the SQAA section to the project file under -g when org is entitled and a project key is discoverable from sonar-project.properties',
+      'on global install, does not write SQAA project-side but warns to run per-project when the org is entitled',
       async () => {
-        // `--global` and `--project` are mutually exclusive on the CLI, so the
-        // project key must be discovered from disk in the global flow.
+        // SQAA is project-scoped: a global install must not touch the project
+        // directory at all, even when a project key is discoverable.
         const { extraEnv } = await setupCloudWithEntitlement();
         harness.cwd.writeFile('sonar-project.properties', `sonar.projectKey=${TEST_PROJECT}\n`);
 
@@ -754,24 +754,17 @@ describe('integrate copilot', () => {
         expect(globalBody).toContain('# SonarQube secrets scanning for prompts protocol');
         expect(globalBody).not.toContain('# SonarQube Agentic Analysis');
 
-        // Project file holds SQAA, NOT prompt-secrets.
-        const projectBody = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
-        expect(projectBody).toContain('# SonarQube Agentic Analysis protocol');
-        expect(projectBody).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
-        expect(projectBody).not.toContain('# SonarQube secrets scanning for prompts protocol');
+        // Project file is NOT written — global installs stay out of the repo.
+        expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(false);
 
         // Declarative state: prompt-secrets is global, SQAA is project-scoped.
         expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('global');
-        expect(findCopilotFeature(harness, 'sqaa-instructions')?.scope).toBe('project');
+        expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
 
-        // Outcome shows both labeled lines pointing to their respective files.
-        const homePathNorm = normalizePath(harness.userHome.path);
-        expect(
-          normalizePath(outcomeLine(result.stdout, 'Instructions (secrets scanning for prompts):')),
-        ).toContain(`${homePathNorm}/.copilot/instructions/sonarqube.instructions.md`);
-        expect(
-          normalizePath(outcomeLine(result.stdout, 'Instructions (SonarQube Agentic Analysis):')),
-        ).toContain('.github/instructions/sonarqube.instructions.md');
+        // The user gets a hint pointing them at the per-project command.
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(output).toContain('SonarQube Agentic Analysis');
+        expect(output).toContain('sonar integrate copilot --project');
       },
       { timeout: 30000 },
     );

--- a/tests/unit/cli/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/integrate.test.ts
@@ -373,12 +373,14 @@ describe('integrateCommand', () => {
 
     await integrateClaude({ global: true }, CLOUD_AUTH);
 
+    // SQAA is project-scoped and must not be installed during a global install,
+    // even when the org is entitled — that's surfaced via a warning instead.
     assertMigrationHookInstallationAndStateUpdateRan(
       'a-project',
       '/project/root',
       homedir(),
       true,
-      true,
+      false,
     );
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **SQAA global integration:**
  - Explicitly skip installation of SQAA hooks, instructions, and state tracking during global (`--global`) integrations.
  - Introduce `warnSqaaSkippedOnGlobal` to prompt users to re-run integration per-project to enable SQAA.
- **Refactoring:**
  - Modularize `TextSnippet` content rendering and update `appendBlock` logic to support robust in-place patching.
  - Decouple `installInstructions` into specific flags `installPromptSecretsInstructions` and `installSqaaInstructions`.
  - Standardize managed blocks with new `sonarBeginMarker` and `sonarEndMarker` helpers.
  - Consolidate `runHealthCheckAndRepair` logic to streamline integration flow and token maintenance.
- **Testing:**
  - Update integration specs to confirm global installations remain project-side clean.
  - Refactor test assertions to verify SQAA state and artifact removal on global runs.


<sub>This will update automatically on new commits.</sub>