### PR TITLE
CLI-447 Use the declarative framework for migrations

### DIFF
--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -21,14 +21,9 @@
 import { join } from 'node:path';
 
 import { createAgentHookEntry, resolveAgentHookScriptPath, upsertAgentHooks } from '../hooks';
-import {
-  type FeatureDeclaration,
-  type IntegrationContext,
-  jsonPatch,
-  type PlatformSpecificContent,
-  sonarSecretsBinaryDependency,
-  wholeFile,
-} from '../registry';
+import { sonarSecretsBinaryDependency } from '../registry/dependencies';
+import { jsonPatch, type PlatformSpecificContent, wholeFile } from '../registry/resources';
+import type { FeatureDeclaration, IntegrationContext } from '../registry/types';
 
 export interface SonarSecretsHooksFeatureOptions {
   installSecretsHooks?: boolean;

--- a/src/cli/commands/integrate/_common/registry/core.ts
+++ b/src/cli/commands/integrate/_common/registry/core.ts
@@ -1,0 +1,109 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { IntegrationDeclaration } from './types';
+
+export class IntegrationRegistry {
+  private readonly declarations = new Map<string, IntegrationDeclaration>();
+
+  register(declaration: IntegrationDeclaration): void {
+    this.validateDeclaration(declaration);
+    if (this.declarations.has(declaration.id)) {
+      throw new Error(`Integration declaration already registered: ${declaration.id}`);
+    }
+    this.declarations.set(declaration.id, declaration);
+  }
+
+  get(id: string): IntegrationDeclaration | undefined {
+    return this.declarations.get(id);
+  }
+
+  list(): IntegrationDeclaration[] {
+    return [...this.declarations.values()];
+  }
+
+  private validateDeclaration(declaration: IntegrationDeclaration): void {
+    this.ensureNonEmptyId(declaration.id, 'Integration');
+    this.ensureUnique(
+      declaration.features.map((feature) => feature.id),
+      `Duplicate feature id in integration ${declaration.id}`,
+    );
+    for (const feature of declaration.features) {
+      this.ensureNonEmptyId(feature.id, 'Feature');
+      this.ensureUnique(
+        (feature.dependencies ?? []).map((dependency) => dependency.id),
+        `Duplicate dependency id in feature ${declaration.id}.${feature.id}`,
+      );
+      this.ensureUnique(
+        (feature.resources ?? []).map((resource) => resource.id),
+        `Duplicate resource id in feature ${declaration.id}.${feature.id}`,
+      );
+      this.ensureUnique(
+        (feature.operations ?? []).map((operation) => operation.id),
+        `Duplicate operation id in feature ${declaration.id}.${feature.id}`,
+      );
+      for (const dependency of feature.dependencies ?? []) {
+        this.ensureNonEmptyId(dependency.id, 'Dependency');
+      }
+      for (const resource of feature.resources ?? []) {
+        this.ensureNonEmptyId(resource.id, 'Resource');
+      }
+      for (const operation of feature.operations ?? []) {
+        this.ensureNonEmptyId(operation.id, 'Operation');
+      }
+    }
+    this.ensureUnique(
+      (declaration.legacyFeatures ?? []).map((feature) => feature.id),
+      `Duplicate legacy feature id in integration ${declaration.id}`,
+    );
+    for (const legacyFeature of declaration.legacyFeatures ?? []) {
+      this.ensureNonEmptyId(legacyFeature.id, 'Legacy feature');
+    }
+  }
+
+  private ensureUnique(values: string[], message: string): void {
+    if (new Set(values).size !== values.length) {
+      throw new Error(message);
+    }
+  }
+
+  private ensureNonEmptyId(id: string, entity: string): void {
+    if (id.trim().length === 0) {
+      throw new Error(`${entity} id must not be empty`);
+    }
+  }
+}
+
+export function registerIntegrations(
+  registry: IntegrationRegistry,
+  declarations: Iterable<IntegrationDeclaration>,
+): void {
+  for (const declaration of declarations) {
+    registry.register(declaration);
+  }
+}
+
+export function createIntegrationRegistry(
+  declarations: Iterable<IntegrationDeclaration> = [],
+): IntegrationRegistry {
+  const registry = new IntegrationRegistry();
+  registerIntegrations(registry, declarations);
+  return registry;
+}

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -18,8 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { IntegrationDeclaration } from './types';
-
+export { createIntegrationRegistry, IntegrationRegistry, registerIntegrations } from './core';
 export {
   type DependencyDeclaration,
   sonarSecretsBinaryDependency,
@@ -62,76 +61,3 @@ export type {
   LegacyFeatureDeclaration,
   MaybePromise,
 } from './types';
-
-export class IntegrationRegistry {
-  private readonly declarations = new Map<string, IntegrationDeclaration>();
-
-  register(declaration: IntegrationDeclaration): void {
-    this.validateDeclaration(declaration);
-    if (this.declarations.has(declaration.id)) {
-      throw new Error(`Integration declaration already registered: ${declaration.id}`);
-    }
-    this.declarations.set(declaration.id, declaration);
-  }
-
-  get(id: string): IntegrationDeclaration | undefined {
-    return this.declarations.get(id);
-  }
-
-  list(): IntegrationDeclaration[] {
-    return [...this.declarations.values()];
-  }
-
-  private validateDeclaration(declaration: IntegrationDeclaration): void {
-    this.ensureNonEmptyId(declaration.id, 'Integration');
-    this.ensureUnique(
-      declaration.features.map((feature) => feature.id),
-      `Duplicate feature id in integration ${declaration.id}`,
-    );
-    for (const feature of declaration.features) {
-      this.ensureNonEmptyId(feature.id, 'Feature');
-      this.ensureUnique(
-        (feature.dependencies ?? []).map((dependency) => dependency.id),
-        `Duplicate dependency id in feature ${declaration.id}.${feature.id}`,
-      );
-      this.ensureUnique(
-        (feature.resources ?? []).map((resource) => resource.id),
-        `Duplicate resource id in feature ${declaration.id}.${feature.id}`,
-      );
-      this.ensureUnique(
-        (feature.operations ?? []).map((operation) => operation.id),
-        `Duplicate operation id in feature ${declaration.id}.${feature.id}`,
-      );
-      for (const dependency of feature.dependencies ?? []) {
-        this.ensureNonEmptyId(dependency.id, 'Dependency');
-      }
-      for (const resource of feature.resources ?? []) {
-        this.ensureNonEmptyId(resource.id, 'Resource');
-      }
-      for (const operation of feature.operations ?? []) {
-        this.ensureNonEmptyId(operation.id, 'Operation');
-      }
-    }
-    this.ensureUnique(
-      (declaration.legacyFeatures ?? []).map((feature) => feature.id),
-      `Duplicate legacy feature id in integration ${declaration.id}`,
-    );
-    for (const legacyFeature of declaration.legacyFeatures ?? []) {
-      this.ensureNonEmptyId(legacyFeature.id, 'Legacy feature');
-    }
-  }
-
-  private ensureUnique(values: string[], message: string): void {
-    if (new Set(values).size !== values.length) {
-      throw new Error(message);
-    }
-  }
-
-  private ensureNonEmptyId(id: string, entity: string): void {
-    if (id.trim().length === 0) {
-      throw new Error(`${entity} id must not be empty`);
-    }
-  }
-}
-
-export const supportedIntegrations = new IntegrationRegistry();

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -37,9 +37,9 @@ import type {
 import { getDefaultState } from '../../../../../lib/state';
 import { info, success, text, warn } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
+import { supportedIntegrations } from '../../index';
+import type { IntegrationRegistry } from './core';
 import type { DependencyDeclaration } from './dependencies';
-import type { IntegrationRegistry } from './index';
-import { supportedIntegrations } from './index';
 import type { ResourceDeclaration } from './resources';
 import type {
   AppliedFeature,

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -22,19 +22,19 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { OBSOLETE_A3S_MARKER, removeObsoleteHookArtifacts } from '../../../../lib/migration';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
   createAgentHookEntry,
   resolveAgentHookScriptPath,
   upsertAgentHooks,
 } from '../_common/hooks';
-import {
-  type IntegrationContext,
-  type IntegrationDeclaration,
-  jsonPatch,
-  supportedIntegrations,
-  wholeFile,
-} from '../_common/registry';
+import { jsonPatch, wholeFile } from '../_common/registry/resources';
+import type {
+  FeatureOperation,
+  IntegrationContext,
+  IntegrationDeclaration,
+} from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import {
   getSecretPreToolTemplateUnix,
@@ -63,46 +63,49 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
   id: CLAUDE_INTEGRATION_ID,
   displayName: 'Claude Code',
   features: [
-    createSonarSecretsHooksFeature({
-      agentDisplayName: 'Claude',
-      configDir: CLAUDE_CONFIG_DIR,
-      hooksConfigFileName: SETTINGS_FILE,
-      hooksPatchId: 'claude-settings-secrets-hooks',
-      scripts: [
-        {
-          id: 'pretool-secrets-script',
-          displayName: 'Claude PreToolUse hook script',
-          scriptPath: PRETOOL_SCRIPT_REL,
-          content: {
-            unix: getSecretPreToolTemplateUnix(),
-            windows: getSecretPreToolTemplateWindows(),
+    {
+      ...createSonarSecretsHooksFeature({
+        agentDisplayName: 'Claude',
+        configDir: CLAUDE_CONFIG_DIR,
+        hooksConfigFileName: SETTINGS_FILE,
+        hooksPatchId: 'claude-settings-secrets-hooks',
+        scripts: [
+          {
+            id: 'pretool-secrets-script',
+            displayName: 'Claude PreToolUse hook script',
+            scriptPath: PRETOOL_SCRIPT_REL,
+            content: {
+              unix: getSecretPreToolTemplateUnix(),
+              windows: getSecretPreToolTemplateWindows(),
+            },
           },
-        },
-        {
-          id: 'prompt-secrets-script',
-          displayName: 'Claude UserPromptSubmit hook script',
-          scriptPath: PROMPT_SCRIPT_REL,
-          content: {
-            unix: getSecretPromptTemplateUnix(),
-            windows: getSecretPromptTemplateWindows(),
+          {
+            id: 'prompt-secrets-script',
+            displayName: 'Claude UserPromptSubmit hook script',
+            scriptPath: PROMPT_SCRIPT_REL,
+            content: {
+              unix: getSecretPromptTemplateUnix(),
+              windows: getSecretPromptTemplateWindows(),
+            },
           },
-        },
-      ],
-      hookEntries: [
-        {
-          eventType: 'PreToolUse',
-          matcher: 'Read',
-          marker: 'sonar-secrets',
-          scriptPath: PRETOOL_SCRIPT_REL,
-        },
-        {
-          eventType: 'UserPromptSubmit',
-          matcher: '*',
-          marker: 'sonar-secrets',
-          scriptPath: PROMPT_SCRIPT_REL,
-        },
-      ],
-    }),
+        ],
+        hookEntries: [
+          {
+            eventType: 'PreToolUse',
+            matcher: 'Read',
+            marker: 'sonar-secrets',
+            scriptPath: PRETOOL_SCRIPT_REL,
+          },
+          {
+            eventType: 'UserPromptSubmit',
+            matcher: '*',
+            marker: 'sonar-secrets',
+            scriptPath: PROMPT_SCRIPT_REL,
+          },
+        ],
+      }),
+      operations: [createRemoveObsoleteA3sArtifactsOperation()],
+    },
     {
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
@@ -145,6 +148,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
             ]),
         }),
       ],
+      operations: [createRemoveObsoleteA3sArtifactsOperation()],
     },
     {
       id: 'mcp-server',
@@ -163,17 +167,6 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     },
   ],
 };
