### PR TITLE
CLI-443 Change model to distinguish features and dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ To add a new command: add it to `src/cli/command-tree.ts` and implement the logi
 Please declare commands using the type defined in `src/cli/commands/_common/sonar-command.ts`.
 By default, new commands should register a `authenticatedAction()`, only technical commands will use `anonymousAction()`.
 
-Declarative integration registry helpers live in `src/cli/commands/integrate/_common/registry/index.ts`. New integration descriptors should use that public entrypoint for resource factories, operations, and registry validation. Command handlers should keep command-specific validation, prompts, and target resolution thin, then delegate feature selection, generic install messages, resource/operation application, and state recording to `src/cli/commands/integrate/_common/installer.ts`.
+Declarative integration registry helpers live in `src/cli/commands/integrate/_common/registry/index.ts`. New integration descriptors should use that public entrypoint for dependency/resource factories, operations, and registry validation. Command handlers should keep command-specific validation, prompts, and target resolution thin, then delegate feature selection, generic install messages, dependency/resource application, and state recording to `src/cli/commands/integrate/_common/installer.ts`.
 
 ### Context Augmentation
 
@@ -67,7 +67,7 @@ Error subclasses extend the abstract `CliError` and carry their own `exitCode`, 
 ## State and auth
 
 - Persistent state (server URL, org, project) is managed via `src/lib/state-manager.ts`.
-- Declarative integration installs are tracked as integration entries in the top-level `integrations.installed` state registry, with installed feature targets nested under each integration. This is the generic state surface for Git, Claude, Codex, Copilot, and future integrations; legacy `agents` and `agentExtensions` remain for compatibility.
+- Declarative integration installs are tracked as integration entries in the top-level `integrations.installed` state registry, with installed feature targets nested under each integration. Shared declarative dependencies (for example SonarSource binaries required by multiple features) are recorded separately in `dependencies.installed` and referenced from features by id. This is the generic state surface for Git, Claude, Codex, Copilot, and future integrations; legacy `agents` and `agentExtensions` remain for compatibility.
 - Tokens are stored in the system keychain via `src/lib/keychain.ts` — never store tokens in plain files.
 - All path and URL constants live in `src/lib/config-constants.ts` — import from there instead of hardcoding.
 - Caller-agent hints (Cursor, Claude Code, or Copilot CLI) from the environment: `src/lib/agent-detector.ts` (`detectCallerAgent`, etc.).

--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -26,6 +26,7 @@ import {
   type IntegrationContext,
   jsonPatch,
   type PlatformSpecificContent,
+  sonarSecretsBinaryDependency,
   wholeFile,
 } from '../registry';
 
@@ -75,6 +76,7 @@ export function createSonarSecretsHooksFeature<TOptions extends SonarSecretsHook
     id: 'sonar-secrets-hooks',
     displayName: 'secrets hooks',
     when: ({ options }) => options.installSecretsHooks === true,
