### PR TITLE
CLI-530 Use .bin extension for Unix instead of .exe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,9 +52,9 @@ jobs:
           PACKAGE_VERSION=$(bun build-scripts/set-build-number.ts "${BUILD_NUMBER}")
           echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
           echo "PROJECT_VERSION=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
-          echo "ARTIFACT_LINUX=sonarqube-cli-${PACKAGE_VERSION}-linux-x86-64.exe" >> $GITHUB_OUTPUT
-          echo "ARTIFACT_LINUX_ARM64=sonarqube-cli-${PACKAGE_VERSION}-linux-arm64.exe" >> $GITHUB_OUTPUT
-          echo "ARTIFACT_MACOS=sonarqube-cli-${PACKAGE_VERSION}-macos-arm64.exe" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_LINUX=sonarqube-cli-${PACKAGE_VERSION}-linux-x86-64.bin" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_LINUX_ARM64=sonarqube-cli-${PACKAGE_VERSION}-linux-arm64.bin" >> $GITHUB_OUTPUT
+          echo "ARTIFACT_MACOS=sonarqube-cli-${PACKAGE_VERSION}-macos-arm64.bin" >> $GITHUB_OUTPUT
           echo "ARTIFACT_WINDOWS=sonarqube-cli-${PACKAGE_VERSION}-windows-x86-64.exe" >> $GITHUB_OUTPUT
 
   build-binaries:
@@ -259,7 +259,7 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           PROJECT: ${{ github.event.repository.name }}
           BUILD_NUMBER: ${{ needs.prepare.outputs.BUILD_NUMBER }}
-          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:exe:linux-x86-64,org.sonarsource.cli:sonarqube-cli:exe:linux-arm64,org.sonarsource.cli:sonarqube-cli:exe:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
+          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:bin:linux-x86-64,org.sonarsource.cli:sonarqube-cli:bin:linux-arm64,org.sonarsource.cli:sonarqube-cli:bin:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
         run: |
           jf config add repox \
             --artifactory-url="${ARTIFACTORY_URL}" \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 A CLI tool (`sonar`) that integrates SonarQube Server and Cloud into developer workflows.
 
-Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `macos-arm64`, and `windows-x86-64`. CDN artifacts use the `.bin` suffix on Linux/macOS and `.exe` on Windows (e.g. `sonarqube-cli-{version}-linux-x86-64.bin`); versions published before that convention remain `.exe` on the CDN. Dependency binaries (sonar-secrets, sca-scanner-cli) still use `.exe` in download URLs. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`) and try `.bin` then `.exe` when downloading.
+Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `macos-arm64`, and `windows-x86-64`. binaries.sonarsource.com artifacts use the `.bin` suffix on Linux/macOS and `.exe` on Windows (e.g. `sonarqube-cli-{version}-linux-x86-64.bin`); versions published before that convention remain `.exe` on the CDN. Dependency binaries (sonar-secrets, sca-scanner-cli) still use `.exe` in download URLs. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`) and try `.bin` then `.exe` when downloading.
 
 # Running checks
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 A CLI tool (`sonar`) that integrates SonarQube Server and Cloud into developer workflows.
 
-Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `macos-arm64`, and `windows-x86-64`. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`).
+Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `macos-arm64`, and `windows-x86-64`. CDN artifacts use the `.bin` suffix on Linux/macOS and `.exe` on Windows (e.g. `sonarqube-cli-{version}-linux-x86-64.bin`); versions published before that convention remain `.exe` on the CDN. Dependency binaries (sonar-secrets, sca-scanner-cli) still use `.exe` in download URLs. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`) and try `.bin` then `.exe` when downloading.
 
 # Running checks
 