-
-let claudeIntegrationRegistered = false;
-
-export function registerClaudeIntegration(): void {
-  if (claudeIntegrationRegistered) {
-    return;
-  }
-
-  supportedIntegrations.register(claudeIntegration);
-  claudeIntegrationRegistered = true;
-}
 
 function resolveClaudeSettingsPath(context: IntegrationContext): string {
   return join(context.targetRoot, CLAUDE_CONFIG_DIR, SETTINGS_FILE);
@@ -238,4 +231,12 @@ function getRequiredStringAttr(context: IntegrationContext, key: string): string
     throw new Error(`Missing integration attribute: ${key}`);
   }
   return value;
+}
+
+function createRemoveObsoleteA3sArtifactsOperation(): FeatureOperation {
+  return {
+    id: 'remove-obsolete-a3s-artifacts',
+    displayName: 'Remove obsolete SQAA hook artifacts',
+    apply: ({ targetRoot }) => removeObsoleteHookArtifacts(targetRoot, OBSOLETE_A3S_MARKER),
+  };
 }

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -22,19 +22,14 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
-import { OBSOLETE_A3S_MARKER, removeObsoleteHookArtifacts } from '../../../../lib/migration';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
   createAgentHookEntry,
   resolveAgentHookScriptPath,
   upsertAgentHooks,
 } from '../_common/hooks';
