### PR TITLE
CLI-493 Disable telemetry when the DO_NOT_TRACK environment variable is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,6 +594,8 @@ Both are enabled by default and share the same opt-out toggle. To disable all da
 sonar config telemetry --disabled
 ```
 
+You can also set the `DO_NOT_TRACK=1` environment variable to disable telemetry for a session without changing persisted configuration.
+
 No personally identifiable information is transmitted.
 
 ## Contributing

--- a/src/cli/commands/config/telemetry.ts
+++ b/src/cli/commands/config/telemetry.ts
@@ -20,6 +20,7 @@
 // Configure CLI settings
 
 import { loadState, saveState } from '../../../lib/repository/state-repository';
+import { describeTelemetryStatus } from '../../../telemetry/enabled.js';
 import { info, success } from '../../../ui';
 import { InvalidOptionError } from '../_common/error';
 
@@ -34,7 +35,7 @@ export function configureTelemetry(options: ConfigureTelemetryOptions): Promise<
   }
   if (!options.enabled && !options.disabled) {
     const state = loadState();
-    info(`Telemetry is currently ${state.telemetry.enabled ? 'enabled' : 'disabled'}.`);
+    info(describeTelemetryStatus(state));
     return Promise.resolve();
   }
   const state = loadState();

--- a/src/cli/commands/config/telemetry.ts
+++ b/src/cli/commands/config/telemetry.ts
@@ -20,7 +20,7 @@
 // Configure CLI settings
 
 import { loadState, saveState } from '../../../lib/repository/state-repository';
-import { describeTelemetryStatus } from '../../../telemetry/enabled.js';
+import { describeTelemetryStatus, isDoNotTrackRequested } from '../../../telemetry/enabled.js';
 import { info, success } from '../../../ui';
 import { InvalidOptionError } from '../_common/error';
 
@@ -39,8 +39,14 @@ export function configureTelemetry(options: ConfigureTelemetryOptions): Promise<
     return Promise.resolve();
   }
   const state = loadState();
-  state.telemetry.enabled = options.enabled ?? false;
+  const persistedEnabled = options.enabled ?? false;
+  state.telemetry.enabled = persistedEnabled;
   saveState(state);
-  success(`Telemetry ${options.enabled ? 'enabled' : 'disabled'}.`);
+  if (persistedEnabled && isDoNotTrackRequested()) {
+    success('Telemetry preference saved as enabled.');
+    info('Telemetry is currently disabled (DO_NOT_TRACK is set).');
+  } else {
+    success(`Telemetry ${persistedEnabled ? 'enabled' : 'disabled'}.`);
+  }
   return Promise.resolve();
 }

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -124,6 +124,13 @@ export const AGENT_ACTIVITY_PATH = '/project/agent_activity';
 export const SONAR_CONTEXT_INVOCATION = 'sonar context';
 
 // ---------------------------------------------------------------------------
+// Telemetry
+// ---------------------------------------------------------------------------
+
+/** Env var that disables telemetry when set to 1. */
+export const ENV_DO_NOT_TRACK = 'DO_NOT_TRACK';
+
+// ---------------------------------------------------------------------------
 // Sentry
 // ---------------------------------------------------------------------------
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -23,6 +23,7 @@ import { homedir } from 'node:os';
 import type { ErrorEvent, EventHint } from '@sentry/bun';
 import * as Sentry from '@sentry/bun';
 
+import { isTelemetryEnabled } from '../telemetry/enabled.js';
 import { getOrCreateUserId } from '../telemetry/user.js';
 import { SENTRY_DSN, SENTRY_FLUSH_TIMEOUT_MS } from './config-constants.js';
 import type { CliState } from './state.js';
@@ -31,7 +32,7 @@ import type { CliState } from './state.js';
  * Initialize Sentry if telemetry is enabled.
  */
 export function initSentry(state: CliState): void {
-  if (!state.telemetry.enabled || process.env.SONARQUBE_CLI_DISABLE_SENTRY) return;
+  if (!isTelemetryEnabled(state) || process.env.SONARQUBE_CLI_DISABLE_SENTRY) return;
 
   const environment = process.env.SONARSOURCE_DOGFOODING === '1' ? 'dogfood' : 'production';
 

--- a/src/telemetry/enabled.ts
+++ b/src/telemetry/enabled.ts
@@ -1,0 +1,39 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { ENV_DO_NOT_TRACK } from '../lib/config-constants.js';
+import type { CliState } from '../lib/state.js';
+
+/** True when DO_NOT_TRACK is set to 1 */
+export function isDoNotTrackRequested(): boolean {
+  return process.env[ENV_DO_NOT_TRACK]?.trim() === '1';
+}
+
+/** Whether telemetry collection and error reporting should run for this session. */
+export function isTelemetryEnabled(state: CliState): boolean {
+  return state.telemetry.enabled && !isDoNotTrackRequested();
+}
+
+export function describeTelemetryStatus(state: CliState): string {
+  if (isDoNotTrackRequested()) {
+    return 'Telemetry is currently disabled (DO_NOT_TRACK is set).';
+  }
+  return `Telemetry is currently ${state.telemetry.enabled ? 'enabled' : 'disabled'}.`;
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -26,6 +26,7 @@ import { version as VERSION } from '../../package.json';
 import { detectCallerAgent } from '../lib/agent-detector.js';
 import type { StoredTelemetryEvent, TelemetryEventPayload } from '../lib/state.js';
 import { getActiveConnection, loadState, saveState } from '../lib/state-manager.js';
+import { isTelemetryEnabled } from './enabled.js';
 import { getOrCreateUserId } from './user.js';
 
 export const TELEMETRY_FLUSH_MODE_ENV = '__SQ_CLI_TELEMETRY_FLUSH__';
@@ -51,7 +52,7 @@ export function storeEvent(command: Command, success: boolean): Promise<void> {
 
   const state = loadState();
 
-  if (!state.telemetry.enabled) {
+  if (!isTelemetryEnabled(state)) {
     return Promise.resolve();
   }
   const commandNames: string[] = [];
@@ -137,7 +138,7 @@ const FLUSH_TIMEOUT_MS = 60_000;
  */
 export async function flushTelemetry(): Promise<void> {
   const state = loadState();
-  if (!state.telemetry.enabled) {
+  if (!isTelemetryEnabled(state)) {
     return;
   }
   const telemetry = state.telemetry;

--- a/tests/integration/specs/config/config-telemetry.test.ts
+++ b/tests/integration/specs/config/config-telemetry.test.ts
@@ -96,4 +96,21 @@ describe('config telemetry', () => {
     },
     { timeout: 15000 },
   );
+
+  it(
+    'reports effective disabled state when --enabled is run with DO_NOT_TRACK set',
+    async () => {
+      const result = await harness.run('config telemetry --enabled', {
+        extraEnv: { DO_NOT_TRACK: '1' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('preference saved as enabled');
+      expect(output).toContain('DO_NOT_TRACK');
+      expect(output).toContain('disabled');
+      expect(output).not.toContain('Telemetry enabled.');
+    },
+    { timeout: 15000 },
+  );
 });

--- a/tests/integration/specs/config/config-telemetry.test.ts
+++ b/tests/integration/specs/config/config-telemetry.test.ts
@@ -22,6 +22,8 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
+import { version as CURRENT_CLI_VERSION } from '../../../../package.json';
+import { getDefaultState } from '../../../../src/lib/state.js';
 import { TestHarness } from '../../harness';
 
 describe('config telemetry', () => {
@@ -75,6 +77,22 @@ describe('config telemetry', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Telemetry disabled');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'reports telemetry disabled when DO_NOT_TRACK is set',
+    async () => {
+      const state = getDefaultState(CURRENT_CLI_VERSION);
+      state.telemetry.enabled = true;
+      harness.state().withRawState(JSON.stringify(state));
+
+      const result = await harness.run('config telemetry', { extraEnv: { DO_NOT_TRACK: '1' } });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).toContain('DO_NOT_TRACK');
+      expect(result.stdout + result.stderr).toContain('disabled');
     },
     { timeout: 15000 },
   );

--- a/tests/unit/cli/commands/config/telemetry.test.ts
+++ b/tests/unit/cli/commands/config/telemetry.test.ts
@@ -1,0 +1,73 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { configureTelemetry } from '../../../../../src/cli/commands/config/telemetry';
+import { ENV_DO_NOT_TRACK } from '../../../../../src/lib/config-constants.js';
+import * as stateRepository from '../../../../../src/lib/repository/state-repository.js';
+import { getDefaultState } from '../../../../../src/lib/state.js';
+import { clearMockUiCalls, findMockUiCall, getMockUiCalls, setMockUi } from '../../../../../src/ui';
+
+let loadStateSpy: ReturnType<typeof spyOn>;
+let saveStateSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  setMockUi(true);
+  loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
+  saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  setMockUi(false);
+  loadStateSpy.mockRestore();
+  saveStateSpy.mockRestore();
+  delete process.env[ENV_DO_NOT_TRACK];
+});
+
+describe('configureTelemetry', () => {
+  it('reports effective disabled state when --enabled is run with DO_NOT_TRACK set', async () => {
+    process.env[ENV_DO_NOT_TRACK] = '1';
+
+    await configureTelemetry({ enabled: true });
+
+    expect(saveStateSpy).toHaveBeenCalled();
+    expect(saveStateSpy.mock.calls[0][0].telemetry.enabled).toBe(true);
+    expect(findMockUiCall('success', 'preference saved as enabled')).toBeDefined();
+    expect(findMockUiCall('info', 'DO_NOT_TRACK')).toBeDefined();
+    expect(findMockUiCall('success', 'Telemetry enabled.')).toBeUndefined();
+  });
+
+  it('reports enabled when --enabled is run without DO_NOT_TRACK', async () => {
+    await configureTelemetry({ enabled: true });
+
+    expect(findMockUiCall('success', 'Telemetry enabled.')).toBeDefined();
+    expect(getMockUiCalls().some((call) => call.method === 'info')).toBe(false);
+  });
+
+  it('reports DO_NOT_TRACK override when showing status', async () => {
+    process.env[ENV_DO_NOT_TRACK] = '1';
+    clearMockUiCalls();
+
+    await configureTelemetry({});
+
+    expect(findMockUiCall('info', 'DO_NOT_TRACK')).toBeDefined();
+  });
+});

--- a/tests/unit/lib/sentry.test.ts
+++ b/tests/unit/lib/sentry.test.ts
@@ -24,6 +24,7 @@ import type { ErrorEvent, EventHint } from '@sentry/bun';
 import * as Sentry from '@sentry/bun';
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
+import { ENV_DO_NOT_TRACK } from '../../../src/lib/config-constants.js';
 import { flushSentry, initSentry } from '../../../src/lib/sentry.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as userModule from '../../../src/telemetry/user.js';
@@ -71,6 +72,7 @@ beforeEach(() => {
   flushSpy = spyOn(Sentry, 'flush').mockResolvedValue(true);
   getClientSpy = spyOn(Sentry, 'getClient').mockReturnValue(undefined);
   delete process.env['SONARQUBE_CLI_DISABLE_SENTRY'];
+  delete process.env[ENV_DO_NOT_TRACK];
 });
 
 afterEach(() => {
@@ -81,6 +83,7 @@ afterEach(() => {
   getClientSpy.mockRestore();
   delete process.env['SONARSOURCE_DOGFOODING'];
   process.env['SONARQUBE_CLI_DISABLE_SENTRY'] = '1';
+  delete process.env[ENV_DO_NOT_TRACK];
 });
 
 describe('initSentry', () => {
@@ -101,6 +104,16 @@ describe('initSentry', () => {
       initSentry(state);
 
       expect(setUserSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not call Sentry.init when DO_NOT_TRACK is set', () => {
+      const state = getDefaultState('1.0.0');
+      state.telemetry.enabled = true;
+      process.env[ENV_DO_NOT_TRACK] = '1';
+
+      initSentry(state);
+
+      expect(initSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/telemetry/enabled.test.ts
+++ b/tests/unit/telemetry/enabled.test.ts
@@ -1,0 +1,97 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { ENV_DO_NOT_TRACK } from '../../../src/lib/config-constants.js';
+import { getDefaultState } from '../../../src/lib/state.js';
+import {
+  describeTelemetryStatus,
+  isDoNotTrackRequested,
+  isTelemetryEnabled,
+} from '../../../src/telemetry/enabled.js';
+
+afterEach(() => {
+  delete process.env[ENV_DO_NOT_TRACK];
+});
+
+describe('isDoNotTrackRequested', () => {
+  it('returns true when set to 1', () => {
+    process.env[ENV_DO_NOT_TRACK] = '1';
+    expect(isDoNotTrackRequested()).toBe(true);
+  });
+
+  it('returns true when set to 1 with surrounding whitespace', () => {
+    process.env[ENV_DO_NOT_TRACK] = ' 1 ';
+    expect(isDoNotTrackRequested()).toBe(true);
+  });
+
+  it.each(['0', 'yes', 'true', ''])('returns false for %s', (value) => {
+    process.env[ENV_DO_NOT_TRACK] = value;
+    expect(isDoNotTrackRequested()).toBe(false);
+  });
+
+  it('returns false when unset', () => {
+    expect(isDoNotTrackRequested()).toBe(false);
+  });
+});
+
+describe('isTelemetryEnabled', () => {
+  it('returns true when enabled in state and DO_NOT_TRACK is unset', () => {
+    const state = getDefaultState('1.0.0');
+    state.telemetry.enabled = true;
+
+    expect(isTelemetryEnabled(state)).toBe(true);
+  });
+
+  it('returns false when disabled in state', () => {
+    const state = getDefaultState('1.0.0');
+    state.telemetry.enabled = false;
+
+    expect(isTelemetryEnabled(state)).toBe(false);
+  });
+
+  it('returns false when DO_NOT_TRACK is set even if enabled in state', () => {
+    const state = getDefaultState('1.0.0');
+    state.telemetry.enabled = true;
+    process.env[ENV_DO_NOT_TRACK] = '1';
+
+    expect(isTelemetryEnabled(state)).toBe(false);
+  });
+});
+
+describe('describeTelemetryStatus', () => {
+  it('mentions DO_NOT_TRACK when it disables telemetry', () => {
+    const state = getDefaultState('1.0.0');
+    state.telemetry.enabled = true;
+    process.env[ENV_DO_NOT_TRACK] = '1';
+
+    expect(describeTelemetryStatus(state)).toBe(
+      'Telemetry is currently disabled (DO_NOT_TRACK is set).',
+    );
+  });
+
+  it('reports persisted state when DO_NOT_TRACK is unset', () => {
+    const state = getDefaultState('1.0.0');
+    state.telemetry.enabled = false;
+
+    expect(describeTelemetryStatus(state)).toBe('Telemetry is currently disabled.');
+  });
+});

--- a/tests/unit/telemetry/telemetry.test.ts
+++ b/tests/unit/telemetry/telemetry.test.ts
@@ -28,6 +28,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Command } from 'commander';
 
 import * as agentDetector from '../../../src/lib/agent-detector.js';
+import { ENV_DO_NOT_TRACK } from '../../../src/lib/config-constants.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
 import type { CliState, StoredTelemetryEvent } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
@@ -118,6 +119,7 @@ afterEach(() => {
   getUserIdSpy.mockRestore();
   spawnSpy.mockRestore();
   delete process.env[TELEMETRY_FLUSH_MODE_ENV];
+  delete process.env[ENV_DO_NOT_TRACK];
   delete process.env.CLAUDECODE;
   delete process.env.CLAUDE_CODE_ENTRYPOINT;
   delete process.env.CLAUDE_PROJECT_DIR;
@@ -141,6 +143,14 @@ describe('storeEvent', () => {
       const state = getDefaultState('1.0.0');
       state.telemetry.enabled = false;
       loadStateSpy.mockReturnValue(state);
+
+      await storeEvent(makeCommand('auth login'), true);
+
+      expect(saveStateSpy).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when DO_NOT_TRACK is set', async () => {
+      process.env[ENV_DO_NOT_TRACK] = '1';
 
       await storeEvent(makeCommand('auth login'), true);
 
@@ -371,6 +381,19 @@ describe('flushTelemetry', () => {
       state.telemetry.enabled = false;
       state.telemetry.events = [makeStoredEvent()];
       loadStateSpy.mockReturnValue(state);
+
+      const fetchSpy = mockFetch();
+      try {
+        await flushTelemetry();
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it('does nothing when DO_NOT_TRACK is set', async () => {
+      process.env[ENV_DO_NOT_TRACK] = '1';
+      loadStateSpy.mockReturnValue(makeStateWithEvents([makeStoredEvent()]));
 
       const fetchSpy = mockFetch();
       try {


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry configuration:**
  - Added `isDoNotTrackRequested` utility to honor the `DO_NOT_TRACK` environment variable.
  - Centralized telemetry status checks in `isTelemetryEnabled`, affecting `storeEvent`, `flushTelemetry`, and `initSentry`.
- **CLI updates:**
  - Updated `config telemetry` command to report when telemetry is disabled via `DO_NOT_TRACK`.
  - Added documentation to `README.md` regarding `DO_NOT_TRACK` support.
- **Testing:**
  - Added unit and integration tests to verify environment variable behavior across telemetry and Sentry features.


<sub>This will update automatically on new commits.</sub>