### PR TITLE
CLI-523 Error output adjustments

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -31,7 +31,7 @@ import {
   storeEvent,
   TELEMETRY_FLUSH_MODE_ENV,
 } from '../telemetry';
-import { warn } from '../ui';
+import { blank, error, warn } from '../ui';
 import { parseInteger } from './commands/_common/parsing';
 import { SonarCommand } from './commands/_common/sonar-command.js';
 import { analyzeAll, type AnalyzeAllOptions } from './commands/analyze/analyze-all';
@@ -88,6 +88,12 @@ COMMAND_TREE.name('sonar')
   .description('SonarQube CLI')
   .version(VERSION, '-v, --version', 'display version for command')
   .enablePositionalOptions()
+  .configureOutput({
+    outputError: (str) => {
+      blank();
+      error(str.trim());
+    },
+  })
   .configureHelp({
     formatHelp: (cmd, helper) => {
       if (!cmd.parent) {

--- a/src/cli/commands/_common/error.ts
+++ b/src/cli/commands/_common/error.ts
@@ -25,7 +25,7 @@ function hintFromCause(cause: unknown): string | undefined {
     return 'Wait a moment and try again.';
   }
   if (cause instanceof ServiceUnavailableError) {
-    return 'Check your network connection and try again in a moment.';
+    return 'Check your network connection and try again later.';
   }
   return undefined;
 }

--- a/src/cli/commands/_common/error.ts
+++ b/src/cli/commands/_common/error.ts
@@ -18,6 +18,18 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { RateLimitError, ServiceUnavailableError } from '../../../sonarqube/errors.js';
+
+function hintFromCause(cause: unknown): string | undefined {
+  if (cause instanceof RateLimitError) {
+    return 'Wait a moment and try again.';
+  }
+  if (cause instanceof ServiceUnavailableError) {
+    return 'Check your network connection and try again in a moment.';
+  }
+  return undefined;
+}
+
 /**
  * Base class for all CLI errors that carry an exit code.
  * runCommand reads exitCode from any subclass — no instanceof checks needed per type.
@@ -26,10 +38,14 @@ export abstract class CliError extends Error {
   abstract readonly exitCode: number;
   readonly remediationHint?: string;
 
-  protected constructor(message: string, remediationHint?: string) {
-    super(message);
-    this.remediationHint = remediationHint;
+  protected constructor(message: string, options?: CliErrorOptions) {
+    super(message, { cause: options?.cause });
+    this.remediationHint = hintFromCause(options?.cause) ?? options?.remediationHint;
   }
+}
+
+interface CliErrorOptions extends ErrorOptions {
+  remediationHint?: string;
 }
 
 /**
@@ -39,14 +55,13 @@ export abstract class CliError extends Error {
 export class InvalidOptionError extends CliError {
   readonly exitCode = 2;
   constructor(reason: string, remediationHint?: string) {
-    super(reason, remediationHint);
+    super(reason, { remediationHint });
     this.name = 'InvalidOptionError';
   }
 }
 
-export interface CommandFailedErrorOptions {
+export interface CommandFailedErrorOptions extends CliErrorOptions {
   exitCode?: number;
-  remediationHint?: string;
 }
 
 /**
@@ -56,7 +71,7 @@ export interface CommandFailedErrorOptions {
 export class CommandFailedError extends CliError {
   readonly exitCode: number;
   constructor(message: string, options?: CommandFailedErrorOptions) {
-    super(message, options?.remediationHint);
+    super(message, { remediationHint: options?.remediationHint, cause: options?.cause });
     this.name = 'CommandFailedError';
     this.exitCode = options?.exitCode ?? 1;
   }

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -149,9 +149,10 @@ async function assertServerSupportsLocalSca(
     let serverVersion: string;
     try {
       serverVersion = await fetchServerVersion(auth.serverUrl);
-    } catch {
+    } catch (err) {
       throw new CommandFailedError(
         `Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
+        { cause: err },
       );
     }
     if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {

--- a/src/cli/commands/analyze/sqaa-api.ts
+++ b/src/cli/commands/analyze/sqaa-api.ts
@@ -136,7 +136,7 @@ export async function fetchWithRetry(
     }
   }
   throw new CommandFailedError(
-    `Agentic Analysis failed after ${MAX_503_RETRIES} retries. The service is still unavailable.`,
+    `SonarQube Agentic Analysis failed after ${MAX_503_RETRIES} retries. The service is still unavailable.`,
     { cause: lastServiceError },
   );
 }

--- a/src/cli/commands/analyze/sqaa-api.ts
+++ b/src/cli/commands/analyze/sqaa-api.ts
@@ -95,10 +95,13 @@ export async function fetchSqaaResponse(
       fileContent,
     });
   } catch (err) {
-    if (err instanceof ServiceUnavailableError) throw err;
+    if (err instanceof ServiceUnavailableError) {
+      throw err;
+    }
     throw new CommandFailedError(
       `SonarQube Agentic Analysis failed.\n  ${(err as Error).message}`,
       {
+        cause: err,
         remediationHint:
           'Check your SonarQube Cloud authentication, project key, and network connectivity, then retry.',
       },
@@ -118,21 +121,23 @@ export async function fetchWithRetry(
   onRetry?: (attempt: number) => Promise<void>,
   pathBase?: string,
 ): Promise<{ issues: SqaaIssue[]; errors?: Array<{ code: string; message: string }> | null }> {
+  let lastServiceError: ServiceUnavailableError | undefined;
   for (let attempt = 1; attempt <= MAX_503_RETRIES + 1; attempt++) {
     try {
       return await fetchSqaaResponse(auth, projectKey, file, fileContent, branch, pathBase);
     } catch (err) {
-      const shouldRetry = err instanceof ServiceUnavailableError && attempt <= MAX_503_RETRIES;
-      if (!shouldRetry) throw err;
-      await waitBeforeRetry(attempt, onRetry);
+      if (!(err instanceof ServiceUnavailableError)) {
+        throw err;
+      }
+      lastServiceError = err;
+      if (attempt <= MAX_503_RETRIES) {
+        await waitBeforeRetry(attempt, onRetry);
+      }
     }
   }
   throw new CommandFailedError(
-    `SonarQube Agentic Analysis failed after ${MAX_503_RETRIES} retries. The service is still unavailable.`,
-    {
-      remediationHint:
-        'Check your SonarQube Cloud authentication, project key, and network connectivity, then retry.',
-    },
+    `Agentic Analysis failed after ${MAX_503_RETRIES} retries. The service is still unavailable.`,
+    { cause: lastServiceError },
   );
 }
 

--- a/src/cli/commands/analyze/sqaa-display.ts
+++ b/src/cli/commands/analyze/sqaa-display.ts
@@ -187,7 +187,7 @@ export function displaySqaaResults(
   blank();
 
   if (issues.length === 0) {
-    if (!inChangeSetMode) {
+    if (!inChangeSetMode && !errors?.length) {
       success('SonarQube Agentic Analysis completed — no issues found.');
     }
   } else {

--- a/src/cli/commands/remediate/index.ts
+++ b/src/cli/commands/remediate/index.ts
@@ -144,6 +144,7 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
   } catch (err) {
     logger.error(`scheduleAgentJob failed: ${(err as Error).message}`);
     throw new CommandFailedError('Remediation job submission failed.', {
+      cause: err,
       remediationHint: mapSubmissionFailureHint((err as Error).message, orgKey),
     });
   }

--- a/src/cli/commands/remediate/index.ts
+++ b/src/cli/commands/remediate/index.ts
@@ -82,28 +82,19 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
 
   const { status: entitlement } = await client.checkAiRemediationEntitlement(orgKey);
   if (entitlement === 'not_eligible') {
-    print(`The Remediation Agent is not available for your organization (${orgKey}).`);
-    print(`Learn more: ${AI_REMEDIATION_DOCS_URL}`);
-    blank();
     throw new CommandFailedError('Remediation Agent unavailable.', {
       remediationHint: `Ask an organization administrator to check eligibility and enable the feature. Learn more: ${AI_REMEDIATION_DOCS_URL}`,
     });
   }
   if (entitlement === 'not_enabled') {
-    print(`The Remediation Agent is not enabled for your organization (${orgKey}).`);
-    print(`Learn more: ${AI_REMEDIATION_DOCS_URL}`);
-    blank();
     throw new CommandFailedError('Remediation Agent unavailable.', {
       remediationHint: `Ask an organization administrator to enable the feature. Learn more: ${AI_REMEDIATION_DOCS_URL}`,
     });
   }
   if (entitlement === 'unknown') {
-    print(
-      'Could not verify Remediation Agent entitlement. Please try again or contact support if the issue persists.',
-    );
-    blank();
     throw new CommandFailedError('Remediation Agent unavailable.', {
-      remediationHint: 'Retry, and contact support if the problem persists.',
+      remediationHint:
+        'Could not verify Remediation Agent entitlement. Retry later, and report to https://github.com/SonarSource/sonarqube-cli/issues if the problem persists.',
     });
   }
 

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -622,6 +622,7 @@ describe('analyze agentic', () => {
       const output = result.stdout + result.stderr;
       expect(output).toContain('NOT_ENTITLED');
       expect(output).toContain('not entitled');
+      expect(output).not.toContain('no issues found');
     },
     { timeout: 15000 },
   );
@@ -1316,7 +1317,7 @@ describe('analyze agentic — API error codes', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('still unavailable');
       expect(result.stdout + result.stderr).toContain(
-        '  → Check your network connection and try again in a moment.',
+        '  → Check your network connection and try again later.',
       );
       // 4 total attempts: 1 initial + 3 retries
       const sqaaCalls = server

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -1290,6 +1290,7 @@ describe('analyze agentic — API error codes', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('Rate limit reached');
+      expect(result.stdout + result.stderr).toContain('  → Wait a moment and try again.');
     },
     { timeout: 15000 },
   );
@@ -1313,7 +1314,10 @@ describe('analyze agentic — API error codes', () => {
       const result = await harness.run('analyze agentic --file src/index.ts');
 
       expect(result.exitCode).toBe(1);
-      expect(result.stdout + result.stderr).toContain('Server busy');
+      expect(result.stdout + result.stderr).toContain('still unavailable');
+      expect(result.stdout + result.stderr).toContain(
+        '  → Check your network connection and try again in a moment.',
+      );
       // 4 total attempts: 1 initial + 3 retries
       const sqaaCalls = server
         .getRecordedRequests()

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -1763,7 +1763,7 @@ describe('integrate — argument validation', () => {
       const result = await harness.run('integrate gemini');
 
       expect(result.exitCode).toBe(1);
-      expect(result.stdout + result.stderr).toContain("error: unknown command 'gemini'");
+      expect(result.stdout + result.stderr).toContain("❌ error: unknown command 'gemini'");
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/list/list-issues.test.ts
+++ b/tests/integration/specs/list/list-issues.test.ts
@@ -165,7 +165,7 @@ describe('list issues', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        "required option '-p, --project <project>' not specified",
+        "❌ error: required option '-p, --project <project>' not specified",
       );
     },
     { timeout: 15000 },
@@ -226,7 +226,7 @@ describe('list issues — argument validation', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        "error: option '--page-size <page-size>' argument 'abc' is invalid. Not a number.",
+        "❌ error: option '--page-size <page-size>' argument 'abc' is invalid. Not a number.",
       );
     },
     { timeout: 15000 },

--- a/tests/integration/specs/list/list-projects.test.ts
+++ b/tests/integration/specs/list/list-projects.test.ts
@@ -118,7 +118,7 @@ describe('list projects', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        "error: option '--page-size <page-size>' argument 'abc' is invalid. Not a number.",
+        "❌ error: option '--page-size <page-size>' argument 'abc' is invalid. Not a number.",
       );
     },
     { timeout: 15000 },

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -107,8 +107,8 @@ describe('sonar remediate', () => {
 
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('The Remediation Agent is not available for your organization');
-      expect(output).toContain(TEST_ORG);
+      expect(output).toContain('Remediation Agent unavailable.');
+      expect(output).toContain('check eligibility');
       expect(output).toContain('docs.sonarsource.com');
       expect(output).not.toContain('Which issues');
     },
@@ -132,8 +132,8 @@ describe('sonar remediate', () => {
 
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('The Remediation Agent is not enabled for your organization');
-      expect(output).toContain(TEST_ORG);
+      expect(output).toContain('Remediation Agent unavailable.');
+      expect(output).toContain('enable the feature');
       expect(output).toContain('docs.sonarsource.com');
       expect(output).not.toContain('Which issues');
     },
@@ -157,8 +157,8 @@ describe('sonar remediate', () => {
 
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('The Remediation Agent is not available for your organization');
-      expect(output).toContain(TEST_ORG);
+      expect(output).toContain('Remediation Agent unavailable.');
+      expect(output).toContain('check eligibility');
       expect(output).toContain('docs.sonarsource.com');
       expect(output).not.toContain('Which issues');
     },
@@ -766,9 +766,8 @@ describe('sonar remediate', () => {
         const result = await harness.run(`remediate --project ${TEST_PROJECT} --issues k1`);
 
         expect(result.exitCode).toBe(1);
-        expect(result.stdout + result.stderr).toContain(
-          'The Remediation Agent is not enabled for your organization',
-        );
+        expect(result.stdout + result.stderr).toContain('Remediation Agent unavailable.');
+        expect(result.stdout + result.stderr).toContain('enable the feature');
 
         const agentJobCalls = server
           .getRecordedRequests()

--- a/tests/unit/cli/commands/_common/sonar-command.test.ts
+++ b/tests/unit/cli/commands/_common/sonar-command.test.ts
@@ -143,9 +143,7 @@ describe('SonarCommand', () => {
       });
 
       const hintCall = getMockUiCalls().find((c) => c.method === 'print');
-      expect(hintCall?.args[0]).toBe(
-        '  → Check your network connection and try again in a moment.',
-      );
+      expect(hintCall?.args[0]).toBe('  → Check your network connection and try again later.');
     });
 
     it('cause-derived hint takes precedence over generic remediationHint', async () => {

--- a/tests/unit/cli/commands/_common/sonar-command.test.ts
+++ b/tests/unit/cli/commands/_common/sonar-command.test.ts
@@ -29,6 +29,7 @@ import {
 import { SonarCommand } from '../../../../../src/cli/commands/_common/sonar-command';
 import type { ResolvedAuth } from '../../../../../src/lib/auth-resolver';
 import * as authResolver from '../../../../../src/lib/auth-resolver';
+import { RateLimitError, ServiceUnavailableError } from '../../../../../src/sonarqube/errors';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../src/ui';
 
 const FAKE_AUTH: ResolvedAuth = {
@@ -121,6 +122,43 @@ describe('SonarCommand', () => {
 
       const hintCall = getMockUiCalls().find((c) => c.method === 'print');
       expect(hintCall?.args[0]).toBe("  → Run 'sonar auth login' to reauthenticate.");
+    });
+
+    it('derives remediation hint from RateLimitError cause when no explicit hint is given', async () => {
+      const cmd = new SonarCommand();
+      await cmd.runCommand(() => {
+        throw new CommandFailedError('API call failed', { cause: new RateLimitError() });
+      });
+
+      const hintCall = getMockUiCalls().find((c) => c.method === 'print');
+      expect(hintCall?.args[0]).toBe('  → Wait a moment and try again.');
+    });
+
+    it('derives remediation hint from ServiceUnavailableError cause when no explicit hint is given', async () => {
+      const cmd = new SonarCommand();
+      await cmd.runCommand(() => {
+        throw new CommandFailedError('API call failed', {
+          cause: new ServiceUnavailableError(),
+        });
+      });
+
+      const hintCall = getMockUiCalls().find((c) => c.method === 'print');
+      expect(hintCall?.args[0]).toBe(
+        '  → Check your network connection and try again in a moment.',
+      );
+    });
+
+    it('cause-derived hint takes precedence over generic remediationHint', async () => {
+      const cmd = new SonarCommand();
+      await cmd.runCommand(() => {
+        throw new CommandFailedError('API call failed', {
+          cause: new RateLimitError(),
+          remediationHint: 'Custom hint.',
+        });
+      });
+
+      const hintCall = getMockUiCalls().find((c) => c.method === 'print');
+      expect(hintCall?.args[0]).toBe('  → Wait a moment and try again.');
     });
   });
 


### PR DESCRIPTION
The fix addresses:
1. formatting Commander errors (like missing required parameters or unknown commands) to align them with the CLI style;
2. mapping some errors to a specific remediation hints by passing them as causes to CLI errors;
3. a few places with incorrect/duplicating error output.

All 3 changes are in separate commits for the ease of review.