-import { jsonPatch, wholeFile } from '../_common/registry/resources';
-import type {
-  FeatureOperation,
-  IntegrationContext,
-  IntegrationDeclaration,
-} from '../_common/registry/types';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
+import { jsonPatch, wholeFile } from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
 import {
   getSecretPreToolTemplateUnix,
@@ -104,7 +99,6 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
           },
         ],
       }),
-      operations: [createRemoveObsoleteA3sArtifactsOperation()],
     },
     {
       id: 'sonar-sqaa-hook',
@@ -148,7 +142,6 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
             ]),
         }),
       ],
-      operations: [createRemoveObsoleteA3sArtifactsOperation()],
     },
     {
       id: 'mcp-server',
@@ -231,12 +224,4 @@ function getRequiredStringAttr(context: IntegrationContext, key: string): string
     throw new Error(`Missing integration attribute: ${key}`);
   }
   return value;
-}
-
-function createRemoveObsoleteA3sArtifactsOperation(): FeatureOperation {
-  return {
-    id: 'remove-obsolete-a3s-artifacts',
-    displayName: 'Remove obsolete SQAA hook artifacts',
-    apply: ({ targetRoot }) => removeObsoleteHookArtifacts(targetRoot, OBSOLETE_A3S_MARKER),
-  };
 }

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -37,13 +37,11 @@ import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
 import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
-import { CLAUDE_INTEGRATION_ID, registerClaudeIntegration } from './declaration';
+import { CLAUDE_INTEGRATION_ID } from './declaration';
 import { runHealthChecks } from './health';
 import { detectGlobalSecretsHook } from './hooks';
 import { repairToken } from './repair';
 import { updateStateAfterConfiguration } from './state';
-
-registerClaudeIntegration();
 
 export interface ConfigurationData {
   serverURL: string;

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -23,13 +23,8 @@ import { join } from 'node:path';
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
-import {
-  type IntegrationContext,
-  type IntegrationDeclaration,
-  supportedIntegrations,
-  tomlPatch,
-  wholeFile,
-} from '../_common/registry';
+import { tomlPatch, wholeFile } from '../_common/registry/resources';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPromptTemplateUnix, getSecretPromptTemplateWindows } from './hook-templates';
 import { buildAgentsMdContent } from './instructions-templates';
@@ -118,17 +113,6 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     },
   ],
 };
-
-let codexIntegrationRegistered = false;
-
-export function registerCodexIntegration(): void {
-  if (codexIntegrationRegistered) {
-    return;
-  }
-
-  supportedIntegrations.register(codexIntegration);
-  codexIntegrationRegistered = true;
-}
 
 function resolveCodexAgentsMdPath(context: IntegrationContext): string {
   return join(context.targetRoot, CODEX_CONFIG_DIR, AGENTS_MD_FILE);

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -31,9 +31,7 @@ import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
 import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
-import { CODEX_INTEGRATION_ID, registerCodexIntegration } from './declaration';
-
-registerCodexIntegration();
+import { CODEX_INTEGRATION_ID } from './declaration';
 
 export async function integrateCodex(
   options: IntegrateAgentOptions,

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -23,14 +23,9 @@ import { join, relative } from 'node:path';
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { CommandFailedError } from '../../_common/error';
-import {
-  type IntegrationContext,
-  type IntegrationDeclaration,
-  jsonPatch,
-  sonarSecretsBinaryDependency,
-  supportedIntegrations,
-  wholeFile,
-} from '../_common/registry';
+import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
+import { jsonPatch, wholeFile } from '../_common/registry/resources';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
 import {
@@ -138,17 +133,6 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     },
   ],
 };
