### PR TITLE
CLI-416, CLI-512 Ask features one by one

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -165,6 +165,10 @@ integrateCommand
   .description(
     'Install a Git pre-commit hook that scans staged files for secrets before each commit, or a Git pre-push hook that scans committed files for secrets before each push.',
   )
+  .option(
+    '--hook <type>',
+    'Hook to install: pre-commit (scan staged files) or pre-push (scan files in unpushed commits)',
+  )
   .option('--force', 'Overwrite existing hook if it is not from sonar integrate git')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .option(

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -207,6 +207,7 @@ integrateCommand
   )
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('--skip-context', 'Skip the sonar-context-augmentation install/init/skill step')
+  .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .addHelpText('after', projectKeyExtraHelp)
   .authenticatedAction((auth, options: IntegrateAgentOptions) => integrateCopilot(auth, options));
 
@@ -236,6 +237,7 @@ integrateCommand
   )
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('--skip-context', 'Skip the sonar-context-augmentation install/init/skill step')
+  .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .addHelpText('after', projectKeyExtraHelp)
   .authenticatedAction((auth, options: IntegrateAgentOptions) => integrateCodex(options, auth));
 

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -165,10 +165,6 @@ integrateCommand
   .description(
     'Install a Git pre-commit hook that scans staged files for secrets before each commit, or a Git pre-push hook that scans committed files for secrets before each push.',
   )
