### PR TITLE
CLI-435 Explicitly show project auto-resolution

### DIFF
--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -31,7 +31,7 @@ import {
 } from '../../../../lib/migration';
 import { type DiscoveredProject, discoverProject } from '../../../../lib/project-workspace';
 import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
-import { blank, info, intro, note, outro, print, success, text, warn } from '../../../../ui';
+import { blank, info, intro, note, outro, success, text, warn } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
@@ -66,9 +66,6 @@ export async function integrateClaude(
   blank();
 
   const project = await discoverProject(process.cwd());
-  for (const configSource of project.configSources) {
-    print(`Found ${configSource}`);
-  }
   const config = loadConfiguration(project, options, auth);
   validateConfiguration(project, config, options.global ?? false);
 

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -25,7 +25,7 @@ import { homedir } from 'node:os';
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
 import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
-import { intro, print, success, warn } from '../../../../ui';
+import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { installIntegration } from '../_common/registry';
 import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
@@ -47,10 +47,6 @@ export async function integrateCodex(
   intro('SonarQube integration for Codex');
 
   const project = await discoverProject(process.cwd());
-  for (const configSource of project.configSources) {
-    print(`Found ${configSource}`);
-  }
-
   const isGlobal = options.global ?? false;
   const projectKey = options.project || project.projectKey;
   if (!isGlobal && !projectKey) {

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -19,7 +19,7 @@
  */
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
-import { intro, print, success, warn } from '../../../../ui';
+import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
 import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
@@ -45,9 +45,6 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
 
   // Discover project
   const project = await discoverProject(process.cwd());
-  for (const configSource of project.configSources) {
-    print(`Found ${configSource}`);
-  }
   const isGlobal = options.global ?? false;
   const projectKey = options.project || project.projectKey;
   if (!isGlobal && !projectKey) {

--- a/src/cli/commands/run/mcp.ts
+++ b/src/cli/commands/run/mcp.ts
@@ -54,7 +54,7 @@ export async function runMcp(auth: ResolvedAuth, options: McpRunOptions = {}): P
 
   const cwd = process.cwd();
   const cwdIsHomeDir = canonicalizePath(cwd) === canonicalizePath(homedir());
-  const discovered = cwdIsHomeDir ? undefined : await discoverProject(cwd);
+  const discovered = cwdIsHomeDir ? undefined : await discoverProject(cwd, true);
   const projectKey = options.project || discovered?.projectKey;
   if (!projectKey) {
     warn(

--- a/src/lib/project-workspace/project-info.ts
+++ b/src/lib/project-workspace/project-info.ts
@@ -137,7 +137,10 @@ export async function discoverProjectInfo(startDir: string): Promise<ProjectInfo
   };
 }
 
-export async function discoverProject(startDir: string): Promise<DiscoveredProject> {
+export async function discoverProject(
+  startDir: string,
+  silent = false,
+): Promise<DiscoveredProject> {
   const projectInfo = await discoverProjectInfo(startDir);
   const config: DiscoveredProject = {
     rootDir: projectInfo.root,
@@ -150,6 +153,12 @@ export async function discoverProject(startDir: string): Promise<DiscoveredProje
     config.serverUrl = projectInfo.sonarPropsData.hostURL;
     config.projectKey = projectInfo.sonarPropsData.projectKey;
     config.organization = projectInfo.sonarPropsData.organization;
+    if (!silent) {
+      const fields = formatConfigFields(config.serverUrl, config.projectKey, config.organization);
+      if (fields) {
+        print(`Found sonar-project.properties: ${fields}`);
+      }
+    }
   }
 
   if (
@@ -161,9 +170,30 @@ export async function discoverProject(startDir: string): Promise<DiscoveredProje
     config.serverUrl = config.serverUrl || projectInfo.sonarLintData.serverURL;
     config.projectKey = config.projectKey || projectInfo.sonarLintData.projectKey;
     config.organization = config.organization || projectInfo.sonarLintData.organization;
+    if (!silent) {
+      const fields = formatConfigFields(
+        projectInfo.sonarLintData.serverURL,
+        projectInfo.sonarLintData.projectKey,
+        projectInfo.sonarLintData.organization,
+      );
+      if (fields) {
+        print(`Found ${projectInfo.sonarLintConfigPath}: ${fields}`);
+      }
+    }
   }
 
   return config;
+}
+
+function formatConfigFields(
+  serverUrl?: string,
+  projectKey?: string,
+  organization?: string,
+): string {
+  return Object.entries({ project: projectKey, server: serverUrl, org: organization })
+    .filter(([, v]) => v !== undefined)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(', ');
 }
 
 export function findGitRoot(startDir: string): { gitRoot: string; isGit: boolean } {


### PR DESCRIPTION
----
## Summary by Gitar

- **Improved project auto-resolution feedback:**
  - Added `formatConfigFields` helper to display discovered configuration sources with key=value format
  - Print specific config fields (project, server, org) when `sonar-project.properties` or SonarLint config is found
  - Replaced generic "Found [config source]" messages with detailed field output in `discoverProject`
  - Removed unused `print` import from integrate command modules

<sub>This will update automatically on new commits.</sub>