-
-let copilotIntegrationRegistered = false;
-
-export function registerCopilotIntegration(): void {
-  if (copilotIntegrationRegistered) {
-    return;
-  }
-
-  supportedIntegrations.register(copilotIntegration);
-  copilotIntegrationRegistered = true;
-}
 
 function resolveCopilotHookScriptPath(context: IntegrationContext): string {
   return join(resolveHooksDir(context), SCRIPT_REL_DIR, hookScriptName());

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -30,11 +30,7 @@ import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
 import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
-import {
-  COPILOT_INTEGRATION_ID,
-  type CopilotIntegrationOptions,
-  registerCopilotIntegration,
-} from './declaration';
+import { COPILOT_INTEGRATION_ID, type CopilotIntegrationOptions } from './declaration';
 import {
   detectGlobalSecretsHook,
   hookScriptName,
@@ -46,8 +42,6 @@ import {
   PROJECT_INSTRUCTIONS_REL_DIR,
   warnIfProjectInstructionsShadowGlobal,
 } from './instructions';
-
-registerCopilotIntegration();
 
 export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAgentOptions) {
   if (options.global && options.project) {

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -39,10 +39,7 @@ import {
   NATIVE_GIT_INTEGRATION_ID,
   PRE_COMMIT_CONFIG_FILE,
   PRE_COMMIT_INTEGRATION_ID,
-  registerGitIntegrations,
 } from './tools';
-
-registerGitIntegrations();
 
 export type { GitHookType, IntegrateGitOptions } from './options';
 export { installViaGitHooks } from './tools';

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -20,12 +20,9 @@
 
 import { join } from 'node:path';
 
-import {
-  type FeatureDeclaration,
-  type IntegrationDeclaration,
-  sonarSecretsBinaryDependency,
-  textSnippet,
-} from '../../../_common/registry';
+import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
+import { textSnippet } from '../../../_common/registry/resources';
+import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { HOOK_MARKER } from '../shared';
 import { getHuskySnippetContent } from './shell-fragments';

--- a/src/cli/commands/integrate/git/tools/index.ts
+++ b/src/cli/commands/integrate/git/tools/index.ts
@@ -18,18 +18,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { supportedIntegrations } from '../../_common/registry';
 import { huskyIntegration } from './husky';
 import { nativeGitIntegration } from './native';
 import { preCommitIntegration } from './pre-commit';
 
-const GIT_INTEGRATIONS = [nativeGitIntegration, huskyIntegration, preCommitIntegration] as const;
-
-export function registerGitIntegrations(registry = supportedIntegrations): void {
-  for (const integration of GIT_INTEGRATIONS) {
-    registry.register(integration);
-  }
-}
+export const GIT_INTEGRATIONS = [
+  nativeGitIntegration,
+  huskyIntegration,
+  preCommitIntegration,
+] as const;
 
 export { HUSKY_INTEGRATION_ID } from './husky';
 export { installViaGitHooks, NATIVE_GIT_INTEGRATION_ID } from './native';

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -21,11 +21,8 @@
 import { normalizePath } from '../../../../../../lib/fs-utils';
 import { spawnProcess } from '../../../../../../lib/process';
 import { CommandFailedError } from '../../../../_common/error';
-import {
-  type FeatureDeclaration,
-  type IntegrationDeclaration,
-  sonarSecretsBinaryDependency,
-} from '../../../_common/registry';
+import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
+import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { nativeGitHookResource } from './resource';
 

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -20,12 +20,9 @@
 
 import { join } from 'node:path';
 
-import {
-  type FeatureDeclaration,
-  type IntegrationDeclaration,
-  sonarSecretsBinaryDependency,
-  yamlPatch,
-} from '../../../_common/registry';
+import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
+import { yamlPatch } from '../../../_common/registry/resources';
+import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
 import {
   activatePreCommitFramework,

--- a/src/cli/commands/integrate/index.ts
+++ b/src/cli/commands/integrate/index.ts
@@ -18,26 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { describe, expect, it } from 'bun:test';
+import { createIntegrationRegistry } from './_common/registry/core';
+import { claudeIntegration } from './claude/declaration';
+import { codexIntegration } from './codex/declaration';
+import { copilotIntegration } from './copilot/declaration';
+import { GIT_INTEGRATIONS } from './git/tools';
 
-import { createIntegrationRegistry } from '../../../../../../src/cli/commands/integrate/_common/registry/core';
-import {
-  GIT_INTEGRATIONS,
-  HUSKY_INTEGRATION_ID,
-  NATIVE_GIT_INTEGRATION_ID,
-  PRE_COMMIT_INTEGRATION_ID,
-} from '../../../../../../src/cli/commands/integrate/git/tools';
+export const ALL_INTEGRATIONS = [
+  claudeIntegration,
+  copilotIntegration,
+  codexIntegration,
+  ...GIT_INTEGRATIONS,
+] as const;
 
-describe('GIT_INTEGRATIONS', () => {
-  it('can seed a registry from the static git integrations list', () => {
-    const expectedIntegrationIds = [
-      NATIVE_GIT_INTEGRATION_ID,
-      HUSKY_INTEGRATION_ID,
-      PRE_COMMIT_INTEGRATION_ID,
-    ];
-
-    const registry = createIntegrationRegistry(GIT_INTEGRATIONS);
-
-    expect(registry.list().map((integration) => integration.id)).toEqual(expectedIntegrationIds);
-  });
-});
+export const supportedIntegrations = createIntegrationRegistry(ALL_INTEGRATIONS);

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -25,12 +25,18 @@ import { join } from 'node:path';
 import { version as CURRENT_VERSION } from '../../package.json';
 import { installContextAugmentationBinary } from '../cli/commands/_common/install/context-augmentation';
 import { installSecretsBinary } from '../cli/commands/_common/install/secrets';
+import { supportedIntegrations } from '../cli/commands/integrate';
 import {
   type ContextAugmentationAgent,
   installContextAugmentationSkill,
   resolveContextAugmentationAgent,
   stopAllContextAugmentationTools,
 } from '../cli/commands/integrate/_common/context-augmentation';
+import {
+  integrationInstaller,
+  type IntegrationRegistry,
+} from '../cli/commands/integrate/_common/registry';
+import { CLAUDE_INTEGRATION_ID } from '../cli/commands/integrate/claude/declaration';
 import { installHooks } from '../cli/commands/integrate/claude/hooks.js';
 import { CONTEXT_AUGMENTATION_BINARY_NAME, SECRETS_BINARY_NAME } from './install-types.js';
 import logger from './logger';
@@ -83,9 +89,67 @@ export async function runPostUpdateActions(): Promise<void> {
 }
 
 async function runActions(_previousVersion: string, _currentVersion: string): Promise<void> {
+  await migrateDeclarativeIntegrations();
   await migrateClaudeCodeHooks();
   await updateSecretsBinaryIfNeeded();
   await updateContextAugmentationIfNeeded();
+}
+
+export async function migrateDeclarativeIntegrations(
+  registry: IntegrationRegistry = supportedIntegrations,
+): Promise<void> {
+  const state = loadState();
+  let stateChanged = false;
+
+  for (const integration of registry.list()) {
+    const installedIntegration = integrationInstaller.findInstalledIntegration(state, integration);
+    if (!installedIntegration) {
+      continue;
+    }
+
+    const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
+    const knownFeatures = installedIntegration.features.filter((feature) =>
+      featuresById.has(feature.featureId),
+    );
+
+    if (knownFeatures.length !== installedIntegration.features.length) {
+      installedIntegration.features = knownFeatures;
+      stateChanged = true;
+    }
+
+    for (const installedFeature of knownFeatures) {
+      const feature = featuresById.get(installedFeature.featureId)!;
+
+      try {
+        const featureContext = {
+          targetRoot: installedFeature.targetRoot,
+          scope: installedFeature.scope,
+          attrs: installedFeature.attrs,
+        };
+        const applied = await integrationInstaller.applyFeature(
+          { state, ...featureContext },
+          installedFeature,
+          feature,
+        );
+        integrationInstaller.recordInstalledFeature(
+          state,
+          featureContext,
+          integration,
+          feature,
+          applied,
+        );
+        stateChanged = true;
+      } catch (err) {
+        logger.debug(
+          `Declarative migration failed for ${integration.id}.${installedFeature.featureId}: ${(err as Error).message}`,
+        );
+      }
+    }
+  }
+
+  if (stateChanged) {
+    saveState(state);
+  }
 }
 
 /**
@@ -306,6 +370,11 @@ function isExistingDirectory(path: string): boolean {
 export async function migrateClaudeCodeHooks(homedirFn: () => string = homedir): Promise<void> {
   const state = loadState();
 
+  if (hasInstalledDeclarativeIntegration(state, CLAUDE_INTEGRATION_ID)) {
+    logger.debug('Declarative Claude integration detected — skipping legacy hook migration');
+    return;
+  }
+
   type Location = { projectRoot: string; globalDir: string | undefined };
   const locations: Location[] = [];
 
@@ -343,4 +412,10 @@ export async function migrateClaudeCodeHooks(homedirFn: () => string = homedir):
       );
     }
   }
+}
+
+function hasInstalledDeclarativeIntegration(state: CliState, integrationId: string): boolean {
+  return state.integrations.installed.some(
+    (entry) => entry.integrationId === integrationId && entry.features.length > 0,
+  );
 }

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -371,7 +371,7 @@ export async function migrateClaudeCodeHooks(homedirFn: () => string = homedir):
   const state = loadState();
 
   if (hasInstalledDeclarativeIntegration(state, CLAUDE_INTEGRATION_ID)) {
-    logger.debug('Declarative Claude integration detected — skipping legacy hook migration');
+    logger.debug('Declarative Claude Code integration detected — skipping legacy hook migration');
     return;
   }
 

--- a/tests/integration/specs/self-update/post-update.test.ts
+++ b/tests/integration/specs/self-update/post-update.test.ts
@@ -29,7 +29,7 @@ import { buildLocalCagBinaryName } from '../../../../src/cli/commands/_common/in
 import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../../src/lib/install-types';
 import { detectPlatform } from '../../../../src/lib/platform-detector';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../../src/lib/signatures';
-import { TestHarness } from '../../harness';
+import { hookScriptName, IS_WINDOWS, TestHarness } from '../../harness';
 import { readCagInvocations } from '../../harness/cag-invocations';
 
 describe('post-update migration', () => {
@@ -192,5 +192,134 @@ describe('post-update migration', () => {
       expect(stopIndex).toBeLessThan(skillIndex);
     },
     { timeout: 30000 },
+  );
+
+  it(
+    'refreshes declarative Claude hook resources on CLI upgrade',
+    async () => {
+      const now = new Date().toISOString();
+      const pretoolScriptRel = `.claude/hooks/sonar-secrets/build-scripts/${hookScriptName('pretool-secrets')}`;
+      const promptScriptRel = `.claude/hooks/sonar-secrets/build-scripts/${hookScriptName('prompt-secrets')}`;
+      const settingsRel = '.claude/settings.json';
+      const expectedPretoolCommand = IS_WINDOWS
+        ? `powershell -NoProfile -File ${pretoolScriptRel}`
+        : pretoolScriptRel;
+      const expectedPromptCommand = IS_WINDOWS
+        ? `powershell -NoProfile -File ${promptScriptRel}`
+        : promptScriptRel;
+
+      harness.cwd.writeFile(
+        pretoolScriptRel,
+        IS_WINDOWS
+          ? '$output = sonar analyze --file $file_path 2>$null\n'
+          : '#!/bin/bash\noutput=$(sonar analyze --file "$file_path" 2>/dev/null)\n',
+      );
+      harness.cwd.writeFile(
+        promptScriptRel,
+        IS_WINDOWS
+          ? '$output = sonar analyze --file $file_path 2>$null\n'
+          : '#!/bin/bash\noutput=$(sonar analyze --file "$file_path" 2>/dev/null)\n',
+      );
+      harness.cwd.writeFile(
+        settingsRel,
+        JSON.stringify(
+          {
+            hooks: {
+              PreToolUse: [
+                {
+                  matcher: 'Read',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: '.claude/hooks/sonar-secrets/build-scripts/old-pretool.sh',
+                      timeout: 60,
+                    },
+                  ],
+                },
+              ],
+              UserPromptSubmit: [
+                {
+                  matcher: '*',
+                  hooks: [
+                    {
+                      type: 'command',
+                      command: '.claude/hooks/sonar-secrets/build-scripts/old-prompt.sh',
+                      timeout: 60,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+      );
+
+      harness.state().withRawState(
+        JSON.stringify({
+          version: '1.0',
+          lastUpdated: now,
+          auth: { isAuthenticated: false, connections: [] },
+          agents: {
+            'claude-code': {
+              configured: true,
+              configuredByCliVersion: '0.5.0',
+              hooks: { installed: [] },
+              skills: { installed: [] },
+            },
+          },
+          config: { cliVersion: '0.5.0' },
+          telemetry: { enabled: false, firstUseDate: now, events: [] },
+          agentExtensions: [],
+          integrations: {
+            installed: [
+              {
+                id: randomUUID(),
+                integrationId: 'claude-code',
+                installedByCliVersion: '0.5.0',
+                installedAt: now,
+                updatedByCliVersion: '0.5.0',
+                updatedAt: now,
+                features: [
+                  {
+                    featureId: 'sonar-secrets-hooks',
+                    scope: 'project',
+                    targetRoot: harness.cwd.path,
+                    installedByCliVersion: '0.5.0',
+                    installedAt: now,
+                    updatedByCliVersion: '0.5.0',
+                    updatedAt: now,
+                    resources: [],
+                    operations: [],
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+
+      const result = await harness.run('--version');
+
+      expect(result.exitCode).toBe(0);
+      expect(harness.cwd.file(pretoolScriptRel).asText()).toContain(
+        'sonar hook claude-pre-tool-use',
+      );
+      expect(harness.cwd.file(promptScriptRel).asText()).toContain(
+        'sonar hook claude-prompt-submit',
+      );
+
+      const settings = harness.cwd.file(settingsRel).asJson();
+      expect(settings.hooks?.PreToolUse?.[0]).toEqual({
+        matcher: 'Read',
+        hooks: [{ type: 'command', command: expectedPretoolCommand, timeout: 60 }],
+      });
+      expect(settings.hooks?.UserPromptSubmit?.[0]).toEqual({
+        matcher: '*',
+        hooks: [{ type: 'command', command: expectedPromptCommand, timeout: 60 }],
+      });
+    },
+    { timeout: 15000 },
   );
 });

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -38,6 +38,7 @@ void mock.module('../../../../../../src/cli/commands/_common/install/binary', ()
 }));
 
 const {
+  createIntegrationRegistry,
   IntegrationInstaller,
   IntegrationRegistry,
   jsonPatch,
@@ -77,6 +78,12 @@ describe('declarative integration framework', () => {
     registry.register(declaration);
 
     expect(() => registry.register(declaration)).toThrow(
+      'Integration declaration already registered: test-integration',
+    );
+  });
+
+  it('rejects duplicate integration ids when seeding a registry from static data', () => {
+    expect(() => createIntegrationRegistry([makeIntegration(), makeIntegration()])).toThrow(
       'Integration declaration already registered: test-integration',
     );
   });

--- a/tests/unit/cli/commands/integrate/index.test.ts
+++ b/tests/unit/cli/commands/integrate/index.test.ts
@@ -20,24 +20,23 @@
 
 import { describe, expect, it } from 'bun:test';
 
-import { createIntegrationRegistry } from '../../../../../../src/cli/commands/integrate/_common/registry/core';
-import {
-  GIT_INTEGRATIONS,
-  HUSKY_INTEGRATION_ID,
-  NATIVE_GIT_INTEGRATION_ID,
-  PRE_COMMIT_INTEGRATION_ID,
-} from '../../../../../../src/cli/commands/integrate/git/tools';
+import { ALL_INTEGRATIONS, supportedIntegrations } from '../../../../../src/cli/commands/integrate';
+import { createIntegrationRegistry } from '../../../../../src/cli/commands/integrate/_common/registry/core';
 
-describe('GIT_INTEGRATIONS', () => {
-  it('can seed a registry from the static git integrations list', () => {
-    const expectedIntegrationIds = [
-      NATIVE_GIT_INTEGRATION_ID,
-      HUSKY_INTEGRATION_ID,
-      PRE_COMMIT_INTEGRATION_ID,
-    ];
+describe('ALL_INTEGRATIONS', () => {
+  it('seeds the global supportedIntegrations registry in order', () => {
+    const expectedIntegrationIds = ALL_INTEGRATIONS.map((integration) => integration.id);
 
-    const registry = createIntegrationRegistry(GIT_INTEGRATIONS);
+    expect(supportedIntegrations.list().map((integration) => integration.id)).toEqual(
+      expectedIntegrationIds,
+    );
+  });
 
-    expect(registry.list().map((integration) => integration.id)).toEqual(expectedIntegrationIds);
+  it('can seed a fresh registry from the static data', () => {
+    const registry = createIntegrationRegistry(ALL_INTEGRATIONS);
+
+    expect(registry.list().map((integration) => integration.id)).toEqual(
+      ALL_INTEGRATIONS.map((integration) => integration.id),
+    );
   });
 });

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -19,6 +19,8 @@
  */
 
 import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
 
@@ -26,11 +28,16 @@ import { version as CURRENT_VERSION } from '../../../../../package.json';
 import * as cagInstall from '../../../../../src/cli/commands/_common/install/context-augmentation';
 import * as secretsInstall from '../../../../../src/cli/commands/_common/install/secrets';
 import * as contextAugmentation from '../../../../../src/cli/commands/integrate/_common/context-augmentation';
+import {
+  IntegrationRegistry,
+  wholeFile,
+} from '../../../../../src/cli/commands/integrate/_common/registry';
 import * as hooks from '../../../../../src/cli/commands/integrate/claude/hooks';
 import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../../../src/lib/install-types';
 import * as migration from '../../../../../src/lib/migration';
 import {
   migrateClaudeCodeHooks,
+  migrateDeclarativeIntegrations,
   runPostUpdateActions,
   updateContextAugmentationIfNeeded,
   updateSecretsBinaryIfNeeded,
@@ -160,19 +167,21 @@ describe('runPostUpdateActions', () => {
   });
 
   it('saves the reloaded state, not the pre-runActions snapshot', async () => {
-    // loadState is called 5 times:
+    // loadState is called 6 times:
     //   1. version check in runPostUpdateActions
-    //   2. inside migrateClaudeCodeHooks
-    //   3. inside updateSecretsBinaryIfNeeded
-    //   4. inside updateContextAugmentationIfNeeded
-    //   5. the reload after runActions (the fix being tested)
+    //   2. inside migrateDeclarativeIntegrations
+    //   3. inside migrateClaudeCodeHooks
+    //   4. inside updateSecretsBinaryIfNeeded
+    //   5. inside updateContextAugmentationIfNeeded
+    //   6. the reload after runActions (the fix being tested)
     const reloadedState = makeState();
     loadStateSpy
       .mockReturnValueOnce(makeState()) // call 1: version check
-      .mockReturnValueOnce(makeState()) // call 2: migrateClaudeCodeHooks
-      .mockReturnValueOnce(makeState()) // call 3: updateSecretsBinaryIfNeeded
-      .mockReturnValueOnce(makeState()) // call 4: updateContextAugmentationIfNeeded
-      .mockReturnValueOnce(reloadedState); // call 5: reload
+      .mockReturnValueOnce(makeState()) // call 2: migrateDeclarativeIntegrations
+      .mockReturnValueOnce(makeState()) // call 3: migrateClaudeCodeHooks
+      .mockReturnValueOnce(makeState()) // call 4: updateSecretsBinaryIfNeeded
+      .mockReturnValueOnce(makeState()) // call 5: updateContextAugmentationIfNeeded
+      .mockReturnValueOnce(reloadedState); // call 6: reload
 
     await runPostUpdateActions();
 
@@ -224,6 +233,130 @@ describe('runPostUpdateActions', () => {
     expect(saved.agents['claude-code'].hooks.installed.some((h) => h.name === 'sonar-a3s')).toBe(
       false,
     );
+  });
+});
+
+describe('migrateDeclarativeIntegrations', () => {
+  let loadStateSpy: Mock<typeof stateRepository.loadState>;
+  let saveStateSpy: Mock<typeof stateRepository.saveState>;
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(join(tmpdir(), 'sonar-cli-post-update-'));
+    loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeState());
+    saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    loadStateSpy.mockRestore();
+    saveStateSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('reapplies installed declarative features and prunes unknown feature state', async () => {
+    const operationCalls: string[] = [];
+    const resourcePath = join(tempDir, 'managed.txt');
+    const now = '2026-01-01T00:00:00.000Z';
+    fs.writeFileSync(resourcePath, 'legacy content', 'utf-8');
+
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: now,
+      updatedByCliVersion: '0.9.0',
+      updatedAt: now,
+      features: [
+        {
+          featureId: 'managed-feature',
+          scope: 'project',
+          targetRoot: tempDir,
+          installedByCliVersion: '0.9.0',
+          installedAt: now,
+          updatedByCliVersion: '0.9.0',
+          updatedAt: now,
+          dependencies: [],
+          resources: [
+            {
+              id: 'managed-file',
+              resourceType: 'whole-file',
+              version: '1',
+              path: resourcePath,
+              updatedByCliVersion: '0.9.0',
+              updatedAt: now,
+            },
+          ],
+          operations: [],
+          attrs: { projectKey: 'project-key' },
+        },
+        {
+          featureId: 'removed-feature',
+          scope: 'project',
+          targetRoot: tempDir,
+          installedByCliVersion: '0.9.0',
+          installedAt: now,
+          updatedByCliVersion: '0.9.0',
+          updatedAt: now,
+          dependencies: [],
+          resources: [],
+          operations: [],
+        },
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [
+        {
+          id: 'managed-feature',
+          displayName: 'Managed feature',
+          resources: [
+            wholeFile({
+              id: 'managed-file',
+              version: '2',
+              targetPath: resourcePath,
+              content: 'fresh content',
+            }),
+          ],
+          operations: [
+            {
+              id: 'refresh-operation',
+              version: '1',
+              apply: () => {
+                operationCalls.push('refresh-operation');
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(fs.readFileSync(resourcePath, 'utf-8')).toBe('fresh content');
+    expect(operationCalls).toEqual(['refresh-operation']);
+    expect(saveStateSpy).toHaveBeenCalledTimes(1);
+
+    const savedState = saveStateSpy.mock.calls[0][0];
+    expect(savedState.integrations.installed).toHaveLength(1);
+    expect(savedState.integrations.installed[0].features).toHaveLength(1);
+    const savedFeature = savedState.integrations.installed[0].features[0];
+    expect(savedFeature.featureId).toBe('managed-feature');
+    expect(savedFeature.resources).toHaveLength(1);
+    expect(savedFeature.resources[0]).toMatchObject({
+      id: 'managed-file',
+      version: '2',
+      path: resourcePath,
+    });
+    expect(savedFeature.operations).toHaveLength(1);
+    expect(savedFeature.operations[0]).toMatchObject({
+      id: 'refresh-operation',
+      version: '1',
+    });
   });
 });
 
@@ -292,6 +425,57 @@ describe('migrateClaudeCodeHooks', () => {
 
     expect(installHooksSpy).not.toHaveBeenCalled();
     expect(migrateHookScriptsSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips legacy migration when Claude is already tracked declaratively', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', false)]);
+    state.integrations.installed.push({
+      id: 'claude-integration-id',
+      integrationId: 'claude-code',
+      installedByCliVersion: '1.0.0',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedByCliVersion: '1.0.0',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      features: [
+        {
+          featureId: 'mcp-server',
+          scope: 'project',
+          targetRoot: '/proj/root',
+          installedByCliVersion: '1.0.0',
+          installedAt: '2026-01-01T00:00:00.000Z',
+          updatedByCliVersion: '1.0.0',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          dependencies: [],
+          resources: [],
+          operations: [],
+        },
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).not.toHaveBeenCalled();
+    expect(migrateHookScriptsSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not skip legacy migration for an empty declarative Claude container', async () => {
+    const state = makeStateWithExtensions([makeExtension('/proj/root', false)]);
+    state.integrations.installed.push({
+      id: 'claude-integration-id',
+      integrationId: 'claude-code',
+      installedByCliVersion: '1.0.0',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedByCliVersion: '1.0.0',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      features: [],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    await migrateClaudeCodeHooks(homedirFn);
+
+    expect(installHooksSpy).toHaveBeenCalledTimes(1);
+    expect(migrateHookScriptsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('installs hooks for each extension in the registry', async () => {

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -253,9 +253,10 @@ describe('migrateDeclarativeIntegrations', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  it('reapplies installed declarative features and prunes unknown feature state', async () => {
+  it('reapplies only installed declarative features and prunes unknown feature state', async () => {
     const operationCalls: string[] = [];
     const resourcePath = join(tempDir, 'managed.txt');
+    const newFeatureResourcePath = join(tempDir, 'new-feature.txt');
     const now = '2026-01-01T00:00:00.000Z';
     fs.writeFileSync(resourcePath, 'legacy content', 'utf-8');
 
@@ -332,6 +333,27 @@ describe('migrateDeclarativeIntegrations', () => {
             },
           ],
         },
+        {
+          id: 'new-feature',
+          displayName: 'New feature',
+          resources: [
+            wholeFile({
+              id: 'new-managed-file',
+              version: '1',
+              targetPath: newFeatureResourcePath,
+              content: 'should not be written automatically',
+            }),
+          ],
+          operations: [
+            {
+              id: 'new-feature-operation',
+              version: '1',
+              apply: () => {
+                operationCalls.push('new-feature-operation');
+              },
+            },
+          ],
+        },
       ],
     });
 
@@ -339,6 +361,7 @@ describe('migrateDeclarativeIntegrations', () => {
 
     expect(fs.readFileSync(resourcePath, 'utf-8')).toBe('fresh content');
     expect(operationCalls).toEqual(['refresh-operation']);
+    expect(fs.existsSync(newFeatureResourcePath)).toBe(false);
     expect(saveStateSpy).toHaveBeenCalledTimes(1);
 
     const savedState = saveStateSpy.mock.calls[0][0];


### PR DESCRIPTION
----
## Summary by Gitar

- **New declarative framework:**
  - Introduced `IntegrationRegistry` core logic to centrally manage and validate integration declarations.
  - Added `ALL_INTEGRATIONS` entry point for automated registration of existing integrations.
- **Migration logic:**
  - Added `migrateDeclarativeIntegrations` to `post-update.ts` to automatically reapply features and prune stale states after CLI upgrades.
  - Integrated `migrateClaudeCodeHooks` with the new framework to skip legacy migration when declarative tracking is present.
- **Testing enhancements:**
  - Added comprehensive unit tests for registry validation and integration seeding.
  - Added integration tests to verify that declarative `Claude` hooks are refreshed correctly during CLI upgrades.

<sub>This will update automatically on new commits.</sub>