### PR TITLE
CLI-447 Use the declarative framework for migrations

### DIFF
--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -22,6 +22,7 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { OBSOLETE_A3S_MARKER, removeObsoleteHookArtifacts } from '../../../../lib/migration';
 import { createSonarSecretsBinaryFeature } from '../_common/features/sonar-secrets-binary-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
@@ -30,6 +31,7 @@ import {
   upsertAgentHooks,
 } from '../_common/hooks';
 import {
+  type FeatureOperation,
   type IntegrationContext,
   type IntegrationDeclaration,
   jsonPatch,
@@ -66,46 +68,49 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
   displayName: 'Claude Code',
   features: [
     createSonarSecretsBinaryFeature(),
-    createSonarSecretsHooksFeature({
-      agentDisplayName: 'Claude',
-      configDir: CLAUDE_CONFIG_DIR,
-      hooksConfigFileName: SETTINGS_FILE,
-      hooksPatchId: 'claude-settings-secrets-hooks',
-      scripts: [
-        {
-          id: 'pretool-secrets-script',
-          displayName: 'Claude PreToolUse hook script',
-          scriptPath: PRETOOL_SCRIPT_REL,
-          content: {
-            unix: getSecretPreToolTemplateUnix(),
-            windows: getSecretPreToolTemplateWindows(),
+    {
+      ...createSonarSecretsHooksFeature({
+        agentDisplayName: 'Claude',
+        configDir: CLAUDE_CONFIG_DIR,
+        hooksConfigFileName: SETTINGS_FILE,
+        hooksPatchId: 'claude-settings-secrets-hooks',
+        scripts: [
+          {
+            id: 'pretool-secrets-script',
+            displayName: 'Claude PreToolUse hook script',
+            scriptPath: PRETOOL_SCRIPT_REL,
+            content: {
+              unix: getSecretPreToolTemplateUnix(),
+              windows: getSecretPreToolTemplateWindows(),
+            },
           },
-        },
-        {
-          id: 'prompt-secrets-script',
-          displayName: 'Claude UserPromptSubmit hook script',
-          scriptPath: PROMPT_SCRIPT_REL,
-          content: {
-            unix: getSecretPromptTemplateUnix(),
-            windows: getSecretPromptTemplateWindows(),
+          {
+            id: 'prompt-secrets-script',
+            displayName: 'Claude UserPromptSubmit hook script',
+            scriptPath: PROMPT_SCRIPT_REL,
+            content: {
+              unix: getSecretPromptTemplateUnix(),
+              windows: getSecretPromptTemplateWindows(),
+            },
           },
-        },
-      ],
-      hookEntries: [
-        {
-          eventType: 'PreToolUse',
-          matcher: 'Read',
-          marker: 'sonar-secrets',
-          scriptPath: PRETOOL_SCRIPT_REL,
-        },
-        {
-          eventType: 'UserPromptSubmit',
-          matcher: '*',
-          marker: 'sonar-secrets',
-          scriptPath: PROMPT_SCRIPT_REL,
-        },
-      ],
-    }),
+        ],
+        hookEntries: [
+          {
+            eventType: 'PreToolUse',
+            matcher: 'Read',
+            marker: 'sonar-secrets',
+            scriptPath: PRETOOL_SCRIPT_REL,
+          },
+          {
+            eventType: 'UserPromptSubmit',
+            matcher: '*',
+            marker: 'sonar-secrets',
+            scriptPath: PROMPT_SCRIPT_REL,
+          },
+        ],
+      }),
+      operations: [createRemoveObsoleteA3sArtifactsOperation()],
+    },
     {
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
@@ -148,6 +153,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
             ]),
         }),
       ],
+      operations: [createRemoveObsoleteA3sArtifactsOperation()],
     },
     {
       id: 'mcp-server',
@@ -241,4 +247,12 @@ function getRequiredStringAttr(context: IntegrationContext, key: string): string
     throw new Error(`Missing integration attribute: ${key}`);
   }
   return value;
+}
+
+function createRemoveObsoleteA3sArtifactsOperation(): FeatureOperation {
+  return {
+    id: 'remove-obsolete-a3s-artifacts',
+    displayName: 'Remove obsolete SQAA hook artifacts',
+    apply: ({ targetRoot }) => removeObsoleteHookArtifacts(targetRoot, OBSOLETE_A3S_MARKER),
+  };
 }

