### PR TITLE
CLI-251 Configure Codex MCP during `integrate codex`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "js-yaml": "^4.1.1",
         "openpgp": "^6.0.0",
         "picocolors": "^1.1.1",
+        "smol-toml": "^1.6.1",
       },
       "devDependencies": {
         "@sentry/cli": "3.4.2",
@@ -560,6 +561,8 @@
     "slice-ansi": ["slice-ansi@7.1.2", "https://repox.jfrog.io/artifactory/api/npm/npm/slice-ansi/-/slice-ansi-7.1.2.tgz", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "slugify": ["slugify@1.6.9", "https://repox.jfrog.io/artifactory/api/npm/npm/slugify/-/slugify-1.6.9.tgz", {}, "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg=="],
+
+    "smol-toml": ["smol-toml@1.6.1", "https://repox.jfrog.io/artifactory/api/npm/npm/smol-toml/-/smol-toml-1.6.1.tgz", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "source-map": ["source-map@0.6.1", "https://repox.jfrog.io/artifactory/api/npm/npm/source-map/-/source-map-0.6.1.tgz", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/package.json
+++ b/package.json
@@ -105,7 +105,8 @@
     "commander": "^14.0.0",
     "js-yaml": "^4.1.1",
     "openpgp": "^6.0.0",
-    "picocolors": "^1.1.1"
+    "picocolors": "^1.1.1",
+    "smol-toml": "^1.6.1"
   },
   "devDependencies": {
     "@sentry/cli": "3.4.2",

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -41,6 +41,8 @@ export {
   type ResourceDeclaration,
   textSnippet,
   type TextSnippetResourceOptions,
+  tomlPatch,
+  type TomlPatchOptions,
   wholeFile,
   type WholeFileContent,
   type WholeFileResourceOptions,

--- a/src/cli/commands/integrate/_common/registry/resources/common.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/common.ts
@@ -76,28 +76,32 @@ export async function readTextFile(path: string): Promise<string | undefined> {
   return readFile(path, 'utf-8');
 }
 
-export interface PatchBase {
-  id: string;
+export interface PatchResourceOptions extends BaseResourceOptions {
   targetPath: PathResolver;
 }
 
-export async function applyPatch(
-  options: PatchBase,
-  resourceType: string,
-  version: string | undefined,
-  context: IntegrationContext,
-  render: (path: string) => Promise<string>,
-): Promise<AppliedResource> {
-  const path = await resolvePath(context, options.targetPath);
-  await writeFileIfChanged(path, await render(path));
-  return { id: options.id, resourceType, version, path };
-}
+export abstract class PatchResource<O extends PatchResourceOptions> implements ResourceDeclaration {
+  readonly id: string;
+  readonly displayName?: string;
+  readonly version?: string;
+  abstract readonly resourceType: string;
 
-export async function isPatchApplied(
-  options: PatchBase,
-  context: IntegrationContext,
-  render: (path: string) => Promise<string>,
-): Promise<boolean> {
-  const path = await resolvePath(context, options.targetPath);
-  return (await readTextFile(path)) === (await render(path));
+  constructor(protected readonly options: O) {
+    this.id = options.id;
+    this.displayName = options.displayName;
+    this.version = options.version;
+  }
+
+  async apply(context: IntegrationContext): Promise<AppliedResource> {
+    const path = await resolvePath(context, this.options.targetPath);
+    await writeFileIfChanged(path, await this.renderContent(path, context));
+    return { id: this.id, resourceType: this.resourceType, version: this.version, path };
+  }
+
+  async isApplied(context: IntegrationContext): Promise<boolean> {
+    const path = await resolvePath(context, this.options.targetPath);
+    return (await readTextFile(path)) === (await this.renderContent(path, context));
+  }
+
+  protected abstract renderContent(path: string, context: IntegrationContext): Promise<string>;
 }

--- a/src/cli/commands/integrate/_common/registry/resources/common.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/common.ts
@@ -75,3 +75,29 @@ export async function readTextFile(path: string): Promise<string | undefined> {
   }
   return readFile(path, 'utf-8');
 }
+
+export interface PatchBase {
+  id: string;
+  targetPath: PathResolver;
+}
+
+export async function applyPatch(
+  options: PatchBase,
+  resourceType: string,
+  version: string | undefined,
+  context: IntegrationContext,
+  render: (path: string) => Promise<string>,
+): Promise<AppliedResource> {
+  const path = await resolvePath(context, options.targetPath);
+  await writeFileIfChanged(path, await render(path));
+  return { id: options.id, resourceType, version, path };
+}
+
+export async function isPatchApplied(
+  options: PatchBase,
+  context: IntegrationContext,
+  render: (path: string) => Promise<string>,
+): Promise<boolean> {
+  const path = await resolvePath(context, options.targetPath);
+  return (await readTextFile(path)) === (await render(path));
+}

--- a/src/cli/commands/integrate/_common/registry/resources/index.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/index.ts
@@ -21,6 +21,7 @@
 export type { BaseResourceOptions, PathResolver, ResourceDeclaration } from './common';
 export { jsonPatch, type JsonPatchOptions } from './json-patch';
 export { TextSnippet, textSnippet, type TextSnippetResourceOptions } from './text-snippet';
+export { TomlPatch, tomlPatch, type TomlPatchOptions } from './toml-patch';
 export {
   type PlatformSpecificContent,
   wholeFile,

--- a/src/cli/commands/integrate/_common/registry/resources/json-patch.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/json-patch.ts
@@ -24,12 +24,11 @@ import { readFile } from 'node:fs/promises';
 import { CommandFailedError } from '../../../../_common/error';
 import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
+  applyPatch,
   type BaseResourceOptions,
+  isPatchApplied,
   type PathResolver,
-  readTextFile,
-  resolvePath,
   type ResourceDeclaration,
-  writeFileIfChanged,
 } from './common';
 
 export interface JsonPatchOptions extends BaseResourceOptions {
@@ -54,15 +53,14 @@ export class JsonPatch implements ResourceDeclaration {
     this.version = options.version;
   }
 
-  async apply(context: IntegrationContext): Promise<AppliedResource> {
-    const path = await resolvePath(context, this.options.targetPath);
-    await writeFileIfChanged(path, await this.renderContent(path, context));
-    return { id: this.id, resourceType: this.resourceType, version: this.version, path };
+  apply(context: IntegrationContext): Promise<AppliedResource> {
+    return applyPatch(this.options, this.resourceType, this.version, context, (path) =>
+      this.renderContent(path, context),
+    );
   }
 
-  async isApplied(context: IntegrationContext): Promise<boolean> {
-    const path = await resolvePath(context, this.options.targetPath);
-    return (await readTextFile(path)) === (await this.renderContent(path, context));
+  isApplied(context: IntegrationContext): Promise<boolean> {
+    return isPatchApplied(this.options, context, (path) => this.renderContent(path, context));
   }
 
   private async renderContent(path: string, context: IntegrationContext): Promise<string> {

--- a/src/cli/commands/integrate/_common/registry/resources/json-patch.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/json-patch.ts
@@ -22,17 +22,10 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
 import { CommandFailedError } from '../../../../_common/error';
-import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
-import {
-  applyPatch,
-  type BaseResourceOptions,
-  isPatchApplied,
-  type PathResolver,
-  type ResourceDeclaration,
-} from './common';
+import type { IntegrationContext, MaybePromise } from '../types';
+import { PatchResource, type PatchResourceOptions, type ResourceDeclaration } from './common';
 
-export interface JsonPatchOptions extends BaseResourceOptions {
-  targetPath: PathResolver;
+export interface JsonPatchOptions extends PatchResourceOptions {
   defaultValue?: unknown;
   patch: (document: unknown, context: IntegrationContext) => MaybePromise<unknown>;
 }
@@ -41,29 +34,10 @@ export function jsonPatch(options: JsonPatchOptions): ResourceDeclaration {
   return new JsonPatch(options);
 }
 
-export class JsonPatch implements ResourceDeclaration {
-  readonly id: string;
-  readonly displayName?: string;
+export class JsonPatch extends PatchResource<JsonPatchOptions> {
   readonly resourceType = 'json-patch';
-  readonly version?: string;
 
-  constructor(private readonly options: JsonPatchOptions) {
-    this.id = options.id;
-    this.displayName = options.displayName;
-    this.version = options.version;
-  }
-
-  apply(context: IntegrationContext): Promise<AppliedResource> {
-    return applyPatch(this.options, this.resourceType, this.version, context, (path) =>
-      this.renderContent(path, context),
-    );
-  }
-
-  isApplied(context: IntegrationContext): Promise<boolean> {
-    return isPatchApplied(this.options, context, (path) => this.renderContent(path, context));
-  }
-
-  private async renderContent(path: string, context: IntegrationContext): Promise<string> {
+  protected async renderContent(path: string, context: IntegrationContext): Promise<string> {
     const document = await readJson(path, this.options.defaultValue ?? {});
     const updated = await this.options.patch(document, context);
     return `${JSON.stringify(updated ?? document, null, 2)}\n`;

--- a/src/cli/commands/integrate/_common/registry/resources/toml-patch.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/toml-patch.ts
@@ -24,17 +24,10 @@ import { readFile } from 'node:fs/promises';
 import { parse, stringify } from 'smol-toml';
 
 import { CommandFailedError } from '../../../../_common/error';
-import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
-import {
-  applyPatch,
-  type BaseResourceOptions,
-  isPatchApplied,
-  type PathResolver,
-  type ResourceDeclaration,
-} from './common';
+import type { IntegrationContext, MaybePromise } from '../types';
+import { PatchResource, type PatchResourceOptions, type ResourceDeclaration } from './common';
 
-export interface TomlPatchOptions extends BaseResourceOptions {
-  targetPath: PathResolver;
+export interface TomlPatchOptions extends PatchResourceOptions {
   defaultValue?: Record<string, unknown>;
   patch: (
     document: Record<string, unknown>,
@@ -46,29 +39,10 @@ export function tomlPatch(options: TomlPatchOptions): ResourceDeclaration {
   return new TomlPatch(options);
 }
 
-export class TomlPatch implements ResourceDeclaration {
-  readonly id: string;
-  readonly displayName?: string;
+export class TomlPatch extends PatchResource<TomlPatchOptions> {
   readonly resourceType = 'toml-patch';
-  readonly version?: string;
 
-  constructor(private readonly options: TomlPatchOptions) {
-    this.id = options.id;
-    this.displayName = options.displayName;
-    this.version = options.version;
-  }
-
-  apply(context: IntegrationContext): Promise<AppliedResource> {
-    return applyPatch(this.options, this.resourceType, this.version, context, (path) =>
-      this.renderContent(path, context),
-    );
-  }
-
-  isApplied(context: IntegrationContext): Promise<boolean> {
-    return isPatchApplied(this.options, context, (path) => this.renderContent(path, context));
-  }
-
-  private async renderContent(path: string, context: IntegrationContext): Promise<string> {
+  protected async renderContent(path: string, context: IntegrationContext): Promise<string> {
     const document = await readToml(path, this.options.defaultValue ?? {});
     const updated = await this.options.patch(document, context);
     return stringify(updated);

--- a/src/cli/commands/integrate/_common/registry/resources/toml-patch.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/toml-patch.ts
@@ -26,12 +26,11 @@ import { parse, stringify } from 'smol-toml';
 import { CommandFailedError } from '../../../../_common/error';
 import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
+  applyPatch,
   type BaseResourceOptions,
+  isPatchApplied,
   type PathResolver,
-  readTextFile,
-  resolvePath,
   type ResourceDeclaration,
-  writeFileIfChanged,
 } from './common';
 
 export interface TomlPatchOptions extends BaseResourceOptions {
@@ -59,15 +58,14 @@ export class TomlPatch implements ResourceDeclaration {
     this.version = options.version;
   }
 
-  async apply(context: IntegrationContext): Promise<AppliedResource> {
-    const path = await resolvePath(context, this.options.targetPath);
-    await writeFileIfChanged(path, await this.renderContent(path, context));
-    return { id: this.id, resourceType: this.resourceType, version: this.version, path };
+  apply(context: IntegrationContext): Promise<AppliedResource> {
+    return applyPatch(this.options, this.resourceType, this.version, context, (path) =>
+      this.renderContent(path, context),
+    );
   }
 
-  async isApplied(context: IntegrationContext): Promise<boolean> {
-    const path = await resolvePath(context, this.options.targetPath);
-    return (await readTextFile(path)) === (await this.renderContent(path, context));
+  isApplied(context: IntegrationContext): Promise<boolean> {
+    return isPatchApplied(this.options, context, (path) => this.renderContent(path, context));
   }
 
   private async renderContent(path: string, context: IntegrationContext): Promise<string> {

--- a/src/cli/commands/integrate/_common/registry/resources/toml-patch.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/toml-patch.ts
@@ -1,0 +1,94 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+
+import { parse, stringify } from 'smol-toml';
+
+import { CommandFailedError } from '../../../../_common/error';
+import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
+import {
+  type BaseResourceOptions,
+  type PathResolver,
+  readTextFile,
+  resolvePath,
+  type ResourceDeclaration,
+  writeFileIfChanged,
+} from './common';
+
+export interface TomlPatchOptions extends BaseResourceOptions {
+  targetPath: PathResolver;
+  defaultValue?: Record<string, unknown>;
+  patch: (
+    document: Record<string, unknown>,
+    context: IntegrationContext,
+  ) => MaybePromise<Record<string, unknown>>;
+}
+
+export function tomlPatch(options: TomlPatchOptions): ResourceDeclaration {
+  return new TomlPatch(options);
+}
+
+export class TomlPatch implements ResourceDeclaration {
+  readonly id: string;
+  readonly displayName?: string;
+  readonly resourceType = 'toml-patch';
+  readonly version?: string;
+
+  constructor(private readonly options: TomlPatchOptions) {
+    this.id = options.id;
+    this.displayName = options.displayName;
+    this.version = options.version;
+  }
+
+  async apply(context: IntegrationContext): Promise<AppliedResource> {
+    const path = await resolvePath(context, this.options.targetPath);
+    await writeFileIfChanged(path, await this.renderContent(path, context));
+    return { id: this.id, resourceType: this.resourceType, version: this.version, path };
+  }
+
+  async isApplied(context: IntegrationContext): Promise<boolean> {
+    const path = await resolvePath(context, this.options.targetPath);
+    return (await readTextFile(path)) === (await this.renderContent(path, context));
+  }
+
+  private async renderContent(path: string, context: IntegrationContext): Promise<string> {
+    const document = await readToml(path, this.options.defaultValue ?? {});
+    const updated = await this.options.patch(document, context);
+    return stringify(updated);
+  }
+}
+
+async function readToml(
+  path: string,
+  defaultValue: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (!existsSync(path)) {
+    return defaultValue;
+  }
+  try {
+    return parse(await readFile(path, 'utf-8'));
+  } catch {
+    throw new CommandFailedError(
+      `${path} contains invalid TOML. Please fix or delete it and re-run.`,
+    );
+  }
+}

--- a/src/cli/commands/integrate/_common/registry/resources/yaml-patch.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/yaml-patch.ts
@@ -23,17 +23,10 @@ import { readFile } from 'node:fs/promises';
 
 import yaml from 'js-yaml';
 
-import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
-import {
-  applyPatch,
-  type BaseResourceOptions,
-  isPatchApplied,
-  type PathResolver,
-  type ResourceDeclaration,
-} from './common';
+import type { IntegrationContext, MaybePromise } from '../types';
+import { PatchResource, type PatchResourceOptions, type ResourceDeclaration } from './common';
 
-export interface YamlPatchOptions extends BaseResourceOptions {
-  targetPath: PathResolver;
+export interface YamlPatchOptions extends PatchResourceOptions {
   patch: (document: unknown, context: IntegrationContext) => MaybePromise<unknown>;
 }
 
@@ -41,29 +34,10 @@ export function yamlPatch(options: YamlPatchOptions): ResourceDeclaration {
   return new YamlPatch(options);
 }
 
-export class YamlPatch implements ResourceDeclaration {
-  readonly id: string;
-  readonly displayName?: string;
+export class YamlPatch extends PatchResource<YamlPatchOptions> {
   readonly resourceType = 'yaml-patch';
-  readonly version?: string;
 
-  constructor(private readonly options: YamlPatchOptions) {
-    this.id = options.id;
-    this.displayName = options.displayName;
-    this.version = options.version;
-  }
-
-  apply(context: IntegrationContext): Promise<AppliedResource> {
-    return applyPatch(this.options, this.resourceType, this.version, context, (path) =>
-      this.renderContent(path, context),
-    );
-  }
-
-  isApplied(context: IntegrationContext): Promise<boolean> {
-    return isPatchApplied(this.options, context, (path) => this.renderContent(path, context));
-  }
-
-  private async renderContent(path: string, context: IntegrationContext): Promise<string> {
+  protected async renderContent(path: string, context: IntegrationContext): Promise<string> {
     const document = await readYaml(path);
     const updated = await this.options.patch(document, context);
     return yaml.dump(updated, { lineWidth: -1 });

--- a/src/cli/commands/integrate/_common/registry/resources/yaml-patch.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/yaml-patch.ts
@@ -25,12 +25,11 @@ import yaml from 'js-yaml';
 
 import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
+  applyPatch,
   type BaseResourceOptions,
+  isPatchApplied,
   type PathResolver,
-  readTextFile,
-  resolvePath,
   type ResourceDeclaration,
-  writeFileIfChanged,
 } from './common';
 
 export interface YamlPatchOptions extends BaseResourceOptions {
@@ -54,15 +53,14 @@ export class YamlPatch implements ResourceDeclaration {
     this.version = options.version;
   }
 
-  async apply(context: IntegrationContext): Promise<AppliedResource> {
-    const path = await resolvePath(context, this.options.targetPath);
-    await writeFileIfChanged(path, await this.renderContent(path, context));
-    return { id: this.id, resourceType: this.resourceType, version: this.version, path };
+  apply(context: IntegrationContext): Promise<AppliedResource> {
+    return applyPatch(this.options, this.resourceType, this.version, context, (path) =>
+      this.renderContent(path, context),
+    );
   }
 
-  async isApplied(context: IntegrationContext): Promise<boolean> {
-    const path = await resolvePath(context, this.options.targetPath);
-    return (await readTextFile(path)) === (await this.renderContent(path, context));
+  isApplied(context: IntegrationContext): Promise<boolean> {
+    return isPatchApplied(this.options, context, (path) => this.renderContent(path, context));
   }
 
   private async renderContent(path: string, context: IntegrationContext): Promise<string> {

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -22,7 +22,6 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
-import { warn } from '../../../../ui';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
   type IntegrationContext,
@@ -97,6 +96,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
           content: (context) =>
             buildAgentsMdContent({
               includeSecrets: getOptionalBoolAttr(context, 'includeSecretsSection'),
+              includeSqaa: getOptionalBoolAttr(context, 'includeSqaa'),
               projectKey: getOptionalStringAttr(context, 'projectKey'),
             }),
         }),
@@ -142,20 +142,10 @@ function upsertCodexMcpServer(
   document: Record<string, unknown>,
   context: IntegrationContext,
 ): Record<string, unknown> {
-  const existingServers = toRecord(document.mcp_servers);
-  if (existingServers.sonarqube !== undefined) {
-    // Preserve any user-customized [mcp_servers.sonarqube] table.
-    const path = resolveCodexMcpConfigPath(context);
-    warn(
-      `[mcp_servers.sonarqube] already exists in ${path}; leaving the existing entry untouched.`,
-    );
-    return document;
-  }
-
   return {
     ...document,
     mcp_servers: {
-      ...existingServers,
+      ...toRecord(document.mcp_servers),
       sonarqube: getDesiredCodexMcpConfig(context),
     },
   };

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -20,11 +20,15 @@
 
 import { join } from 'node:path';
 
+import { CLI_COMMAND } from '../../../../lib/config-constants';
+import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { warn } from '../../../../ui';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
   type IntegrationContext,
   type IntegrationDeclaration,
   supportedIntegrations,
+  tomlPatch,
   wholeFile,
 } from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
@@ -44,6 +48,7 @@ export interface CodexIntegrationOptions extends IntegrateAgentOptions {
   installSecretsInstructions?: boolean;
   /** Render the post-tool SQAA section into `.codex/AGENTS.md`. */
   installSqaaInstructions?: boolean;
+  installMcp?: boolean;
 }
 
 export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> = {
@@ -97,6 +102,20 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
         }),
       ],
     },
+    {
+      id: 'mcp-server',
+      displayName: 'MCP server',
+      when: ({ options }) => options.installMcp === true,
+      resources: [
+        tomlPatch({
+          id: 'codex-mcp-config',
+          displayName: 'Codex MCP configuration',
+          targetPath: resolveCodexMcpConfigPath,
+          defaultValue: {},
+          patch: (document, context) => upsertCodexMcpServer(document, context),
+        }),
+      ],
+    },
   ],
 };
 
@@ -113,6 +132,53 @@ export function registerCodexIntegration(): void {
 
 function resolveCodexAgentsMdPath(context: IntegrationContext): string {
   return join(context.targetRoot, CODEX_CONFIG_DIR, AGENTS_MD_FILE);
+}
+
+function resolveCodexMcpConfigPath(context: IntegrationContext): string {
+  return getMcpConfigFilePath('codex', context.scope === 'global', context.targetRoot);
+}
+
+function upsertCodexMcpServer(
+  document: Record<string, unknown>,
+  context: IntegrationContext,
+): Record<string, unknown> {
+  const existingServers = toRecord(document.mcp_servers);
+  if (existingServers.sonarqube !== undefined) {
+    // Preserve any user-customized [mcp_servers.sonarqube] table.
+    const path = resolveCodexMcpConfigPath(context);
+    warn(
+      `[mcp_servers.sonarqube] already exists in ${path}; leaving the existing entry untouched.`,
+    );
+    return document;
+  }
+
+  return {
+    ...document,
+    mcp_servers: {
+      ...existingServers,
+      sonarqube: getDesiredCodexMcpConfig(context),
+    },
+  };
+}
+
+function getDesiredCodexMcpConfig(context: IntegrationContext) {
+  return getMcpConfig(
+    CLI_COMMAND,
+    context.scope === 'global'
+      ? { withFsMount: false }
+      : {
+          withFsMount: true,
+          projectRoot: context.targetRoot,
+          projectKey: getOptionalStringAttr(context, 'projectKey'),
+        },
+  );
+}
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return { ...(value as Record<string, unknown>) };
 }
 
 function getOptionalStringAttr(context: IntegrationContext, key: string): string | undefined {

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -78,6 +78,7 @@ export async function integrateCodex(
       installSecretsHooks: true,
       installSecretsInstructions: true,
       installSqaaInstructions: includeSqaaSection,
+      installMcp: true,
     },
     targetRoot: installRoot,
     scope: installScope,

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -64,12 +64,10 @@ export async function integrateCodex(
   //    the warning for unentitled orgs to avoid noise about a feature they
   //    cannot use.
   const sqaaEligible = await resolveSqaaEntitlement(auth.serverUrl, auth.token, auth.orgKey);
-  const sqaaProjectKey = !isGlobal && sqaaEligible && projectKey ? projectKey : undefined;
+  const includeSqaa = !isGlobal && sqaaEligible && Boolean(projectKey);
 
   const installRoot = isGlobal ? homedir() : project.rootDir;
   const installScope: IntegrationScope = isGlobal ? 'global' : 'project';
-
-  const includeSqaaSection = sqaaProjectKey !== undefined;
 
   await installIntegration({
     integrationId: CODEX_INTEGRATION_ID,
@@ -77,12 +75,16 @@ export async function integrateCodex(
       ...options,
       installSecretsHooks: true,
       installSecretsInstructions: true,
-      installSqaaInstructions: includeSqaaSection,
+      installSqaaInstructions: includeSqaa,
       installMcp: true,
     },
     targetRoot: installRoot,
     scope: installScope,
-    attrs: buildAttrs({ includeSecretsSection: true, projectKey: sqaaProjectKey }),
+    attrs: buildAttrs({
+      includeSecretsSection: true,
+      projectKey,
+      includeSqaa,
+    }),
   });
 
   if (!options.skipContext) {
@@ -110,9 +112,11 @@ export async function integrateCodex(
 function buildAttrs(args: {
   includeSecretsSection: boolean;
   projectKey: string | undefined;
+  includeSqaa: boolean;
 }): Record<string, IntegrationStateAttribute> {
   return {
     includeSecretsSection: args.includeSecretsSection,
     projectKey: args.projectKey ?? null,
+    includeSqaa: args.includeSqaa,
   };
 }

--- a/src/cli/commands/integrate/codex/instructions-templates.ts
+++ b/src/cli/commands/integrate/codex/instructions-templates.ts
@@ -45,7 +45,7 @@ If the command reports that the file contains a secret, **do not read the file**
 
 export interface AgentsMdSections {
   includeSecrets: boolean;
-  /** Project key to bake into the SQAA section. Section is omitted when undefined. */
+  includeSqaa: boolean;
   projectKey?: string;
 }
 
@@ -54,7 +54,7 @@ export function buildAgentsMdContent(sections: AgentsMdSections): string {
   if (sections.includeSecrets) {
     parts.push(SECRETS_ON_READ_SECTION);
   }
-  if (sections.projectKey) {
+  if (sections.includeSqaa && sections.projectKey) {
     parts.push(buildSqaaSection(sections.projectKey));
   }
   return `${parts.join('\n').trimEnd()}\n`;

--- a/src/lib/mcp/mcp-helper.ts
+++ b/src/lib/mcp/mcp-helper.ts
@@ -166,6 +166,10 @@ export function getMcpConfigFilePath(
     return isGlobal
       ? join(homedir(), '.copilot', 'mcp-config.json')
       : join(projectRoot, '.mcp.json');
+  } else if (agent === 'codex') {
+    return isGlobal
+      ? join(homedir(), '.codex', 'config.toml')
+      : join(projectRoot, '.codex', 'config.toml');
   }
   throw new Error(`Unsupported agent: ${agent}`);
 }

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -32,6 +32,7 @@ import { hookScriptName, hookScriptPath, normalizePath, TestHarness } from '../.
 const PROMPT_SCRIPT_DIRS = ['.codex', 'hooks', 'sonar-secrets', 'build-scripts'];
 const HOOKS_JSON_DIRS = ['.codex', 'hooks.json'];
 const AGENTS_MD_DIRS = ['.codex', 'AGENTS.md'];
+const CONFIG_TOML_DIRS = ['.codex', 'config.toml'];
 const SECRETS_HEADING = '# SonarQube secrets scanning for files protocol';
 const SQAA_HEADING = '# SonarQube Agentic Analysis protocol';
 
@@ -162,6 +163,175 @@ describe('integrate codex', () => {
         );
         expect(isAbsolute(command)).toBe(true);
         expect(command.startsWith(normalizePath(harness.userHome.path))).toBe(true);
+      },
+      { timeout: 30000 },
+    );
+  });
+
+  describe('MCP server config', () => {
+    it(
+      'writes [mcp_servers.sonarqube] to .codex/config.toml at project scope',
+      async () => {
+        harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=my-project\n');
+
+        const result = await harness.run('integrate codex');
+
+        // Assert on the result and the file contents
+        expect(result.exitCode).toBe(0);
+        expect(harness.cwd.exists(...CONFIG_TOML_DIRS)).toBe(true);
+        const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
+        expect(tomlBody).toContain('[mcp_servers.sonarqube]');
+        expect(tomlBody).toContain('run');
+        expect(tomlBody).toContain('mcp');
+        expect(tomlBody).toContain('--project');
+        expect(tomlBody).toContain('my-project');
+
+        // Assert on the state
+        const state = harness.stateJsonFile.asJson();
+        const codex = state.integrations.installed.find(
+          (entry: { integrationId: string }) => entry.integrationId === 'codex',
+        );
+        const mcpFeature = codex?.features?.find(
+          (feature: { featureId: string }) => feature.featureId === 'mcp-server',
+        );
+        expect(mcpFeature).toMatchObject({
+          resources: [
+            {
+              id: 'codex-mcp-config',
+              resourceType: 'toml-patch',
+              path: harness.cwd.file(...CONFIG_TOML_DIRS).path,
+            },
+          ],
+        });
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'writes the MCP config to $HOME/.codex/config.toml for global installs',
+      async () => {
+        const result = await harness.run('integrate codex -g');
+
+        // Assert on the result and the file contents
+        expect(result.exitCode).toBe(0);
+        expect(harness.cwd.exists(...CONFIG_TOML_DIRS)).toBe(false);
+        expect(harness.userHome.exists(...CONFIG_TOML_DIRS)).toBe(true);
+        const tomlBody = harness.userHome.file(...CONFIG_TOML_DIRS).asText();
+        expect(tomlBody).toContain('[mcp_servers.sonarqube]');
+        expect(tomlBody).toContain('run');
+        expect(tomlBody).toContain('mcp');
+
+        // Assert on the state
+        const state = harness.stateJsonFile.asJson();
+        const codex = state.integrations.installed.find(
+          (entry: { integrationId: string }) => entry.integrationId === 'codex',
+        );
+        const mcpFeature = codex?.features?.find(
+          (feature: { featureId: string }) => feature.featureId === 'mcp-server',
+        );
+        expect(mcpFeature).toMatchObject({
+          resources: [
+            {
+              id: 'codex-mcp-config',
+              resourceType: 'toml-patch',
+              path: harness.userHome.file(...CONFIG_TOML_DIRS).path,
+            },
+          ],
+        });
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      're-running does not change the config.toml or duplicate [mcp_servers.sonarqube]',
+      async () => {
+        await harness.run('integrate codex');
+        const firstBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
+
+        const result = await harness.run('integrate codex');
+
+        expect(result.exitCode).toBe(0);
+        expect(harness.cwd.file(...CONFIG_TOML_DIRS).asText()).toBe(firstBody);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'overwrites an existing [mcp_servers.sonarqube] entry with the canonical config',
+      async () => {
+        harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=my-project\n');
+        harness.cwd.writeFile(
+          '.codex/config.toml',
+          '[mcp_servers.sonarqube]\ncommand = "custom-sonar"\nargs = ["custom", "args"]\n',
+        );
+
+        const result = await harness.run('integrate codex');
+
+        expect(result.exitCode).toBe(0);
+        const body = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
+        expect(body).not.toContain('custom-sonar');
+        expect(body).toContain('[mcp_servers.sonarqube]');
+        expect(body).toContain('my-project');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'fails when the existing config.toml contains invalid TOML',
+      async () => {
+        harness.cwd.writeFile('.codex/config.toml', '= not valid toml =');
+
+        const result = await harness.run('integrate codex');
+
+        expect(result.exitCode).toBe(1);
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(output).toContain('config.toml contains invalid TOML');
+        expect(output).toContain('Please fix or delete it and re-run.');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'omits --project from the args array when no project key is known',
+      async () => {
+        const result = await harness.run('integrate codex');
+
+        expect(result.exitCode).toBe(0);
+        const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
+        expect(tomlBody).toContain('[mcp_servers.sonarqube]');
+        expect(tomlBody).not.toContain('--project');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'merges the sonarqube entry alongside pre-existing Codex config without touching unrelated tables',
+      async () => {
+        harness.cwd.writeFile(
+          '.codex/config.toml',
+          [
+            'model = "gpt-5.3-codex"',
+            'model_reasoning_effort = "medium"',
+            '',
+            '[plugins."browser-use@openai-bundled"]',
+            'enabled = true',
+            '',
+            '[mcp_servers.other]',
+            'command = "other"',
+            'args = ["go"]',
+            '',
+          ].join('\n'),
+        );
+
+        const result = await harness.run('integrate codex');
+
+        expect(result.exitCode).toBe(0);
+        const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
+        expect(tomlBody).toContain('model = "gpt-5.3-codex"');
+        expect(tomlBody).toContain('model_reasoning_effort = "medium"');
+        expect(tomlBody).toContain('[plugins."browser-use@openai-bundled"]');
+        expect(tomlBody).toContain('[mcp_servers.other]');
+        expect(tomlBody).toContain('[mcp_servers.sonarqube]');
       },
       { timeout: 30000 },
     );

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -44,6 +44,7 @@ const {
   SonarSourceBinary,
   sonarSourceBinary,
   textSnippet,
+  tomlPatch,
   wholeFile,
   yamlPatch,
 } = await import('../../../../../../src/cli/commands/integrate/_common/registry');
@@ -322,6 +323,11 @@ describe('declarative integration framework', () => {
           targetPath: join(tempDir, 'config.yml'),
           patch: () => ({ repos: [{ repo: 'local' }] }),
         }),
+        tomlPatch({
+          id: 'toml',
+          targetPath: join(tempDir, 'config.toml'),
+          patch: (document) => ({ ...document, enabled: true }),
+        }),
         textSnippet({
           id: 'text',
           targetPath: join(tempDir, 'pre-commit-config.yaml'),
@@ -355,6 +361,7 @@ describe('declarative integration framework', () => {
     expect(second.resources.map((resource) => resource.id).sort()).toEqual([
       'json',
       'text',
+      'toml',
       'whole',
       'yaml',
     ]);
@@ -822,6 +829,26 @@ describe('declarative integration framework', () => {
     );
     expect(jsonResource.isApplied(context)).rejects.toThrow(
       `${jsonPath} contains invalid JSON. Please fix or delete it and re-run.`,
+    );
+  });
+
+  it('fails when TOML files contain invalid content', async () => {
+    const state = getDefaultState('test');
+    const context = makeContext(state, tempDir);
+    const tomlPath = join(tempDir, 'config.toml');
+    await writeFile(tomlPath, '= not valid toml =');
+    const tomlResource = tomlPatch({
+      id: 'toml-invalid',
+      targetPath: tomlPath,
+      defaultValue: {},
+      patch: (document) => document,
+    });
+
+    expect(tomlResource.apply(context)).rejects.toThrow(
+      `${tomlPath} contains invalid TOML. Please fix or delete it and re-run.`,
+    );
+    expect(tomlResource.isApplied(context)).rejects.toThrow(
+      `${tomlPath} contains invalid TOML. Please fix or delete it and re-run.`,
     );
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **MCP Integration:**
  - Added `tomlPatch` utility for modifying `.codex/config.toml` files during integration.
  - Configured `integrate codex` to automatically register the SonarQube MCP server in Codex configuration.
- **Testing:**
  - Added comprehensive integration tests to verify MCP configuration in both project and global scopes.
- **Dependencies:**
  - Introduced `smol-toml` to handle TOML parsing and serialization for configuration patching.

<sub>This will update automatically on new commits.</sub>