--- a/src/lib/sonarsource-releases.ts
+++ b/src/lib/sonarsource-releases.ts
@@ -33,7 +33,9 @@ import logger from './logger.js';
 const DOWNLOAD_TIMEOUT_MS = 60000;
 
 /**
- * Build the download filename — Sonarsource always uses .exe regardless of platform.
+ * Build the CDN filename for dependency binaries installed via `buildDownloadUrl`
+ * (e.g. sonar-secrets, sca-scanner-cli). Unlike the sonarqube-cli release artifact,
+ * these always use a `.exe` suffix on binaries.sonarsource.com regardless of platform.
  */
 function buildDownloadFilename(
   binaryName: string,

--- a/user-scripts/install-prerelease.sh
+++ b/user-scripts/install-prerelease.sh
@@ -54,22 +54,36 @@ fetch_with_auth() {
   fi
 }
 
+# Optional fourth argument "quiet": return 1 on failure instead of exiting (stderr suppressed).
 download_with_auth() {
   local url="$1"
   local dest="$2"
   local token="$3"
+  local quiet="${4:-}"
   if command -v curl &>/dev/null; then
-    curl -fsSL -H "Authorization: Bearer $token" "$url" -o "$dest"
-  elif command -v wget &>/dev/null; then
-    wget -qO "$dest" --header="Authorization: Bearer $token" "$url"
-  else
-    echo "Error: neither curl nor wget is available. Please install one and retry." >&2
-    exit 1
+    if [[ -n "$quiet" ]]; then
+      curl -fsSL -H "Authorization: Bearer $token" "$url" -o "$dest" 2>/dev/null
+    else
+      curl -fsSL -H "Authorization: Bearer $token" "$url" -o "$dest"
+    fi
+    return
   fi
+  if command -v wget &>/dev/null; then
+    if [[ -n "$quiet" ]]; then
+      wget -qO "$dest" --header="Authorization: Bearer $token" "$url" 2>/dev/null
+    else
+      wget -qO "$dest" --header="Authorization: Bearer $token" "$url"
+    fi
+    return
+  fi
+  if [[ -n "$quiet" ]]; then
+    return 1
+  fi
+  echo "Error: neither curl nor wget is available. Please install one and retry." >&2
+  exit 1
 }
 
-# Try .bin first (current Unix pre-releases), then .exe (legacy artifacts).
-# Remove fallback once .bin is released
+# Tries .bin first, then .exe for legacy Artifactory artifacts. Remove .exe fallback once .bin is released.
 download_cli_prerelease_artifact() {
   local version="$1"
   local platform="$2"
@@ -79,27 +93,13 @@ download_cli_prerelease_artifact() {
   local url_bin="$BASE_URL/$version/${base}.bin"
   local url_exe="$BASE_URL/$version/${base}.exe"
 
-  if command -v curl &>/dev/null; then
-    if curl -fsSL -H "Authorization: Bearer $token" "$url_bin" -o "$dest" 2>/dev/null; then
-      echo "  $url_bin"
-      return 0
-    fi
-    if curl -fsSL -H "Authorization: Bearer $token" "$url_exe" -o "$dest" 2>/dev/null; then
-      echo "  $url_exe"
-      return 0
-    fi
-  elif command -v wget &>/dev/null; then
-    if wget -qO "$dest" --header="Authorization: Bearer $token" "$url_bin" 2>/dev/null; then
-      echo "  $url_bin"
-      return 0
-    fi
-    if wget -qO "$dest" --header="Authorization: Bearer $token" "$url_exe" 2>/dev/null; then
-      echo "  $url_exe"
-      return 0
-    fi
-  else
-    echo "Error: neither curl nor wget is available. Please install one and retry." >&2
-    exit 1
+  if download_with_auth "$url_bin" "$dest" "$token" quiet; then
+    echo "  $url_bin"
+    return 0
+  fi
+  if download_with_auth "$url_exe" "$dest" "$token" quiet; then
+    echo "  $url_exe"
+    return 0
   fi
 
   echo "Error: could not download sonarqube-cli pre-release (tried .bin and .exe):" >&2

--- a/user-scripts/install-prerelease.sh
+++ b/user-scripts/install-prerelease.sh
@@ -68,6 +68,46 @@ download_with_auth() {
   fi
 }
 
+# Try .bin first (current Unix pre-releases), then .exe (legacy artifacts).
+# Remove fallback once .bin is released
+download_cli_prerelease_artifact() {
+  local version="$1"
+  local platform="$2"
+  local dest="$3"
+  local token="$4"
+  local base="sonarqube-cli-${version}-${platform}"
+  local url_bin="$BASE_URL/$version/${base}.bin"
+  local url_exe="$BASE_URL/$version/${base}.exe"
+
+  if command -v curl &>/dev/null; then
+    if curl -fsSL -H "Authorization: Bearer $token" "$url_bin" -o "$dest" 2>/dev/null; then
+      echo "  $url_bin"
+      return 0
+    fi
+    if curl -fsSL -H "Authorization: Bearer $token" "$url_exe" -o "$dest" 2>/dev/null; then
+      echo "  $url_exe"
+      return 0
+    fi
+  elif command -v wget &>/dev/null; then
+    if wget -qO "$dest" --header="Authorization: Bearer $token" "$url_bin" 2>/dev/null; then
+      echo "  $url_bin"
+      return 0
+    fi
+    if wget -qO "$dest" --header="Authorization: Bearer $token" "$url_exe" 2>/dev/null; then
+      echo "  $url_exe"
+      return 0
+    fi
+  else
+    echo "Error: neither curl nor wget is available. Please install one and retry." >&2
+    exit 1
+  fi
+
+  echo "Error: could not download sonarqube-cli pre-release (tried .bin and .exe):" >&2
+  echo "  $url_bin" >&2
+  echo "  $url_exe" >&2
+  exit 1
+}
+
 resolve_latest_version() {
   local token="$1"
   local api_url="https://repox.jfrog.io/artifactory/api/search/latestVersion?g=org.sonarsource.cli&a=sonarqube-cli&repos=sonarsource-public-builds"
@@ -184,21 +224,19 @@ main() {
   local platform
   platform="$(detect_platform)"
 
-  local filename="sonarqube-cli-${version}-${platform}.exe"
-  local url="$BASE_URL/$version/$filename"
+  local artifact_basename="sonarqube-cli-${version}-${platform}"
   local dest="$INSTALL_DIR/$BINARY_NAME"
   TMP_DIR="$(mktemp -d -t 'sonarqube-cli-install.XXXXXX')"
 
   echo "Installing pre-release sonarqube-cli $version"
   echo "Detected platform: $platform"
   echo "Downloading from:"
-  echo "  $url"
 
   mkdir -p "$INSTALL_DIR"
 
-  local tmp_bin="$TMP_DIR/$filename"
+  local tmp_bin="$TMP_DIR/$artifact_basename"
 
-  download_with_auth "$url" "$tmp_bin" "$token"
+  download_cli_prerelease_artifact "$version" "$platform" "$tmp_bin" "$token"
 
   mv "$tmp_bin" "$dest"
   chmod +x "$dest"

--- a/user-scripts/install.sh
+++ b/user-scripts/install.sh
@@ -61,21 +61,36 @@ resolve_latest_version() {
   echo "$version"
 }
 
+# Optional third argument "quiet": return 1 on failure instead of exiting (stderr suppressed).
 download() {
   local url="$1"
   local dest="$2"
+  local quiet="${3:-}"
   if command -v curl &>/dev/null; then
-    curl -fsSL "$url" -o "$dest"
-  elif command -v wget &>/dev/null; then
-    wget -qO "$dest" "$url"
-  else
-    echo "Error: neither curl nor wget is available. Please install one and retry." >&2
-    exit 1
+    if [[ -n "$quiet" ]]; then
+      curl -fsSL "$url" -o "$dest" 2>/dev/null
+    else
+      curl -fsSL "$url" -o "$dest"
+    fi
+    return
   fi
+  if command -v wget &>/dev/null; then
+    if [[ -n "$quiet" ]]; then
+      wget -qO "$dest" "$url" 2>/dev/null
+    else
+      wget -qO "$dest" "$url"
+    fi
+    return
+  fi
+  if [[ -n "$quiet" ]]; then
+    return 1
+  fi
+  echo "Error: neither curl nor wget is available. Please install one and retry." >&2
+  exit 1
 }
 
-# Download the CLI from binaries.sonarsource.com (not bundled in the sonar binary).
-# Remove fallback once .bin is released
+# Fetches the CLI from binaries.sonarsource.com (sonar self-update runs this script from GitHub).
+# Tries .bin first, then .exe for legacy CDN builds. Remove .exe fallback once .bin is released.
 download_cli_artifact() {
   local version="$1"
   local platform="$2"
@@ -85,27 +100,13 @@ download_cli_artifact() {
   local url_bin="$BASE_URL/$version/$os/${base}.bin"
   local url_exe="$BASE_URL/$version/$os/${base}.exe"
 
-  if command -v curl &>/dev/null; then
-    if curl -fsSL "$url_bin" -o "$dest" 2>/dev/null; then
-      echo "  $url_bin"
-      return 0
-    fi
-    if curl -fsSL "$url_exe" -o "$dest" 2>/dev/null; then
-      echo "  $url_exe"
-      return 0
-    fi
-  elif command -v wget &>/dev/null; then
-    if wget -qO "$dest" "$url_bin" 2>/dev/null; then
-      echo "  $url_bin"
-      return 0
-    fi
-    if wget -qO "$dest" "$url_exe" 2>/dev/null; then
-      echo "  $url_exe"
-      return 0
-    fi
-  else
-    echo "Error: neither curl nor wget is available. Please install one and retry." >&2
-    exit 1
+  if download "$url_bin" "$dest" quiet; then
+    echo "  $url_bin"
+    return 0
+  fi
+  if download "$url_exe" "$dest" quiet; then
+    echo "  $url_exe"
+    return 0
   fi
 
   echo "Error: could not download sonarqube-cli (tried .bin and .exe):" >&2

--- a/user-scripts/install.sh
+++ b/user-scripts/install.sh
@@ -74,6 +74,46 @@ download() {
   fi
 }
 
+# Download the CLI from binaries.sonarsource.com (not bundled in the sonar binary).
+# Remove fallback once .bin is released
+download_cli_artifact() {
+  local version="$1"
+  local platform="$2"
+  local os="$3"
+  local dest="$4"
+  local base="sonarqube-cli-${version}-${platform}"
+  local url_bin="$BASE_URL/$version/$os/${base}.bin"
+  local url_exe="$BASE_URL/$version/$os/${base}.exe"
+
+  if command -v curl &>/dev/null; then
+    if curl -fsSL "$url_bin" -o "$dest" 2>/dev/null; then
+      echo "  $url_bin"
+      return 0
+    fi
+    if curl -fsSL "$url_exe" -o "$dest" 2>/dev/null; then
+      echo "  $url_exe"
+      return 0
+    fi
+  elif command -v wget &>/dev/null; then
+    if wget -qO "$dest" "$url_bin" 2>/dev/null; then
+      echo "  $url_bin"
+      return 0
+    fi
+    if wget -qO "$dest" "$url_exe" 2>/dev/null; then
+      echo "  $url_exe"
+      return 0
+    fi
+  else
+    echo "Error: neither curl nor wget is available. Please install one and retry." >&2
+    exit 1
+  fi
+
+  echo "Error: could not download sonarqube-cli (tried .bin and .exe):" >&2
+  echo "  $url_bin" >&2
+  echo "  $url_exe" >&2
+  exit 1
+}
+
 # Detect the best shell profile file to update (inspired by nvm_detect_profile).
 # Honors $PROFILE override, detects shell from $SHELL, respects $ZDOTDIR for zsh.
 # Outputs exactly one file path, or nothing if no profile is found.
@@ -148,20 +188,18 @@ main() {
   local os
   os="$(detect_os)"
 
-  local filename="sonarqube-cli-${version}-${platform}.exe"
-  local url="$BASE_URL/$version/$os/$filename"
+  local artifact_basename="sonarqube-cli-${version}-${platform}"
   local dest="$INSTALL_DIR/$BINARY_NAME"
   TMP_DIR="$(mktemp -d -t 'sonarqube-cli-install.XXXXXX')"
 
   echo "Detected platform: $platform"
   echo "Downloading sonarqube-cli from:"
-  echo "  $url"
 
   mkdir -p "$INSTALL_DIR"
 
-  local tmp_bin="$TMP_DIR/$filename"
+  local tmp_bin="$TMP_DIR/$artifact_basename"
 
-  download "$url" "$tmp_bin"
+  download_cli_artifact "$version" "$platform" "$os" "$tmp_bin"
 
   mv "$tmp_bin" "$dest"
   chmod +x "$dest"


### PR DESCRIPTION
----
## Summary by Gitar

- **Artifact Extension Update:**
  - Updated release configuration to use `.bin` extension for Unix artifacts (`linux-x86-64`, `linux-arm64`, `macos-arm64`) while keeping `.exe` for Windows.
- **Installer Refactoring:**
  - Updated `install.sh` and `install-prerelease.sh` to introduce fallback logic, attempting to download `.bin` artifacts first and falling back to `.exe` for backward compatibility.
- **Build and Documentation:**
  - Updated `build.yml` to reflect new artifact naming conventions in both workflow outputs and Artifactory deployment steps.
  - Added explanatory context to `CLAUDE.md` regarding the transition from `.exe` to `.bin` suffixes for Unix systems.


<sub>This will update automatically on new commits.</sub>