--- a/src/cli/commands/integrate/git/tools/index.ts
+++ b/src/cli/commands/integrate/git/tools/index.ts
@@ -27,6 +27,9 @@ const GIT_INTEGRATIONS = [nativeGitIntegration, huskyIntegration, preCommitInteg
 
 export function registerGitIntegrations(registry = supportedIntegrations): void {
   for (const integration of GIT_INTEGRATIONS) {
+    if (registry.get(integration.id)) {
+      continue;
+    }
     registry.register(integration);
   }
 }

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -31,7 +31,18 @@ import {
   resolveContextAugmentationAgent,
   stopAllContextAugmentationTools,
 } from '../cli/commands/integrate/_common/context-augmentation';
+import {
+  integrationInstaller,
+  type IntegrationRegistry,
+  supportedIntegrations,
+} from '../cli/commands/integrate/_common/registry';
+import {
+  CLAUDE_INTEGRATION_ID,
+  registerClaudeIntegration,
+} from '../cli/commands/integrate/claude/declaration';
 import { installHooks } from '../cli/commands/integrate/claude/hooks.js';
+import { registerCodexIntegration } from '../cli/commands/integrate/codex/declaration';
+import { registerGitIntegrations } from '../cli/commands/integrate/git/tools';
 import { CONTEXT_AUGMENTATION_BINARY_NAME, SECRETS_BINARY_NAME } from './install-types.js';
 import logger from './logger';
 import {
@@ -83,9 +94,82 @@ export async function runPostUpdateActions(): Promise<void> {
 }
 
 async function runActions(_previousVersion: string, _currentVersion: string): Promise<void> {
+  await migrateDeclarativeIntegrations();
   await migrateClaudeCodeHooks();
   await updateSecretsBinaryIfNeeded();
   await updateContextAugmentationIfNeeded();
+}
+
+export async function migrateDeclarativeIntegrations(
+  registry: IntegrationRegistry = supportedIntegrations,
+): Promise<void> {
+  ensureBuiltInIntegrationsRegistered(registry);
+
+  const state = loadState();
+  let stateChanged = false;
+
+  for (const integration of registry.list()) {
+    const installedIntegration = integrationInstaller.findInstalledIntegration(state, integration);
+    if (!installedIntegration) {
+      continue;
+    }
+
+    const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
+    const knownFeatures = installedIntegration.features.filter((feature) =>
+      featuresById.has(feature.featureId),
+    );
+
+    if (knownFeatures.length !== installedIntegration.features.length) {
+      installedIntegration.features = knownFeatures;
+      stateChanged = true;
+    }
+
+    for (const installedFeature of knownFeatures) {
+      const feature = featuresById.get(installedFeature.featureId);
+      if (!feature) {
+        continue;
+      }
+
+      try {
+        const featureContext = {
+          targetRoot: installedFeature.targetRoot,
+          scope: installedFeature.scope,
+          attrs: installedFeature.attrs,
+        };
+        const applied = await integrationInstaller.applyFeature(
+          { state, ...featureContext },
+          installedFeature,
+          feature,
+        );
+        integrationInstaller.recordInstalledFeature(
+          state,
+          featureContext,
+          integration,
+          feature,
+          applied,
+        );
+        stateChanged = true;
+      } catch (err) {
+        logger.debug(
+          `Declarative migration failed for ${integration.id}.${installedFeature.featureId}: ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+
+  if (stateChanged) {
+    saveState(state);
+  }
+}
+
+function ensureBuiltInIntegrationsRegistered(registry: IntegrationRegistry): void {
+  if (registry !== supportedIntegrations) {
+    return;
+  }
+
+  registerClaudeIntegration();
+  registerCodexIntegration();
+  registerGitIntegrations();
 }
 
 /**
@@ -306,6 +390,11 @@ function isExistingDirectory(path: string): boolean {
 export async function migrateClaudeCodeHooks(homedirFn: () => string = homedir): Promise<void> {
   const state = loadState();
 
+  if (hasInstalledDeclarativeIntegration(state, CLAUDE_INTEGRATION_ID)) {
+    logger.debug('Declarative Claude integration detected — skipping legacy hook migration');
+    return;
+  }
+
   type Location = { projectRoot: string; globalDir: string | undefined };
   const locations: Location[] = [];
 
@@ -343,4 +432,8 @@ export async function migrateClaudeCodeHooks(homedirFn: () => string = homedir):
       );
     }
   }
+}
+
+function hasInstalledDeclarativeIntegration(state: CliState, integrationId: string): boolean {
+  return state.integrations.installed.some((entry) => entry.integrationId === integrationId);
 }

--- a/tests/integration/specs/self-update/post-update.test.ts
+++ b/tests/integration/specs/self-update/post-update.test.ts
@@ -29,7 +29,7 @@ import { buildLocalCagBinaryName } from '../../../../src/cli/commands/_common/in
 import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../../src/lib/install-types';
 import { detectPlatform } from '../../../../src/lib/platform-detector';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../../src/lib/signatures';
-import { TestHarness } from '../../harness';
+import { hookScriptName, IS_WINDOWS, TestHarness } from '../../harness';
 import { readCagInvocations } from '../../harness/cag-invocations';
 
 describe('post-update migration', () => {
@@ -192,5 +192,134 @@ describe('post-update migration', () => {
       expect(stopIndex).toBeLessThan(skillIndex);
     },
     { timeout: 30000 },
+  );
+
+  it(
+    'refreshes declarative Claude hook resources on CLI upgrade',
+    async () => {
+      const now = new Date().toISOString();
+      const pretoolScriptRel = `.claude/hooks/sonar-secrets/build-scripts/${hookScriptName('pretool-secrets')}`;
+      const promptScriptRel = `.claude/hooks/sonar-secrets/build-scripts/${hookScriptName('prompt-secrets')}`;
+      const settingsRel = '.claude/settings.json';
+      const expectedPretoolCommand = IS_WINDOWS
+        ? `powershell -NoProfile -File ${pretoolScriptRel}`
+        : pretoolScriptRel;
+      const expectedPromptCommand = IS_WINDOWS
+        ? `powershell -NoProfile -File ${promptScriptRel}`
+        : promptScriptRel;
+
+      harness.cwd.writeFile(
+        pretoolScriptRel,
+        IS_WINDOWS
+          ? '$output = sonar analyze --file $file_path 2>$null\n'
+          : '#!/bin/bash\noutput=$(sonar analyze --file "$file_path" 2>/dev/null)\n',
+      );
+      harness.cwd.writeFile(
+        promptScriptRel,
+        IS_WINDOWS
+          ? '$output = sonar analyze --file $file_path 2>$null\n'
+          : '#!/bin/bash\noutput=$(sonar analyze --file "$file_path" 2>/dev/null)\n',
+      );
+      harness.cwd.writeFile(
+        settingsRel,
+        JSON.stringify(
+          {
+            hooks: {
+              PreToolUse: [
+                {
+                  matcher: 'Read',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: '.claude/hooks/sonar-secrets/build-scripts/old-pretool.sh',
+                      timeout: 60,
+                    },
+                  ],
+                },
+              ],
+              UserPromptSubmit: [
+                {
+                  matcher: '*',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: '.claude/hooks/sonar-secrets/build-scripts/old-prompt.sh',
+                      timeout: 60,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      harness.state().withRawState(
+        JSON.stringify({
+          version: '1.0',
+          lastUpdated: now,
+          auth: { isAuthenticated: false, connections: [] },
+          agents: {
+            'claude-code': {
+              configured: true,
+              configuredByCliVersion: '0.5.0',
+              hooks: { installed: [] },
+              skills: { installed: [] },
+            },
+          },
+          config: { cliVersion: '0.5.0' },
+          telemetry: { enabled: false, firstUseDate: now, events: [] },
+          agentExtensions: [],
+          integrations: {
+            installed: [
+              {
+                id: randomUUID(),
+                integrationId: 'claude-code',
+                installedByCliVersion: '0.5.0',
+                installedAt: now,
+                updatedByCliVersion: '0.5.0',
+                updatedAt: now,
+                features: [
+                  {
+                    featureId: 'sonar-secrets-hooks',
+                    scope: 'project',
+                    targetRoot: harness.cwd.path,
+                    installedByCliVersion: '0.5.0',
+                    installedAt: now,
+                    updatedByCliVersion: '0.5.0',
+                    updatedAt: now,
+                    resources: [],
+                    operations: [],
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await harness.run('--version');
+
+      expect(result.exitCode).toBe(0);
+      expect(harness.cwd.file(pretoolScriptRel).asText()).toContain(
+        'sonar hook claude-pre-tool-use',
+      );
+      expect(harness.cwd.file(promptScriptRel).asText()).toContain(
+        'sonar hook claude-prompt-submit',
+      );
+
+      const settings = harness.cwd.file(settingsRel).asJson();
+      expect(settings.hooks?.PreToolUse?.[0]).toEqual({
+        matcher: 'Read',
+        hooks: [{ type: 'command', command: expectedPretoolCommand, timeout: 60 }],
+      });
+      expect(settings.hooks?.UserPromptSubmit?.[0]).toEqual({
+        matcher: '*',
+        hooks: [{ type: 'command', command: expectedPromptCommand, timeout: 60 }],
+      });
+    },
+    { timeout: 15000 },
   );
 });

--- a/tests/unit/cli/commands/integrate/git/git-tools.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-tools.test.ts
@@ -29,18 +29,18 @@ import {
 } from '../../../../../../src/cli/commands/integrate/git/tools';
 
 describe('registerGitIntegrations', () => {
-  it('rejects duplicate git integration registration', () => {
+  it('is idempotent when git integrations are already registered', () => {
     const registry = new IntegrationRegistry();
-
-    registerGitIntegrations(registry);
-
-    expect(registry.list().map((integration) => integration.id)).toEqual([
+    const expectedIntegrationIds = [
       NATIVE_GIT_INTEGRATION_ID,
       HUSKY_INTEGRATION_ID,
       PRE_COMMIT_INTEGRATION_ID,
-    ]);
-    expect(() => registerGitIntegrations(registry)).toThrow(
-      'Integration declaration already registered: native-git',
-    );
+    ];
+
+    registerGitIntegrations(registry);
+
+    expect(registry.list().map((integration) => integration.id)).toEqual(expectedIntegrationIds);
+    expect(() => registerGitIntegrations(registry)).not.toThrow();
+    expect(registry.list().map((integration) => integration.id)).toEqual(expectedIntegrationIds);
   });
 });

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -19,6 +19,8 @@
  */
 
 import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
 
@@ -26,11 +28,16 @@ import { version as CURRENT_VERSION } from '../../../../../package.json';
 import * as cagInstall from '../../../../../src/cli/commands/_common/install/context-augmentation';
 import * as secretsInstall from '../../../../../src/cli/commands/_common/install/secrets';
 import * as contextAugmentation from '../../../../../src/cli/commands/integrate/_common/context-augmentation';
+import {
+  IntegrationRegistry,
+  wholeFile,
+} from '../../../../../src/cli/commands/integrate/_common/registry';
 import * as hooks from '../../../../../src/cli/commands/integrate/claude/hooks';
 import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../../../src/lib/install-types';
 import * as migration from '../../../../../src/lib/migration';
 import {
   migrateClaudeCodeHooks,
+  migrateDeclarativeIntegrations,
   runPostUpdateActions,
   updateContextAugmentationIfNeeded,
   updateSecretsBinaryIfNeeded,
@@ -160,19 +167,21 @@ describe('runPostUpdateActions', () => {
   });
 
   it('saves the reloaded state, not the pre-runActions snapshot', async () => {
-    // loadState is called 5 times:
+    // loadState is called 6 times:
     //   1. version check in runPostUpdateActions
-    //   2. inside migrateClaudeCodeHooks
-    //   3. inside updateSecretsBinaryIfNeeded
-    //   4. inside updateContextAugmentationIfNeeded
-    //   5. the reload after runActions (the fix being tested)
+    //   2. inside migrateDeclarativeIntegrations
+    //   3. inside migrateClaudeCodeHooks
+    //   4. inside updateSecretsBinaryIfNeeded
+    //   5. inside updateContextAugmentationIfNeeded
+    //   6. the reload after runActions (the fix being tested)
     const reloadedState = makeState();
     loadStateSpy
       .mockReturnValueOnce(makeState()) // call 1: version check
-      .mockReturnValueOnce(makeState()) // call 2: migrateClaudeCodeHooks
-      .mockReturnValueOnce(makeState()) // call 3: updateSecretsBinaryIfNeeded
-      .mockReturnValueOnce(makeState()) // call 4: updateContextAugmentationIfNeeded
-      .mockReturnValueOnce(reloadedState); // call 5: reload
+      .mockReturnValueOnce(makeState()) // call 2: migrateDeclarativeIntegrations
+      .mockReturnValueOnce(makeState()) // call 3: migrateClaudeCodeHooks
+      .mockReturnValueOnce(makeState()) // call 4: updateSecretsBinaryIfNeeded
+      .mockReturnValueOnce(makeState()) // call 5: updateContextAugmentationIfNeeded
+      .mockReturnValueOnce(reloadedState); // call 6: reload
 
     await runPostUpdateActions();
 
@@ -224,6 +233,128 @@ describe('runPostUpdateActions', () => {
     expect(saved.agents['claude-code'].hooks.installed.some((h) => h.name === 'sonar-a3s')).toBe(
       false,
     );
+  });
+});
+
+describe('migrateDeclarativeIntegrations', () => {
+  let loadStateSpy: Mock<typeof stateRepository.loadState>;
+  let saveStateSpy: Mock<typeof stateRepository.saveState>;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(join(tmpdir(), 'sonar-cli-post-update-'));
+    loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeState());
+    saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    loadStateSpy.mockRestore();
+    saveStateSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reapplies installed declarative features and prunes unknown feature state', async () => {
+    const operationCalls: string[] = [];
+    const resourcePath = join(tempDir, 'managed.txt');
+    const now = '2026-01-01T00:00:00.000Z';
+    fs.writeFileSync(resourcePath, 'legacy content', 'utf-8');
+
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: now,
+      updatedByCliVersion: '0.9.0',
+      updatedAt: now,
+      features: [
+        {
+          featureId: 'managed-feature',
+          scope: 'project',
+          targetRoot: tempDir,
+          installedByCliVersion: '0.9.0',
+          installedAt: now,
+          updatedByCliVersion: '0.9.0',
+          updatedAt: now,
+          resources: [
+            {
+              id: 'managed-file',
+              resourceType: 'whole-file',
+              version: '1',
+              path: resourcePath,
+              updatedByCliVersion: '0.9.0',
+              updatedAt: now,
+            },
+          ],
+          operations: [],
+          attrs: { projectKey: 'project-key' },
+        },
+        {
+          featureId: 'removed-feature',
+          scope: 'project',
+          targetRoot: tempDir,
+          installedByCliVersion: '0.9.0',
+          installedAt: now,
+          updatedByCliVersion: '0.9.0',
+          updatedAt: now,
+          resources: [],
+          operations: [],
+        },
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [
+        {
+          id: 'managed-feature',
+          displayName: 'Managed feature',
+          resources: [
+            wholeFile({
+              id: 'managed-file',
+              version: '2',
+              targetPath: resourcePath,
+              content: 'fresh content',
+            }),
+          ],
+          operations: [
+            {
+              id: 'refresh-operation',
+              version: '1',
+              apply: () => {
+                operationCalls.push('refresh-operation');
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(fs.readFileSync(resourcePath, 'utf-8')).toBe('fresh content');
+    expect(operationCalls).toEqual(['refresh-operation']);
+    expect(saveStateSpy).toHaveBeenCalledTimes(1);
+
+    const savedState = saveStateSpy.mock.calls[0][0];
+    expect(savedState.integrations.installed).toHaveLength(1);
+    expect(savedState.integrations.installed[0].features).toHaveLength(1);
+    const savedFeature = savedState.integrations.installed[0].features[0];
+    expect(savedFeature.featureId).toBe('managed-feature');
+    expect(savedFeature.resources).toHaveLength(1);
+    expect(savedFeature.resources[0]).toMatchObject({
+      id: 'managed-file',
+      version: '2',
+      path: resourcePath,
+    });
+    expect(savedFeature.operations).toHaveLength(1);
+    expect(savedFeature.operations[0]).toMatchObject({
+      id: 'refresh-operation',
+      version: '1',
+    });
   });
 });
 
@@ -287,6 +418,25 @@ describe('migrateClaudeCodeHooks', () => {
     ];
     loadStateSpy.mockReturnValue(state);
     existsSyncSpy.mockReturnValue(false); // global hooks dir does not exist
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).not.toHaveBeenCalled();
+    expect(migrateHookScriptsSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips legacy migration when Claude is already tracked declaratively', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', false)]);
+    state.integrations.installed.push({
+      id: 'claude-integration-id',
+      integrationId: 'claude-code',
+      installedByCliVersion: '1.0.0',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedByCliVersion: '1.0.0',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      features: [],
+    });
+    loadStateSpy.mockReturnValue(state);
 
     await migrateClaudeCodeHooks(homedirFn);
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Migration framework:**
  - Added `migrateDeclarativeIntegrations` to `runPostUpdateActions` to manage feature lifecycle and apply updates.
  - Implemented `hasInstalledDeclarativeIntegration` to prevent legacy hook migration when declarative integration is active.
- **Claude integration:**
  - Configured `claudeIntegration` to use the declarative framework for `sonar-secrets` hooks.
  - Added `createRemoveObsoleteA3sArtifactsOperation` to cleanup legacy SQAA artifacts during migration.
- **Infrastructure:**
  - Added `ensureBuiltInIntegrationsRegistered` to `post-update.ts` to ensure all integrations are registered before migration.
  - Updated `registerGitIntegrations` to prevent duplicate registration in the integration registry.
  - Updated `git-tools.test.ts` to verify `registerGitIntegrations` is idempotent rather than throwing on duplicate registration.

<sub>This will update automatically on new commits.</sub>