### PR TITLE
CLI-494 Offer 'yes' as default option during git integration

### DIFF
--- a/src/cli/commands/analyze/sqaa-auth.ts
+++ b/src/cli/commands/analyze/sqaa-auth.ts
@@ -170,7 +170,7 @@ export async function confirmLargeChangeset(fileCount: number): Promise<boolean>
   }
 
   blank();
-  const confirmed = await confirmPrompt('Do you wish to proceed?');
+  const confirmed = await confirmPrompt('Do you wish to proceed?', true);
   if (!confirmed) {
     blank();
     text('Analysis cancelled. Use --force to bypass the file count check.');

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -193,7 +193,7 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   blank();
 
   if (!options.nonInteractive) {
-    const confirmed = await confirmPrompt('Proceed with global installation?');
+    const confirmed = await confirmPrompt('Proceed with global installation?', true);
     if (confirmed === false || confirmed === null) {
       throw new CommandFailedError('Installation cancelled');
     }
@@ -231,7 +231,7 @@ export async function integrateGit(options: IntegrateGitOptions): Promise<void> 
   blank();
 
   if (!options.nonInteractive) {
-    const confirmed = await confirmPrompt('Install here?');
+    const confirmed = await confirmPrompt('Install here?', true);
     if (confirmed === false || confirmed === null) {
       throw new CommandFailedError('Installation cancelled');
     }

--- a/src/ui/components/prompts.ts
+++ b/src/ui/components/prompts.ts
@@ -57,9 +57,12 @@ export async function textPrompt(message: string): Promise<string | null> {
 /**
  * Yes/No confirmation prompt. Returns null if cancelled (Ctrl+C).
  */
-export async function confirmPrompt(message: string): Promise<boolean | null> {
+export async function confirmPrompt(
+  message: string,
+  defaultValue: boolean,
+): Promise<boolean | null> {
   if (isMockActive()) {
-    const value = dequeueMockResponse<boolean>(false);
+    const value = dequeueMockResponse<boolean>(defaultValue);
     recordCall('confirmPrompt', message, value);
     return value;
   }
@@ -67,6 +70,7 @@ export async function confirmPrompt(message: string): Promise<boolean | null> {
   const prompt = new ConfirmPrompt({
     active: 'Yes',
     inactive: 'No',
+    initialValue: defaultValue,
     render() {
       if (this.state === 'submit')
         return `  ${green('✓')}  ${message} ${dim(this.value ? 'Yes' : 'No')}`;

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -373,8 +373,8 @@ describe('integrate git (native hooks)', () => {
       initGitRepo(harness);
 
       // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: 'y' confirms 'Install here?', then '\r' selects pre-commit
-      const result = await harness.run('integrate git', { stdinChunks: ['y', '\r'] });
+      // both at once: '\r' confirms 'Install here?', then '\r' selects pre-commit
+      const result = await harness.run('integrate git', { stdinChunks: ['\r', '\r'] });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
@@ -418,9 +418,9 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // 'y' confirms 'Install here?'; '\x1b[B' moves the selection down to pre-push; '\r' submits
+      // '\r' confirms 'Install here?'; '\x1b[B' moves the selection down to pre-push; '\r' submits
       const result = await harness.run('integrate git', {
-        stdinChunks: ['y', '\x1b[B', '\r'],
+        stdinChunks: ['\r', '\x1b[B', '\r'],
       });
 
       expect(result.exitCode).toBe(0);
@@ -436,8 +436,8 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
       // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: 'y' confirms global hook warning, then '\r' selects pre-commit
-      const result = await harness.run('integrate git --global', { stdinChunks: ['y', '\r'] });
+      // both at once: '\r' confirms global hook warning, then '\r' selects pre-commit
+      const result = await harness.run('integrate git --global', { stdinChunks: ['\r', '\r'] });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
@@ -477,9 +477,9 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
       // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: 'y' confirms global hook warning, then '\r' selects pre-push
+      // both at once: '\r' confirms global hook warning, then '\r' selects pre-push
       const result = await harness.run('integrate git --global', {
-        stdinChunks: ['y', '\x1b[B', '\r'],
+        stdinChunks: ['\r', '\x1b[B', '\r'],
       });
 
       expect(result.exitCode).toBe(0);

--- a/tests/unit/ui/prompts-real.test.ts
+++ b/tests/unit/ui/prompts-real.test.ts
@@ -151,19 +151,19 @@ describe('confirmPrompt: real prompt path', () => {
 
   it('returns true when prompt confirms', async () => {
     mockConfirmResult = true;
-    const result = await confirmPrompt('Are you sure?');
+    const result = await confirmPrompt('Are you sure?', true);
     expect(result).toBe(true);
   });
 
   it('returns false when prompt declines', async () => {
     mockConfirmResult = false;
-    const result = await confirmPrompt('Are you sure?');
+    const result = await confirmPrompt('Are you sure?', true);
     expect(result).toBe(false);
   });
 
   it('returns null when prompt is cancelled (symbol returned)', async () => {
     mockConfirmResult = Symbol('cancel');
-    const result = await confirmPrompt('Are you sure?');
+    const result = await confirmPrompt('Are you sure?', true);
     expect(result).toBeNull();
   });
 });

--- a/tests/unit/ui/prompts.test.ts
+++ b/tests/unit/ui/prompts.test.ts
@@ -104,7 +104,7 @@ describe('confirmPrompt: mock mode', () => {
 
   it('returns queued true response and records call', async () => {
     queueMockResponse(true);
-    const result = await confirmPrompt('Are you sure?');
+    const result = await confirmPrompt('Are you sure?', true);
     expect(result).toBe(true);
     const calls = getMockUiCalls();
     expect(calls.some((c) => c.method === 'confirmPrompt' && c.args[0] === 'Are you sure?')).toBe(
@@ -114,20 +114,25 @@ describe('confirmPrompt: mock mode', () => {
 
   it('returns queued false response', async () => {
     queueMockResponse(false);
-    const result = await confirmPrompt('Proceed?');
+    const result = await confirmPrompt('Proceed?', false);
     expect(result).toBe(false);
   });
 
-  it('returns false as fallback when queue is empty', async () => {
-    const result = await confirmPrompt('Delete everything?');
+  it('returns default when queue is empty', async () => {
+    const result = await confirmPrompt('Proceed?', true);
+    expect(result).toBe(true);
+  });
+
+  it('returns explicit default when queue is empty and default is false', async () => {
+    const result = await confirmPrompt('Delete everything?', false);
     expect(result).toBe(false);
   });
 
   it('dequeues boolean responses in FIFO order', async () => {
     queueMockResponse(true);
     queueMockResponse(false);
-    expect(await confirmPrompt('First?')).toBe(true);
-    expect(await confirmPrompt('Second?')).toBe(false);
+    expect(await confirmPrompt('First?', true)).toBe(true);
+    expect(await confirmPrompt('Second?', false)).toBe(false);
   });
 });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **UI enhancements:**
  - Added `defaultValue` parameter to `confirmPrompt` to support configurable default selections.
  - Updated the underlying `ConfirmPrompt` component to respect the `initialValue` property.

<sub>This will update automatically on new commits.</sub>