### PR TITLE
CLI-545 Fix macOS-local test failures (path canonicalization + Keychain ACL)

### DIFF
--- a/tests/e2e/bun-secrets-keychain.test.ts
+++ b/tests/e2e/bun-secrets-keychain.test.ts
@@ -102,7 +102,17 @@ async function setupAuth(ctx: E2eContext): Promise<string> {
   return account;
 }
 
-describe('Bun.secrets keychain via CLI', () => {
+// macOS Keychain attaches a per-process ACL to entries written via
+// `Bun.secrets.set`. The test process is on the ACL list; the CLI subprocess
+// spawned by `runCli` is not, so its `Bun.secrets.get` call fails with
+// `errSecAuthFailed` (no GUI in headless test mode to grant access). CI never
+// runs e2e on macOS (only Linux + Windows in the Build workflow), so skip here
+// to keep `bun run test:e2e` clean on macOS dev machines without losing any
+// coverage CI relies on.
+const describeKeychain =
+  process.platform === 'darwin' && process.env.CI !== 'true' ? describe.skip : describe;
+
+describeKeychain('Bun.secrets keychain via CLI', () => {
   let ctx: E2eContext;
 
   beforeEach(async () => {

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -20,7 +20,7 @@
 
 // TestHarness — main entry point for integration tests
 
-import { chmodSync, copyFileSync, mkdirSync } from 'node:fs';
+import { chmodSync, copyFileSync, mkdirSync, realpathSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -71,8 +71,14 @@ export class TestHarness {
   }
 
   static create(): Promise<TestHarness> {
-    const tempDir = join(tmpdir(), `sonar-cli-harness-${Date.now()}-${crypto.randomUUID()}`);
-    mkdirSync(tempDir, { recursive: true });
+    const rawDir = join(tmpdir(), `sonar-cli-harness-${Date.now()}-${crypto.randomUUID()}`);
+    mkdirSync(rawDir, { recursive: true });
+    // Resolve symlinks (macOS exposes $TMPDIR as `/var/folders/...` which is a
+    // symlink to `/private/var/folders/...`). The CLI canonicalises project
+    // roots via project-workspace::canonicalizePath, so state recordings use
+    // the resolved path; matching that here keeps test assertions stable on
+    // macOS local runs.
+    const tempDir = realpathSync(rawDir);
     return Promise.resolve(new TestHarness(tempDir));
   }
 


### PR DESCRIPTION
## Summary

Ten tests fail when running `bun test ./tests/integration/` and `bun run test:e2e` on macOS dev machines. CI is unaffected — these suites only run on Linux/Windows in the Build workflow, where the same code paths behave differently.

### Integration (8 failures) — `/private` symlink resolution

The harness creates its temp dir under `tmpdir()`, which on macOS is `/var/folders/...` — a symlink to `/private/var/folders/...`. Several `integrate {git,claude,codex}` tests compare `state.json` snapshots that include `targetRoot`, and the CLI resolves project roots via `project-workspace::canonicalizePath`, recording the `/private/...` form. Result: macOS-local snapshot mismatches.

Fix: `realpathSync` the temp dir at creation in `TestHarness.create()`. No-op on Linux.

### E2E (2 failures) — macOS Keychain per-binary ACL

`Bun.secrets.set` from the test process attaches the **test runner's** code-signing identity to each Keychain entry. The CLI subprocess spawned by `runCli` has a different identity (ad-hoc signed local dev build), so its `Bun.secrets.get` is blocked from reading without a GUI prompt — exits 1.

Tried multiple bypasses, none viable on a dev machine:
- `security add-generic-password -A` (allow any app) → subsequent `Bun.secrets.get` from the test still prompts
- `security add-generic-password -T <bun> -T <cli>` (explicit trusted apps) → CLI is ad-hoc signed with no stable identity, ACL doesn't match at read time
- `security set-generic-password-partition-list -S apple-tool:,apple:,unsigned:` → requires keychain login password interactively
- Rewriting `setupAuth` to use the CLI's `auth login` flow would only fix the CLI's reads, not the test's own direct `Bun.secrets.get` assertions

Fix: `describe.skip` on `darwin` when `CI !== 'true'`. CI keeps full coverage via `libsecret` + `gnome-keyring` on Linux, which has no per-binary ACL.

## Test plan

- [x] `bun test ./tests/integration/` — 440 pass / 1 skip / 0 fail (was 8 fail)
- [x] `bun run test:e2e` — 4 pass / 14 skip / 0 fail (was 2 fail)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 0 errors

CI behaviour unchanged: integration on Linux+Windows still asserts the snapshots directly (no `/private` prefix issue), and e2e on Linux still runs the full `Bun.secrets keychain via CLI` describe block.