### PR TITLE
CLI-525 do not skip SQAA silently

### DIFF
--- a/src/cli/commands/analyze/analyze-all.ts
+++ b/src/cli/commands/analyze/analyze-all.ts
@@ -81,7 +81,9 @@ export async function analyzeAll(
 
   if (file !== undefined) {
     await analyzeSecrets({ paths: [file] }, auth);
-    await analyzeSqaa({ file, format }, auth, command);
+    // Bare `analyze` is a best-effort catch-all: skip agentic gracefully when no
+    // project is configured rather than failing the whole command.
+    await analyzeSqaa({ file, format }, auth, command, { requireProject: false });
     return;
   }
 
@@ -100,7 +102,8 @@ export async function analyzeAll(
   // analyzeSqaa resolves the change set again internally. The two resolutions may
   // cover slightly different sets if the working tree changes between calls — this
   // is acceptable since the analyses are independent and best-effort.
-  await analyzeSqaa({ staged, base, force, format }, auth, command);
+  // requireProject: false → bare `analyze` skips agentic gracefully when unconfigured.
+  await analyzeSqaa({ staged, base, force, format }, auth, command, { requireProject: false });
 }
 
 async function analyzeAllJson(

--- a/src/cli/commands/analyze/sqaa-auth.ts
+++ b/src/cli/commands/analyze/sqaa-auth.ts
@@ -22,8 +22,6 @@
 
 import { resolve } from 'node:path';
 
-import type { Command } from 'commander';
-
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import logger from '../../../lib/logger';
 import { spawnProcess } from '../../../lib/process';
@@ -47,27 +45,36 @@ export interface CloudAuth {
 }
 
 /**
- * Combines cloud-auth validation and project-key resolution.
- * Returns null (with a warning already printed) when SQAA should be skipped.
+ * Outcome of resolving cloud auth + project key for SQAA. This resolver reports
+ * what it found and leaves the policy (skip vs. fail) to the caller:
+ * - `resolved`: usable cloud auth and project key.
+ * - `no-cloud`: connection is not SonarQube Cloud (a warning was already emitted,
+ *   since agentic analysis is Cloud-only and this is always a graceful skip).
+ * - `no-project`: cloud auth is fine but no project is configured. The caller
+ *   decides whether this is an error or a graceful skip.
+ */
+export type SqaaAuthResolution =
+  | { kind: 'resolved'; cloudAuth: CloudAuth; projectKey: string }
+  | { kind: 'no-cloud' }
+  | { kind: 'no-project' };
+
+/**
+ * Combines cloud-auth validation and project-key resolution. Pure with respect to
+ * the missing-project case: it never throws or warns for `no-project` — the caller
+ * owns that decision (see `resolveSqaaContext` in sqaa.ts).
  */
 export async function resolveCloudAuthAndProject(
   auth: ResolvedAuth,
   explicitProject: string | undefined,
-  command: Command | undefined,
   projectRoot?: string,
-): Promise<{ cloudAuth: CloudAuth; projectKey: string } | null> {
+): Promise<SqaaAuthResolution> {
   const cloudAuth = resolveCloudAuth(auth, explicitProject);
-  if (!cloudAuth) return null;
+  if (!cloudAuth) return { kind: 'no-cloud' };
 
-  const projectKey = explicitProject ?? (await resolveSqaaProjectKey(command, projectRoot));
-  if (!projectKey) {
-    warn(
-      'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate claude',
-    );
-    return null;
-  }
+  const projectKey = explicitProject ?? (await resolveSqaaProjectKey(projectRoot));
+  if (!projectKey) return { kind: 'no-project' };
 
-  return { cloudAuth, projectKey };
+  return { kind: 'resolved', cloudAuth, projectKey };
 }
 
 /**
@@ -109,10 +116,7 @@ export function resolveCloudAuth(
  * Falls back to `process.cwd()` when not inside a git repository so the
  * single-file path still works outside git.
  */
-export async function resolveSqaaProjectKey(
-  command?: Command,
-  projectRoot?: string,
-): Promise<string | null> {
+export async function resolveSqaaProjectKey(projectRoot?: string): Promise<string | null> {
   try {
     const root = projectRoot ?? (await tryResolveRepoRoot(process.cwd()));
     const state = loadState();
@@ -125,9 +129,6 @@ export async function resolveSqaaProjectKey(
       logger.debug(
         'SonarQube Agentic Analysis skipped: no project key found in extensions registry',
       );
-      if (process.stdin.isTTY) {
-        command?.outputHelp();
-      }
       return null;
     }
 

--- a/src/cli/commands/analyze/sqaa.ts
+++ b/src/cli/commands/analyze/sqaa.ts
@@ -22,9 +22,9 @@ import { existsSync } from 'node:fs';
 import type { Command } from 'commander';
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
-import { blank, print, text } from '../../../ui';
+import { blank, print, text, warn } from '../../../ui';
 import { SqaaProgress } from '../../../ui/components/sqaa-progress.js';
-import { InvalidOptionError } from '../_common/error.js';
+import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
 import type { RunContext } from './sqaa-analysis';
 import { runAnalyses } from './sqaa-analysis';
 import {
@@ -33,7 +33,7 @@ import {
   readSqaaFileContent,
   toRelativePosixPath,
 } from './sqaa-api';
-import type { CloudAuth } from './sqaa-auth';
+import type { CloudAuth, SqaaAuthResolution } from './sqaa-auth';
 import { confirmLargeChangeset, resolveCloudAuthAndProject } from './sqaa-auth';
 import type { ChangeSetResult } from './sqaa-changeset';
 import { resolveChangeSet } from './sqaa-changeset';
@@ -66,11 +66,53 @@ export interface AnalyzeSqaaOptions {
   format?: OutputFormat;
 }
 
+/**
+ * Apply the command's policy to an auth/project resolution. This is where the
+ * caller (not the resolver) decides what a missing project means:
+ * - `requireProject` (explicit `analyze agentic` / `verify`): throw so the command
+ *   exits with code 1 instead of skipping silently.
+ * - otherwise (the bare `sonar analyze` catch-all): warn and return null so the
+ *   surrounding command can proceed with its other analyses.
+ *
+ * A non-Cloud connection is always a graceful skip (the warning was already emitted
+ * by resolveCloudAuth), since agentic analysis is Cloud-only.
+ */
+function resolveSqaaContext(
+  resolution: SqaaAuthResolution,
+  policy: { requireProject: boolean; command?: Command },
+): { cloudAuth: CloudAuth; projectKey: string } | null {
+  switch (resolution.kind) {
+    case 'resolved':
+      return { cloudAuth: resolution.cloudAuth, projectKey: resolution.projectKey };
+    case 'no-cloud':
+      return null;
+    case 'no-project':
+      if (policy.requireProject) {
+        throw new CommandFailedError(
+          'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
+          {
+            remediationHint:
+              "Specify one with --project, or run 'sonar integrate' to configure this project.",
+          },
+        );
+      }
+      warn(
+        'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
+      );
+      if (process.stdin.isTTY) policy.command?.outputHelp();
+      return null;
+  }
+}
+
 export async function analyzeSqaa(
   options: AnalyzeSqaaOptions,
   auth: ResolvedAuth,
   command?: Command,
+  runOptions: { requireProject?: boolean } = {},
 ): Promise<void> {
+  // Explicit `analyze agentic` / `verify` require a project (exit 1 when missing);
+  // the bare `sonar analyze` catch-all opts out so it can still run other analyses.
+  const { requireProject = true } = runOptions;
   const { file, staged, base, branch, project, force, format = 'text' } = options;
 
   if (staged && base !== undefined) {
@@ -81,7 +123,7 @@ export async function analyzeSqaa(
     if (!existsSync(file)) {
       throw new InvalidOptionError(`File not found: ${file}`);
     }
-    await runSqaaAnalysis(file, auth, branch, project, command, format);
+    await runSqaaAnalysis(file, auth, branch, project, command, format, requireProject);
     return;
   }
 
@@ -104,7 +146,8 @@ export async function analyzeSqaa(
 
   // Resolve cloud auth + project key BEFORE prompting.
   // Pass repoRoot so we reuse the already-resolved root instead of spawning git again.
-  const resolved = await resolveCloudAuthAndProject(auth, project, command, changeSet.repoRoot);
+  const resolution = await resolveCloudAuthAndProject(auth, project, changeSet.repoRoot);
+  const resolved = resolveSqaaContext(resolution, { requireProject, command });
   if (!resolved) return;
 
   // JSON mode is consumed by scripts/CI: never block on an interactive prompt
@@ -123,8 +166,10 @@ async function runSqaaAnalysis(
   explicitProject?: string,
   command?: Command,
   format: OutputFormat = 'text',
+  requireProject = true,
 ): Promise<void> {
-  const resolved = await resolveCloudAuthAndProject(auth, explicitProject, command);
+  const resolution = await resolveCloudAuthAndProject(auth, explicitProject);
+  const resolved = resolveSqaaContext(resolution, { requireProject, command });
   if (!resolved) return;
 
   const { cloudAuth, projectKey } = resolved;
@@ -219,7 +264,8 @@ export async function buildSqaaJsonReport(
   const { file, staged, base, branch, project, force } = options;
 
   if (file !== undefined) {
-    const resolved = await resolveCloudAuthAndProject(auth, project, command);
+    const resolution = await resolveCloudAuthAndProject(auth, project);
+    const resolved = resolveSqaaContext(resolution, { requireProject: false, command });
     if (!resolved) return null;
 
     const { cloudAuth, projectKey } = resolved;
@@ -237,7 +283,8 @@ export async function buildSqaaJsonReport(
     );
   }
 
-  const resolved = await resolveCloudAuthAndProject(auth, project, command, changeSet.repoRoot);
+  const resolution = await resolveCloudAuthAndProject(auth, project, changeSet.repoRoot);
+  const resolved = resolveSqaaContext(resolution, { requireProject: false, command });
   if (!resolved) return null;
 
   // JSON mode is consumed by scripts/CI: never block on an interactive prompt

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -457,7 +457,7 @@ describe('analyze agentic', () => {
   );
 
   it(
-    'exits with code 0, warns, and skips SQAA when no extension registered for this project',
+    'exits with code 1 when no extension registered for this project',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -465,16 +465,16 @@ describe('analyze agentic', () => {
         .withSqaaResponse({ issues: [] })
         .start();
 
-      // Connection exists but no withSqaaExtension() → no projectKey in registry → skip
+      // Connection exists but no withSqaaExtension() → no projectKey in registry → error
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       harness.cwd.writeFile('src/index.ts', 'const x = 1;');
 
       const result = await harness.run('analyze agentic --file src/index.ts');
 
-      expect(result.exitCode).toBe(0);
+      expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate claude',
+        'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -975,7 +975,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
   );
 
   it(
-    'exits with code 0 and warns when no project is configured in change-set mode',
+    'exits with code 1 when no project is configured in change-set mode',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -983,13 +983,43 @@ describe('analyze agentic — change-set mode (no --file)', () => {
         .withSqaaResponse({ issues: [] })
         .start();
 
-      // Cloud auth but no extension registered → no projectKey in registry → skip
+      // Cloud auth but no extension registered → no projectKey in registry → error
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       commitFile(harness.cwd.path, 'README.md', 'hello');
       harness.cwd.writeFile('app.ts', 'const a = 1;');
 
       const result = await harness.run('analyze agentic');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain(
+        'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
+      );
+      const sqaaCalls = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/a3s-analysis/analyses');
+      expect(sqaaCalls).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'exits with code 0 and skips agentic gracefully for the bare `analyze` command when no project is configured',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+
+      // Cloud auth but no extension registered. The bare `analyze` catch-all must
+      // still skip agentic gracefully (Option A) rather than failing the command.
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      commitFile(harness.cwd.path, 'README.md', 'hello');
+      harness.cwd.writeFile('app.ts', 'const a = 1;');
+
+      const result = await harness.run('analyze');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(

--- a/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
@@ -128,36 +128,55 @@ describe('analyzeSqaa: input validation', () => {
   });
 });
 
-describe('analyzeSqaa: auth resolution', () => {
-  it('skips SQAA and warns when extension has no projectKey', async () => {
-    const state = getDefaultState('test');
-    stateManager.addOrUpdateConnection(state, SONARCLOUD_URL, 'cloud', {
-      orgKey: TEST_ORG,
-    });
-    // Extension exists but projectKey is undefined
-    stateManager.upsertAgentExtension(state, {
-      id: 'ext-no-key',
-      agentId: 'claude-code',
-      projectRoot: process.cwd(),
-      global: false,
-      orgKey: TEST_ORG,
-      serverUrl: SONARCLOUD_URL,
-      updatedByCliVersion: '1.0.0',
-      updatedAt: new Date().toISOString(),
-      kind: 'hook',
-      name: 'sonar-sqaa',
-      hookType: 'PostToolUse',
-    });
-    loadStateSpy.mockReturnValue(state);
+function stateWithExtensionMissingProjectKey() {
+  const state = getDefaultState('test');
+  stateManager.addOrUpdateConnection(state, SONARCLOUD_URL, 'cloud', {
+    orgKey: TEST_ORG,
+  });
+  // Extension exists but projectKey is undefined
+  stateManager.upsertAgentExtension(state, {
+    id: 'ext-no-key',
+    agentId: 'claude-code',
+    projectRoot: process.cwd(),
+    global: false,
+    orgKey: TEST_ORG,
+    serverUrl: SONARCLOUD_URL,
+    updatedByCliVersion: '1.0.0',
+    updatedAt: new Date().toISOString(),
+    kind: 'hook',
+    name: 'sonar-sqaa',
+    hookType: 'PostToolUse',
+  });
+  return state;
+}
 
-    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH);
+describe('analyzeSqaa: auth resolution', () => {
+  it('throws CommandFailedError when extension has no projectKey (explicit agentic)', async () => {
+    loadStateSpy.mockReturnValue(stateWithExtensionMissingProjectKey());
+
+    let thrown: unknown;
+    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH).catch((err: unknown) => {
+      thrown = err;
+    });
+
+    expect(thrown).toBeInstanceOf(CommandFailedError);
+    expect((thrown as Error).message).toContain(
+      'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
+    );
+    expect(analyzeFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips SQAA and warns when extension has no projectKey and requireProject is false (bare analyze)', async () => {
+    loadStateSpy.mockReturnValue(stateWithExtensionMissingProjectKey());
+
+    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH, undefined, { requireProject: false });
 
     expect(analyzeFileSpy).not.toHaveBeenCalled();
     const output = getMockUiCalls()
       .map((c) => String(c.args[0]))
       .join('\n');
     expect(output).toContain(
-      'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate claude',
+      'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
     );
   });
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored SQAA auth resolution:**
  - Introduced `SqaaAuthResolution` and `resolveSqaaContext` to explicitly handle project-missing states.
  - Decoupled error policy from the resolution logic, allowing specific commands to enforce project requirements.
- **Improved error handling:**
  - Updated `analyze agentic` to throw `CommandFailedError` (exit code 1) when no project is configured, instead of skipping silently.
  - Maintained graceful skipping behavior for the catch-all `sonar analyze` command by setting `requireProject: false`.


<sub>This will update automatically on new commits.</sub>