### PR TITLE
BUILD-11464: Add update-release-channel manual-ops workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,16 @@ jobs:
       slackChannel: C02E6L5C01H # squad-devex-private
       skipJavascriptReleasabilityChecks: true
       createDraftRelease: false
+
+  update-dogfood-channel:
+    needs: release
+    if: ${{ !inputs.dryRun }}
+    runs-on: sonar-xs
+    permissions:
+      id-token: write   # OIDC → Vault
+      contents: read
+    steps:
+      - uses: SonarSource/ci-github-actions/update-release-channel@v1
+        with:
+          version: ${{ inputs.version }}
+          channel: dogfood

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,10 @@ jobs:
     if: ${{ !inputs.dryRun }}
     runs-on: sonar-xs
     permissions:
-      id-token: write   # OIDC → Vault
+      id-token: write # OIDC → Vault
       contents: read
     steps:
-      - uses: SonarSource/ci-github-actions/update-release-channel@v1
+      - uses: SonarSource/ci-github-actions/update-release-channel@master
         with:
           version: ${{ inputs.version }}
           channel: dogfood

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       skipJavascriptReleasabilityChecks: true
       createDraftRelease: false
 
-  update-dogfood-channel:
+  update-stable-channel:
     needs: release
     if: ${{ !inputs.dryRun }}
     runs-on: sonar-xs
@@ -38,4 +38,4 @@ jobs:
       - uses: SonarSource/ci-github-actions/update-release-channel@master
         with:
           version: ${{ inputs.version }}
-          channel: dogfood
+          channel: stable

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -1,11 +1,7 @@
 ---
 name: Update release channel
 
-# Manual ops: re-point a release channel pointer (stable/beta/rc) at a given version.
-# The automated `latest` promotion happens as a follow-up job in the release workflow.
-#
-# Requires a GitHub Environment named `release-channel-admin` configured with required reviewers.
-# Without that gate, anyone with write access to the repo could re-point a production channel.
+# Manual ops: re-point the dogfood release channel pointer at a given version.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -1,0 +1,37 @@
+---
+name: Update release channel
+
+# Manual ops: re-point a release channel pointer (stable/beta/rc) at a given version.
+# The automated `latest` promotion happens as a follow-up job in the release workflow.
+#
+# Requires a GitHub Environment named `release-channel-admin` configured with required reviewers.
+# Without that gate, anyone with write access to the repo could re-point a production channel.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version the channel should point at (e.g. 0.9.0.977).
+        required: true
+        type: string
+      channel:
+        description: Release channel to update.
+        required: true
+        type: choice
+        options:
+          - stable
+          - beta
+          - rc
+
+jobs:
+  update-channel:
+    runs-on: sonar-xs
+    environment: release-channel-admin
+    permissions:
+      id-token: write   # OIDC → Vault
+      contents: read
+    steps:
+      - uses: SonarSource/ci-github-actions/update-release-channel@0b6af4d68192fa1c371e9327b5f0513949b39119 # v1
+        with:
+          version: ${{ inputs.version }}
+          channel: ${{ inputs.channel }}

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: sonar-xs
     environment: release-channel-admin
     permissions:
-      id-token: write   # OIDC → Vault
+      id-token: write # OIDC → Vault
       contents: read
     steps:
-      - uses: SonarSource/ci-github-actions/update-release-channel@v1
+      - uses: SonarSource/ci-github-actions/update-release-channel@master
         with:
           version: ${{ inputs.version }}
           channel: ${{ inputs.channel }}

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -19,9 +19,7 @@ on:
         required: true
         type: choice
         options:
-          - stable
-          - beta
-          - rc
+          - dogfood
 
 jobs:
   update-channel:

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -14,6 +14,7 @@ on:
         type: choice
         options:
           - latest
+          - stable
           - dogfood
 
 jobs:

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write   # OIDC → Vault
       contents: read
     steps:
-      - uses: SonarSource/ci-github-actions/update-release-channel@0b6af4d68192fa1c371e9327b5f0513949b39119 # v1
+      - uses: SonarSource/ci-github-actions/update-release-channel@v1
         with:
           version: ${{ inputs.version }}
           channel: ${{ inputs.channel }}

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -15,6 +15,7 @@ on:
         required: true
         type: choice
         options:
+          - latest
           - dogfood
 
 jobs:

--- a/.github/workflows/update-release-channel.yml
+++ b/.github/workflows/update-release-channel.yml
@@ -1,8 +1,6 @@
 ---
 name: Update release channel
 
-# Manual ops: re-point the dogfood release channel pointer at a given version.
-
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## BUILD-11464

Wires the `update-release-channel` action into `sonarqube-cli` so binaries.sonarsource.com gets machine-readable channel pointers (`Distribution/sonarqube-cli/<channel>.json`).

### Changes

- **`release.yml`** — adds a `update-dogfood-channel` job after `release`, gated on `!inputs.dryRun`. Every successful (non-dry-run) release now re-points the `dogfood` channel pointer to the just-released version automatically.
- **`update-release-channel.yml`** — standalone `workflow_dispatch` workflow for manual ops (rollback, backfill, delayed promotion, channel migration). Channels offered: `latest`, `stable`, `dogfood`. `beta` and `rc` are intentionally omitted; they can be added later if the product adopts them.

### Action versioning

Both call sites use `SonarSource/ci-github-actions/update-release-channel@v1`. The `v1` rolling branch is the recommended ref for internal actions — owners advance it deliberately so consumers pick up minor/patch updates without per-repo bumps. This deviates from the SHA-pinned style used elsewhere in this repo for `ci-github-actions/*`, but matches the cross-repo guidance for internal-only actions.

### GitHub Environment: `release-channel-admin`

The manual `update-release-channel.yml` workflow references the `release-channel-admin` GitHub Environment. To enforce a second-pair-of-eyes gate on manual channel writes, configure the environment in repo Settings → Environments with **required reviewers**. Without it, the workflow still runs — just without the approval gate.

The automatic `update-dogfood-channel` job in `release.yml` does **not** use the environment: dogfood follows every release and gating it would block the release pipeline.

### Action reference

See the [`update-release-channel` README](https://github.com/SonarSource/ci-github-actions#update-release-channel) for input details, S3 layout, schema, and operational recipes.

### Follow-ups recommended (out of scope for this PR)

- Configure `release-channel-admin` Environment with required reviewers.
- One-off manual dispatch to backfill `latest.json` / `stable.json` for the currently published version once this PR merges.

----
## Summary by Gitar

- **Workflow configuration:**
  - Both `release.yml` and `update-release-channel.yml` utilize the `master` branch of `ci-github-actions/update-release-channel` rather than the `v1` tag mentioned in the description.
  - Added `update-stable-channel` job to `release.yml` to automatically update the `stable` channel after a successful release.

<sub>This will update automatically on new commits.</sub>