+    dependencies: [sonarSecretsBinaryDependency],
     resources: [
       ...config.scripts.map((script) =>
         wholeFile({

--- a/src/cli/commands/integrate/_common/registry/dependencies/common.ts
+++ b/src/cli/commands/integrate/_common/registry/dependencies/common.ts
@@ -18,14 +18,19 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export type { BaseResourceOptions, PathResolver, ResourceDeclaration } from './common';
-export { jsonPatch, type JsonPatchOptions } from './json-patch';
-export { TextSnippet, textSnippet, type TextSnippetResourceOptions } from './text-snippet';
-export {
-  type PlatformSpecificContent,
-  wholeFile,
-  type WholeFileContent,
-  WholeFileResource,
-  type WholeFileResourceOptions,
-} from './whole-file';
-export { YamlPatch, yamlPatch, type YamlPatchOptions } from './yaml-patch';
+import type { InstalledDependency, IntegrationContext, MaybePromise } from '../types';
+
+export interface BaseDependencyOptions {
+  id: string;
+  displayName?: string;
+  version?: string;
+}
+
+export interface DependencyDeclaration {
+  id: string;
+  displayName?: string;
+  dependencyType: string;
+  version?: string;
+  install: (context: IntegrationContext) => MaybePromise<InstalledDependency>;
+  isInstalled: (context: IntegrationContext) => MaybePromise<boolean>;
+}

--- a/src/cli/commands/integrate/_common/registry/dependencies/index.ts
+++ b/src/cli/commands/integrate/_common/registry/dependencies/index.ts
@@ -18,25 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { type FeatureDeclaration, SonarSourceBinary, sonarSourceBinary } from '../registry';
-
-export interface SonarSecretsBinaryFeatureOptions {
-  installBinary?: boolean;
-}
-
-export function createSonarSecretsBinaryFeature<
-  TOptions extends SonarSecretsBinaryFeatureOptions,
->(): FeatureDeclaration<TOptions> {
-  return {
-    id: 'sonar-secrets-binary',
-    displayName: 'sonar-secrets binary',
-    when: ({ options }) => options.installBinary === true,
-    resources: [
-      sonarSourceBinary({
-        id: 'sonar-secrets',
-        displayName: 'sonar-secrets binary',
-        binary: SonarSourceBinary.SonarSecrets,
-      }),
-    ],
-  };
-}
+export type { BaseDependencyOptions, DependencyDeclaration } from './common';
+export {
+  sonarSecretsBinaryDependency,
+  SonarSourceBinary,
+  sonarSourceBinary,
+  SonarSourceBinaryDependency,
+  type SonarSourceBinaryDependencyOptions,
+  type SonarSourceBinaryDescriptor,
+} from './sonarsource-binary';

--- a/src/cli/commands/integrate/_common/registry/dependencies/sonarsource-binary.ts
+++ b/src/cli/commands/integrate/_common/registry/dependencies/sonarsource-binary.ts
@@ -30,8 +30,8 @@ import {
   installBinary,
   resolveBinaryPath,
 } from '../../../../_common/install/binary';
-import type { AppliedResource, IntegrationContext } from '../types';
-import { type BaseResourceOptions, type ResourceDeclaration } from './common';
+import type { InstalledDependency, IntegrationContext } from '../types';
+import { type BaseDependencyOptions, type DependencyDeclaration } from './common';
 
 export interface SonarSourceBinaryDescriptor {
   id: string;
@@ -51,37 +51,45 @@ export const SonarSourceBinary = {
   },
 } as const satisfies Record<string, SonarSourceBinaryDescriptor>;
 
-export interface SonarSourceBinaryResourceOptions extends BaseResourceOptions {
+export interface SonarSourceBinaryDependencyOptions extends BaseDependencyOptions {
   binary: SonarSourceBinaryDescriptor;
 }
 
-export function sonarSourceBinary(options: SonarSourceBinaryResourceOptions): ResourceDeclaration {
-  return new SonarSourceBinaryResource(options);
+export function sonarSourceBinary(
+  options: SonarSourceBinaryDependencyOptions,
+): DependencyDeclaration {
+  return new SonarSourceBinaryDependency(options);
 }
 
-export class SonarSourceBinaryResource implements ResourceDeclaration {
+export class SonarSourceBinaryDependency implements DependencyDeclaration {
   readonly id: string;
   readonly displayName?: string;
-  readonly resourceType = 'sonarsource-binary';
+  readonly dependencyType = 'sonarsource-binary';
   readonly version: string;
 
-  constructor(private readonly options: SonarSourceBinaryResourceOptions) {
+  constructor(private readonly options: SonarSourceBinaryDependencyOptions) {
     this.id = options.id;
     this.displayName = options.displayName;
     this.version = options.version ?? options.binary.spec.version;
   }
 
-  async apply(_context: IntegrationContext): Promise<AppliedResource> {
+  async install(_context: IntegrationContext): Promise<InstalledDependency> {
     const result = await installBinary(this.options.binary.spec);
     return {
       id: this.id,
-      resourceType: this.resourceType,
+      dependencyType: this.dependencyType,
       version: this.version,
       path: result.binaryPath,
     };
   }
 
-  isApplied(_context: IntegrationContext): boolean {
+  isInstalled(_context: IntegrationContext): boolean {
     return resolveBinaryPath(this.options.binary.spec) !== null;
   }
 }
+
+export const sonarSecretsBinaryDependency = sonarSourceBinary({
+  id: 'sonar-secrets',
+  displayName: 'sonar-secrets binary',
+  binary: SonarSourceBinary.SonarSecrets,
+});

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -21,6 +21,14 @@
 import type { IntegrationDeclaration } from './types';
 
 export {
+  type DependencyDeclaration,
+  sonarSecretsBinaryDependency,
+  SonarSourceBinary,
+  sonarSourceBinary,
+  type SonarSourceBinaryDependencyOptions,
+  type SonarSourceBinaryDescriptor,
+} from './dependencies';
+export {
   installIntegration,
   type InstallIntegrationOptions,
   IntegrationInstaller,
@@ -31,10 +39,6 @@ export {
   type JsonPatchOptions,
   type PlatformSpecificContent,
   type ResourceDeclaration,
-  SonarSourceBinary,
-  sonarSourceBinary,
-  type SonarSourceBinaryDescriptor,
-  type SonarSourceBinaryResourceOptions,
   textSnippet,
   type TextSnippetResourceOptions,
   wholeFile,
@@ -49,6 +53,7 @@ export type {
   AppliedResource,
   FeatureDeclaration,
   FeatureOperation,
+  InstalledDependency,
   IntegrationContext,
   IntegrationDeclaration,
   IntegrationInvocation,
@@ -84,6 +89,10 @@ export class IntegrationRegistry {
     for (const feature of declaration.features) {
       this.ensureNonEmptyId(feature.id, 'Feature');
       this.ensureUnique(
+        (feature.dependencies ?? []).map((dependency) => dependency.id),
+        `Duplicate dependency id in feature ${declaration.id}.${feature.id}`,
+      );
+      this.ensureUnique(
         (feature.resources ?? []).map((resource) => resource.id),
         `Duplicate resource id in feature ${declaration.id}.${feature.id}`,
       );
@@ -91,6 +100,9 @@ export class IntegrationRegistry {
         (feature.operations ?? []).map((operation) => operation.id),
         `Duplicate operation id in feature ${declaration.id}.${feature.id}`,
       );
+      for (const dependency of feature.dependencies ?? []) {
+        this.ensureNonEmptyId(dependency.id, 'Dependency');
+      }
       for (const resource of feature.resources ?? []) {
         this.ensureNonEmptyId(resource.id, 'Resource');
       }

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -26,6 +26,8 @@ import { loadState, saveState } from '../../../../../lib/repository/state-reposi
 import type {
   CliState,
   InstalledIntegration,
+  InstalledIntegrationDependency,
+  InstalledIntegrationDependencyReference,
   InstalledIntegrationFeature,
   InstalledIntegrationOperation,
   InstalledIntegrationResource,
@@ -35,6 +37,7 @@ import type {
 import { getDefaultState } from '../../../../../lib/state';
 import { info, success, text, warn } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
+import type { DependencyDeclaration } from './dependencies';
 import type { IntegrationRegistry } from './index';
 import { supportedIntegrations } from './index';
 import type { ResourceDeclaration } from './resources';
@@ -44,12 +47,15 @@ import type {
   AppliedResource,
   FeatureDeclaration,
   FeatureOperation,
+  InstalledDependency,
   IntegrationContext,
   IntegrationDeclaration,
   IntegrationInvocation,
 } from './types';
 
 interface ApplyFeatureCallbacks {
+  onDependencyInstalled?: (dependency: DependencyDeclaration) => void;
+  onDependencySkipped?: (dependency: DependencyDeclaration) => void;
   onResourceInstalled?: (resource: ResourceDeclaration) => void;
   onResourceSkipped?: (resource: ResourceDeclaration) => void;
   onOperationApplied?: (operation: FeatureOperation) => void;
@@ -105,6 +111,27 @@ export class IntegrationInstaller {
     return state.integrations.installed.find((entry) => entry.integrationId === integration.id);
   }
 
+  findInstalledDependency(
+    state: CliState,
+    dependency: DependencyDeclaration,
+  ): InstalledIntegrationDependency | undefined {
+    return state.dependencies.installed.find((entry) => entry.id === dependency.id);
+  }
+
+  async dependencyNeedsInstall(
+    context: IntegrationContext,
+    dependency: DependencyDeclaration,
+  ): Promise<boolean> {
+    const installedDependency = this.findInstalledDependency(context.state, dependency);
+    if (!installedDependency) {
+      return true;
+    }
+    if (installedDependency.version !== dependency.version) {
+      return true;
+    }
+    return !(await dependency.isInstalled(context));
+  }
+
   async resourceNeedsApply(
     context: IntegrationContext,
     installedFeature: InstalledIntegrationFeature | undefined,
@@ -136,8 +163,18 @@ export class IntegrationInstaller {
     feature: FeatureDeclaration<TOptions>,
     callbacks: ApplyFeatureCallbacks = {},
   ): Promise<AppliedFeature> {
+    const dependencies: InstalledDependency[] = [];
     const resources: AppliedResource[] = [];
     const operations: AppliedOperation[] = [];
+
+    for (const dependency of feature.dependencies ?? []) {
+      if (!(await this.dependencyNeedsInstall(context, dependency))) {
+        callbacks.onDependencySkipped?.(dependency);
+        continue;
+      }
+      dependencies.push(await dependency.install(context));
+      callbacks.onDependencyInstalled?.(dependency);
+    }
 
     for (const resource of feature.resources ?? []) {
       if (!(await this.resourceNeedsApply(context, installedFeature, resource))) {
@@ -157,7 +194,7 @@ export class IntegrationInstaller {
       callbacks.onOperationApplied?.(operation);
     }
 
-    return { resources, operations };
+    return { dependencies, resources, operations };
   }
 
   async applyAndRecordFeature<TOptions>(
@@ -199,6 +236,10 @@ export class IntegrationInstaller {
       installedAt: existing?.installedAt ?? now,
       updatedByCliVersion: VERSION,
       updatedAt: now,
+      dependencies: this.upsertDependencyReferences(
+        existing?.dependencies ?? [],
+        new Set((feature.dependencies ?? []).map((dependency) => dependency.id)),
+      ),
       resources: this.upsertResources(
         existing?.resources ?? [],
         applied.resources,
@@ -216,11 +257,18 @@ export class IntegrationInstaller {
 
     if (existing) {
       Object.assign(existing, next);
-      return existing;
+    } else {
+      installedIntegration.features.push(next);
     }
 
-    installedIntegration.features.push(next);
-    return next;
+    state.dependencies.installed = this.upsertDependencies(
+      state.dependencies.installed,
+      applied.dependencies,
+      now,
+      this.collectReferencedDependencyIds(state),
+    );
+
+    return existing ?? next;
   }
 
   private upsertInstalledIntegration<TOptions>(
@@ -246,6 +294,42 @@ export class IntegrationInstaller {
     };
     state.integrations.installed.push(next);
     return next;
+  }
+
+  private upsertDependencyReferences(
+    existing: InstalledIntegrationDependencyReference[],
+    declaredIds: Set<string>,
+  ): InstalledIntegrationDependencyReference[] {
+    return existing
+      .filter((dependency) => declaredIds.has(dependency.id))
+      .concat(
+        [...declaredIds]
+          .filter((id) => !existing.some((dependency) => dependency.id === id))
+          .map((id) => ({ id })),
+      );
+  }
+
+  private upsertDependencies(
+    existing: InstalledIntegrationDependency[],
+    applied: InstalledDependency[],
+    now: string,
+    referencedIds: Set<string>,
+  ): InstalledIntegrationDependency[] {
+    const dependencies = existing.filter((dependency) => referencedIds.has(dependency.id));
+    for (const dependency of applied) {
+      const next: InstalledIntegrationDependency = {
+        ...dependency,
+        updatedByCliVersion: VERSION,
+        updatedAt: now,
+      };
+      const index = dependencies.findIndex((entry) => entry.id === dependency.id);
+      if (index >= 0) {
+        dependencies[index] = next;
+      } else {
+        dependencies.push(next);
+      }
+    }
+    return dependencies;
   }
 
   private upsertResources(
@@ -293,6 +377,16 @@ export class IntegrationInstaller {
     }
     return operations;
   }
+
+  private collectReferencedDependencyIds(state: CliState): Set<string> {
+    return new Set(
+      state.integrations.installed.flatMap((integration) =>
+        integration.features.flatMap((feature) =>
+          feature.dependencies.map((dependency) => dependency.id),
+        ),
+      ),
+    );
+  }
 }
 
 export const integrationInstaller = new IntegrationInstaller();
@@ -324,6 +418,12 @@ export async function installIntegration<TOptions>({
     );
     text(`Installing ${integration.displayName}: ${feature.displayName}`);
     const applied = await integrationInstaller.applyFeature(context, installedFeature, feature, {
+      onDependencyInstalled: (dependency) => {
+        success(`Installed ${dependency.displayName ?? dependency.id}`);
+      },
+      onDependencySkipped: (dependency) => {
+        info(`${dependency.displayName ?? dependency.id} already installed`);
+      },
       onResourceInstalled: (resource) => {
         success(`Installed ${resource.displayName ?? resource.id}`);
       },

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -23,6 +23,7 @@ import type {
   IntegrationScope,
   IntegrationStateAttribute,
 } from '../../../../../lib/state';
+import type { DependencyDeclaration } from './dependencies';
 import type { ResourceDeclaration } from './resources';
 
 export type MaybePromise<T> = T | Promise<T>;
@@ -64,6 +65,7 @@ export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
   when?: (invocation: IntegrationInvocation<TOptions>) => boolean;
   targetRoot?: FeatureTargetRoot<TOptions>;
   scope?: FeatureScope<TOptions>;
+  dependencies?: DependencyDeclaration[];
   resources?: ResourceDeclaration[];
   operations?: FeatureOperation[];
 }
@@ -87,8 +89,16 @@ export interface AppliedOperation {
 }
 
 export interface AppliedFeature {
+  dependencies: InstalledDependency[];
   resources: AppliedResource[];
   operations: AppliedOperation[];
+}
+
+export interface InstalledDependency {
+  id: string;
+  dependencyType: string;
+  version?: string;
+  path?: string;
 }
 
 export interface AppliedResource {

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -22,7 +22,6 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
-import { createSonarSecretsBinaryFeature } from '../_common/features/sonar-secrets-binary-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
   createAgentHookEntry,
@@ -55,7 +54,6 @@ export const CLAUDE_INTEGRATION_ID = 'claude-code';
 
 export interface ClaudeIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
-  installBinary?: boolean;
   installSecretsHooks?: boolean;
   installSqaaHook?: boolean;
   installMcp?: boolean;
@@ -65,7 +63,6 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
   id: CLAUDE_INTEGRATION_ID,
   displayName: 'Claude Code',
   features: [
-    createSonarSecretsBinaryFeature(),
     createSonarSecretsHooksFeature({
       agentDisplayName: 'Claude',
       configDir: CLAUDE_CONFIG_DIR,

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -125,7 +125,6 @@ export async function integrateClaude(
     options: {
       ...options,
       projectRoot: project.rootDir,
-      installBinary: true,
       installSecretsHooks: !skipSecretsHooks,
       installSqaaHook: sqaaEnabled && config.projectKey !== undefined,
       installMcp: true,

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -20,7 +20,6 @@
 
 import { join } from 'node:path';
 
-import { createSonarSecretsBinaryFeature } from '../_common/features/sonar-secrets-binary-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
   type IntegrationContext,
@@ -40,7 +39,6 @@ const PROMPT_SCRIPT_REL = 'sonar-secrets/build-scripts/prompt-secrets';
 export const CODEX_INTEGRATION_ID = 'codex';
 
 export interface CodexIntegrationOptions extends IntegrateAgentOptions {
-  installBinary?: boolean;
   installSecretsHooks?: boolean;
   /** Render the pre-tool secrets-on-read section into `.codex/AGENTS.md`. */
   installSecretsInstructions?: boolean;
@@ -52,7 +50,6 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
   id: CODEX_INTEGRATION_ID,
   displayName: 'Codex',
   features: [
-    createSonarSecretsBinaryFeature(),
     createSonarSecretsHooksFeature({
       agentDisplayName: 'Codex',
       configDir: CODEX_CONFIG_DIR,

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -75,7 +75,6 @@ export async function integrateCodex(
     integrationId: CODEX_INTEGRATION_ID,
     options: {
       ...options,
-      installBinary: true,
       installSecretsHooks: true,
       installSecretsInstructions: true,
       installSqaaInstructions: includeSqaaSection,

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -27,8 +27,7 @@ import {
   type IntegrationContext,
   type IntegrationDeclaration,
   jsonPatch,
-  SonarSourceBinary,
-  sonarSourceBinary,
+  sonarSecretsBinaryDependency,
   supportedIntegrations,
   wholeFile,
 } from '../_common/registry';
@@ -55,7 +54,6 @@ export const COPILOT_INTEGRATION_ID = 'copilot-cli';
 
 export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
-  installBinary?: boolean;
   installHook?: boolean;
   installInstructions?: boolean;
   installSqaaInstructions?: boolean;
@@ -67,21 +65,10 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
   displayName: 'Copilot',
   features: [
     {
-      id: 'sonar-secrets-binary',
-      displayName: 'sonar-secrets binary',
-      when: ({ options }) => options.installBinary === true,
-      resources: [
-        sonarSourceBinary({
-          id: 'sonar-secrets',
-          displayName: 'sonar-secrets binary',
-          binary: SonarSourceBinary.SonarSecrets,
-        }),
-      ],
-    },
-    {
       id: 'pre-tool-use-hook',
       displayName: 'pre-tool-use hook',
       when: ({ options }) => options.installHook === true,
+      dependencies: [sonarSecretsBinaryDependency],
       resources: [
         wholeFile({
           id: 'pretool-secrets-script',

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -82,7 +82,6 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
   const integrationOptions: CopilotIntegrationOptions = {
     ...options,
     projectRoot: project.rootDir,
-    installBinary: true,
     installHook,
     installInstructions: true,
     installSqaaInstructions: sqaaProjectKey !== undefined,

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -23,8 +23,7 @@ import { join } from 'node:path';
 import {
   type FeatureDeclaration,
   type IntegrationDeclaration,
-  SonarSourceBinary,
-  sonarSourceBinary,
+  sonarSecretsBinaryDependency,
   textSnippet,
 } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
@@ -44,12 +43,8 @@ function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitO
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
     when: ({ options }) => options.hook === hook,
+    dependencies: [sonarSecretsBinaryDependency],
     resources: [
-      sonarSourceBinary({
-        id: 'sonar-secrets',
-        displayName: 'sonar-secrets binary',
-        binary: SonarSourceBinary.SonarSecrets,
-      }),
       textSnippet({
         id: 'hook-file',
         displayName: `${hook} hook`,

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -24,8 +24,7 @@ import { CommandFailedError } from '../../../../_common/error';
 import {
   type FeatureDeclaration,
   type IntegrationDeclaration,
-  SonarSourceBinary,
-  sonarSourceBinary,
+  sonarSecretsBinaryDependency,
 } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { nativeGitHookResource } from './resource';
@@ -45,12 +44,8 @@ function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<Integrate
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
     when: ({ options }) => options.hook === hook,
+    dependencies: [sonarSecretsBinaryDependency],
     resources: [
-      sonarSourceBinary({
-        id: 'sonar-secrets',
-        displayName: 'sonar-secrets binary',
-        binary: SonarSourceBinary.SonarSecrets,
-      }),
       nativeGitHookResource({
         id: 'hook-file',
         displayName: `${hook} hook`,

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -23,8 +23,7 @@ import { join } from 'node:path';
 import {
   type FeatureDeclaration,
   type IntegrationDeclaration,
-  SonarSourceBinary,
-  sonarSourceBinary,
+  sonarSecretsBinaryDependency,
   yamlPatch,
 } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
@@ -49,12 +48,8 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
     when: ({ options }) => options.hook === hook,
+    dependencies: [sonarSecretsBinaryDependency],
     resources: [
-      sonarSourceBinary({
-        id: 'sonar-secrets',
-        displayName: 'sonar-secrets binary',
-        binary: SonarSourceBinary.SonarSecrets,
-      }),
       yamlPatch({
         id: 'hook-config',
         displayName: `${hook} hook`,

--- a/src/lib/repository/state-repository.ts
+++ b/src/lib/repository/state-repository.ts
@@ -61,6 +61,9 @@ function migrateState(raw: Record<string, unknown>): CliState {
   if (!raw.integrations) {
     raw.integrations = { installed: [] };
   }
+  if (!raw.dependencies) {
+    raw.dependencies = { installed: [] };
+  }
   if (!raw.auth) {
     raw.auth = getDefaultState(VERSION).auth;
     return raw as unknown as CliState;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -255,6 +255,32 @@ export interface ToolsState {
 }
 
 /**
+ * Installed dependency metadata shared across declarative integration features.
+ */
+export interface InstalledIntegrationDependency {
+  /** Stable dependency identifier from the integration declaration */
+  id: string;
+  /** Dependency type from the integration declaration */
+  dependencyType: string;
+  /** Dependency declaration version, when versioned */
+  version?: string;
+  /** Resolved path for dependencies materialized on disk */
+  path?: string;
+  /** CLI version that last updated this dependency */
+  updatedByCliVersion: string;
+  /** ISO timestamp of the last update */
+  updatedAt: string;
+}
+
+/**
+ * Shared dependency installation state.
+ */
+export interface DependenciesState {
+  /** Installed dependencies shared by declarative integrations */
+  installed: InstalledIntegrationDependency[];
+}
+
+/**
  * Scope where an integration feature was installed.
  */
 export type IntegrationScope = 'project' | 'global';
@@ -297,6 +323,14 @@ export interface InstalledIntegrationOperation {
 }
 
 /**
+ * Dependency reference stored on an installed declarative integration feature.
+ */
+export interface InstalledIntegrationDependencyReference {
+  /** Stable dependency identifier from the integration declaration */
+  id: string;
+}
+
+/**
  * Installed declarative integration feature.
  */
 export interface InstalledIntegrationFeature {
@@ -314,6 +348,8 @@ export interface InstalledIntegrationFeature {
   updatedByCliVersion: string;
   /** ISO timestamp of the last update */
   updatedAt: string;
+  /** Shared dependencies required by this feature */
+  dependencies: InstalledIntegrationDependencyReference[];
   /** Resources installed for this feature */
   resources: InstalledIntegrationResource[];
   /** Operations applied for this feature */
@@ -427,6 +463,8 @@ export interface CliState {
   config: CliConfig;
   /** Installed tools */
   tools?: ToolsState;
+  /** Shared declarative integration dependencies */
+  dependencies: DependenciesState;
   /** Telemetry configuration and pending event batch */
   telemetry: TelemetryState;
   /** Registry of all agent extensions (hooks, skills) installed per project */
@@ -464,6 +502,9 @@ export function getDefaultState(cliVersion: string): CliState {
       cliVersion,
     },
     tools: {
+      installed: [],
+    },
+    dependencies: {
       installed: [],
     },
     telemetry: {

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -45,7 +45,11 @@ import { generateKeychainAccount } from '../../../src/lib/keychain';
 import { detectPlatform } from '../../../src/lib/platform-detector.js';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../src/lib/signatures.js';
 import { buildDownloadUrl } from '../../../src/lib/sonarsource-releases.js';
-import type { CliState, InstalledTool } from '../../../src/lib/state.js';
+import type {
+  CliState,
+  InstalledIntegrationDependency,
+  InstalledTool,
+} from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import { IS_WINDOWS } from './platform';
 
@@ -288,13 +292,23 @@ export class EnvironmentBuilder {
     const resolvePath = (name: string): string => (binDir ? join(binDir, name) : name);
 
     const installed: InstalledTool[] = [];
+    const installedDependencies: InstalledIntegrationDependency[] = [];
     if (this._installSecretsBinary) {
+      const binaryPath = resolvePath(buildLocalBinaryName(SECRETS_SPEC, detectPlatform()));
       installed.push({
         name: SECRETS_SPEC.name,
         version: SECRETS_SPEC.version,
-        path: resolvePath(buildLocalBinaryName(SECRETS_SPEC, detectPlatform())),
+        path: binaryPath,
         installedAt: new Date().toISOString(),
         installedByCliVersion: 'integration-test',
+      });
+      installedDependencies.push({
+        id: SECRETS_SPEC.name,
+        dependencyType: 'sonarsource-binary',
+        version: SECRETS_SPEC.version,
+        path: binaryPath,
+        updatedAt: new Date().toISOString(),
+        updatedByCliVersion: 'integration-test',
       });
     }
     if (this._installCagBinary) {
@@ -317,6 +331,9 @@ export class EnvironmentBuilder {
     }
     if (installed.length > 0) {
       state.tools = { installed };
+    }
+    if (installedDependencies.length > 0) {
+      state.dependencies = { installed: installedDependencies };
     }
 
     for (const ext of this.sqaaExtensions) {

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -110,7 +110,7 @@ describe('integrate claude', () => {
         claudeIntegration.features
           .map((feature: { featureId: string }) => feature.featureId)
           .sort(),
-      ).toEqual(['mcp-server', 'sonar-secrets-binary', 'sonar-secrets-hooks']);
+      ).toEqual(['mcp-server', 'sonar-secrets-hooks']);
 
       const secretsHooksFeature = claudeIntegration.features.find(
         (feature: { featureId: string }) => feature.featureId === 'sonar-secrets-hooks',
@@ -120,6 +120,7 @@ describe('integrate claude', () => {
       );
       expect(secretsHooksFeature).toMatchObject({
         scope: 'project',
+        dependencies: [{ id: 'sonar-secrets' }],
         attrs: {
           projectKey: 'my-project',
           serverUrl: server.baseUrl(),
@@ -135,6 +136,12 @@ describe('integrate claude', () => {
         ],
         operations: [],
       });
+      expect(state.dependencies.installed).toMatchObject([
+        {
+          id: 'sonar-secrets',
+          dependencyType: 'sonarsource-binary',
+        },
+      ]);
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -158,22 +158,24 @@ describe('integrate copilot', () => {
           copilotIntegration.features
             .map((feature: { featureId: string }) => feature.featureId)
             .sort(),
-        ).toEqual([
-          'mcp-server',
-          'pre-tool-use-hook',
-          'prompt-secrets-instructions',
-          'sonar-secrets-binary',
-        ]);
+        ).toEqual(['mcp-server', 'pre-tool-use-hook', 'prompt-secrets-instructions']);
 
         const hookFeature = copilotIntegration.features.find(
           (feature: { featureId: string }) => feature.featureId === 'pre-tool-use-hook',
         );
         expect(hookFeature).toMatchObject({
           scope: 'project',
+          dependencies: [{ id: 'sonar-secrets' }],
           attrs: {
             projectKey: 'my-project',
           },
         });
+        expect(state.dependencies.installed).toMatchObject([
+          {
+            id: 'sonar-secrets',
+            dependencyType: 'sonarsource-binary',
+          },
+        ]);
       },
       { timeout: 30000 },
     );
@@ -581,7 +583,8 @@ describe('integrate copilot', () => {
           copilotIntegration.features
             .map((feature: { featureId: string }) => feature.featureId)
             .sort(),
-        ).toEqual(['mcp-server', 'prompt-secrets-instructions', 'sonar-secrets-binary']);
+        ).toEqual(['mcp-server', 'prompt-secrets-instructions']);
+        expect(state.dependencies.installed).toEqual([]);
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -112,6 +112,12 @@ const INTEGRATION_TEST_TOKEN = 'test-token';
 const LEGACY_PRE_COMMIT_REPO = 'https://github.com/SonarSource/sonar-secrets-pre-commit';
 
 type InstalledStateJson = {
+  dependencies: {
+    installed: Array<{
+      id: string;
+      dependencyType: string;
+    }>;
+  };
   integrations: {
     installed: Array<{
       integrationId: string;
@@ -120,6 +126,7 @@ type InstalledStateJson = {
         scope: string;
         targetRoot: string;
         attrs?: Record<string, unknown>;
+        dependencies: Array<{ id: string }>;
         resources: Array<{ id: string; resourceType: string }>;
         operations: Array<{ id: string }>;
       }>;
@@ -143,6 +150,22 @@ function getInstalledIntegration(state: InstalledStateJson, integrationId: strin
   );
   expect(integration).toBeDefined();
   return integration as InstalledIntegrationJson;
+}
+
+function expectInstalledDependency(
+  state: InstalledStateJson,
+  id: string,
+  dependencyType: string,
+): void {
+  const dependency = state.dependencies.installed.find((entry) => entry.id === id);
+  expect(dependency).toBeDefined();
+  expect(dependency?.dependencyType).toBe(dependencyType);
+}
+
+function expectFeatureDependency(feature: InstalledFeatureJson, id: string): void {
+  const dependency = feature.dependencies.find((entry) => entry.id === id);
+  expect(dependency).toBeDefined();
+  expect(dependency?.id).toBe(id);
 }
 
 function expectInstalledResource(
@@ -381,9 +404,10 @@ describe('integrate git (native hooks)', () => {
           hook: 'pre-commit',
         },
       });
-      expectInstalledResource(feature, 'sonar-secrets', 'sonarsource-binary');
+      expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'git-hook-file');
       expect(feature.operations).toEqual([]);
+      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
     },
     { timeout: 15000 },
   );
@@ -507,9 +531,10 @@ describe('integrate git (husky)', () => {
           hook: 'pre-commit',
         },
       });
-      expectInstalledResource(feature, 'sonar-secrets', 'sonarsource-binary');
+      expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
       expect(feature.operations).toEqual([]);
+      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
     },
     { timeout: 15000 },
   );
@@ -574,9 +599,10 @@ describe('integrate git (husky)', () => {
           hook: 'pre-push',
         },
       });
-      expectInstalledResource(feature, 'sonar-secrets', 'sonarsource-binary');
+      expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
       expect(feature.operations).toEqual([]);
+      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
     },
     { timeout: 15000 },
   );
@@ -671,9 +697,10 @@ describe('integrate git (pre-commit framework)', () => {
           hook: 'pre-commit',
         },
       });
-      expectInstalledResource(feature, 'sonar-secrets', 'sonarsource-binary');
+      expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
       expectInstalledOperation(feature, 'activate-hook');
+      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
     },
     { timeout: 15000 },
   );
@@ -720,9 +747,10 @@ describe('integrate git (pre-commit framework)', () => {
           hook: 'pre-push',
         },
       });
-      expectInstalledResource(feature, 'sonar-secrets', 'sonarsource-binary');
+      expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
       expectInstalledOperation(feature, 'activate-hook');
+      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
     },
     { timeout: 15000 },
   );

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -80,7 +80,7 @@ describe('declarative integration framework', () => {
     );
   });
 
-  it('rejects duplicate feature, resource, and operation ids', () => {
+  it('rejects duplicate feature, dependency, resource, and operation ids', () => {
     const registry = new IntegrationRegistry();
 
     expect(() =>
@@ -93,6 +93,23 @@ describe('declarative integration framework', () => {
         }),
       ),
     ).toThrow('Duplicate feature id in integration test-integration');
+
+    expect(() =>
+      registry.register(
+        makeIntegration({
+          features: [
+            {
+              id: 'feature',
+              displayName: 'Feature',
+              dependencies: [
+                sonarSourceBinary({ id: 'same', binary: SonarSourceBinary.SonarSecrets }),
+                sonarSourceBinary({ id: 'same', binary: SonarSourceBinary.SonarSecrets }),
+              ],
+            },
+          ],
+        }),
+      ),
+    ).toThrow('Duplicate dependency id in feature test-integration.feature');
 
     expect(() =>
       registry.register(
@@ -153,6 +170,21 @@ describe('declarative integration framework', () => {
         }),
       ),
     ).toThrow('Feature id must not be empty');
+    expect(() =>
+      registry.register(
+        makeIntegration({
+          features: [
+            {
+              id: 'feature',
+              displayName: 'Feature',
+              dependencies: [
+                sonarSourceBinary({ id: ' ', binary: SonarSourceBinary.SonarSecrets }),
+              ],
+            },
+          ],
+        }),
+      ),
+    ).toThrow('Dependency id must not be empty');
     expect(() =>
       registry.register(
         makeIntegration({
@@ -266,6 +298,12 @@ describe('declarative integration framework', () => {
     const feature: FeatureDeclaration = {
       id: 'feature',
       displayName: 'Feature',
+      dependencies: [
+        sonarSourceBinary({
+          id: 'binary',
+          binary: SonarSourceBinary.SonarSecrets,
+        }),
+      ],
       resources: [
         wholeFile({
           id: 'whole',
@@ -291,10 +329,6 @@ describe('declarative integration framework', () => {
           executable: true,
           startMarker: '# sonar:begin text',
         }),
-        sonarSourceBinary({
-          id: 'binary',
-          binary: SonarSourceBinary.SonarSecrets,
-        }),
       ],
       operations: [
         {
@@ -317,14 +351,22 @@ describe('declarative integration framework', () => {
     expect(state.integrations.installed[0].features).toHaveLength(1);
     expect(state.integrations.installed[0].features[0].attrs?.projectKey).toBe('project');
     expect(state.integrations.installed[0].features[0].targetRoot).toBe(tempDir);
+    expect(second.dependencies).toEqual([{ id: 'binary' }]);
     expect(second.resources.map((resource) => resource.id).sort()).toEqual([
-      'binary',
       'json',
       'text',
       'whole',
       'yaml',
     ]);
     expect(second.operations.map((operation) => operation.id)).toEqual(['operation']);
+    expect(state.dependencies.installed).toMatchObject([
+      {
+        id: 'binary',
+        dependencyType: 'sonarsource-binary',
+        version: SonarSourceBinary.SonarSecrets.spec.version,
+        path: join(tempDir, 'bin', 'sonar-secrets'),
+      },
+    ]);
     expect(operationCalls).toEqual(['operation', 'operation']);
     expect(await readFile(join(tempDir, 'script.sh'), 'utf-8')).toBe('#!/bin/sh\necho sonar\n');
     expect(JSON.parse(await readFile(join(tempDir, 'settings.json'), 'utf-8'))).toEqual({
@@ -614,37 +656,84 @@ describe('declarative integration framework', () => {
     ]);
   });
 
-  it('checks SonarSource binary resources by their descriptor', async () => {
+  it('prunes stale shared dependency state when no installed feature references it', async () => {
+    const state = getDefaultState('test');
+    const context = makeContext(state, tempDir);
+    const legacyFeature: FeatureDeclaration = {
+      id: 'feature',
+      displayName: 'Feature',
+      dependencies: [
+        sonarSourceBinary({
+          id: 'binary',
+          binary: SonarSourceBinary.SonarSecrets,
+        }),
+      ],
+    };
+    const currentFeature: FeatureDeclaration = {
+      id: 'feature',
+      displayName: 'Feature',
+      resources: [
+        wholeFile({
+          id: 'current',
+          targetPath: join(tempDir, 'current.txt'),
+          content: 'current',
+        }),
+      ],
+    };
+
+    await installer.applyAndRecordFeature(
+      context,
+      makeIntegration({ features: [legacyFeature] }),
+      legacyFeature,
+    );
+    const installed = await installer.applyAndRecordFeature(
+      context,
+      makeIntegration({ features: [currentFeature] }),
+      currentFeature,
+    );
+
+    expect(installed.dependencies).toEqual([]);
+    expect(state.dependencies.installed).toEqual([]);
+  });
+
+  it('checks SonarSource binary dependencies by their descriptor', async () => {
     const state = getDefaultState('test');
     const binaryPath = join(tempDir, 'bin', 'sonar-secrets');
-    const resource = sonarSourceBinary({
+    const dependency = sonarSourceBinary({
       id: 'binary',
       binary: SonarSourceBinary.SonarSecrets,
     });
     const context = makeContext(state, tempDir);
 
-    expect(await resource.isApplied(context)).toBe(false);
+    expect(await dependency.isInstalled(context)).toBe(false);
 
     resolveBinaryPathSpy.mockReturnValue(binaryPath);
 
-    expect(await resource.isApplied(context)).toBe(true);
+    expect(await dependency.isInstalled(context)).toBe(true);
 
-    const applied = await resource.apply(context);
+    const applied = await dependency.install(context);
 
     expect(installBinarySpy).toHaveBeenCalledWith(SonarSourceBinary.SonarSecrets.spec);
     expect(applied).toEqual({
       id: 'binary',
-      resourceType: 'sonarsource-binary',
+      dependencyType: 'sonarsource-binary',
       version: SonarSourceBinary.SonarSecrets.spec.version,
       path: binaryPath,
     });
   });
 
-  it('reports whether resources and operations need to be applied', async () => {
+  it('reports whether dependencies, resources, and operations need to be applied', async () => {
     const state = getDefaultState('test');
     const feature: FeatureDeclaration = {
       id: 'feature',
       displayName: 'Feature',
+      dependencies: [
+        sonarSourceBinary({
+          id: 'dependency',
+          version: '1',
+          binary: SonarSourceBinary.SonarSecrets,
+        }),
+      ],
       resources: [
         wholeFile({
           id: 'resource',
@@ -658,6 +747,7 @@ describe('declarative integration framework', () => {
     const integration = makeIntegration({ features: [feature] });
     const context = makeContext(state, tempDir);
 
+    expect(await installer.dependencyNeedsInstall(context, feature.dependencies![0])).toBe(true);
     expect(await installer.resourceNeedsApply(context, undefined, feature.resources![0])).toBe(
       true,
     );
@@ -668,12 +758,24 @@ describe('declarative integration framework', () => {
 
     const installed = await installer.applyAndRecordFeature(context, integration, feature);
     const found = installer.findInstalledFeature(state, context, integration, feature);
+    resolveBinaryPathSpy.mockReturnValue(join(tempDir, 'bin', 'sonar-secrets'));
 
     expect(found?.featureId).toBe(installed.featureId);
+    expect(await installer.dependencyNeedsInstall(context, feature.dependencies![0])).toBe(false);
     expect(await installer.resourceNeedsApply(context, installed, feature.resources![0])).toBe(
       false,
     );
     expect(installer.operationNeedsApply(installed, feature.operations![0])).toBe(false);
+    expect(
+      await installer.dependencyNeedsInstall(
+        context,
+        sonarSourceBinary({
+          id: 'dependency',
+          version: '2',
+          binary: SonarSourceBinary.SonarSecrets,
+        }),
+      ),
+    ).toBe(true);
     expect(
       await installer.resourceNeedsApply(
         context,

--- a/tests/unit/cli/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/integrate.test.ts
@@ -768,7 +768,6 @@ describe('integrateCommand', () => {
         integrationId: 'claude-code',
         options: expect.objectContaining({
           projectRoot,
-          installBinary: true,
           installSecretsHooks,
           installSqaaHook,
           installMcp: true,

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -617,12 +617,19 @@ describe('integrateGit', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: TEMP_DIR,
+        dependencies: [{ id: 'sonar-secrets' }],
       });
       expect(
         feature?.resources.some(
           (resource) => resource.id === 'hook-file' && resource.resourceType === 'text-snippet',
         ),
       ).toBe(true);
+      expect(state.dependencies.installed).toMatchObject([
+        {
+          id: 'sonar-secrets',
+          dependencyType: 'sonarsource-binary',
+        },
+      ]);
     } finally {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });
@@ -653,6 +660,7 @@ describe('integrateGit', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: TEMP_DIR,
+        dependencies: [{ id: 'sonar-secrets' }],
       });
       expect(
         feature?.resources.some(
@@ -660,6 +668,12 @@ describe('integrateGit', () => {
         ),
       ).toBe(true);
       expect(feature?.operations.some((operation) => operation.id === 'activate-hook')).toBe(true);
+      expect(state.dependencies.installed).toMatchObject([
+        {
+          id: 'sonar-secrets',
+          dependencyType: 'sonarsource-binary',
+        },
+      ]);
     } finally {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });
@@ -679,6 +693,7 @@ describe('integrateGit', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: TEMP_DIR,
+        dependencies: [{ id: 'sonar-secrets' }],
       });
       expect(
         feature?.resources.some(
@@ -686,6 +701,12 @@ describe('integrateGit', () => {
         ),
       ).toBe(true);
       expect(feature?.operations).toEqual([]);
+      expect(state.dependencies.installed).toMatchObject([
+        {
+          id: 'sonar-secrets',
+          dependencyType: 'sonarsource-binary',
+        },
+      ]);
     } finally {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });

--- a/tests/unit/lib/state-manager.test.ts
+++ b/tests/unit/lib/state-manager.test.ts
@@ -334,6 +334,17 @@ describe('loadState: migration', () => {
     expect(state.integrations).toEqual({ installed: [] });
   });
 
+  it('initialises dependencies to empty installed list when absent in state file', () => {
+    const raw = getDefaultState('0.1.0') as unknown as Record<string, unknown>;
+    delete raw['dependencies'];
+    mkdirSync(testCliDir, { recursive: true });
+    writeFileSync(testStateFile, JSON.stringify(raw), 'utf-8');
+
+    const state = loadState('0.1.0');
+
+    expect(state.dependencies).toEqual({ installed: [] });
+  });
+
   it('initialises telemetry when absent in state file', () => {
     const raw = getDefaultState('0.1.0') as unknown as Record<string, unknown>;
     delete raw['telemetry'];

--- a/tests/unit/lib/state.test.ts
+++ b/tests/unit/lib/state.test.ts
@@ -44,6 +44,7 @@ describe('State Management', () => {
       expect(agent.skills.installed).toEqual([]);
       expect(agent.configuredAt).toBeUndefined();
       expect(agent.configuredByCliVersion).toBeUndefined();
+      expect(state.dependencies.installed).toEqual([]);
       expect(state.integrations.installed).toEqual([]);
     });
   });


### PR DESCRIPTION
----
## Summary by Gitar

- **Model refactoring:**
  - Introduced `dependencies` registry in `CliState` to decouple shared binaries from individual integration features.
  - Updated `InstalledIntegrationFeature` to reference shared dependencies by ID rather than embedding resources.
- **Migration:**
  - Added `migrateLegacyIntegrationDependencies` to automatically move existing binary resources into the new shared dependency registry.
- **Framework updates:**
  - Enhanced `IntegrationInstaller` to support `dependencyNeedsApply`, `onDependencyInstalled` callbacks, and cross-feature dependency tracking.
  - Updated `IntegrationRegistry` to validate unique dependency IDs during registration.


<sub>This will update automatically on new commits.</sub>