### PR TITLE
CLI-537 Replace link to SCA in CLI documentation

### DIFF
--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -166,7 +166,7 @@ async function assertServerSupportsLocalSca(
       'Software Composition Analysis is not available for the current server connection.',
       {
         remediationHint:
-          'Software Composition Analysis must be enabled by an administrator and requires an eligible SonarQube plan. Learn more: https://www.sonarsource.com/products/sonarqube/advanced-security/',
+          'Software Composition Analysis must be enabled by an administrator and requires an eligible SonarQube plan. Learn more: https://docs.sonarsource.com/sonarqube-cli/analysis/sca',
       },
     );
   }


### PR DESCRIPTION
Part of CLI-504

----
## Summary by Gitar

- **Documentation updates:**
  - Updated the SCA help link in `src/cli/commands/analyze/dependency-risks.ts` to point to the official CLI documentation.

<sub>This will update automatically on new commits.</sub>