-  .option(
-    '--hook <type>',
-    'Hook to install: pre-commit (scan staged files) or pre-push (scan files in unpushed commits)',
-  )
   .option('--force', 'Overwrite existing hook if it is not from sonar integrate git')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .option(

--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -22,12 +22,13 @@ import { join } from 'node:path';
 
 import { createAgentHookEntry, resolveAgentHookScriptPath, upsertAgentHooks } from '../hooks';
 import { sonarSecretsBinaryDependency } from '../registry/dependencies';
+import { isFeatureInstalled } from '../registry/installer';
 import { jsonPatch, type PlatformSpecificContent, wholeFile } from '../registry/resources';
 import type { FeatureDeclaration, IntegrationContext } from '../registry/types';
 
-export interface SonarSecretsHooksFeatureOptions {
-  installSecretsHooks?: boolean;
-}
+const SONAR_SECRETS_HOOKS_FEATURE_ID = 'sonar-secrets-hooks';
+const SONAR_SECRETS_HOOKS_HINT =
+  'scans prompts and file reads for secrets before they reach the agent';
 
 export interface SonarSecretsHookScriptSpec {
   id: string;
@@ -44,6 +45,7 @@ export interface SonarSecretsHookEntrySpec {
 }
 
 export interface SonarSecretsHooksFeatureConfig {
+  integrationId: string;
   agentDisplayName: string;
   configDir: string;
   hooksConfigFileName: string;
@@ -61,16 +63,22 @@ export function resolveAgentHooksConfigPath(
   return join(context.targetRoot, configDir, fileName);
 }
 
-export function createSonarSecretsHooksFeature<TOptions extends SonarSecretsHooksFeatureOptions>(
+export function createSonarSecretsHooksFeature<TOptions>(
   config: SonarSecretsHooksFeatureConfig,
 ): FeatureDeclaration<TOptions> {
   const resolveHooksConfigPath = (context: IntegrationContext) =>
     resolveAgentHooksConfigPath(context, config.configDir, config.hooksConfigFileName);
 
   return {
-    id: 'sonar-secrets-hooks',
+    id: SONAR_SECRETS_HOOKS_FEATURE_ID,
     displayName: 'secrets hooks',
-    when: ({ options }) => options.installSecretsHooks === true,
+    hint: SONAR_SECRETS_HOOKS_HINT,
+    // Skip project-level install when a global secrets hook already covers it; otherwise ask.
+    when: ({ scope, state }) =>
+      scope === 'project' &&
+      isFeatureInstalled(state, config.integrationId, SONAR_SECRETS_HOOKS_FEATURE_ID, 'global')
+        ? { kind: 'skip', reason: 'global hook already covers this' }
+        : { kind: 'ask' },
     dependencies: [sonarSecretsBinaryDependency],
     resources: [
       ...config.scripts.map((script) =>

--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -27,8 +27,7 @@ import { jsonPatch, type PlatformSpecificContent, wholeFile } from '../registry/
 import type { FeatureDeclaration, IntegrationContext } from '../registry/types';
 
 const SONAR_SECRETS_HOOKS_FEATURE_ID = 'sonar-secrets-hooks';
-const SONAR_SECRETS_HOOKS_HINT =
-  'scans prompts and file reads for secrets before they reach the agent';
+const SONAR_SECRETS_HOOKS_HINT = 'prevents leaked secrets in AI prompts';
 
 export interface SonarSecretsHookScriptSpec {
   id: string;
@@ -71,7 +70,7 @@ export function createSonarSecretsHooksFeature<TOptions>(
 
   return {
     id: SONAR_SECRETS_HOOKS_FEATURE_ID,
-    displayName: 'secrets hooks',
+    displayName: 'secret scanning hooks',
     hint: SONAR_SECRETS_HOOKS_HINT,
     // Skip project-level install when a global secrets hook already covers it; otherwise ask.
     when: ({ scope, state }) =>

--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -37,10 +37,16 @@ export function withSonarMarkers(id: string, body: string): string {
   return `<!-- sonar:begin:${id} -->\n${body.trimEnd()}\n<!-- sonar:end:${id} -->\n`;
 }
 
+export const SQAA_MARKER_ID = 'sqaa-protocol';
+export const SQAA_START_MARKER = `<!-- sonar:begin:${SQAA_MARKER_ID} -->`;
+export const SQAA_END_MARKER = `<!-- sonar:end:${SQAA_MARKER_ID} -->`;
+
 export function buildSqaaSection(projectKey: string): string {
-  return withSonarMarkers(
-    'sqaa-protocol',
-    `# SonarQube Agentic Analysis protocol
+  return withSonarMarkers(SQAA_MARKER_ID, buildSqaaBody(projectKey));
+}
+
+export function buildSqaaBody(projectKey: string): string {
+  return `# SonarQube Agentic Analysis protocol
 
 SonarQube Agentic Analysis is the final confirmation layer at the end of every turn in which you wrote to one or more files in the workspace (create, edit, patch, format — any tool call that changed file contents on disk).
 
@@ -62,6 +68,5 @@ Non-negotiable rules:
 3. If SonarQube Agentic Analysis reports issues on lines you touched in this turn, fix them, then re-run SonarQube Agentic Analysis on that file. Repeat until the file is clean (or only pre-existing findings on lines you did not touch remain). Pre-existing findings on untouched lines are out of scope — do not "fix" them unless the user asked.
 4. If SonarQube Agentic Analysis is skipped (no SonarQube Cloud connection, or no project configured), state the skip reason to the user once and continue — do not retry.
 5. Do not suppress, summarize away, or omit SonarQube Agentic Analysis findings from your reply. Surface them verbatim.
-`,
-  );
+`;
 }

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -32,6 +32,7 @@ export {
   type InstallIntegrationOptions,
   IntegrationInstaller,
   integrationInstaller,
+  isFeatureInstalled,
 } from './installer';
 export {
   jsonPatch,

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -108,7 +108,7 @@ export class IntegrationInstaller {
       }
 
       const question = this.buildPromptQuestion(feature, result);
-      const answer = invocation.nonInteractive ? true : await confirmPrompt(question);
+      const answer = invocation.nonInteractive ? true : await confirmPrompt(question, true);
       if (answer === null) {
         throw new CommandFailedError('Installation cancelled');
       }

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -109,6 +109,9 @@ export class IntegrationInstaller {
 
       const question = this.buildPromptQuestion(feature, result);
       const answer = invocation.nonInteractive ? true : await confirmPrompt(question);
+      if (answer === null) {
+        throw new CommandFailedError('Installation cancelled');
+      }
       if (answer) {
         selected.push(feature);
       }

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -35,7 +35,7 @@ import type {
   IntegrationStateAttribute,
 } from '../../../../../lib/state';
 import { getDefaultState } from '../../../../../lib/state';
-import { info, success, text, warn } from '../../../../../ui';
+import { confirmPrompt, info, success, text, warn } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
 import { supportedIntegrations } from '../../index';
 import type { IntegrationRegistry } from './core';
@@ -47,10 +47,12 @@ import type {
   AppliedResource,
   FeatureDeclaration,
   FeatureOperation,
+  FeatureWhenContext,
   InstalledDependency,
   IntegrationContext,
   IntegrationDeclaration,
   IntegrationInvocation,
+  WhenResult,
 } from './types';
 
 interface ApplyFeatureCallbacks {
@@ -69,6 +71,7 @@ export interface InstallIntegrationOptions<TOptions> {
   scope: IntegrationScope;
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
+  nonInteractive?: boolean;
 }
 
 export class IntegrationInstaller {
@@ -83,11 +86,45 @@ export class IntegrationInstaller {
     });
   }
 
-  selectFeaturesForInvocation<TOptions>(
+  async selectFeaturesForInvocation<TOptions>(
     integration: IntegrationDeclaration<TOptions>,
     invocation: IntegrationInvocation<TOptions>,
-  ): FeatureDeclaration<TOptions>[] {
-    return integration.features.filter((feature) => !feature.when || feature.when(invocation));
+  ): Promise<FeatureDeclaration<TOptions>[]> {
+    const state = loadStateForInstallation();
+    const whenCtx: FeatureWhenContext<TOptions> = {
+      options: invocation.options,
+      scope: invocation.scope,
+      state,
+    };
+    const selected: FeatureDeclaration<TOptions>[] = [];
+    for (const feature of integration.features) {
+      const result: WhenResult = feature.when ? await feature.when(whenCtx) : { kind: 'ask' };
+
+      if (result.kind === 'skip') {
+        if (result.reason) {
+          info(`${feature.displayName}: ${result.reason}`);
+        }
+        continue;
+      }
+
+      const question = this.buildPromptQuestion(feature, result);
+      const answer = invocation.nonInteractive ? true : await confirmPrompt(question);
+      if (answer) {
+        selected.push(feature);
+      }
+    }
+    return selected;
+  }
+
+  private buildPromptQuestion<TOptions>(
+    feature: FeatureDeclaration<TOptions>,
+    result: WhenResult,
+  ): string {
+    if (result.kind === 'ask' && result.question) {
+      return result.question;
+    }
+    const base = `Set up ${feature.displayName}?`;
+    return feature.hint ? `${base} (${feature.hint})` : base;
   }
 
   findInstalledFeature<TOptions>(
@@ -391,6 +428,17 @@ export class IntegrationInstaller {
 
 export const integrationInstaller = new IntegrationInstaller();
 
+export function isFeatureInstalled(
+  state: CliState,
+  integrationId: string,
+  featureId: string,
+  scope: IntegrationScope,
+): boolean {
+  return !!state.integrations.installed
+    .find((integration) => integration.integrationId === integrationId)
+    ?.features.some((feature) => feature.featureId === featureId && feature.scope === scope);
+}
+
 export async function installIntegration<TOptions>({
   registry = supportedIntegrations,
   integrationId,
@@ -399,12 +447,14 @@ export async function installIntegration<TOptions>({
   scope,
   force,
   attrs,
+  nonInteractive,
 }: InstallIntegrationOptions<TOptions>): Promise<InstalledIntegrationFeature[]> {
   const integration = getIntegrationDeclaration<TOptions>(registry, integrationId);
-  const invocation = makeInvocation(options, targetRoot, scope, force, attrs);
-  const features = integrationInstaller.selectFeaturesForInvocation(integration, invocation);
+  const invocation = makeInvocation(options, targetRoot, scope, force, attrs, nonInteractive);
+  const features = await integrationInstaller.selectFeaturesForInvocation(integration, invocation);
   if (features.length === 0) {
-    throw new CommandFailedError(`No feature selected for ${integration.displayName}`);
+    info(`Nothing to install for ${integration.displayName}`);
+    return [];
   }
 
   const installedFeatures: InstalledIntegrationFeature[] = [];
@@ -503,6 +553,7 @@ function makeInvocation<TOptions>(
   scope: IntegrationScope,
   force: boolean | undefined,
   attrs: Record<string, IntegrationStateAttribute> | undefined,
+  nonInteractive: boolean | undefined,
 ): IntegrationInvocation<TOptions> {
   return {
     options,
@@ -510,6 +561,7 @@ function makeInvocation<TOptions>(
     scope,
     force,
     attrs,
+    nonInteractive,
   };
 }
 

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -99,24 +99,35 @@ export class IntegrationInstaller {
     const selected: FeatureDeclaration<TOptions>[] = [];
     for (const feature of integration.features) {
       const result: WhenResult = feature.when ? await feature.when(whenCtx) : { kind: 'ask' };
-
-      if (result.kind === 'skip') {
-        if (result.reason) {
-          info(`${feature.displayName}: ${result.reason}`);
-        }
-        continue;
-      }
-
-      const question = this.buildPromptQuestion(feature, result);
-      const answer = invocation.nonInteractive ? true : await confirmPrompt(question, true);
-      if (answer === null) {
-        throw new CommandFailedError('Installation cancelled');
-      }
-      if (answer) {
+      if (await this.shouldSelectFeature(feature, result, invocation.nonInteractive)) {
         selected.push(feature);
       }
     }
     return selected;
+  }
+
+  private async shouldSelectFeature<TOptions>(
+    feature: FeatureDeclaration<TOptions>,
+    result: WhenResult,
+    nonInteractive: boolean | undefined,
+  ): Promise<boolean> {
+    if (result.kind === 'skip') {
+      if (result.reason) {
+        info(`${feature.displayName}: ${result.reason}`);
+      }
+      return false;
+    }
+
+    if (result.kind === 'install') {
+      return true;
+    }
+
+    const question = this.buildPromptQuestion(feature, result);
+    const answer = nonInteractive ? true : await confirmPrompt(question, true);
+    if (answer === null) {
+      throw new CommandFailedError('Installation cancelled');
+    }
+    return answer;
   }
 
   private buildPromptQuestion<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { AppliedResource, IntegrationContext } from '../types';
+import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
   type BaseResourceOptions,
   type PathResolver,
@@ -28,9 +28,11 @@ import {
   writeFileIfChanged,
 } from './common';
 
+export type TextSnippetContent = string | ((context: IntegrationContext) => MaybePromise<string>);
+
 export interface TextSnippetResourceOptions extends BaseResourceOptions {
   targetPath: PathResolver;
-  content: string;
+  content: TextSnippetContent;
   executable?: boolean;
   startMarker: string;
   endMarker?: string;
@@ -54,7 +56,12 @@ export class TextSnippet implements ResourceDeclaration {
 
   async apply(context: IntegrationContext): Promise<AppliedResource> {
     const path = await resolvePath(context, this.options.targetPath);
-    await writeFileIfChanged(path, await this.renderContent(path), this.options.executable);
+    const managedBlock = await this.renderManagedBlock(context);
+    await writeFileIfChanged(
+      path,
+      await this.renderContent(path, managedBlock),
+      this.options.executable,
+    );
     return { id: this.id, resourceType: this.resourceType, version: this.version, path };
   }
 
@@ -64,12 +71,11 @@ export class TextSnippet implements ResourceDeclaration {
     if (existing === undefined) {
       return false;
     }
-    return existing.includes(this.renderManagedBlock());
+    return existing.includes(await this.renderManagedBlock(context));
   }
 
-  private async renderContent(path: string): Promise<string> {
+  private async renderContent(path: string, managedBlock: string): Promise<string> {
     const existing = (await readTextFile(path)) ?? '';
-    const managedBlock = this.renderManagedBlock();
     const pattern = new RegExp(
       String.raw`${escapeRegExp(this.startMarker)}[\s\S]*?${escapeRegExp(this.endMarker)}`,
     );
@@ -85,8 +91,12 @@ export class TextSnippet implements ResourceDeclaration {
     return appendBlock(existing, managedBlock);
   }
 
-  private renderManagedBlock(): string {
-    return `${this.startMarker}\n${this.options.content.trimEnd()}\n${this.endMarker}`;
+  private async renderManagedBlock(context: IntegrationContext): Promise<string> {
+    const content =
+      typeof this.options.content === 'function'
+        ? await this.options.content(context)
+        : this.options.content;
+    return `${this.startMarker}\n${content.trimEnd()}\n${this.endMarker}`;
   }
 
   private get startMarker(): string {

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -45,7 +45,10 @@ export interface IntegrationInvocation<TOptions = Record<string, unknown>> {
   nonInteractive?: boolean;
 }
 
-export type WhenResult = { kind: 'ask'; question?: string } | { kind: 'skip'; reason?: string };
+export type WhenResult =
+  | { kind: 'ask'; question?: string }
+  | { kind: 'skip'; reason?: string }
+  | { kind: 'install' };
 
 export interface FeatureWhenContext<TOptions = Record<string, unknown>> {
   options: TOptions;

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -42,6 +42,15 @@ export interface IntegrationInvocation<TOptions = Record<string, unknown>> {
   scope: IntegrationScope;
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
+  nonInteractive?: boolean;
+}
+
+export type WhenResult = { kind: 'ask'; question?: string } | { kind: 'skip'; reason?: string };
+
+export interface FeatureWhenContext<TOptions = Record<string, unknown>> {
+  options: TOptions;
+  scope: IntegrationScope;
+  state: CliState;
 }
 
 export type FeatureTargetRoot<TOptions = Record<string, unknown>> =
@@ -62,7 +71,10 @@ export interface IntegrationDeclaration<TOptions = Record<string, unknown>> {
 export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
   id: string;
   displayName: string;
-  when?: (invocation: IntegrationInvocation<TOptions>) => boolean;
+  /** Appended in parens to the default prompt. Ignored if `when` returns a custom question. */
+  hint?: string;
+  /** Skip the feature with a reason or ask to install it. Defaults to ask. */
+  when?: (ctx: FeatureWhenContext<TOptions>) => MaybePromise<WhenResult>;
   targetRoot?: FeatureTargetRoot<TOptions>;
   scope?: FeatureScope<TOptions>;
   dependencies?: DependencyDeclaration[];

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -20,6 +20,35 @@
 
 import { SonarQubeClient } from '../../../../sonarqube/client';
 import { warn } from '../../../../ui';
+import type { WhenResult } from './registry/types';
+
+export interface SqaaFeatureOptions {
+  serverURL?: string;
+  token?: string;
+  organization?: string;
+  projectKey?: string;
+}
+
+/**
+ * Shared `when` condition for the agentic analysis (SQAA) feature across agent
+ * integrations: skip when connection/project context is missing, then ask or
+ * skip based on the org's SQAA entitlement.
+ */
+export async function resolveSqaaFeatureCondition(
+  options: SqaaFeatureOptions,
+): Promise<WhenResult> {
+  if (!options.serverURL || !options.token || !options.projectKey) {
+    return { kind: 'skip' };
+  }
+  const entitled = await resolveSqaaEntitlement(
+    options.serverURL,
+    options.token,
+    options.organization,
+  );
+  return entitled
+    ? { kind: 'ask' }
+    : { kind: 'skip', reason: 'Agentic Analysis available on SonarQube Cloud' };
+}
 
 /**
  * Check if the organization has SonarQube Agentic Analysis (SQAA) entitlement.

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -28,8 +28,9 @@ import {
   resolveAgentHookScriptPath,
   upsertAgentHooks,
 } from '../_common/hooks';
-import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
-import { jsonPatch, wholeFile } from '../_common/registry';
+import { jsonPatch, wholeFile } from '../_common/registry/resources';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
+import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import {
   getSecretPreToolTemplateUnix,
@@ -49,61 +50,74 @@ export const CLAUDE_INTEGRATION_ID = 'claude-code';
 
 export interface ClaudeIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
-  installSecretsHooks?: boolean;
-  installSqaaHook?: boolean;
-  installMcp?: boolean;
+  serverURL?: string;
+  token?: string;
+  organization?: string;
+  projectKey?: string;
 }
 
 export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions> = {
   id: CLAUDE_INTEGRATION_ID,
   displayName: 'Claude Code',
   features: [
-    {
-      ...createSonarSecretsHooksFeature({
-        agentDisplayName: 'Claude',
-        configDir: CLAUDE_CONFIG_DIR,
-        hooksConfigFileName: SETTINGS_FILE,
-        hooksPatchId: 'claude-settings-secrets-hooks',
-        scripts: [
-          {
-            id: 'pretool-secrets-script',
-            displayName: 'Claude PreToolUse hook script',
-            scriptPath: PRETOOL_SCRIPT_REL,
-            content: {
-              unix: getSecretPreToolTemplateUnix(),
-              windows: getSecretPreToolTemplateWindows(),
-            },
+    createSonarSecretsHooksFeature({
+      integrationId: CLAUDE_INTEGRATION_ID,
+      agentDisplayName: 'Claude',
+      configDir: CLAUDE_CONFIG_DIR,
+      hooksConfigFileName: SETTINGS_FILE,
+      hooksPatchId: 'claude-settings-secrets-hooks',
+      scripts: [
+        {
+          id: 'pretool-secrets-script',
+          displayName: 'Claude PreToolUse hook script',
+          scriptPath: PRETOOL_SCRIPT_REL,
+          content: {
+            unix: getSecretPreToolTemplateUnix(),
+            windows: getSecretPreToolTemplateWindows(),
           },
-          {
-            id: 'prompt-secrets-script',
-            displayName: 'Claude UserPromptSubmit hook script',
-            scriptPath: PROMPT_SCRIPT_REL,
-            content: {
-              unix: getSecretPromptTemplateUnix(),
-              windows: getSecretPromptTemplateWindows(),
-            },
+        },
+        {
+          id: 'prompt-secrets-script',
+          displayName: 'Claude UserPromptSubmit hook script',
+          scriptPath: PROMPT_SCRIPT_REL,
+          content: {
+            unix: getSecretPromptTemplateUnix(),
+            windows: getSecretPromptTemplateWindows(),
           },
-        ],
-        hookEntries: [
-          {
-            eventType: 'PreToolUse',
-            matcher: 'Read',
-            marker: 'sonar-secrets',
-            scriptPath: PRETOOL_SCRIPT_REL,
-          },
-          {
-            eventType: 'UserPromptSubmit',
-            matcher: '*',
-            marker: 'sonar-secrets',
-            scriptPath: PROMPT_SCRIPT_REL,
-          },
-        ],
-      }),
-    },
+        },
+      ],
+      hookEntries: [
+        {
+          eventType: 'PreToolUse',
+          matcher: 'Read',
+          marker: 'sonar-secrets',
+          scriptPath: PRETOOL_SCRIPT_REL,
+        },
+        {
+          eventType: 'UserPromptSubmit',
+          matcher: '*',
+          marker: 'sonar-secrets',
+          scriptPath: PROMPT_SCRIPT_REL,
+        },
+      ],
+    }),
     {
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
-      when: ({ options }) => options.installSqaaHook === true,
+      hint: 'guides Claude to fix issues found by SonarQube Agentic Analysis',
+      when: async ({ options }) => {
+        if (!options.serverURL || !options.token || !options.projectKey) {
+          return { kind: 'skip' };
+        }
+        const entitled = await resolveSqaaEntitlement(
+          options.serverURL,
+          options.token,
+          options.organization,
+        );
+        return entitled
+          ? { kind: 'ask' }
+          : { kind: 'skip', reason: 'Agentic Analysis available on SonarQube Cloud' };
+      },
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [
@@ -146,7 +160,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      when: ({ options }) => options.installMcp === true,
+      hint: 'gives Claude access to SonarQube data',
       resources: [
         jsonPatch({
           id: 'claude-mcp-config',

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -103,8 +103,8 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     }),
     {
       id: 'sonar-sqaa-hook',
-      displayName: 'SonarQube Agentic Analysis hook',
-      hint: 'guides Claude to fix issues found by SonarQube Agentic Analysis',
+      displayName: 'agentic analysis',
+      hint: 'on-demand analysis',
       when: async ({ options }) => {
         if (!options.serverURL || !options.token || !options.projectKey) {
           return { kind: 'skip' };
@@ -159,7 +159,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     },
     {
       id: 'mcp-server',
-      displayName: 'MCP server',
+      displayName: 'MCP Server',
       hint: 'gives Claude access to SonarQube data',
       resources: [
         jsonPatch({

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -30,7 +30,7 @@ import {
 } from '../_common/hooks';
 import { jsonPatch, wholeFile } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
+import { resolveSqaaFeatureCondition } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import {
   getSecretPreToolTemplateUnix,
@@ -105,19 +105,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
       id: 'sonar-sqaa-hook',
       displayName: 'agentic analysis',
       hint: 'on-demand analysis',
-      when: async ({ options }) => {
-        if (!options.serverURL || !options.token || !options.projectKey) {
-          return { kind: 'skip' };
-        }
-        const entitled = await resolveSqaaEntitlement(
-          options.serverURL,
-          options.token,
-          options.organization,
-        );
-        return entitled
-          ? { kind: 'ask' }
-          : { kind: 'skip', reason: 'Agentic Analysis available on SonarQube Cloud' };
-      },
+      when: ({ options }) => resolveSqaaFeatureCondition(options),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -123,9 +123,10 @@ export async function integrateClaude(
     options: {
       ...options,
       projectRoot: project.rootDir,
-      installSecretsHooks: !skipSecretsHooks,
-      installSqaaHook: sqaaEnabled && config.projectKey !== undefined,
-      installMcp: true,
+      serverURL: config.serverURL,
+      token,
+      organization: config.organization,
+      projectKey: config.projectKey,
     },
     targetRoot: installRoot,
     scope: installScope,

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -131,6 +131,7 @@ export async function integrateClaude(
     targetRoot: installRoot,
     scope: installScope,
     attrs: featureAttrs,
+    nonInteractive: options.nonInteractive,
   });
   await removeObsoleteHookArtifacts(project.rootDir, OBSOLETE_A3S_MARKER);
   await updateStateAfterConfiguration(config, project.rootDir, isGlobal, sqaaEnabled, {

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -22,12 +22,24 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { CommandFailedError } from '../../_common/error';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
-import { tomlPatch, wholeFile } from '../_common/registry/resources';
+import {
+  buildSqaaBody,
+  SQAA_END_MARKER,
+  SQAA_START_MARKER,
+} from '../_common/instructions-templates';
+import { isFeatureInstalled } from '../_common/registry/installer';
+import { textSnippet, tomlPatch } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
+import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPromptTemplateUnix, getSecretPromptTemplateWindows } from './hook-templates';
-import { buildAgentsMdContent } from './instructions-templates';
+import {
+  CODEX_SECRETS_BODY,
+  CODEX_SECRETS_END_MARKER,
+  CODEX_SECRETS_START_MARKER,
+} from './instructions-templates';
 
 const CODEX_CONFIG_DIR = '.codex';
 const HOOKS_FILE = 'hooks.json';
@@ -37,12 +49,10 @@ const PROMPT_SCRIPT_REL = 'sonar-secrets/build-scripts/prompt-secrets';
 export const CODEX_INTEGRATION_ID = 'codex';
 
 export interface CodexIntegrationOptions extends IntegrateAgentOptions {
-  installSecretsHooks?: boolean;
-  /** Render the pre-tool secrets-on-read section into `.codex/AGENTS.md`. */
-  installSecretsInstructions?: boolean;
-  /** Render the post-tool SQAA section into `.codex/AGENTS.md`. */
-  installSqaaInstructions?: boolean;
-  installMcp?: boolean;
+  projectRoot?: string;
+  serverURL?: string;
+  token?: string;
+  organization?: string;
 }
 
 export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> = {
@@ -50,6 +60,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
   displayName: 'Codex',
   features: [
     createSonarSecretsHooksFeature({
+      integrationId: CODEX_INTEGRATION_ID,
       agentDisplayName: 'Codex',
       configDir: CODEX_CONFIG_DIR,
       hooksConfigFileName: HOOKS_FILE,
@@ -75,32 +86,70 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       ],
     }),
     {
-      id: 'agents-md-instructions',
-      displayName: 'Codex AGENTS.md instructions',
-      // Fires whenever at least one section is enabled. Each section's
-      // inclusion is then decided from attrs by the content function, so the
-      // two flags act as independent toggles even though both sections share
-      // a single file.
-      when: ({ options }) =>
-        options.installSecretsInstructions === true || options.installSqaaInstructions === true,
+      id: 'secrets-instructions',
+      displayName: 'Codex secrets-on-read instructions',
+      hint: 'tells Codex to scan files for secrets before reading',
+      when: ({ scope, state }) => {
+        if (scope === 'global') return { kind: 'ask' };
+        const globalExists = isFeatureInstalled(
+          state,
+          CODEX_INTEGRATION_ID,
+          'secrets-instructions',
+          'global',
+        );
+        return globalExists
+          ? {
+              kind: 'ask',
+              question:
+                'Global Codex instructions already exist. Also create a project-local copy?',
+            }
+          : { kind: 'ask' };
+      },
       resources: [
-        wholeFile({
-          id: 'codex-agents-md',
-          displayName: 'Codex AGENTS.md',
+        textSnippet({
+          id: 'codex-secrets-instructions-file',
+          displayName: 'Codex secrets-on-read instructions',
           targetPath: resolveCodexAgentsMdPath,
-          content: (context) =>
-            buildAgentsMdContent({
-              includeSecrets: getOptionalBoolAttr(context, 'includeSecretsSection'),
-              includeSqaa: getOptionalBoolAttr(context, 'includeSqaa'),
-              projectKey: getOptionalStringAttr(context, 'projectKey'),
-            }),
+          content: CODEX_SECRETS_BODY,
+          startMarker: CODEX_SECRETS_START_MARKER,
+          endMarker: CODEX_SECRETS_END_MARKER,
+        }),
+      ],
+    },
+    {
+      id: 'sqaa-instructions',
+      displayName: 'SonarQube Agentic Analysis instructions',
+      hint: 'guides Codex to fix issues found by SonarQube Agentic Analysis',
+      when: async ({ options }) => {
+        if (!options.serverURL || !options.token) {
+          return { kind: 'skip' };
+        }
+        const entitled = await resolveSqaaEntitlement(
+          options.serverURL,
+          options.token,
+          options.organization,
+        );
+        return entitled
+          ? { kind: 'ask' }
+          : { kind: 'skip', reason: 'Agentic Analysis available on SonarQube Cloud' };
+      },
+      targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
+      scope: 'project',
+      resources: [
+        textSnippet({
+          id: 'codex-sqaa-instructions-file',
+          displayName: 'Codex SQAA instructions',
+          targetPath: resolveCodexAgentsMdPath,
+          content: (context) => buildSqaaBody(getRequiredStringAttr(context, 'projectKey')),
+          startMarker: SQAA_START_MARKER,
+          endMarker: SQAA_END_MARKER,
         }),
       ],
     },
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      when: ({ options }) => options.installMcp === true,
+      hint: 'gives Codex access to SonarQube data',
       resources: [
         tomlPatch({
           id: 'codex-mcp-config',
@@ -160,6 +209,10 @@ function getOptionalStringAttr(context: IntegrationContext, key: string): string
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
-function getOptionalBoolAttr(context: IntegrationContext, key: string): boolean {
-  return context.attrs?.[key] === true;
+function getRequiredStringAttr(context: IntegrationContext, key: string): string {
+  const value = getOptionalStringAttr(context, key);
+  if (!value) {
+    throw new CommandFailedError(`Missing required integration attribute: ${key}`);
+  }
+  return value;
 }

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -32,7 +32,7 @@ import {
 import { isFeatureInstalled } from '../_common/registry/installer';
 import { textSnippet, tomlPatch } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
+import { resolveSqaaFeatureCondition } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPromptTemplateUnix, getSecretPromptTemplateWindows } from './hook-templates';
 import {
@@ -121,19 +121,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       id: 'sqaa-instructions',
       displayName: 'agentic analysis',
       hint: 'on-demand analysis',
-      when: async ({ options }) => {
-        if (!options.serverURL || !options.token || !options.projectKey) {
-          return { kind: 'skip' };
-        }
-        const entitled = await resolveSqaaEntitlement(
-          options.serverURL,
-          options.token,
-          options.organization,
-        );
-        return entitled
-          ? { kind: 'ask' }
-          : { kind: 'skip', reason: 'Agentic Analysis available on SonarQube Cloud' };
-      },
+      when: ({ options }) => resolveSqaaFeatureCondition(options),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -53,6 +53,7 @@ export interface CodexIntegrationOptions extends IntegrateAgentOptions {
   serverURL?: string;
   token?: string;
   organization?: string;
+  projectKey?: string;
 }
 
 export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> = {
@@ -121,7 +122,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       displayName: 'SonarQube Agentic Analysis instructions',
       hint: 'guides Codex to fix issues found by SonarQube Agentic Analysis',
       when: async ({ options }) => {
-        if (!options.serverURL || !options.token) {
+        if (!options.serverURL || !options.token || !options.projectKey) {
           return { kind: 'skip' };
         }
         const entitled = await resolveSqaaEntitlement(

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -119,8 +119,8 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     },
     {
       id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis instructions',
-      hint: 'guides Codex to fix issues found by SonarQube Agentic Analysis',
+      displayName: 'agentic analysis',
+      hint: 'on-demand analysis',
       when: async ({ options }) => {
         if (!options.serverURL || !options.token || !options.projectKey) {
           return { kind: 'skip' };
@@ -149,7 +149,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     },
     {
       id: 'mcp-server',
-      displayName: 'MCP server',
+      displayName: 'MCP Server',
       hint: 'gives Codex access to SonarQube data',
       resources: [
         tomlPatch({

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -62,6 +62,7 @@ export async function integrateCodex(
     serverURL: auth.serverUrl,
     token: auth.token,
     organization: auth.orgKey,
+    projectKey: projectKey ?? undefined,
   };
 
   await installIntegration({

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -24,14 +24,13 @@ import { homedir } from 'node:os';
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
-import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
+import type { IntegrationScope } from '../../../../lib/state';
 import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
-import { CODEX_INTEGRATION_ID } from './declaration';
+import { CODEX_INTEGRATION_ID, type CodexIntegrationOptions } from './declaration';
 
 export async function integrateCodex(
   options: IntegrateAgentOptions,
@@ -54,35 +53,24 @@ export async function integrateCodex(
     );
   }
 
-  // SQAA is always project-scoped:
-  //  - project install: include the SQAA section if the org is entitled AND
-  //    we know a project key.
-  //  - global install: don't write SQAA anywhere, but if the org is entitled
-  //    surface a hint pointing the user at the per-project command. We skip
-  //    the warning for unentitled orgs to avoid noise about a feature they
-  //    cannot use.
-  const sqaaEligible = await resolveSqaaEntitlement(auth.serverUrl, auth.token, auth.orgKey);
-  const includeSqaa = !isGlobal && sqaaEligible && Boolean(projectKey);
-
   const installRoot = isGlobal ? homedir() : project.rootDir;
   const installScope: IntegrationScope = isGlobal ? 'global' : 'project';
 
+  const integrationOptions: CodexIntegrationOptions = {
+    ...options,
+    projectRoot: project.rootDir,
+    serverURL: auth.serverUrl,
+    token: auth.token,
+    organization: auth.orgKey,
+  };
+
   await installIntegration({
     integrationId: CODEX_INTEGRATION_ID,
-    options: {
-      ...options,
-      installSecretsHooks: true,
-      installSecretsInstructions: true,
-      installSqaaInstructions: includeSqaa,
-      installMcp: true,
-    },
+    options: integrationOptions,
     targetRoot: installRoot,
     scope: installScope,
-    attrs: buildAttrs({
-      includeSecretsSection: true,
-      projectKey,
-      includeSqaa,
-    }),
+    attrs: { projectKey: projectKey ?? null },
+    nonInteractive: options.nonInteractive,
   });
 
   if (!options.skipContext) {
@@ -97,24 +85,7 @@ export async function integrateCodex(
 
   if (isGlobal) {
     success('Codex integration successfully configured globally');
-    if (sqaaEligible) {
-      warn(
-        'SonarQube Agentic Analysis is project-scoped and is not enabled by this global install. Run `sonar integrate codex --project <key>` from a project directory to enable it for that project.',
-      );
-    }
   } else {
     success('Codex integration successfully configured at the project level');
   }
-}
-
-function buildAttrs(args: {
-  includeSecretsSection: boolean;
-  projectKey: string | undefined;
-  includeSqaa: boolean;
-}): Record<string, IntegrationStateAttribute> {
-  return {
-    includeSecretsSection: args.includeSecretsSection,
-    projectKey: args.projectKey ?? null,
-    includeSqaa: args.includeSqaa,
-  };
 }

--- a/src/cli/commands/integrate/codex/instructions-templates.ts
+++ b/src/cli/commands/integrate/codex/instructions-templates.ts
@@ -18,16 +18,17 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Markdown sections rendered into `.codex/AGENTS.md`. The file is CLI-owned;
-// each run overwrites the whole document with the composition of the
-// applicable sections. The SQAA section is shared with the Copilot
-// integration so the wording stays consistent across agents.
+// Markdown sections rendered into `.codex/AGENTS.md`. Each section is wrapped
+// by its own sonar:begin/end markers so the secrets and SQAA features can be
+// installed independently and coexist in the same file. The SQAA section is
+// shared with the Copilot integration so the wording stays consistent across
+// agents.
 
-import { buildSqaaSection, withSonarMarkers } from '../_common/instructions-templates';
+export const CODEX_SECRETS_MARKER_ID = 'codex-secrets-on-read';
+export const CODEX_SECRETS_START_MARKER = `<!-- sonar:begin:${CODEX_SECRETS_MARKER_ID} -->`;
+export const CODEX_SECRETS_END_MARKER = `<!-- sonar:end:${CODEX_SECRETS_MARKER_ID} -->`;
 
-const SECRETS_ON_READ_SECTION = withSonarMarkers(
-  'codex-secrets-on-read',
-  `# SonarQube secrets scanning for files protocol
+export const CODEX_SECRETS_BODY = `# SonarQube secrets scanning for files protocol
 
 Before reading any file in this workspace, scan it for secrets with the deterministic scanner:
 
@@ -40,22 +41,4 @@ If the command reports that the file contains a secret, **do not read the file**
 1. Inform the user that the file appears to contain a secret or credential and that reading it would expose the value in chat history, logs, and any downstream telemetry.
 2. Advise them to rotate the leaked credential at its source of truth and remove it from the file.
 3. Do not proceed with the original request until the secret has been removed.
-`,
-);
-
-export interface AgentsMdSections {
-  includeSecrets: boolean;
-  includeSqaa: boolean;
-  projectKey?: string;
-}
-
-export function buildAgentsMdContent(sections: AgentsMdSections): string {
-  const parts: string[] = [];
-  if (sections.includeSecrets) {
-    parts.push(SECRETS_ON_READ_SECTION);
-  }
-  if (sections.includeSqaa && sections.projectKey) {
-    parts.push(buildSqaaSection(sections.projectKey));
-  }
-  return `${parts.join('\n').trimEnd()}\n`;
-}
+`;

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -32,7 +32,7 @@ import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
 import { isFeatureInstalled } from '../_common/registry/installer';
 import { jsonPatch, textSnippet, wholeFile } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
+import { resolveSqaaFeatureCondition } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
 import {
@@ -133,17 +133,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       id: 'sqaa-instructions',
       displayName: 'agentic analysis',
       hint: 'on-demand analysis',
-      when: async ({ options }) => {
-        if (!options.serverURL || !options.token || !options.projectKey) return { kind: 'skip' };
-        const entitled = await resolveSqaaEntitlement(
-          options.serverURL,
-          options.token,
-          options.organization,
-        );
-        return entitled
-          ? { kind: 'ask' }
-          : { kind: 'skip', reason: 'Agentic Analysis available on SonarQube Cloud' };
-      },
+      when: ({ options }) => resolveSqaaFeatureCondition(options),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -60,6 +60,7 @@ export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   serverURL?: string;
   token?: string;
   organization?: string;
+  projectKey?: string;
 }
 
 export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOptions> = {
@@ -133,7 +134,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       displayName: 'SonarQube Agentic Analysis instructions',
       hint: 'guides Copilot to fix issues found by SonarQube Agentic Analysis',
       when: async ({ options }) => {
-        if (!options.serverURL || !options.token) return { kind: 'skip' };
+        if (!options.serverURL || !options.token || !options.projectKey) return { kind: 'skip' };
         const entitled = await resolveSqaaEntitlement(
           options.serverURL,
           options.token,

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -131,8 +131,8 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     },
     {
       id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis instructions',
-      hint: 'guides Copilot to fix issues found by SonarQube Agentic Analysis',
+      displayName: 'agentic analysis',
+      hint: 'on-demand analysis',
       when: async ({ options }) => {
         if (!options.serverURL || !options.token || !options.projectKey) return { kind: 'skip' };
         const entitled = await resolveSqaaEntitlement(
@@ -159,7 +159,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     },
     {
       id: 'mcp-server',
-      displayName: 'MCP server',
+      displayName: 'MCP Server',
       hint: 'gives Copilot access to SonarQube data',
       resources: [
         jsonPatch({

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -23,9 +23,16 @@ import { join, relative } from 'node:path';
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { CommandFailedError } from '../../_common/error';
+import {
+  buildSqaaBody,
+  SQAA_END_MARKER,
+  SQAA_START_MARKER,
+} from '../_common/instructions-templates';
 import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
-import { jsonPatch, wholeFile } from '../_common/registry/resources';
+import { isFeatureInstalled } from '../_common/registry/installer';
+import { jsonPatch, textSnippet, wholeFile } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
+import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
 import {
@@ -39,20 +46,20 @@ import {
   SCRIPT_REL_DIR,
 } from './hooks';
 import {
-  buildInstructionsBody,
-  buildSqaaInstructionsBody,
   INSTRUCTIONS_FILENAME,
   PROJECT_INSTRUCTIONS_REL_DIR,
+  PROMPT_SECRETS_BODY,
+  PROMPT_SECRETS_END_MARKER,
+  PROMPT_SECRETS_START_MARKER,
 } from './instructions';
 
 export const COPILOT_INTEGRATION_ID = 'copilot-cli';
 
 export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
-  installHook?: boolean;
-  installInstructions?: boolean;
-  installSqaaInstructions?: boolean;
-  installMcp?: boolean;
+  serverURL?: string;
+  token?: string;
+  organization?: string;
 }
 
 export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOptions> = {
@@ -62,7 +69,13 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'pre-tool-use-hook',
       displayName: 'pre-tool-use hook',
-      when: ({ options }) => options.installHook === true,
+      hint: 'blocks Copilot from running commands that leak secrets',
+      when: ({ scope, state }) => {
+        if (scope === 'global') return { kind: 'ask' };
+        return isFeatureInstalled(state, COPILOT_INTEGRATION_ID, 'pre-tool-use-hook', 'global')
+          ? { kind: 'skip', reason: 'global hook already covers this' }
+          : { kind: 'ask' };
+      },
       dependencies: [sonarSecretsBinaryDependency],
       resources: [
         wholeFile({
@@ -87,39 +100,66 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'prompt-secrets-instructions',
       displayName: 'prompt-secrets instructions',
-      when: ({ options }) => options.installInstructions === true,
+      hint: 'tells Copilot to avoid emitting secrets in prompts',
+      when: ({ scope, state }) => {
+        if (scope === 'global') return { kind: 'ask' };
+        const globalExists = isFeatureInstalled(
+          state,
+          COPILOT_INTEGRATION_ID,
+          'prompt-secrets-instructions',
+          'global',
+        );
+        return globalExists
+          ? {
+              kind: 'ask',
+              question:
+                'Global Copilot instructions already exist. Also create a project-local copy?',
+            }
+          : { kind: 'ask' };
+      },
       resources: [
-        wholeFile({
+        textSnippet({
           id: 'prompt-secrets-instructions-file',
           displayName: 'Copilot prompt-secrets instructions',
           targetPath: resolveInstructionsPath,
-          content: (context) =>
-            context.scope === 'project' && getBooleanAttr(context, 'sqaaEnabled')
-              ? buildInstructionsBody(getRequiredStringAttr(context, 'projectKey'))
-              : buildInstructionsBody(),
+          content: PROMPT_SECRETS_BODY,
+          startMarker: PROMPT_SECRETS_START_MARKER,
+          endMarker: PROMPT_SECRETS_END_MARKER,
         }),
       ],
     },
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      when: ({ options, scope }) => scope === 'global' && options.installSqaaInstructions === true,
+      hint: 'guides Copilot to fix issues found by SonarQube Agentic Analysis',
+      when: async ({ options }) => {
+        if (!options.serverURL || !options.token) return { kind: 'skip' };
+        const entitled = await resolveSqaaEntitlement(
+          options.serverURL,
+          options.token,
+          options.organization,
+        );
+        return entitled
+          ? { kind: 'ask' }
+          : { kind: 'skip', reason: 'Agentic Analysis available on SonarQube Cloud' };
+      },
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [
-        wholeFile({
+        textSnippet({
           id: 'sqaa-instructions-file',
           displayName: 'Copilot SQAA instructions',
           targetPath: resolveInstructionsPath,
-          content: (context) =>
-            buildSqaaInstructionsBody(getRequiredStringAttr(context, 'projectKey')),
+          content: (context) => buildSqaaBody(getRequiredStringAttr(context, 'projectKey')),
+          startMarker: SQAA_START_MARKER,
+          endMarker: SQAA_END_MARKER,
         }),
       ],
     },
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      when: ({ options }) => options.installMcp === true,
+      hint: 'gives Copilot access to SonarQube data',
       resources: [
         jsonPatch({
           id: 'copilot-mcp-config',
@@ -237,10 +277,6 @@ function getRequiredStringAttr(context: IntegrationContext, key: string): string
     throw new CommandFailedError(`Missing required integration attribute: ${key}`);
   }
   return value;
-}
-
-function getBooleanAttr(context: IntegrationContext, key: string): boolean {
-  return context.attrs?.[key] === true;
 }
 
 function toJsonObject(document: unknown): Record<string, unknown> {

--- a/src/cli/commands/integrate/copilot/hooks.ts
+++ b/src/cli/commands/integrate/copilot/hooks.ts
@@ -18,12 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { info, warn } from '../../../../ui';
-import { readOrInitJson, SONAR_SECRETS_MARKER } from '../_common/hooks';
+import { SONAR_SECRETS_MARKER } from '../_common/hooks';
 
 export const SCRIPT_REL_DIR = join(SONAR_SECRETS_MARKER, 'build-scripts');
 export const SCRIPT_BASENAME = 'pretool-secrets';
@@ -31,7 +28,6 @@ export const HOOKS_JSON = 'hooks.json';
 export const HOOK_TIMEOUT_SEC = 60;
 
 export const PROJECT_HOOKS_REL_DIR = join('.github', 'hooks');
-export const GLOBAL_HOOKS_DIR = join(homedir(), '.copilot', 'hooks');
 
 export interface HookCommandEntry {
   type: 'command';
@@ -47,41 +43,6 @@ export interface HooksJson {
     preToolUse?: HookCommandEntry[];
     [eventType: string]: HookCommandEntry[] | undefined;
   };
-}
-
-/**
- * Probe `~/.copilot/hooks` for an existing global sonar-secrets pre-tool-use
- * hook. Returns the path of the active hook script when a healthy global
- * install is found (caller should skip project-level install to avoid
- * double-scanning), and `undefined` otherwise.
- *
- *  - Healthy global install → `info(...)` and return the script path.
- *  - Orphaned install (`hooks.json` references sonar-secrets but the backing
- *    script is missing) → `warn(...)` and return `undefined`.
- *  - No global install → silent, return `undefined`.
- */
-export async function detectGlobalSecretsHook(): Promise<string | undefined> {
-  const hooksJsonPath = join(GLOBAL_HOOKS_DIR, HOOKS_JSON);
-  if (!existsSync(hooksJsonPath)) return undefined;
-  const parsed = await readOrInitJson<HooksJson>(hooksJsonPath, { version: 1, hooks: {} });
-  const entries = parsed.hooks?.preToolUse;
-  const matchedEntry = Array.isArray(entries)
-    ? entries.find((e) => entryReferencesSonarSecrets(e))
-    : undefined;
-  if (!matchedEntry) return undefined;
-
-  const scriptPath = matchedEntry.bash ?? matchedEntry.powershell;
-  if (!scriptPath || !existsSync(scriptPath)) {
-    warn(
-      `Global hook configuration detected at ${hooksJsonPath} but the backing script is missing. Falling back to project-level installation.`,
-    );
-    return undefined;
-  }
-
-  info(
-    `A global secrets scanning hook is already configured at ${scriptPath}. Skipping project-level hook to avoid duplicate execution.`,
-  );
-  return scriptPath;
 }
 
 export function entryReferencesSonarSecrets(entry: HookCommandEntry): boolean {

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -23,25 +23,15 @@ import { join } from 'node:path';
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
-import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
+import type { IntegrationScope } from '../../../../lib/state';
 import { intro, success, warn } from '../../../../ui';
 import { InvalidOptionError } from '../../_common/error';
 import { setupContextAugmentation } from '../_common/context-augmentation';
 import { installIntegration } from '../_common/registry';
-import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { COPILOT_INTEGRATION_ID, type CopilotIntegrationOptions } from './declaration';
-import {
-  detectGlobalSecretsHook,
-  hookScriptName,
-  PROJECT_HOOKS_REL_DIR,
-  SCRIPT_REL_DIR,
-} from './hooks';
-import {
-  INSTRUCTIONS_FILENAME,
-  PROJECT_INSTRUCTIONS_REL_DIR,
-  warnIfProjectInstructionsShadowGlobal,
-} from './instructions';
+import { hookScriptName, PROJECT_HOOKS_REL_DIR, SCRIPT_REL_DIR } from './hooks';
+import { INSTRUCTIONS_FILENAME, PROJECT_INSTRUCTIONS_REL_DIR } from './instructions';
 
 export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAgentOptions) {
   if (options.global && options.project) {
@@ -61,33 +51,27 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     );
   }
 
-  const entitled = await resolveSqaaEntitlement(auth.serverUrl, auth.token, auth.orgKey);
-  const sqaaProjectKey = entitled && projectKey ? projectKey : undefined;
-
   const targetRoot = isGlobal ? homedir() : project.rootDir;
   const scope: IntegrationScope = isGlobal ? 'global' : 'project';
-  const existingGlobalHookPath = isGlobal ? undefined : await detectGlobalSecretsHook();
-  const installHook = existingGlobalHookPath === undefined;
-  if (!isGlobal) {
-    warnIfProjectInstructionsShadowGlobal();
-  }
 
   const integrationOptions: CopilotIntegrationOptions = {
     ...options,
     projectRoot: project.rootDir,
-    installHook,
-    installInstructions: true,
-    installSqaaInstructions: sqaaProjectKey !== undefined,
-    installMcp: true,
+    serverURL: auth.serverUrl,
+    token: auth.token,
+    organization: auth.orgKey,
   };
 
-  await installIntegration({
+  const installed = await installIntegration({
     integrationId: COPILOT_INTEGRATION_ID,
     options: integrationOptions,
     targetRoot,
     scope,
-    attrs: buildIntegrationAttrs(projectKey, sqaaProjectKey !== undefined),
+    attrs: { projectKey: projectKey ?? null },
+    nonInteractive: options.nonInteractive,
   });
+
+  const sqaaInstalled = installed.some((feature) => feature.featureId === 'sqaa-instructions');
 
   if (!options.skipContext) {
     await setupContextAugmentation({
@@ -101,10 +85,9 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
 
   reportInstallationOutcome({
     isGlobal,
-    hookPath: existingGlobalHookPath ?? expectedHookPath(targetRoot, scope),
+    hookPath: expectedHookPath(targetRoot, scope),
     promptInstructionsPath: expectedPromptInstructionsPath(targetRoot, scope),
-    sqaaInstructionsPath:
-      sqaaProjectKey === undefined ? undefined : expectedSqaaInstructionsPath(project.rootDir),
+    sqaaInstructionsPath: sqaaInstalled ? expectedSqaaInstructionsPath(project.rootDir) : undefined,
   });
 }
 
@@ -156,16 +139,6 @@ function expectedPromptInstructionsPath(targetRoot: string, scope: IntegrationSc
   return scope === 'global'
     ? join(targetRoot, '.copilot', 'instructions', INSTRUCTIONS_FILENAME)
     : expectedSqaaInstructionsPath(targetRoot);
-}
-
-function buildIntegrationAttrs(
-  projectKey: string | undefined,
-  sqaaEnabled: boolean,
-): Record<string, IntegrationStateAttribute> {
-  return {
-    projectKey: projectKey ?? null,
-    sqaaEnabled,
-  };
 }
 
 function expectedSqaaInstructionsPath(projectRoot: string): string {

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -60,6 +60,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     serverURL: auth.serverUrl,
     token: auth.token,
     organization: auth.orgKey,
+    projectKey: projectKey ?? undefined,
   };
 
   const installed = await installIntegration({

--- a/src/cli/commands/integrate/copilot/instructions.ts
+++ b/src/cli/commands/integrate/copilot/instructions.ts
@@ -27,20 +27,16 @@
 // secret, and (b) direct the agent to run `sonar analyze agentic` at
 // end-of-turn for files modified in that turn.
 
-import { existsSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
-
-import { warn } from '../../../../ui';
-import { buildSqaaSection, withSonarMarkers } from '../_common/instructions-templates';
 
 export const INSTRUCTIONS_FILENAME = 'sonarqube.instructions.md';
 export const PROJECT_INSTRUCTIONS_REL_DIR = join('.github', 'instructions');
-export const GLOBAL_INSTRUCTIONS_DIR = join(homedir(), '.copilot', 'instructions');
 
-const PROMPT_SECRETS_SECTION = withSonarMarkers(
-  'copilot-prompt-secrets',
-  `# SonarQube secrets scanning for prompts protocol
+export const PROMPT_SECRETS_MARKER_ID = 'copilot-prompt-secrets';
+export const PROMPT_SECRETS_START_MARKER = `<!-- sonar:begin:${PROMPT_SECRETS_MARKER_ID} -->`;
+export const PROMPT_SECRETS_END_MARKER = `<!-- sonar:end:${PROMPT_SECRETS_MARKER_ID} -->`;
+
+export const PROMPT_SECRETS_BODY = `# SonarQube secrets scanning for prompts protocol
 
 Before acting on any user prompt, scan the prompt text for secrets or credentials. Treat the following as secrets (non-exhaustive):
 
@@ -61,27 +57,4 @@ If the prompt appears to contain any such secret (either by your judgement or th
 
 1. Inform the user that their prompt appears to contain a secret or credential and that it may now be exposed in chat history, logs, and any downstream telemetry.
 2. Advise them to rotate the leaked credential immediately at its source of truth.
-`,
-);
-
-export function buildInstructionsBody(projectKey?: string): string {
-  const sections = [PROMPT_SECRETS_SECTION];
-  if (projectKey) {
-    sections.push(buildSqaaSection(projectKey));
-  }
-  return `${sections.join('\n\n').trimEnd()}\n`;
-}
-
-export function buildSqaaInstructionsBody(projectKey: string): string {
-  return `${buildSqaaSection(projectKey).trimEnd()}\n`;
-}
-
-export function warnIfProjectInstructionsShadowGlobal(): void {
-  const filePath = join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME);
-  if (!existsSync(filePath)) {
-    return;
-  }
-  warn(
-    `Found existing Copilot instructions at '${filePath}'; this run only updates the project-level file. Remove the existing one if it is no longer needed.`,
-  );
-}
+`;

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -27,8 +27,8 @@ import { join } from 'node:path';
 import { GLOBAL_HOOKS_DIR } from '../../../../lib/config-constants';
 import { normalizePath } from '../../../../lib/fs-utils';
 import { findGitRoot } from '../../../../lib/project-workspace';
-import { blank, confirmPrompt, info, intro, note, selectPrompt, text, warn } from '../../../../ui';
-import { CommandFailedError, InvalidOptionError } from '../../_common/error';
+import { blank, confirmPrompt, info, intro, note, text, warn } from '../../../../ui';
+import { CommandFailedError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
 import { installIntegration } from '../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from './options';
@@ -91,42 +91,6 @@ export async function detectSonarHookInstallation(root: string): Promise<HookIns
 // Shared interaction helpers
 // ---------------------------------------------------------------------------
 
-/** Rejects invalid `--hook` when it is set */
-export function validateHookOption(hook: string | undefined): void {
-  if (hook !== undefined && !isGitHookType(hook)) {
-    throw new InvalidOptionError('--hook must be pre-commit or pre-push');
-  }
-}
-
-/**
- * Validates and returns explicit `--hook`, or `pre-commit` when non-interactive with no hook, or prompts to select.
- */
-export async function resolveHookType(options: IntegrateGitOptions): Promise<GitHookType> {
-  if (options.hook !== undefined) {
-    return options.hook;
-  }
-  if (options.nonInteractive) {
-    return 'pre-commit';
-  }
-  const choice = await selectPrompt<GitHookType>(
-    'Would you like to install the pre-commit or pre-push hook?',
-    [
-      {
-        value: 'pre-commit' as const,
-        label: 'pre-commit (scan staged files)',
-      },
-      {
-        value: 'pre-push' as const,
-        label: 'pre-push (scan files in unpushed commits)',
-      },
-    ],
-  );
-  if (choice === null) {
-    throw new CommandFailedError('Installation cancelled');
-  }
-  return choice;
-}
-
 export function showPostInstallInfo(hook: GitHookType): void {
   blank();
   text(
@@ -175,8 +139,6 @@ export async function showInstallationStatus(root: string): Promise<void> {
 }
 
 async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
-  validateHookOption(options.hook);
-
   warn('Global hook installation');
   text('  Git prioritizes local repository settings over global ones.');
   text('  If a project has a local core.hooksPath set,');
@@ -197,18 +159,14 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   }
   blank();
 
-  const hook = await resolveHookType(options);
-  text(`Hook: ${hook}`);
-  blank();
-
-  await installGitFeatures({ ...options, hook }, GLOBAL_HOOKS_DIR, 'global');
-  showPostInstallInfo(hook);
-  showVerificationGuide(hook);
+  const hooks = await installGitFeatures(options, GLOBAL_HOOKS_DIR, 'global');
+  for (const hook of hooks) {
+    showPostInstallInfo(hook);
+    showVerificationGuide(hook);
+  }
 }
 
 export async function integrateGit(options: IntegrateGitOptions): Promise<void> {
-  validateHookOption(options.hook);
-
   intro('SonarQube Git integration (secrets scanning)');
   blank();
 
@@ -235,33 +193,31 @@ export async function integrateGit(options: IntegrateGitOptions): Promise<void> 
   }
   blank();
 
-  const hook = await resolveHookType(options);
-  text(`Hook: ${hook}`);
-  blank();
-
-  await installGitFeatures({ ...options, hook }, gitRoot, 'project');
-
-  showPostInstallInfo(hook);
+  const hooks = await installGitFeatures(options, gitRoot, 'project');
+  for (const hook of hooks) {
+    showPostInstallInfo(hook);
+  }
   await showInstallationStatus(gitRoot);
-  showVerificationGuide(hook);
+  for (const hook of hooks) {
+    showVerificationGuide(hook);
+  }
 }
 
 async function installGitFeatures(
-  options: IntegrateGitOptions & { hook: GitHookType },
+  options: IntegrateGitOptions,
   targetRoot: string,
   scope: 'project' | 'global',
-): Promise<void> {
+): Promise<GitHookType[]> {
   const integrationId = await resolveGitIntegrationId(targetRoot, scope);
-  await installIntegration({
+  const installed = await installIntegration({
     integrationId,
     options,
     targetRoot,
     scope,
     force: options.force,
-    attrs: {
-      hook: options.hook,
-    },
+    nonInteractive: options.nonInteractive,
   });
+  return installed.map((f) => f.featureId.replace('-hook', '') as GitHookType);
 }
 
 async function resolveGitIntegrationId(

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -28,7 +28,7 @@ import { GLOBAL_HOOKS_DIR } from '../../../../lib/config-constants';
 import { normalizePath } from '../../../../lib/fs-utils';
 import { findGitRoot } from '../../../../lib/project-workspace';
 import { blank, confirmPrompt, info, intro, note, text, warn } from '../../../../ui';
-import { CommandFailedError } from '../../_common/error';
+import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
 import { installIntegration } from '../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from './options';
@@ -45,6 +45,17 @@ export type { GitHookType, IntegrateGitOptions } from './options';
 export { installViaGitHooks } from './tools';
 
 type GitIntegrationId = 'native-git' | 'husky' | 'pre-commit';
+
+export function isGitHookType(s: string): s is GitHookType {
+  return s === 'pre-commit' || s === 'pre-push';
+}
+
+/** Rejects invalid `--hook` when it is set */
+export function validateHookOption(hook: string | undefined): void {
+  if (hook !== undefined && !isGitHookType(hook)) {
+    throw new InvalidOptionError('--hook must be pre-commit or pre-push');
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Hook detection
@@ -135,6 +146,8 @@ export async function showInstallationStatus(root: string): Promise<void> {
 }
 
 async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
+  validateHookOption(options.hook);
+
   warn('Global hook installation');
   text('  Git prioritizes local repository settings over global ones.');
   text('  If a project has a local core.hooksPath set,');
@@ -163,6 +176,8 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
 }
 
 export async function integrateGit(options: IntegrateGitOptions): Promise<void> {
+  validateHookOption(options.hook);
+
   intro('SonarQube Git integration (secrets scanning)');
   blank();
 

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -46,10 +46,6 @@ export { installViaGitHooks } from './tools';
 
 type GitIntegrationId = 'native-git' | 'husky' | 'pre-commit';
 
-export function isGitHookType(s: string): s is GitHookType {
-  return s === 'pre-commit' || s === 'pre-push';
-}
-
 // ---------------------------------------------------------------------------
 // Hook detection
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/integrate/git/options.ts
+++ b/src/cli/commands/integrate/git/options.ts
@@ -21,7 +21,6 @@
 export type GitHookType = 'pre-commit' | 'pre-push';
 
 export interface IntegrateGitOptions {
-  hook?: GitHookType;
   force?: boolean;
   nonInteractive?: boolean;
   global?: boolean;

--- a/src/cli/commands/integrate/git/options.ts
+++ b/src/cli/commands/integrate/git/options.ts
@@ -21,6 +21,7 @@
 export type GitHookType = 'pre-commit' | 'pre-push';
 
 export interface IntegrateGitOptions {
+  hook?: GitHookType;
   force?: boolean;
   nonInteractive?: boolean;
   global?: boolean;

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -24,7 +24,7 @@ import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependen
 import { textSnippet } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { HOOK_MARKER } from '../shared';
+import { gitHookWhen, HOOK_MARKER } from '../shared';
 import { getHuskySnippetContent } from './shell-fragments';
 
 export const HUSKY_INTEGRATION_ID = 'husky';
@@ -40,8 +40,7 @@ function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitO
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
     hint: hook === 'pre-commit' ? 'scan staged files' : 'scan files in unpushed commits',
-    when: ({ options }) =>
-      options.nonInteractive === true && hook !== 'pre-commit' ? { kind: 'skip' } : { kind: 'ask' },
+    when: gitHookWhen(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [
       textSnippet({

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -39,7 +39,9 @@ function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitO
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    when: ({ options }) => options.hook === hook,
+    hint: hook === 'pre-commit' ? 'scan staged files' : 'scan files in unpushed commits',
+    when: ({ options }) =>
+      options.nonInteractive === true && hook !== 'pre-commit' ? { kind: 'skip' } : { kind: 'ask' },
     dependencies: [sonarSecretsBinaryDependency],
     resources: [
       textSnippet({

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -24,6 +24,7 @@ import { CommandFailedError } from '../../../../_common/error';
 import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
+import { gitHookWhen } from '../shared';
 import { nativeGitHookResource } from './resource';
 
 export const NATIVE_GIT_INTEGRATION_ID = 'native-git';
@@ -41,8 +42,7 @@ function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<Integrate
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
     hint: hook === 'pre-commit' ? 'scan staged files' : 'scan files in unpushed commits',
-    when: ({ options }) =>
-      options.nonInteractive === true && hook !== 'pre-commit' ? { kind: 'skip' } : { kind: 'ask' },
+    when: gitHookWhen(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [
       nativeGitHookResource({

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -40,7 +40,9 @@ function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    when: ({ options }) => options.hook === hook,
+    hint: hook === 'pre-commit' ? 'scan staged files' : 'scan files in unpushed commits',
+    when: ({ options }) =>
+      options.nonInteractive === true && hook !== 'pre-commit' ? { kind: 'skip' } : { kind: 'ask' },
     dependencies: [sonarSecretsBinaryDependency],
     resources: [
       nativeGitHookResource({

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -24,6 +24,7 @@ import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependen
 import { yamlPatch } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
+import { gitHookWhen } from '../shared';
 import {
   activatePreCommitFramework,
   normalizePreCommitConfig,
@@ -45,8 +46,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
     hint: hook === 'pre-commit' ? 'scan staged files' : 'scan files in unpushed commits',
-    when: ({ options }) =>
-      options.nonInteractive === true && hook !== 'pre-commit' ? { kind: 'skip' } : { kind: 'ask' },
+    when: gitHookWhen(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [
       yamlPatch({

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -44,7 +44,9 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    when: ({ options }) => options.hook === hook,
+    hint: hook === 'pre-commit' ? 'scan staged files' : 'scan files in unpushed commits',
+    when: ({ options }) =>
+      options.nonInteractive === true && hook !== 'pre-commit' ? { kind: 'skip' } : { kind: 'ask' },
     dependencies: [sonarSecretsBinaryDependency],
     resources: [
       yamlPatch({

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -18,11 +18,28 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { GitHookType } from '../options';
+import type { FeatureWhenContext, WhenResult } from '../../_common/registry/types';
+import type { GitHookType, IntegrateGitOptions } from '../options';
 
 export const HOOK_MARKER = 'Sonar secrets scan - installed by sonar integrate git';
 export const SONAR_HOOK_SKIP_SECRETS_MESSAGE = 'sonarqube-cli not found, skipping secrets scan';
 
 export function resolveSonarHookCommand(hook: GitHookType): string {
   return hook === 'pre-commit' ? 'git-pre-commit' : 'git-pre-push';
+}
+
+/**
+ * Shared `when` gate for git hook features.
+ * - With `--hook`: auto-install the matching hook and skip the other (no prompt).
+ * - Without `--hook`: ask, except non-interactive defaults to pre-commit only.
+ */
+export function gitHookWhen(hook: GitHookType) {
+  return ({ options }: FeatureWhenContext<IntegrateGitOptions>): WhenResult => {
+    if (options.hook !== undefined) {
+      return options.hook === hook ? { kind: 'install' } : { kind: 'skip' };
+    }
+    return options.nonInteractive === true && hook !== 'pre-commit'
+      ? { kind: 'skip' }
+      : { kind: 'ask' };
+  };
 }

--- a/src/ui/components/prompts.ts
+++ b/src/ui/components/prompts.ts
@@ -59,10 +59,10 @@ export async function textPrompt(message: string): Promise<string | null> {
  */
 export async function confirmPrompt(
   message: string,
-  defaultValue: boolean,
+  initialValue = false,
 ): Promise<boolean | null> {
   if (isMockActive()) {
-    const value = dequeueMockResponse<boolean>(defaultValue);
+    const value = dequeueMockResponse<boolean>(initialValue);
     recordCall('confirmPrompt', message, value);
     return value;
   }
@@ -70,7 +70,7 @@ export async function confirmPrompt(
   const prompt = new ConfirmPrompt({
     active: 'Yes',
     inactive: 'No',
-    initialValue: defaultValue,
+    initialValue,
     render() {
       if (this.state === 'submit')
         return `  ${green('✓')}  ${message} ${dim(this.value ? 'Yes' : 'No')}`;

--- a/tests/integration/harness/cli-runner.ts
+++ b/tests/integration/harness/cli-runner.ts
@@ -94,12 +94,15 @@ export async function runCli(
     sink.end();
   }
 
+  // Pump stdin chunks concurrently (awaited after exit): with browserToken, stdout must stay
+  // drained and the loopback token deliverable while chunks feed the prompts that follow repair.
+  let stdinPump: Promise<void> | undefined;
   if (options.stdinChunks !== undefined && proc.stdin) {
     const sink = proc.stdin as { write(data: Uint8Array): void; end(): void };
     const encoder = new TextEncoder();
     // Write each chunk with a delay so readline in the CLI process finishes
     // handling one prompt before the next chunk arrives for the next prompt.
-    await (async () => {
+    stdinPump = (async () => {
       for (const chunk of options.stdinChunks ?? []) {
         await new Promise((r) => setTimeout(r, STDIN_CHUNK_DELAY_MS));
         sink.write(encoder.encode(chunk));
@@ -127,6 +130,7 @@ export async function runCli(
   }
 
   const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
+  await stdinPump?.catch(() => {});
 
   clearTimeout(timer);
 

--- a/tests/integration/harness/cli-runner.ts
+++ b/tests/integration/harness/cli-runner.ts
@@ -58,6 +58,7 @@ export async function runCli(
   options: {
     stdin?: string;
     stdinChunks?: string[];
+    deferStdinUntilBrowserAuth?: boolean;
     timeoutMs?: number;
     cwd: string;
     browserToken?: string;
@@ -94,15 +95,21 @@ export async function runCli(
     sink.end();
   }
 
+  let signalTokenDelivered: (() => void) | undefined;
+  const tokenDelivered = new Promise<void>((resolve) => {
+    signalTokenDelivered = resolve;
+  });
+
   // Pump stdin chunks concurrently (awaited after exit): with browserToken, stdout must stay
   // drained and the loopback token deliverable while chunks feed the prompts that follow repair.
   let stdinPump: Promise<void> | undefined;
   if (options.stdinChunks !== undefined && proc.stdin) {
     const sink = proc.stdin as { write(data: Uint8Array): void; end(): void };
     const encoder = new TextEncoder();
-    // Write each chunk with a delay so readline in the CLI process finishes
-    // handling one prompt before the next chunk arrives for the next prompt.
     stdinPump = (async () => {
+      if (options.deferStdinUntilBrowserAuth) await tokenDelivered;
+      // Write each chunk with a delay so readline in the CLI process finishes
+      // handling one prompt before the next chunk arrives for the next prompt.
       for (const chunk of options.stdinChunks ?? []) {
         await new Promise((r) => setTimeout(r, STDIN_CHUNK_DELAY_MS));
         sink.write(encoder.encode(chunk));
@@ -124,6 +131,7 @@ export async function runCli(
       proc.stdout,
       options.browserToken,
       options.browserTokenName,
+      () => signalTokenDelivered?.(),
     );
   } else {
     stdout = await new Response(proc.stdout).text();
@@ -173,6 +181,7 @@ async function streamStdoutAndDeliverToken(
   stream: ReadableStream<Uint8Array>,
   token: string,
   tokenName?: string,
+  onDelivered?: () => void,
 ): Promise<string> {
   const decoder = new TextDecoder();
   const reader = stream.getReader();
@@ -188,10 +197,13 @@ async function streamStdoutAndDeliverToken(
 
       if (!tokenDelivered) {
         tokenDelivered = tryDeliverToken(accumulated, token, tokenName);
+        if (tokenDelivered) onDelivered?.();
       }
     }
   } finally {
     reader.releaseLock();
+    // Unblock the pump if the token never arrived, so a broken run fails fast.
+    onDelivered?.();
   }
 
   return accumulated;

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -49,6 +49,7 @@ import type {
   CliState,
   InstalledIntegrationDependency,
   InstalledTool,
+  IntegrationScope,
 } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import { IS_WINDOWS } from './platform';
@@ -94,6 +95,11 @@ export class EnvironmentBuilder {
   private readonly keychainTokens: Array<{ serverURL: string; token: string; org?: string }> = [];
   private readonly sqaaExtensions: SqaaExtensionConfig[] = [];
   private readonly contextAugmentationSkills: ContextAugmentationSkillConfig[] = [];
+  private readonly installedIntegrationFeatures: Array<{
+    integrationId: string;
+    featureId: string;
+    scope: IntegrationScope;
+  }> = [];
 
   withActiveConnection(
     url: string,
@@ -271,6 +277,20 @@ export class EnvironmentBuilder {
     return this;
   }
 
+  /**
+   * Pre-seeds a declarative integration feature in state so that
+   * `isFeatureInstalled(state, integrationId, featureId, scope)` returns true
+   * before the CLI binary runs.
+   */
+  withInstalledIntegrationFeature(
+    integrationId: string,
+    featureId: string,
+    scope: IntegrationScope,
+  ): this {
+    this.installedIntegrationFeatures.push({ integrationId, featureId, scope });
+    return this;
+  }
+
   build(binDir?: string): CliState {
     // Default to the current CLI version so post-update is a no-op. Tests that
     // need to exercise the upgrade migration inject a stale version via
@@ -392,6 +412,42 @@ export class EnvironmentBuilder {
         name: CONTEXT_AUGMENTATION_BINARY_NAME,
         version: SONAR_CONTEXT_AUGMENTATION_VERSION,
         scaEnabled: skill.scaEnabled ?? false,
+      });
+    }
+
+    const byIntegrationId = new Map<
+      string,
+      Array<{ featureId: string; scope: IntegrationScope }>
+    >();
+    for (const { integrationId, featureId, scope } of this.installedIntegrationFeatures) {
+      let features = byIntegrationId.get(integrationId);
+      if (!features) {
+        features = [];
+        byIntegrationId.set(integrationId, features);
+      }
+      features.push({ featureId, scope });
+    }
+    const now = new Date().toISOString();
+    for (const [integrationId, features] of byIntegrationId) {
+      state.integrations.installed.push({
+        id: randomUUID(),
+        integrationId,
+        installedByCliVersion: 'integration-test',
+        installedAt: now,
+        updatedByCliVersion: 'integration-test',
+        updatedAt: now,
+        features: features.map(({ featureId, scope }) => ({
+          featureId,
+          scope,
+          targetRoot: '',
+          installedByCliVersion: 'integration-test',
+          installedAt: now,
+          updatedByCliVersion: 'integration-test',
+          updatedAt: now,
+          dependencies: [],
+          resources: [],
+          operations: [],
+        })),
       });
     }
 

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -190,6 +190,7 @@ export class TestHarness {
     return runCli(command, this.env(options), {
       stdin: options?.stdin,
       stdinChunks: options?.stdinChunks,
+      deferStdinUntilBrowserAuth: options?.deferStdinUntilBrowserAuth,
       timeoutMs: options?.timeoutMs,
       cwd: options?.cwd ?? this.cwd.path,
       browserToken: options?.browserToken,

--- a/tests/integration/harness/types.ts
+++ b/tests/integration/harness/types.ts
@@ -41,6 +41,12 @@ export interface RunOptions {
    */
   stdinChunks?: string[];
   /**
+   * Holds `stdinChunks` until the browser-auth token is delivered. Set it when the
+   * prompts come after browser auth (e.g. `integrate <agent>` repair); leave it
+   * unset when they come before (e.g. `auth login` selection), or the run deadlocks.
+   */
+  deferStdinUntilBrowserAuth?: boolean;
+  /**
    * When set, the harness streams CLI stdout looking for the loopback OAuth
    * port (pattern: `port=\d+`), then delivers this token via POST request to
    * the loopback server. Use this to test interactive browser-auth flows.

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -289,6 +289,9 @@ describe('integrate claude', () => {
 
       const result = await harness.run('integrate claude', {
         browserToken: 'browser-token',
+        // After the interactive browser repair, the installer asks per feature (secrets, mcp);
+        // 'y' to each. sqaa is auto-skipped (not a cloud connection).
+        stdinChunks: ['y', 'y'],
       });
 
       expect(result.exitCode).toBe(0);
@@ -314,6 +317,8 @@ describe('integrate claude', () => {
 
       const result = await harness.run('integrate claude', {
         browserToken: 'valid-browser-token',
+        // Answer the per-feature prompts (secrets, mcp) that follow the browser repair.
+        stdinChunks: ['y', 'y'],
       });
 
       expect(result.exitCode).toBe(0);
@@ -411,6 +416,9 @@ describe('integrate claude', () => {
             SONARQUBE_CLI_SERVER: server.baseUrl(),
             // no browserToken: if browser auth is triggered the test times out
           },
+          // Env-based auth skips browser repair but feature selection stays interactive;
+          // answer the per-feature prompts (secrets, mcp) so the run can complete.
+          stdinChunks: ['y', 'y'],
         },
       );
 
@@ -1037,6 +1045,9 @@ describe('integrate claude — file placement (local vs global)', () => {
   // ─── Global pre-exists, project install runs ────────────────────
 
   function writeExistingGlobalSecretsHook(): void {
+    // Record the global secrets-hooks install in state — this is the source of truth the
+    // declarative installer consults to skip the project-level secrets feature.
+    harness.state().withInstalledIntegrationFeature('claude-code', 'sonar-secrets-hooks', 'global');
     // Simulate the on-disk footprint of a previous `sonar integrate claude -g` run:
     // .claude/settings.json with a sonar-secrets PreToolUse entry plus the script file.
     const globalScriptRel =

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -292,6 +292,7 @@ describe('integrate claude', () => {
         // After the interactive browser repair, the installer asks per feature (secrets, mcp);
         // 'y' to each. sqaa is auto-skipped (not a cloud connection).
         stdinChunks: ['y', 'y'],
+        deferStdinUntilBrowserAuth: true,
       });
 
       expect(result.exitCode).toBe(0);
@@ -319,6 +320,7 @@ describe('integrate claude', () => {
         browserToken: 'valid-browser-token',
         // Answer the per-feature prompts (secrets, mcp) that follow the browser repair.
         stdinChunks: ['y', 'y'],
+        deferStdinUntilBrowserAuth: true,
       });
 
       expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -63,7 +63,7 @@ describe('integrate codex', () => {
     it(
       'writes an executable prompt-submit script and a hooks.json entry under .codex/',
       async () => {
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
 
@@ -86,7 +86,7 @@ describe('integrate codex', () => {
     it(
       'uses a project-relative command path so the config is portable',
       async () => {
-        await harness.run('integrate codex');
+        await harness.run('integrate codex --non-interactive');
 
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
         const command = hookScriptPath(
@@ -101,8 +101,8 @@ describe('integrate codex', () => {
     it(
       're-running does not duplicate the UserPromptSubmit entry',
       async () => {
-        await harness.run('integrate codex');
-        const result = await harness.run('integrate codex');
+        await harness.run('integrate codex --non-interactive');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
@@ -130,7 +130,7 @@ describe('integrate codex', () => {
           }),
         );
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
@@ -148,7 +148,7 @@ describe('integrate codex', () => {
     it(
       'writes script + hooks.json under $HOME/.codex/ with an absolute command path',
       async () => {
-        const result = await harness.run('integrate codex -g');
+        const result = await harness.run('integrate codex --non-interactive -g');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists('.codex')).toBe(false);
@@ -174,7 +174,7 @@ describe('integrate codex', () => {
       async () => {
         harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=my-project\n');
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         // Assert on the result and the file contents
         expect(result.exitCode).toBe(0);
@@ -210,7 +210,7 @@ describe('integrate codex', () => {
     it(
       'writes the MCP config to $HOME/.codex/config.toml for global installs',
       async () => {
-        const result = await harness.run('integrate codex -g');
+        const result = await harness.run('integrate codex --non-interactive -g');
 
         // Assert on the result and the file contents
         expect(result.exitCode).toBe(0);
@@ -245,10 +245,10 @@ describe('integrate codex', () => {
     it(
       're-running does not change the config.toml or duplicate [mcp_servers.sonarqube]',
       async () => {
-        await harness.run('integrate codex');
+        await harness.run('integrate codex --non-interactive');
         const firstBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.file(...CONFIG_TOML_DIRS).asText()).toBe(firstBody);
@@ -265,7 +265,7 @@ describe('integrate codex', () => {
           '[mcp_servers.sonarqube]\ncommand = "custom-sonar"\nargs = ["custom", "args"]\n',
         );
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
@@ -281,7 +281,7 @@ describe('integrate codex', () => {
       async () => {
         harness.cwd.writeFile('.codex/config.toml', '= not valid toml =');
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(1);
         const output = `${result.stdout}\n${result.stderr}`;
@@ -294,7 +294,7 @@ describe('integrate codex', () => {
     it(
       'omits --project from the args array when no project key is known',
       async () => {
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
@@ -323,7 +323,7 @@ describe('integrate codex', () => {
           ].join('\n'),
         );
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
@@ -353,7 +353,7 @@ describe('integrate codex', () => {
     it(
       'writes the secrets-on-read section to <repo>/.codex/AGENTS.md at project scope (no SQAA without entitlement)',
       async () => {
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...AGENTS_MD_DIRS).asText();
@@ -379,12 +379,15 @@ describe('integrate codex', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
 
-        const result = await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
-          extraEnv: {
-            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
-            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        const result = await harness.run(
+          `integrate codex --non-interactive --project ${TEST_PROJECT}`,
+          {
+            extraEnv: {
+              SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+              SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+            },
           },
-        });
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...AGENTS_MD_DIRS).asText();
@@ -402,7 +405,7 @@ describe('integrate codex', () => {
     it(
       'writes ~/.codex/AGENTS.md (and nothing project-side) at global scope without SQAA entitlement, and does NOT warn about SQAA',
       async () => {
-        const result = await harness.run('integrate codex -g');
+        const result = await harness.run('integrate codex --non-interactive -g');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists(...AGENTS_MD_DIRS)).toBe(false);
@@ -416,7 +419,7 @@ describe('integrate codex', () => {
     );
 
     it(
-      'on global install, does not write SQAA project-side but warns to run per-project when the org is entitled',
+      'on global install, writes secrets to ~/.codex/AGENTS.md and SQAA to the project AGENTS.md when org is entitled',
       async () => {
         const server = await harness
           .newFakeServer()
@@ -429,7 +432,7 @@ describe('integrate codex', () => {
         harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
         harness.cwd.writeFile('sonar-project.properties', `sonar.projectKey=${TEST_PROJECT}\n`);
 
-        const result = await harness.run('integrate codex -g', {
+        const result = await harness.run('integrate codex --non-interactive -g', {
           extraEnv: {
             SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
             SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -437,15 +440,18 @@ describe('integrate codex', () => {
         });
 
         expect(result.exitCode).toBe(0);
-        expect(harness.cwd.exists(...AGENTS_MD_DIRS)).toBe(false);
 
+        // Global AGENTS.md: secrets instructions, no SQAA.
         const globalBody = harness.userHome.file(...AGENTS_MD_DIRS).asText();
         expect(globalBody).toContain(SECRETS_HEADING);
         expect(globalBody).not.toContain(SQAA_HEADING);
 
-        const output = `${result.stdout}\n${result.stderr}`;
-        expect(output).toContain('SonarQube Agentic Analysis');
-        expect(output).toContain('sonar integrate codex --project');
+        // sqaa-instructions has scope:'project', so it always writes to the project dir.
+        expect(harness.cwd.exists(...AGENTS_MD_DIRS)).toBe(true);
+        const projectBody = harness.cwd.file(...AGENTS_MD_DIRS).asText();
+        expect(projectBody).toContain(SQAA_HEADING);
+        expect(projectBody).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
+        expect(projectBody).not.toContain(SECRETS_HEADING);
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/context-augmentation.test.ts
+++ b/tests/integration/specs/integrate/context-augmentation.test.ts
@@ -650,7 +650,7 @@ describe('integrate copilot — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate copilot', {
+      const result = await harness.run('integrate copilot --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -719,7 +719,7 @@ describe('integrate codex — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate codex', {
+      const result = await harness.run('integrate codex --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -773,7 +773,7 @@ describe('integrate codex — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate codex --skip-context', {
+      const result = await harness.run('integrate codex --non-interactive --skip-context', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -814,7 +814,7 @@ describe('integrate codex — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate codex', {
+      const result = await harness.run('integrate codex --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -842,7 +842,7 @@ describe('integrate codex — Context Augmentation', () => {
       harness.state().withContextAugmentationBinaryInstalled();
       // No sonar-project.properties — projectKey is undefined.
 
-      const result = await harness.run('integrate codex', {
+      const result = await harness.run('integrate codex --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -872,8 +872,8 @@ describe('integrate <agent> --global — Context Augmentation', () => {
 
   it.each([
     ['claude', 'integrate claude -g --non-interactive'],
-    ['copilot', 'integrate copilot -g'],
-    ['codex', 'integrate codex -g'],
+    ['copilot', 'integrate copilot -g --non-interactive'],
+    ['codex', 'integrate codex -g --non-interactive'],
   ])(
     'skips CAG entirely on "integrate %s --global"',
     async (_agent, command) => {

--- a/tests/integration/specs/integrate/copilot-test-helpers.ts
+++ b/tests/integration/specs/integrate/copilot-test-helpers.ts
@@ -125,7 +125,7 @@ export function findCopilotFeature(
   );
 }
 
-/** Simulates a previous `sonar integrate copilot -g` run on disk. */
+/** Simulates a previous `sonar integrate copilot -g` run on disk and in state. */
 export function writeExistingGlobalHook(harness: TestHarness): void {
   const scriptRel = `.copilot/hooks/sonar-secrets/build-scripts/${PRETOOL_SECRETS_SCRIPT}`;
   harness.userHome.writeFile(scriptRel, '#!/bin/bash\nexit 0\n');
@@ -135,14 +135,18 @@ export function writeExistingGlobalHook(harness: TestHarness): void {
     hooks: { preToolUse: [makeHookEntry(normalizePath(absScriptPath))] },
   };
   harness.userHome.writeFile('.copilot/hooks/hooks.json', JSON.stringify(hooksJson));
+  harness.state().withInstalledIntegrationFeature('copilot-cli', 'pre-tool-use-hook', 'global');
 }
 
-/** Simulates a pre-existing global instructions file. */
+/** Simulates a pre-existing global instructions file and state entry. */
 export function writeExistingGlobalInstructions(harness: TestHarness): void {
   harness.userHome.writeFile(
     '.copilot/instructions/sonarqube.instructions.md',
     '# pre-existing global instructions\n',
   );
+  harness
+    .state()
+    .withInstalledIntegrationFeature('copilot-cli', 'prompt-secrets-instructions', 'global');
 }
 
 /**

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -66,7 +66,7 @@ describe('integrate copilot', () => {
     it(
       'writes hook script (executable), hooks.json, instructions, and .mcp.json under .github/',
       async () => {
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
 
@@ -99,7 +99,7 @@ describe('integrate copilot', () => {
     it(
       'writes a relative-path preToolUse entry in hooks.json with timeoutSec=60',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
         expect(json.hooks.preToolUse).toHaveLength(1);
@@ -119,7 +119,7 @@ describe('integrate copilot', () => {
     it(
       'does not touch ~/.copilot when running without --global',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         expect(harness.userHome.exists('.copilot')).toBe(false);
       },
@@ -129,7 +129,7 @@ describe('integrate copilot', () => {
     it(
       'records default project-scope features in integrations.installed',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         const copilotIntegration = getCopilotIntegration(harness);
         expect(copilotIntegration).toBeDefined();
@@ -147,7 +147,7 @@ describe('integrate copilot', () => {
     it(
       'records declarative Copilot features in integrations.installed for project installs',
       async () => {
-        await harness.run('integrate copilot --project my-project');
+        await harness.run('integrate copilot --non-interactive --project my-project');
 
         const state = harness.stateJsonFile.asJson();
         const copilotIntegration = state.integrations.installed.find(
@@ -184,8 +184,8 @@ describe('integrate copilot', () => {
     it(
       'running twice yields exactly one preToolUse entry in hooks.json',
       async () => {
-        await harness.run('integrate copilot');
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
+        await harness.run('integrate copilot --non-interactive');
 
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
         expect(json.hooks.preToolUse).toHaveLength(1);
@@ -196,7 +196,7 @@ describe('integrate copilot', () => {
     it(
       'appends --project <key> to the MCP server args when --project is provided',
       async () => {
-        await harness.run('integrate copilot --project my-project');
+        await harness.run('integrate copilot --non-interactive --project my-project');
 
         const mcp = harness.cwd.file('.mcp.json').asJson() as McpJson;
         const args = mcp.mcpServers?.sonarqube?.args ?? [];
@@ -210,7 +210,7 @@ describe('integrate copilot', () => {
     it(
       'pretool-secrets script uses the correct subcommand (sonar hook copilot-pre-tool-use)',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         const content = harness.cwd.file(...PROJECT_HOOK_SCRIPT_PATH).asText();
         expect(content).toContain('sonar hook copilot-pre-tool-use');
@@ -232,7 +232,7 @@ describe('integrate copilot', () => {
           }),
         );
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
@@ -252,7 +252,7 @@ describe('integrate copilot', () => {
         // and without dropping the existing `version` field.
         harness.cwd.writeFile('.github/hooks/hooks.json', JSON.stringify({ version: 1 }));
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
@@ -267,7 +267,7 @@ describe('integrate copilot', () => {
     it(
       'prints a project-level outcome message with the written hook and instructions paths',
       async () => {
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain(
@@ -293,7 +293,7 @@ describe('integrate copilot', () => {
     it(
       'writes hook script, hooks.json, instructions, and mcp-config.json under ~/.copilot/',
       async () => {
-        const result = await harness.run('integrate copilot -g');
+        const result = await harness.run('integrate copilot --non-interactive -g');
 
         expect(result.exitCode).toBe(0);
         expect(harness.userHome.exists(...GLOBAL_HOOK_SCRIPT_PATH)).toBe(true);
@@ -307,7 +307,7 @@ describe('integrate copilot', () => {
     it(
       'uses an absolute path in the hooks.json preToolUse entry under ~/.copilot/hooks/',
       async () => {
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot --non-interactive -g');
 
         const json = harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
         const command = normalizePath(String(json.hooks.preToolUse?.[0]?.[HOOK_FIELD] ?? ''));
@@ -321,7 +321,7 @@ describe('integrate copilot', () => {
     it(
       'does not create .github/ inside the project directory when -g is set',
       async () => {
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot --non-interactive -g');
 
         expect(harness.cwd.exists('.github', 'hooks')).toBe(false);
         expect(harness.cwd.exists('.github', 'instructions')).toBe(false);
@@ -333,7 +333,7 @@ describe('integrate copilot', () => {
     it(
       'records hook and prompt instructions as global features in declarative state',
       async () => {
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot --non-interactive -g');
 
         expect(findCopilotFeature(harness, 'pre-tool-use-hook')?.scope).toBe('global');
         expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('global');
@@ -342,20 +342,21 @@ describe('integrate copilot', () => {
     );
 
     it(
-      'overwrites pre-existing global instructions (CLI-owned file)',
+      'merges the prompt-secrets section into a pre-existing global instructions file',
       async () => {
-        // sonarqube.instructions.md is CLI-owned, so any pre-existing content
-        // is replaced with the freshly rendered prompt-secrets section.
+        // The instructions file is a marker-delimited textSnippet: the sonar
+        // section is inserted between its begin/end markers and any pre-existing
+        // content outside those markers is preserved.
         harness.userHome.writeFile(
           '.copilot/instructions/sonarqube.instructions.md',
           '# pre-existing\n',
         );
 
-        const result = await harness.run('integrate copilot -g');
+        const result = await harness.run('integrate copilot --non-interactive -g');
 
         expect(result.exitCode).toBe(0);
         const body = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
-        expect(body).not.toContain('# pre-existing');
+        expect(body).toContain('# pre-existing');
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
       },
       { timeout: 30000 },
@@ -364,8 +365,8 @@ describe('integrate copilot', () => {
     it(
       'is idempotent: running -g twice yields exactly one prompt-secrets section',
       async () => {
-        await harness.run('integrate copilot -g');
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot --non-interactive -g');
+        await harness.run('integrate copilot --non-interactive -g');
 
         const body = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
         const headingCount =
@@ -378,7 +379,7 @@ describe('integrate copilot', () => {
     it(
       'prints a global outcome message with the written hook and instructions paths under ~/.copilot/',
       async () => {
-        const result = await harness.run('integrate copilot -g');
+        const result = await harness.run('integrate copilot --non-interactive -g');
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('Copilot integration successfully configured globally');
@@ -402,12 +403,12 @@ describe('integrate copilot', () => {
       async () => {
         writeExistingGlobalHook(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists('.github', 'hooks', 'sonar-secrets')).toBe(false);
         expect(harness.cwd.exists('.github', 'hooks', 'hooks.json')).toBe(false);
-        expect(result.stdout).toContain('A global secrets scanning hook is already configured at');
+        expect(result.stdout + result.stderr).toContain('global hook already covers this');
       },
       { timeout: 30000 },
     );
@@ -417,9 +418,10 @@ describe('integrate copilot', () => {
       async () => {
         writeExistingGlobalHook(harness);
 
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
-        expect(findCopilotFeature(harness, 'pre-tool-use-hook')).toBeUndefined();
+        // No project-scoped hook was installed; global is from state seed.
+        expect(findCopilotFeature(harness, 'pre-tool-use-hook', 'project')).toBeUndefined();
         // Instructions are independent — the project-level instructions
         // write still runs because the global instructions file does not exist.
         expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('project');
@@ -433,7 +435,7 @@ describe('integrate copilot', () => {
         writeExistingGlobalHook(harness);
         const before = harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asText();
 
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         expect(harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asText()).toBe(before);
       },
@@ -441,9 +443,9 @@ describe('integrate copilot', () => {
     );
 
     it(
-      'falls back to a project-level install (and warns) when the referenced global script is missing (orphaned)',
+      'ignores orphaned global hooks.json entry (no matching state) and runs fresh project install',
       async () => {
-        // Write hooks.json that references a sonar-secrets script that does not exist on disk.
+        // No global state recorded — orphaned hooks.json entry must be ignored (detection is state-based).
         const orphanScript = harness.userHome.file(
           `.copilot/hooks/sonar-secrets/build-scripts/${PRETOOL_SECRETS_SCRIPT}`,
         ).path;
@@ -453,12 +455,9 @@ describe('integrate copilot', () => {
         };
         harness.userHome.writeFile('.copilot/hooks/hooks.json', JSON.stringify(orphanedJson));
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
-        expect(result.stderr + result.stdout).toContain(
-          'Falling back to project-level installation',
-        );
         expect(harness.cwd.exists('.github', 'hooks', 'hooks.json')).toBe(true);
       },
       { timeout: 30000 },
@@ -478,7 +477,7 @@ describe('integrate copilot', () => {
         harness.userHome.writeFile('.copilot/hooks/hooks.json', JSON.stringify(globalJson));
         const before = harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asText();
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists('.github', 'hooks', 'hooks.json')).toBe(true);
@@ -502,27 +501,25 @@ describe('integrate copilot', () => {
 
   describe('project-level install when global Copilot instructions already exist', () => {
     it(
-      'writes the project-level instructions file, leaves the global file untouched, and warns about it',
+      'writes the project-level instructions file and leaves the global file untouched',
       async () => {
         writeExistingGlobalInstructions(harness);
         const before = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
-        // Project file is written despite the global file existing.
+        // Project file is written; the custom question is auto-accepted in non-interactive mode.
         expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(true);
         expect(harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText()).toContain(
           '# SonarQube secrets scanning for prompts protocol',
         );
-        // Global file is byte-identical (orphan; not touched).
+        // Global file is byte-identical (not touched).
         expect(harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText()).toBe(before);
-        // Declarative state records the project-scoped prompt-secrets feature.
-        expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('project');
-        // Orphan warning surfaces the stale global file path.
-        expect(result.stderr + result.stdout).toContain('Found existing Copilot instructions at');
-        expect(normalizePath(result.stderr + result.stdout)).toContain(
-          '.copilot/instructions/sonarqube.instructions.md',
+        // Declarative state records the project-scoped prompt-secrets feature
+        // (the seeded global entry remains, so query by project scope).
+        expect(findCopilotFeature(harness, 'prompt-secrets-instructions', 'project')?.scope).toBe(
+          'project',
         );
       },
       { timeout: 30000 },
@@ -533,7 +530,7 @@ describe('integrate copilot', () => {
       async () => {
         writeExistingGlobalInstructions(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const instructionsLine = normalizePath(
@@ -555,7 +552,7 @@ describe('integrate copilot', () => {
         writeExistingGlobalHook(harness);
         writeExistingGlobalInstructions(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         // Hook is short-circuited; no project-level hook artifacts.
@@ -564,13 +561,12 @@ describe('integrate copilot', () => {
         expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(true);
 
         const state = harness.stateJsonFile.asJson();
-        expect(findCopilotFeature(harness, 'pre-tool-use-hook')).toBeUndefined();
-        expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('project');
-
-        const homePathNorm = normalizePath(harness.userHome.path);
-        expect(normalizePath(outcomeLine(result.stdout, 'Hook:'))).toContain(
-          `${homePathNorm}/.copilot/hooks/sonar-secrets`,
+        // No project-scoped hook was installed; global is from state seed.
+        expect(findCopilotFeature(harness, 'pre-tool-use-hook', 'project')).toBeUndefined();
+        expect(findCopilotFeature(harness, 'prompt-secrets-instructions', 'project')?.scope).toBe(
+          'project',
         );
+
         expect(
           normalizePath(outcomeLine(result.stdout, 'Instructions (secrets scanning for prompts):')),
         ).toContain('.github/instructions/sonarqube.instructions.md');
@@ -579,11 +575,11 @@ describe('integrate copilot', () => {
           (integration: { integrationId: string }) => integration.integrationId === 'copilot-cli',
         );
         expect(copilotIntegration).toBeDefined();
-        expect(
-          copilotIntegration.features
-            .map((feature: { featureId: string }) => feature.featureId)
-            .sort(),
-        ).toEqual(['mcp-server', 'prompt-secrets-instructions']);
+        const projectFeatureIds = copilotIntegration.features
+          .filter((feature: { scope: string }) => feature.scope === 'project')
+          .map((feature: { featureId: string }) => feature.featureId)
+          .sort();
+        expect(projectFeatureIds).toEqual(['mcp-server', 'prompt-secrets-instructions']);
         expect(state.dependencies.installed).toEqual([]);
       },
       { timeout: 30000 },
@@ -603,7 +599,7 @@ describe('integrate copilot', () => {
       async () => {
         obstructHooksJson(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         expect(result.stdout + result.stderr).toContain('contains invalid JSON');
@@ -625,7 +621,7 @@ describe('integrate copilot', () => {
       async () => {
         obstructInstructionsFile(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         expect(result.stdout).not.toContain('Copilot integration successfully configured');
@@ -645,7 +641,7 @@ describe('integrate copilot', () => {
       async () => {
         harness.cwd.writeFile('.mcp.json', '{ invalid json\n');
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         expect(result.stdout + result.stderr).toContain('.mcp.json contains invalid JSON');
@@ -664,7 +660,9 @@ describe('integrate copilot', () => {
     it(
       'exits with code 2 when both --global and --project are provided',
       async () => {
-        const result = await harness.run('integrate copilot --global --project foo');
+        const result = await harness.run(
+          'integrate copilot --non-interactive --global --project foo',
+        );
 
         expect(result.exitCode).toBe(2);
         expect(result.stdout + result.stderr).toContain(
@@ -714,9 +712,12 @@ describe('integrate copilot', () => {
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
-          extraEnv,
-        });
+        const result = await harness.run(
+          `integrate copilot --non-interactive --project ${TEST_PROJECT}`,
+          {
+            extraEnv,
+          },
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -725,14 +726,12 @@ describe('integrate copilot', () => {
         // Project key is baked into the example command.
         expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
 
-        // Project-scope installs keep SQAA in the prompt instructions feature.
+        // prompt-secrets-instructions is a project-scoped feature.
         const promptSecrets = findCopilotFeature(harness, 'prompt-secrets-instructions');
         expect(promptSecrets?.scope).toBe('project');
-        expect(promptSecrets?.attrs).toMatchObject({
-          projectKey: TEST_PROJECT,
-          sqaaEnabled: true,
-        });
-        expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
+        expect(promptSecrets?.attrs).toMatchObject({ projectKey: TEST_PROJECT });
+        // sqaa-instructions is now a separate project-scoped feature.
+        expect(findCopilotFeature(harness, 'sqaa-instructions')?.scope).toBe('project');
       },
       { timeout: 30000 },
     );
@@ -745,7 +744,7 @@ describe('integrate copilot', () => {
         const { extraEnv } = await setupCloudWithEntitlement();
         harness.cwd.writeFile('sonar-project.properties', `sonar.projectKey=${TEST_PROJECT}\n`);
 
-        const result = await harness.run('integrate copilot -g', { extraEnv });
+        const result = await harness.run('integrate copilot --non-interactive -g', { extraEnv });
 
         expect(result.exitCode).toBe(0);
 
@@ -781,7 +780,7 @@ describe('integrate copilot', () => {
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run('integrate copilot', { extraEnv });
+        const result = await harness.run('integrate copilot --non-interactive', { extraEnv });
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -799,9 +798,12 @@ describe('integrate copilot', () => {
           enabled: false,
         });
 
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
-          extraEnv,
-        });
+        const result = await harness.run(
+          `integrate copilot --non-interactive --project ${TEST_PROJECT}`,
+          {
+            extraEnv,
+          },
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -816,7 +818,7 @@ describe('integrate copilot', () => {
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run('integrate copilot -g', { extraEnv });
+        const result = await harness.run('integrate copilot --non-interactive -g', { extraEnv });
 
         expect(result.exitCode).toBe(0);
         // Without a project key the SQAA section cannot bake one in, so the
@@ -836,7 +838,9 @@ describe('integrate copilot', () => {
       async () => {
         // Default beforeEach sets up on-premise auth (no org). hasSqaaEntitlement
         // returns false fast without hitting the API in this case.
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`);
+        const result = await harness.run(
+          `integrate copilot --non-interactive --project ${TEST_PROJECT}`,
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -857,12 +861,15 @@ describe('integrate copilot', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
 
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
-          extraEnv: {
-            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
-            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        const result = await harness.run(
+          `integrate copilot --non-interactive --project ${TEST_PROJECT}`,
+          {
+            extraEnv: {
+              SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+              SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+            },
           },
-        });
+        );
 
         // Command must not abort — degraded success.
         expect(result.exitCode).toBe(0);
@@ -886,7 +893,7 @@ describe('integrate copilot', () => {
         // unauthenticated path.
         harness.clearAuth();
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         const output = result.stdout + result.stderr;

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -417,6 +417,52 @@ describe('integrate git (native hooks)', () => {
   );
 
   it(
+    'installs only the pre-push hook with --hook pre-push --non-interactive',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      const result = await harness.run('integrate git --hook pre-push --non-interactive');
+
+      expect(result.exitCode).toBe(0);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(false);
+      const state = harness.stateJsonFile.asJson() as InstalledStateJson;
+      const gitIntegration = getInstalledIntegration(state, 'native-git');
+      expect(gitIntegration.features).toHaveLength(1);
+      expect(gitIntegration.features[0]).toMatchObject({
+        featureId: 'pre-push-hook',
+        scope: 'project',
+        targetRoot: harness.cwd.path,
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'installs only the pre-commit hook with --hook pre-commit --non-interactive',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      const result = await harness.run('integrate git --hook pre-commit --non-interactive');
+
+      expect(result.exitCode).toBe(0);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(false);
+      const state = harness.stateJsonFile.asJson() as InstalledStateJson;
+      const gitIntegration = getInstalledIntegration(state, 'native-git');
+      expect(gitIntegration.features).toHaveLength(1);
+      expect(gitIntegration.features[0]).toMatchObject({
+        featureId: 'pre-commit-hook',
+        scope: 'project',
+        targetRoot: harness.cwd.path,
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'installs native pre-push hook via interactive prompts when secrets is already installed',
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -41,6 +41,13 @@ function pathWithoutNodeModules(envPath: string | undefined): string {
 // Intentional fixture for secret detection (split literal avoids hardcoded-secret rules)
 const GITHUB_TEST_TOKEN = 'ghp_' + 'CID7e8gGxQcMIJeFmEfRsV3zkXPUC42CjFbm';
 
+// Interactive `confirmPrompt` answers, one keypress per prompt, in order:
+//   1. "Install here?" / "Proceed with global installation?"
+//   2. "Set up pre-commit hook?"
+//   3. "Set up pre-push hook?"
+const PRECOMMIT_ONLY_ANSWERS = ['y', 'y', 'n'];
+const PREPUSH_ONLY_ANSWERS = ['y', 'n', 'y'];
+
 /** Env for `git commit` / `git push` so the installed hook sees the same HOME + keychain as `harness.run()`. */
 function buildHookEnv(sonarBinDir: string, harness: TestHarness): Record<string, string> {
   const env: Record<string, string> = {
@@ -242,14 +249,14 @@ describe('integrate git (native hooks)', () => {
   });
 
   it(
-    'exits with error when user cancels the hook-type selection',
+    'exits with error when user cancels the install confirmation',
     async () => {
       await setupAuthenticated(harness);
 
       // Minimal git repo: findGitRoot() detects the .git directory
       harness.cwd.writeFile('.git/.keep', '');
 
-      // Ctrl+C sent to stdin cancels the interactive confirmPrompt
+      // Ctrl+C sent to stdin cancels the interactive 'Install here?' confirmPrompt
       const result = await harness.run('integrate git', { stdin: '\x03' });
 
       expect(result.exitCode).toBe(1);
@@ -293,7 +300,7 @@ describe('integrate git (native hooks)', () => {
       // to a non-existent gitdir so git rev-parse --git-path hooks fails.
       harness.cwd.writeFile('.git', 'gitdir: not-a-real-git-dir\n');
 
-      const result = await harness.run('integrate git --hook pre-commit --non-interactive');
+      const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
@@ -312,7 +319,7 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      const result = await harness.run('integrate git --hook pre-commit --non-interactive');
+      const result = await harness.run('integrate git --non-interactive');
       expect(result.exitCode).toBe(0);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
 
@@ -335,7 +342,7 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      const result = await harness.run('integrate git --hook pre-push --non-interactive');
+      const result = await harness.run('integrate git', { stdinChunks: PREPUSH_ONLY_ANSWERS });
       expect(result.exitCode).toBe(0);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
 
@@ -372,9 +379,9 @@ describe('integrate git (native hooks)', () => {
       // and resolveGitHooksDir() resolves to .git/hooks as expected
       initGitRepo(harness);
 
-      // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: '\r' confirms 'Install here?', then '\r' selects pre-commit
-      const result = await harness.run('integrate git', { stdinChunks: ['\r', '\r'] });
+      // One stdin chunk per prompt (delays prevent readline from buffering them together):
+      // 'y' confirms 'Install here?', 'y' sets up pre-commit, 'n' skips pre-push.
+      const result = await harness.run('integrate git', { stdinChunks: PRECOMMIT_ONLY_ANSWERS });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
@@ -389,7 +396,7 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      const result = await harness.run('integrate git --hook pre-commit --non-interactive');
+      const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);
       const state = harness.stateJsonFile.asJson() as InstalledStateJson;
@@ -400,9 +407,6 @@ describe('integrate git (native hooks)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'git-hook-file');
@@ -418,9 +422,9 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' confirms 'Install here?'; '\x1b[B' moves the selection down to pre-push; '\r' submits
+      // 'y' confirms 'Install here?', 'n' skips pre-commit, 'y' sets up pre-push.
       const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', '\x1b[B', '\r'],
+        stdinChunks: PREPUSH_ONLY_ANSWERS,
       });
 
       expect(result.exitCode).toBe(0);
@@ -435,9 +439,11 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: '\r' confirms global hook warning, then '\r' selects pre-commit
-      const result = await harness.run('integrate git --global', { stdinChunks: ['\r', '\r'] });
+      // One stdin chunk per prompt: 'y' confirms global installation, 'y' sets up
+      // pre-commit, 'n' skips pre-push.
+      const result = await harness.run('integrate git --global', {
+        stdinChunks: PRECOMMIT_ONLY_ANSWERS,
+      });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
@@ -452,7 +458,9 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      const result = await harness.run('integrate git --global --hook pre-push --non-interactive');
+      const result = await harness.run('integrate git --global', {
+        stdinChunks: PREPUSH_ONLY_ANSWERS,
+      });
 
       expect(result.exitCode).toBe(0);
       const state = harness.stateJsonFile.asJson() as InstalledStateJson;
@@ -462,9 +470,6 @@ describe('integrate git (native hooks)', () => {
         featureId: 'pre-push-hook',
         scope: 'global',
         targetRoot: harness.userHome.file('.sonar', 'sonarqube-cli', 'hooks').path,
-        attrs: {
-          hook: 'pre-push',
-        },
       });
       expectInstalledOperation(feature, 'configure-global-hooks-path');
     },
@@ -476,10 +481,9 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: '\r' confirms global hook warning, then '\r' selects pre-push
+      // 'y' confirms global installation, 'n' skips pre-commit, 'y' sets up pre-push.
       const result = await harness.run('integrate git --global', {
-        stdinChunks: ['\r', '\x1b[B', '\r'],
+        stdinChunks: PREPUSH_ONLY_ANSWERS,
       });
 
       expect(result.exitCode).toBe(0);
@@ -508,7 +512,7 @@ describe('integrate git (husky)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepoWithHusky(harness);
 
-      const result = await harness.run('integrate git --hook pre-commit --non-interactive');
+      const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(
@@ -527,9 +531,6 @@ describe('integrate git (husky)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
@@ -557,7 +558,7 @@ describe('integrate git (husky)', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate git --hook pre-commit --non-interactive');
+      const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);
       const hookContent = readFileSync(join(harness.cwd.path, '.husky', 'pre-commit'), 'utf-8');
@@ -576,7 +577,7 @@ describe('integrate git (husky)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepoWithHusky(harness);
 
-      const result = await harness.run('integrate git --hook pre-push --non-interactive');
+      const result = await harness.run('integrate git', { stdinChunks: PREPUSH_ONLY_ANSWERS });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(
@@ -595,9 +596,6 @@ describe('integrate git (husky)', () => {
         featureId: 'pre-push-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-push',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
@@ -665,7 +663,7 @@ describe('integrate git (pre-commit framework)', () => {
         }),
       );
 
-      const result = await harness.run('integrate git --hook pre-commit --non-interactive', {
+      const result = await harness.run('integrate git --non-interactive', {
         extraEnv: setupFakePreCommit(preCommitLog),
       });
 
@@ -693,9 +691,6 @@ describe('integrate git (pre-commit framework)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
@@ -712,7 +707,8 @@ describe('integrate git (pre-commit framework)', () => {
       initGitRepoWithPreCommitConfig(harness);
       const preCommitLog = join(harness.cwd.path, 'pre-commit.log');
 
-      const result = await harness.run('integrate git --hook pre-push --non-interactive', {
+      const result = await harness.run('integrate git', {
+        stdinChunks: PREPUSH_ONLY_ANSWERS,
         extraEnv: setupFakePreCommit(preCommitLog),
       });
 
@@ -743,9 +739,6 @@ describe('integrate git (pre-commit framework)', () => {
         featureId: 'pre-push-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-push',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
@@ -774,10 +767,10 @@ describe('integrate git (pre-commit framework)', () => {
       );
 
       const extraEnv = setupFakePreCommit(preCommitLog);
-      const first = await harness.run('integrate git --hook pre-commit --non-interactive', {
+      const first = await harness.run('integrate git --non-interactive', {
         extraEnv,
       });
-      const second = await harness.run('integrate git --hook pre-commit --non-interactive', {
+      const second = await harness.run('integrate git --non-interactive', {
         extraEnv,
       });
 
@@ -811,9 +804,6 @@ describe('integrate git (pre-commit framework)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
     },
     { timeout: 15000 },

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -34,7 +34,12 @@ import {
 } from '../../../../../../src/cli/commands/integrate/_common/registry';
 import * as stateRepository from '../../../../../../src/lib/repository/state-repository';
 import { getDefaultState } from '../../../../../../src/lib/state';
-import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../../src/ui';
+import {
+  clearMockUiCalls,
+  getMockUiCalls,
+  queueMockResponse,
+  setMockUi,
+} from '../../../../../../src/ui';
 
 describe('generic integration installer', () => {
   let tempDir: string;
@@ -276,6 +281,29 @@ describe('generic integration installer', () => {
 
     expect(installed).toEqual([]);
     expect(hasUiCall('info', 'Nothing to install for Test Integration')).toBe(true);
+  });
+
+  it('selects a feature whose when returns install without prompting', async () => {
+    const integration = registerIntegration(registry, 'installer-auto-install', [
+      {
+        id: 'feature',
+        displayName: 'Feature',
+        when: () => ({ kind: 'install' }),
+        operations: [{ id: 'operation', apply: () => undefined }],
+      },
+    ]);
+
+    // Interactive mode with a queued "no" answer: install must ignore the prompt and select anyway.
+    queueMockResponse(false);
+    const installed = await installIntegration({
+      registry,
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(installed.map((feature) => feature.featureId)).toEqual(['feature']);
   });
 
   it('passes force through the integration context for protected whole files', async () => {

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -25,7 +25,6 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error';
 import {
   type FeatureDeclaration,
   installIntegration,
@@ -94,6 +93,7 @@ describe('generic integration installer', () => {
       targetRoot: tempDir,
       scope: 'project',
       attrs: { projectKey: 'project' },
+      nonInteractive: true,
     });
 
     expect(installed).toHaveLength(1);
@@ -115,51 +115,46 @@ describe('generic integration installer', () => {
     loadStateSpy.mockReturnValue(state);
     const mainRoot = join(tempDir, 'global');
     const projectRoot = join(tempDir, 'project');
-    const integration = registerIntegration<{
-      installMain?: boolean;
-      installProject?: boolean;
-      projectRoot?: string;
-    }>(registry, 'installer-feature-routing', [
-      {
-        id: 'main',
-        displayName: 'Main feature',
-        when: ({ options }) => options.installMain === true,
-        resources: [
-          wholeFile({
-            id: 'main-file',
-            displayName: 'Main file',
-            targetPath: (context) => join(context.targetRoot, 'main.txt'),
-            content: 'main\n',
-          }),
-        ],
-      },
-      {
-        id: 'project',
-        displayName: 'Project feature',
-        when: ({ options }) => options.installProject === true,
-        targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
-        scope: 'project',
-        resources: [
-          wholeFile({
-            id: 'project-file',
-            displayName: 'Project file',
-            targetPath: (context) => join(context.targetRoot, 'project.txt'),
-            content: 'project\n',
-          }),
-        ],
-      },
-    ]);
+    const integration = registerIntegration<{ projectRoot?: string }>(
+      registry,
+      'installer-feature-routing',
+      [
+        {
+          id: 'main',
+          displayName: 'Main feature',
+          resources: [
+            wholeFile({
+              id: 'main-file',
+              displayName: 'Main file',
+              targetPath: (context) => join(context.targetRoot, 'main.txt'),
+              content: 'main\n',
+            }),
+          ],
+        },
+        {
+          id: 'project',
+          displayName: 'Project feature',
+          targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
+          scope: 'project',
+          resources: [
+            wholeFile({
+              id: 'project-file',
+              displayName: 'Project file',
+              targetPath: (context) => join(context.targetRoot, 'project.txt'),
+              content: 'project\n',
+            }),
+          ],
+        },
+      ],
+    );
 
     const installed = await installIntegration({
       registry,
       integrationId: integration.id,
-      options: {
-        installMain: true,
-        installProject: true,
-        projectRoot,
-      },
+      options: { projectRoot },
       targetRoot: mainRoot,
       scope: 'global',
+      nonInteractive: true,
     });
 
     expect(installed).toMatchObject([
@@ -193,6 +188,7 @@ describe('generic integration installer', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      nonInteractive: true,
     });
     clearMockUiCalls();
 
@@ -202,6 +198,7 @@ describe('generic integration installer', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      nonInteractive: true,
     });
 
     expect(installed[0].resources.some((resource) => resource.id === 'file')).toBe(true);
@@ -233,6 +230,7 @@ describe('generic integration installer', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      nonInteractive: true,
     });
 
     expect(called).toBe(false);
@@ -242,7 +240,7 @@ describe('generic integration installer', () => {
     );
   });
 
-  it('throws when the integration is unknown or no feature matches the invocation', async () => {
+  it('throws when the integration is unknown', async () => {
     const missingError = await catchError(() =>
       installIntegration({
         registry,
@@ -256,31 +254,28 @@ describe('generic integration installer', () => {
     expect(missingError?.message).toBe(
       'Integration declaration is not registered: missing-integration',
     );
+  });
 
-    const integration = registerIntegration<{ enabled?: boolean }>(
+  it('returns empty array and logs info when no feature matches the invocation', async () => {
+    const integration = registerIntegration(registry, 'installer-no-feature', [
+      {
+        id: 'feature',
+        displayName: 'Feature',
+        when: () => ({ kind: 'skip' }),
+      },
+    ]);
+
+    const installed = await installIntegration({
       registry,
-      'installer-no-feature',
-      [
-        {
-          id: 'feature',
-          displayName: 'Feature',
-          when: ({ options }) => options.enabled === true,
-        },
-      ],
-    );
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+      nonInteractive: true,
+    });
 
-    const noFeatureError = await catchError(() =>
-      installIntegration({
-        registry,
-        integrationId: integration.id,
-        options: {},
-        targetRoot: tempDir,
-        scope: 'project',
-      }),
-    );
-
-    expect(noFeatureError).toBeInstanceOf(CommandFailedError);
-    expect(noFeatureError?.message).toBe('No feature selected for Test Integration');
+    expect(installed).toEqual([]);
+    expect(hasUiCall('info', 'Nothing to install for Test Integration')).toBe(true);
   });
 
   it('passes force through the integration context for protected whole files', async () => {
@@ -311,6 +306,7 @@ describe('generic integration installer', () => {
         options: {},
         targetRoot: tempDir,
         scope: 'project',
+        nonInteractive: true,
       }),
     ).rejects.toThrow(
       `Refusing to overwrite existing pre-commit hook at ${targetPath}. Use --force to replace.`,
@@ -322,6 +318,7 @@ describe('generic integration installer', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      nonInteractive: true,
       force: true,
     });
 
@@ -351,6 +348,7 @@ describe('generic integration installer', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      nonInteractive: true,
     });
 
     expect(installed).toEqual([]);

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -419,6 +419,26 @@ describe('declarative integration framework', () => {
     expect(selected).toHaveLength(0);
   });
 
+  it('aborts the installation when the user cancels the prompt (Ctrl+C)', () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [
+        { id: 'a', displayName: 'A', when: () => ({ kind: 'ask' }) },
+        { id: 'b', displayName: 'B', when: () => ({ kind: 'ask' }) },
+      ],
+    });
+    queueMockResponse(null);
+
+    expect(
+      installer.selectFeaturesForInvocation(integration, makeInvocation(tempDir)),
+    ).rejects.toThrow('Installation cancelled');
+
+    expect(
+      getMockUiCalls().filter(
+        (c) => c.method === 'confirmPrompt' && String(c.args[0]) === 'Set up B?',
+      ),
+    ).toHaveLength(0);
+  });
+
   it('auto-accepts all ask features in nonInteractive mode without prompting', async () => {
     const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
       features: [

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -31,6 +31,12 @@ import type {
   IntegrationDeclaration,
 } from '../../../../../../src/cli/commands/integrate/_common/registry';
 import { getDefaultState } from '../../../../../../src/lib/state';
+import {
+  clearMockUiCalls,
+  getMockUiCalls,
+  queueMockResponse,
+  setMockUi,
+} from '../../../../../../src/ui';
 
 const binaryInstall = await import('../../../../../../src/cli/commands/_common/install/binary');
 void mock.module('../../../../../../src/cli/commands/_common/install/binary', () => ({
@@ -63,9 +69,12 @@ describe('declarative integration framework', () => {
       freshlyInstalled: true,
     });
     resolveBinaryPathSpy = spyOn(binaryInstall, 'resolveBinaryPath').mockReturnValue(null);
+    setMockUi(true);
+    clearMockUiCalls();
   });
 
   afterEach(() => {
+    setMockUi(false);
     installBinarySpy.mockRestore();
     resolveBinaryPathSpy.mockRestore();
     rmSync(tempDir, { recursive: true, force: true });
@@ -257,47 +266,202 @@ describe('declarative integration framework', () => {
     );
   });
 
-  it('selects features matching an invocation', () => {
+  it('selects features matching an invocation', async () => {
     interface GitOptions {
-      hook?: 'pre-commit' | 'pre-push';
+      nonInteractive?: boolean;
     }
     const integration: IntegrationDeclaration<GitOptions> = makeIntegration({
       features: [
         {
           id: 'pre-commit',
           displayName: 'Pre-commit',
-          when: ({ options }) => !options.hook || options.hook === 'pre-commit',
         },
         {
           id: 'pre-push',
           displayName: 'Pre-push',
-          when: ({ options }) => options.hook === 'pre-push',
-        },
-        {
-          id: 'always',
-          displayName: 'Always',
+          when: ({ options }) =>
+            options.nonInteractive === true ? { kind: 'skip' } : { kind: 'ask' },
         },
       ],
     });
 
     expect(
-      installer
-        .selectFeaturesForInvocation(integration, {
-          options: {},
+      (
+        await installer.selectFeaturesForInvocation(integration, {
+          options: { nonInteractive: true },
           targetRoot: tempDir,
           scope: 'project',
+          nonInteractive: true,
         })
-        .map((feature) => feature.id),
-    ).toEqual(['pre-commit', 'always']);
+      ).map((feature) => feature.id),
+    ).toEqual(['pre-commit']);
+
+    queueMockResponse(true);
+    queueMockResponse(true);
     expect(
-      installer
-        .selectFeaturesForInvocation(integration, {
-          options: { hook: 'pre-push' },
+      (
+        await installer.selectFeaturesForInvocation(integration, {
+          options: { nonInteractive: false },
           targetRoot: tempDir,
           scope: 'project',
+          nonInteractive: false,
         })
-        .map((feature) => feature.id),
-    ).toEqual(['pre-push', 'always']);
+      ).map((feature) => feature.id),
+    ).toEqual(['pre-commit', 'pre-push']);
+  });
+
+  it('skips feature and shows reason when when() returns skip with reason', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [
+        {
+          id: 'f',
+          displayName: 'My Feature',
+          when: () => ({ kind: 'skip', reason: 'already done' }),
+        },
+      ],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(
+      integration,
+      makeInvocation(tempDir),
+    );
+
+    expect(selected).toHaveLength(0);
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'info' && String(c.args[0]) === 'My Feature: already done',
+      ),
+    ).toBe(true);
+  });
+
+  it('skips feature silently when when() returns skip without reason', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [{ id: 'f', displayName: 'My Feature', when: () => ({ kind: 'skip' }) }],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(
+      integration,
+      makeInvocation(tempDir),
+    );
+
+    expect(selected).toHaveLength(0);
+    expect(getMockUiCalls().some((c) => c.method === 'info')).toBe(false);
+  });
+
+  it('prompts with default question including hint when when() returns ask', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [
+        { id: 'f', displayName: 'My Feature', hint: 'does X', when: () => ({ kind: 'ask' }) },
+      ],
+    });
+    queueMockResponse(true);
+
+    const selected = await installer.selectFeaturesForInvocation(
+      integration,
+      makeInvocation(tempDir),
+    );
+
+    expect(selected.map((f) => f.id)).toEqual(['f']);
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'confirmPrompt' && String(c.args[0]) === 'Set up My Feature? (does X)',
+      ),
+    ).toBe(true);
+  });
+
+  it('prompts with default question when no hint is set', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [{ id: 'f', displayName: 'My Feature', when: () => ({ kind: 'ask' }) }],
+    });
+    queueMockResponse(true);
+
+    await installer.selectFeaturesForInvocation(integration, makeInvocation(tempDir));
+
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'confirmPrompt' && String(c.args[0]) === 'Set up My Feature?',
+      ),
+    ).toBe(true);
+  });
+
+  it('uses custom question when when() returns ask with question', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [
+        {
+          id: 'f',
+          displayName: 'My Feature',
+          when: () => ({ kind: 'ask', question: 'Enable this?' }),
+        },
+      ],
+    });
+    queueMockResponse(true);
+
+    await installer.selectFeaturesForInvocation(integration, makeInvocation(tempDir));
+
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'confirmPrompt' && String(c.args[0]) === 'Enable this?',
+      ),
+    ).toBe(true);
+  });
+
+  it('excludes feature when user declines the prompt', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [{ id: 'f', displayName: 'My Feature', when: () => ({ kind: 'ask' }) }],
+    });
+    queueMockResponse(false);
+
+    const selected = await installer.selectFeaturesForInvocation(
+      integration,
+      makeInvocation(tempDir),
+    );
+
+    expect(selected).toHaveLength(0);
+  });
+
+  it('auto-accepts all ask features in nonInteractive mode without prompting', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [
+        { id: 'a', displayName: 'A', when: () => ({ kind: 'ask' }) },
+        { id: 'b', displayName: 'B' },
+      ],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(
+      integration,
+      makeInvocation(tempDir, { nonInteractive: true }),
+    );
+
+    expect(selected.map((f) => f.id)).toEqual(['a', 'b']);
+    expect(getMockUiCalls().some((c) => c.method === 'confirmPrompt')).toBe(false);
+  });
+
+  it('handles async when() callbacks', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [
+        { id: 'f', displayName: 'My Feature', when: () => Promise.resolve({ kind: 'ask' }) },
+      ],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(
+      integration,
+      makeInvocation(tempDir, { nonInteractive: true }),
+    );
+
+    expect(selected.map((f) => f.id)).toEqual(['f']);
+  });
+
+  it('includes feature when no when() is defined', async () => {
+    const integration: IntegrationDeclaration = makeIntegration<Record<string, unknown>>({
+      features: [{ id: 'f', displayName: 'My Feature' }],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(
+      integration,
+      makeInvocation(tempDir, { nonInteractive: true }),
+    );
+
+    expect(selected.map((f) => f.id)).toEqual(['f']);
   });
 
   it('applies declared resources and records the feature once', async () => {
@@ -900,5 +1064,14 @@ function makeContext(
     scope: 'project',
     force,
     attrs,
+  };
+}
+
+function makeInvocation(targetRoot: string, opts?: { nonInteractive?: boolean }) {
+  return {
+    options: {} as Record<string, unknown>,
+    targetRoot,
+    scope: 'project' as const,
+    ...opts,
   };
 }

--- a/tests/unit/cli/commands/integrate/claude/hooks.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/hooks.test.ts
@@ -25,10 +25,8 @@ import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:te
 
 import {
   areHooksInstalled,
-  detectGlobalSecretsHook,
   installHooks,
 } from '../../../../../../src/cli/commands/integrate/claude/hooks';
-import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../../src/ui';
 
 const PROJECT_ROOT = '/fake/project';
 const GLOBAL_DIR = '/fake/global';
@@ -63,104 +61,6 @@ function getScriptPathFor(nameFragment: string): string | undefined {
 }
 
 let writeFileSpy: Mock<Extract<(typeof fsPromises)['writeFile'], (...args: any[]) => any>>;
-
-describe('detectGlobalSecretsHook', () => {
-  let existsSyncSpy: Mock<Extract<(typeof nodeFs)['existsSync'], (...args: any[]) => any>>;
-  let readFileSpy: Mock<Extract<(typeof fsPromises)['readFile'], (...args: any[]) => any>>;
-
-  const SETTINGS_WITH_SECRETS = {
-    hooks: {
-      PreToolUse: [
-        {
-          matcher: 'Read',
-          hooks: [
-            { type: 'command', command: '.claude/hooks/sonar-secrets/pretool.sh', timeout: 60 },
-          ],
-        },
-      ],
-    },
-  };
-
-  beforeEach(() => {
-    setMockUi(true);
-    existsSyncSpy = spyOn(nodeFs, 'existsSync').mockReturnValue(true);
-    readFileSpy = spyOn(fsPromises, 'readFile').mockResolvedValue('{}');
-  });
-
-  afterEach(() => {
-    clearMockUiCalls();
-    setMockUi(false);
-    existsSyncSpy.mockRestore();
-    readFileSpy.mockRestore();
-  });
-
-  it('returns undefined and stays silent when settings.json does not exist (absent)', async () => {
-    existsSyncSpy.mockReturnValue(false);
-
-    expect(await detectGlobalSecretsHook(PROJECT_ROOT)).toBeUndefined();
-    const noisy = getMockUiCalls().filter((c) => c.method === 'info' || c.method === 'warn');
-    expect(noisy).toHaveLength(0);
-  });
-
-  it('returns undefined and stays silent when no PreToolUse entry references sonar-secrets (absent)', async () => {
-    readFileSpy.mockResolvedValue(JSON.stringify({ hooks: { PreToolUse: [] } }));
-
-    expect(await detectGlobalSecretsHook(PROJECT_ROOT)).toBeUndefined();
-    const noisy = getMockUiCalls().filter((c) => c.method === 'info' || c.method === 'warn');
-    expect(noisy).toHaveLength(0);
-  });
-
-  it('returns undefined and stays silent when settings.json contains malformed JSON (absent)', async () => {
-    readFileSpy.mockResolvedValue('{ invalid json !!!');
-
-    expect(await detectGlobalSecretsHook(PROJECT_ROOT)).toBeUndefined();
-    const noisy = getMockUiCalls().filter((c) => c.method === 'info' || c.method === 'warn');
-    expect(noisy).toHaveLength(0);
-  });
-
-  it('returns undefined and emits warn(...) when settings entry exists but the sonar-secrets script directory is missing (orphaned)', async () => {
-    readFileSpy.mockResolvedValue(JSON.stringify(SETTINGS_WITH_SECRETS));
-    existsSyncSpy.mockImplementation((p: nodeFs.PathLike) => {
-      const path = normPath(String(p));
-      if (path.endsWith('.claude/hooks/sonar-secrets')) return false;
-      return path.endsWith('.claude/settings.json');
-    });
-
-    const result = await detectGlobalSecretsHook(PROJECT_ROOT);
-
-    expect(result).toBeUndefined();
-    const warnCall = getMockUiCalls().find(
-      (c) =>
-        c.method === 'warn' &&
-        String(c.args[0]).includes(
-          'WARNING: Global hook configuration detected, but the source files are missing',
-        ),
-    );
-    expect(warnCall).toBeDefined();
-  });
-
-  it('returns the hook dir and emits info(...) when both settings entry and sonar-secrets script directory are present (installed)', async () => {
-    readFileSpy.mockResolvedValue(JSON.stringify(SETTINGS_WITH_SECRETS));
-    existsSyncSpy.mockImplementation((p: nodeFs.PathLike) => {
-      const path = normPath(String(p));
-      return path.endsWith('.claude/settings.json') || path.endsWith('.claude/hooks/sonar-secrets');
-    });
-
-    const result = await detectGlobalSecretsHook(PROJECT_ROOT);
-
-    expect(result).toBeDefined();
-    expect(normPath(result ?? '')).toEndWith('.claude/hooks/sonar-secrets');
-    const infoCall = getMockUiCalls().find(
-      (c) =>
-        c.method === 'info' &&
-        String(c.args[0]).includes(
-          'A global secrets scanning hook is already configured for SonarQube',
-        ) &&
-        String(c.args[0]).includes('project-level secrets hooks were skipped'),
-    );
-    expect(infoCall).toBeDefined();
-  });
-});
 
 describe('areHooksInstalled', () => {
   let existsSyncSpy: Mock<Extract<(typeof nodeFs)['existsSync'], (...args: any[]) => any>>;

--- a/tests/unit/cli/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/integrate.test.ts
@@ -534,8 +534,6 @@ describe('integrateCommand', () => {
         auth: SERVER_AUTH,
         projectRoot: '/project/root',
         projectKey: 'a-project',
-        installSecretsHooks: false,
-        installSqaaHook: false,
       });
       expect(runMigrationsSpy).toHaveBeenCalledWith(
         '/project/root',
@@ -565,8 +563,6 @@ describe('integrateCommand', () => {
         auth: CLOUD_AUTH,
         projectRoot: '/project/root',
         projectKey: 'a-project',
-        installSecretsHooks: false,
-        installSqaaHook: true,
       });
     });
 
@@ -612,8 +608,6 @@ describe('integrateCommand', () => {
         auth: SERVER_AUTH,
         projectRoot: '/project/root',
         projectKey: 'a-project',
-        installSecretsHooks: true,
-        installSqaaHook: false,
       });
     });
 
@@ -705,7 +699,6 @@ describe('integrateCommand', () => {
     isGlobal: boolean,
     sqaaEnabled: boolean,
     auth: ResolvedAuth = CLOUD_AUTH,
-    skipSecretsHooks = false,
   ): void {
     const expectedOptions = { skipSecretsHooks: false };
     expect(runMigrationsSpy).toHaveBeenCalledTimes(1);
@@ -725,8 +718,6 @@ describe('integrateCommand', () => {
       auth,
       projectRoot: projectRootDir,
       projectKey,
-      installSecretsHooks: !skipSecretsHooks,
-      installSqaaHook: sqaaEnabled && projectKey !== undefined,
     });
 
     expect(updateStateAfterConfigurationSpy).toHaveBeenCalledTimes(1);
@@ -745,16 +736,12 @@ describe('integrateCommand', () => {
     auth,
     projectRoot,
     projectKey,
-    installSecretsHooks,
-    installSqaaHook,
   }: {
     targetRoot: string;
     scope: 'global' | 'project';
     auth: ResolvedAuth;
     projectRoot: string;
     projectKey?: string;
-    installSecretsHooks: boolean;
-    installSqaaHook: boolean;
   }): void {
     const attrs = {
       orgKey: auth.orgKey ?? null,
@@ -768,9 +755,10 @@ describe('integrateCommand', () => {
         integrationId: 'claude-code',
         options: expect.objectContaining({
           projectRoot,
-          installSecretsHooks,
-          installSqaaHook,
-          installMcp: true,
+          serverURL: auth.serverUrl,
+          token: auth.token,
+          organization: auth.orgKey,
+          projectKey,
         }),
         scope,
         targetRoot,

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -23,20 +23,14 @@ import { isAbsolute, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import {
-  CommandFailedError,
-  InvalidOptionError,
-} from '../../../../../../src/cli/commands/_common/error.js';
+import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error.js';
 import * as binaryInstall from '../../../../../../src/cli/commands/_common/install/binary';
 import {
   detectSonarHookInstallation as detectHookInstallation,
   hasMarker,
   installViaGitHooks,
   integrateGit,
-  type IntegrateGitOptions,
-  isGitHookType,
   resolveGitHooksDir,
-  resolveHookType,
   showInstallationStatus,
   showPostInstallInfo,
 } from '../../../../../../src/cli/commands/integrate/git';
@@ -58,15 +52,6 @@ const TEMP_DIR = join(process.cwd(), 'tests', 'unit', '.integrate-git-tmp');
 
 /** Simulate `git config core.hooksPath` returning "not set" (exit code 1). */
 const NO_HOOKS_PATH = { exitCode: 1, stdout: '', stderr: '' };
-
-describe('isGitHookType', () => {
-  it('returns true for valid hook types and false otherwise', () => {
-    expect(isGitHookType('pre-commit')).toBe(true);
-    expect(isGitHookType('pre-push')).toBe(true);
-    expect(isGitHookType('commit-msg')).toBe(false);
-    expect(isGitHookType('')).toBe(false);
-  });
-});
 
 describe('hasMarker', () => {
   it('returns true only when the file exists and contains the marker', () => {
@@ -328,55 +313,6 @@ describe('detectHookInstallation', () => {
   });
 });
 
-describe('resolveHookType', () => {
-  it('returns pre-commit when --hook pre-commit is passed', async () => {
-    const result = await resolveHookType({ hook: 'pre-commit' });
-    expect(result).toBe('pre-commit');
-  });
-
-  it('returns pre-push when --hook pre-push is passed', async () => {
-    const result = await resolveHookType({ hook: 'pre-push' });
-    expect(result).toBe('pre-push');
-  });
-
-  it('defaults to pre-commit when non-interactive and hook is omitted', async () => {
-    const result = await resolveHookType({ nonInteractive: true });
-    expect(result).toBe('pre-commit');
-  });
-
-  it('returns pre-commit when the user selects it from the prompt', async () => {
-    setMockUi(true);
-    queueMockResponse('pre-commit');
-    try {
-      const result = await resolveHookType({});
-      expect(result).toBe('pre-commit');
-    } finally {
-      setMockUi(false);
-    }
-  });
-
-  it('returns pre-push when the user selects it from the prompt', async () => {
-    setMockUi(true);
-    queueMockResponse('pre-push');
-    try {
-      const result = await resolveHookType({});
-      expect(result).toBe('pre-push');
-    } finally {
-      setMockUi(false);
-    }
-  });
-
-  it('throws CommandFailedError when the user cancels the prompt', () => {
-    setMockUi(true);
-    queueMockResponse(null);
-    try {
-      expect(resolveHookType({})).rejects.toThrow('Installation cancelled');
-    } finally {
-      setMockUi(false);
-    }
-  });
-});
-
 describe('showPostInstallInfo', () => {
   beforeEach(() => {
     setMockUi(true);
@@ -552,33 +488,6 @@ describe('integrateGit', () => {
     saveStateSpy.mockRestore();
   });
 
-  /* eslint-disable @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable */
-  it('throws InvalidOptionError when --hook is invalid before git checks', async () => {
-    await expect(
-      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
-    ).rejects.toBeInstanceOf(InvalidOptionError);
-    await expect(
-      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
-    ).rejects.toThrow('--hook must be pre-commit or pre-push');
-  });
-
-  it('throws InvalidOptionError for invalid --hook on global install before other work', async () => {
-    await expect(
-      integrateGit({
-        global: true,
-        nonInteractive: true,
-        hook: 'typo',
-      } as unknown as IntegrateGitOptions),
-    ).rejects.toBeInstanceOf(InvalidOptionError);
-    await expect(
-      integrateGit({
-        global: true,
-        nonInteractive: true,
-        hook: 'typo',
-      } as unknown as IntegrateGitOptions),
-    ).rejects.toThrow('--hook must be pre-commit or pre-push');
-  });
-
   it('throws CommandFailedError when not inside a git repository', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: '/not-a-repo', isGit: false });
     expect(integrateGit({ nonInteractive: true })).rejects.toThrow('No git repository found');
@@ -610,7 +519,7 @@ describe('integrateGit', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ nonInteractive: true });
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('husky');
       expect(feature).toMatchObject({
@@ -653,7 +562,7 @@ describe('integrateGit', () => {
       throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
     });
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ nonInteractive: true });
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('pre-commit');
       expect(feature).toMatchObject({
@@ -685,7 +594,7 @@ describe('integrateGit', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: TEMP_DIR, isGit: true });
     const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(NO_HOOKS_PATH);
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ nonInteractive: true });
       expect(existsSync(join(TEMP_DIR, '.git', 'hooks', 'pre-commit'))).toBe(true);
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('native-git');
@@ -746,7 +655,7 @@ describe('integrateGitGlobal', () => {
     queueMockResponse(null);
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: false, hook: 'pre-commit' });
+      await integrateGit({ global: true, nonInteractive: false });
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -757,7 +666,7 @@ describe('integrateGitGlobal', () => {
     installBinarySpy.mockRejectedValue(new Error('download failed'));
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ global: true, nonInteractive: true });
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -771,7 +680,7 @@ describe('integrateGitGlobal', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ global: true, nonInteractive: true });
       const calls = getMockUiCalls();
       expect(
         calls.some(
@@ -799,7 +708,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+        await integrateGit({ global: true, nonInteractive: true });
       } catch (e) {
         caughtError = e;
       }
@@ -821,7 +730,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+        await integrateGit({ global: true, nonInteractive: true });
       } catch (e) {
         caughtError = e;
       }

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -528,7 +528,6 @@ describe('integrateGit', () => {
       } as unknown as IntegrateGitOptions),
     ).rejects.toThrow('--hook must be pre-commit or pre-push');
   });
-  /* eslint-enable @typescript-eslint/await-thenable */
 
   it('throws CommandFailedError when not inside a git repository', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: '/not-a-repo', isGit: false });
@@ -561,7 +560,7 @@ describe('integrateGit', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ nonInteractive: true });
+      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('husky');
       expect(feature).toMatchObject({
@@ -604,7 +603,7 @@ describe('integrateGit', () => {
       throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
     });
     try {
-      await integrateGit({ nonInteractive: true });
+      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('pre-commit');
       expect(feature).toMatchObject({
@@ -636,7 +635,7 @@ describe('integrateGit', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: TEMP_DIR, isGit: true });
     const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(NO_HOOKS_PATH);
     try {
-      await integrateGit({ nonInteractive: true });
+      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
       expect(existsSync(join(TEMP_DIR, '.git', 'hooks', 'pre-commit'))).toBe(true);
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('native-git');
@@ -697,7 +696,7 @@ describe('integrateGitGlobal', () => {
     queueMockResponse(null);
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: false });
+      await integrateGit({ global: true, nonInteractive: false, hook: 'pre-commit' });
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -708,7 +707,7 @@ describe('integrateGitGlobal', () => {
     installBinarySpy.mockRejectedValue(new Error('download failed'));
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: true });
+      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -722,7 +721,7 @@ describe('integrateGitGlobal', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ global: true, nonInteractive: true });
+      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
       const calls = getMockUiCalls();
       expect(
         calls.some(
@@ -750,7 +749,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true });
+        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
       } catch (e) {
         caughtError = e;
       }
@@ -772,7 +771,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true });
+        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
       } catch (e) {
         caughtError = e;
       }

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -23,13 +23,18 @@ import { isAbsolute, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error.js';
+import {
+  CommandFailedError,
+  InvalidOptionError,
+} from '../../../../../../src/cli/commands/_common/error.js';
 import * as binaryInstall from '../../../../../../src/cli/commands/_common/install/binary';
 import {
   detectSonarHookInstallation as detectHookInstallation,
   hasMarker,
   installViaGitHooks,
   integrateGit,
+  type IntegrateGitOptions,
+  isGitHookType,
   resolveGitHooksDir,
   showInstallationStatus,
   showPostInstallInfo,
@@ -52,6 +57,15 @@ const TEMP_DIR = join(process.cwd(), 'tests', 'unit', '.integrate-git-tmp');
 
 /** Simulate `git config core.hooksPath` returning "not set" (exit code 1). */
 const NO_HOOKS_PATH = { exitCode: 1, stdout: '', stderr: '' };
+
+describe('isGitHookType', () => {
+  it('returns true for valid hook types and false otherwise', () => {
+    expect(isGitHookType('pre-commit')).toBe(true);
+    expect(isGitHookType('pre-push')).toBe(true);
+    expect(isGitHookType('commit-msg')).toBe(false);
+    expect(isGitHookType('')).toBe(false);
+  });
+});
 
 describe('hasMarker', () => {
   it('returns true only when the file exists and contains the marker', () => {
@@ -487,6 +501,34 @@ describe('integrateGit', () => {
     loadStateSpy.mockRestore();
     saveStateSpy.mockRestore();
   });
+
+  /* eslint-disable @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable */
+  it('throws InvalidOptionError when --hook is invalid before git checks', async () => {
+    await expect(
+      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
+    ).rejects.toBeInstanceOf(InvalidOptionError);
+    await expect(
+      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
+    ).rejects.toThrow('--hook must be pre-commit or pre-push');
+  });
+
+  it('throws InvalidOptionError for invalid --hook on global install before other work', async () => {
+    await expect(
+      integrateGit({
+        global: true,
+        nonInteractive: true,
+        hook: 'typo',
+      } as unknown as IntegrateGitOptions),
+    ).rejects.toBeInstanceOf(InvalidOptionError);
+    await expect(
+      integrateGit({
+        global: true,
+        nonInteractive: true,
+        hook: 'typo',
+      } as unknown as IntegrateGitOptions),
+    ).rejects.toThrow('--hook must be pre-commit or pre-push');
+  });
+  /* eslint-enable @typescript-eslint/await-thenable */
 
   it('throws CommandFailedError when not inside a git repository', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: '/not-a-repo', isGit: false });

--- a/tests/unit/ui/prompts.test.ts
+++ b/tests/unit/ui/prompts.test.ts
@@ -128,6 +128,11 @@ describe('confirmPrompt: mock mode', () => {
     expect(result).toBe(false);
   });
 
+  it('uses initialValue as fallback when queue is empty', async () => {
+    const result = await confirmPrompt('Set up feature?', true);
+    expect(result).toBe(true);
+  });
+
   it('dequeues boolean responses in FIFO order', async () => {
     queueMockResponse(true);
     queueMockResponse(false);


### PR DESCRIPTION
----
## Summary by Gitar

- **Interactive Integration Flow:**
  - Refactored integration framework to enable interactive, per-feature selection, replacing rigid `--hook` or `--install` flags with a declarative `when` condition.
  - Added `--non-interactive` flag to all `integrate` commands to bypass prompts.
- **Feature Selection & Logic:**
  - Replaced hardcoded integration flags with a flexible `when` condition supporting `ask`, `skip`, or `install` logic.
  - Implemented `isFeatureInstalled` checks to prevent redundant installations and manage global-to-local transitions.
- **Instruction Templates:**
  - Updated `textSnippet` to use marker-delimited blocks, allowing multiple features (e.g., secrets scanning and SQAA) to coexist in instructions files.
- **CLI Command Cleanup:**
  - Standardized `integrate git` to prompt for hook selection interactively, removing the redundant `--hook` option.
  - Migrated Git, Copilot, and Codex integrations to the new declarative installation registry.


<sub>This will update automatically on new commits.</sub>