### PR TITLE
DEX-50 Stop accepting external PR contributions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report something that isn't working as expected in the SonarQube CLI.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in the fields below so we can reproduce and triage it quickly.
+  - type: input
+    id: version
+    attributes:
+      label: CLI version
+      description: Output of `sonar --version`.
+      placeholder: e.g. 1.4.0
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: Operating system and version
+      placeholder: e.g. macOS 15.4 (arm64), Ubuntu 24.04 (x86-64), Windows 11
+    validations:
+      required: true
+  - type: textarea
+    id: command
+    attributes:
+      label: Command you ran
+      description: The exact `sonar` command (redact tokens and other secrets).
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened
+      description: The full error message or output (with sensitive info redacted).
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else that might help — for auth issues, note whether you target SonarQube Cloud or Server.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+blank_issues_enabled: false
+contact_links:
+  # GitHub automatically adds a "Report a security vulnerability" link here because
+  # SECURITY.md exists, so we intentionally don't duplicate it in this file.
+  - name: General SonarQube product questions
+    url: https://community.sonarsource.com/
+    about: For questions not specific to the CLI, ask the SonarSource Community forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest an idea or improvement for the SonarQube CLI.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! We can't promise every idea ships, but describing the problem clearly helps us plan and prioritize.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what's getting in the way today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like the CLI to do?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches or workarounds you've tried or thought about.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,15 @@
+name: Question / feedback
+description: Ask a question about the SonarQube CLI or share general feedback.
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question about the CLI, or feedback that isn't a bug or a feature request? Tell us here.
+
+        For general SonarQube product questions not specific to the CLI, the [Community forum](https://community.sonarsource.com/) is usually the faster path.
+  - type: textarea
+    id: details
+    attributes:
+      label: Your question or feedback
+    validations:
+      required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing to sonarqube-cli
 
+> **We don't accept external pull requests on this project.** Keeping all changes in one
+> place lets us properly track, plan, prioritize, and test everything that goes into the
+> CLI. If you've found a bug or have an idea, please
+> [open a GitHub Issue](https://github.com/SonarSource/sonarqube-cli/issues/new/choose)
+> instead — we'd love to hear from you.
+>
+> The source is public, so you're welcome to fork it, read it, and experiment. The rest
+> of this guide explains how to build and run the CLI from source.
+
 ## Prerequisites
 
 - [Bun](https://bun.sh/) 1.3.9+ — required for running tests and building binaries
@@ -30,7 +39,7 @@ Produces `dist/sonarqube-cli` using Bun's single-file compiler. To use it locall
 
 ## Checks
 
-Run these before opening a pull request:
+Run these to validate your local build:
 
 ```bash
 # Lint (ESLint + TypeScript-aware rules)
@@ -98,7 +107,7 @@ After this, every build signs the binary automatically. On machines without the 
 
 ## Doc generation
 
-The README.md file is generated from the source code. When adding or modifying a command, please call:
+The docs site under `docs/` (`commands.json`, `llms.txt`, `sitemap.xml`) is generated from the source code. When adding or modifying a command, regenerate it with:
 
 ```bash
 bun run gen:docs

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ Secrets scanning is intentionally sensitive to avoid missing real credentials. F
 ### Still having issues?
 
 - **Search existing issues:** [GitHub Issues](https://github.com/SonarSource/sonarqube-cli/issues)
-- **Open a new issue:** [New Issue](https://github.com/SonarSource/sonarqube-cli/issues/new)
+- **Open a new issue:** [New Issue](https://github.com/SonarSource/sonarqube-cli/issues/new/choose)
 
 Include in your report:
 
@@ -598,10 +598,11 @@ No personally identifiable information is transmitted.
 
 ## Contributing
 
-Please be aware that we are not actively looking for feature contributions. The truth is that it's extremely difficult for someone outside
-SonarSource to comply with our roadmap and expectations. Therefore, we typically only accept minor cosmetic changes and typo fixes.
+We don't accept external pull requests on this project. This isn't about the quality of your change — keeping all changes in one place lets us properly track, plan, prioritize, and test everything that goes into the CLI.
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup instructions, coding guidelines, and how to run tests.
+That doesn't mean we don't want to hear from you — we do. If you've hit a bug or have an idea, please [open a GitHub Issue](https://github.com/SonarSource/sonarqube-cli/issues/new/choose) and we'll take it from there.
+
+The source is public, so you're welcome to fork it, read it, and experiment. See [CONTRIBUTING.md](./CONTRIBUTING.md) if you'd like to build the CLI from source.
 
 ## License
 


### PR DESCRIPTION
- README/CONTRIBUTING: no external PRs, redirect to GitHub Issues, keep build-from-source guidance
- Add structured issue forms (bug/feature/question) + config.yml (forum link; blank issues disabled). SECURITY.md is surfaced automatically by GitHub, so no security link here
- Issue forms apply no labels: labels are added manually during triage, so an unlabeled issue means 'not yet triaged'

External PRs are handled manually by the team (comment + close); GitHub's fork-PR
approval gate already prevents untrusted CI from running unattended.