### PR TITLE
CLI-484 Fix release notes automation

### DIFF
--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Verify draft release exists for expected version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           VERSION: ${{ steps.version.outputs.release-version }}
         run: |
           echo "Expecting a draft release tagged '$VERSION'."
@@ -132,6 +133,7 @@ jobs:
       - name: Copy draft body to published release and delete draft
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           DRAFT_VERSION: ${{ needs.check-draft-exists.outputs.release-version }}
           RELEASED_VERSION: ${{ needs.release.outputs.released-version }}
         run: |


### PR DESCRIPTION
gh release needs a repo context; without actions/checkout, it tries to use the local git remote and fails with fatal: not a git repository.

----
## Summary by Gitar

- **CI/CD Configuration:**
  - Added `GH_REPO` environment variable to `full-release.yml` for release verification and publication steps.

<sub>This will update automatically on new commits.</sub>