### PR TITLE
CLI-560 SCA hook: backend helpers and sca-scanner plumbing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "js-yaml": "^4.1.1",
         "openpgp": "^6.0.0",
         "picocolors": "^1.1.1",
+        "picomatch": "^4.0.3",
         "smol-toml": "^1.6.1",
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@types/istanbul-lib-report": "3.0.3",
         "@types/istanbul-reports": "3.0.4",
         "@types/js-yaml": "^4.0.9",
+        "@types/picomatch": "^4.0.2",
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "ajv": "^8.18.0",
@@ -229,6 +231,8 @@
     "@types/pg": ["@types/pg@8.15.6", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/pg/-/pg-8.15.6.tgz", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
 
     "@types/pg-pool": ["@types/pg-pool@2.0.7", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/pg-pool/-/pg-pool-2.0.7.tgz", { "dependencies": { "@types/pg": "*" } }, "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng=="],
+
+    "@types/picomatch": ["@types/picomatch@4.0.3", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/picomatch/-/picomatch-4.0.3.tgz", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
     "@types/tedious": ["@types/tedious@4.0.14", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/tedious/-/tedious-4.0.14.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "js-yaml": "^4.1.1",
     "openpgp": "^6.0.0",
     "picocolors": "^1.1.1",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "picomatch": "^4.0.3"
   },
   "devDependencies": {
     "@sentry/cli": "3.4.2",
@@ -117,6 +118,7 @@
     "@types/istanbul-lib-report": "3.0.3",
     "@types/istanbul-reports": "3.0.4",
     "@types/js-yaml": "^4.0.9",
+    "@types/picomatch": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "ajv": "^8.18.0",

--- a/src/cli/commands/_common/install/sca-scanner.ts
+++ b/src/cli/commands/_common/install/sca-scanner.ts
@@ -28,7 +28,12 @@ import {
   SONARSOURCE_PUBLIC_KEY,
 } from '../../../../lib/signatures';
 import { discreetSuccess } from '../../../../ui';
-import { type BinarySpec, buildLocalBinaryName as buildBinaryName, installBinary } from './binary';
+import {
+  type BinarySpec,
+  buildLocalBinaryName as buildBinaryName,
+  installBinary,
+  resolveBinaryPath,
+} from './binary';
 
 export const SCA_SCANNER_SPEC: BinarySpec = {
   name: SCA_SCANNER_BINARY_NAME,
@@ -50,6 +55,14 @@ export function buildLocalBinaryName(platformInfo: PlatformInfo): string {
   return buildBinaryName(SCA_SCANNER_SPEC, platformInfo);
 }
 
+/**
+ * Returns the path to the installed sca-scanner binary, or null if not present.
+ * Never downloads — use this where silent operation is required (e.g. hook handlers).
+ */
+export function resolveScaScannerBinaryPath(): string | null {
+  return resolveBinaryPath(SCA_SCANNER_SPEC);
+}
+
 export interface ScaScannerInstaller {
   install(): Promise<string>;
 }
@@ -57,5 +70,12 @@ export interface ScaScannerInstaller {
 export class DefaultScaScannerInstaller implements ScaScannerInstaller {
   install(): Promise<string> {
     return installScaScannerBinary();
+  }
+}
+
+export class ScaScannerNoopInstaller implements ScaScannerInstaller {
+  constructor(private readonly binaryPath: string) {}
+  install(): Promise<string> {
+    return Promise.resolve(this.binaryPath);
   }
 }

--- a/src/cli/commands/_common/sca-availability.ts
+++ b/src/cli/commands/_common/sca-availability.ts
@@ -1,0 +1,58 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { fetchServerVersion, isAtLeast } from '../../../lib/server-info';
+import type { SonarQubeClient } from '../../../sonarqube/client';
+import { CommandFailedError } from './error';
+
+export const MIN_SCA_SQS_VERSION = '2026.4';
+
+export async function assertScaAvailable(
+  client: Pick<SonarQubeClient, 'checkScaEnabled'>,
+  auth: Pick<ResolvedAuth, 'connectionType' | 'serverUrl' | 'orgKey'>,
+): Promise<void> {
+  if (auth.connectionType !== 'cloud') {
+    let serverVersion: string;
+    try {
+      serverVersion = await fetchServerVersion(auth.serverUrl);
+    } catch (err) {
+      throw new CommandFailedError(
+        `Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
+        { cause: err },
+      );
+    }
+    if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
+      throw new CommandFailedError(
+        `Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
+      );
+    }
+  }
+  const enabled = await client.checkScaEnabled(auth.connectionType, auth.orgKey);
+  if (!enabled) {
+    throw new CommandFailedError(
+      'Software Composition Analysis is not available for the current connection.',
+      {
+        remediationHint:
+          'Software Composition Analysis must be enabled by an administrator and requires an eligible SonarQube plan. Learn more: https://docs.sonarsource.com/sonarqube-cli/analysis/sca',
+      },
+    );
+  }
+}

--- a/src/cli/commands/analyze/dependency-risk-helpers/count-selected-risks.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/count-selected-risks.ts
@@ -1,0 +1,35 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { DependencyRisksViewModel } from './view-model';
+import type { RiskVM } from './view-model/risk';
+
+export function countSelectedRisks(
+  vm: DependencyRisksViewModel,
+  predicate: (risk: RiskVM) => boolean = () => true,
+): number {
+  let count = 0;
+  for (const pkg of vm.packages) {
+    for (const group of pkg.groups) {
+      count += group.selectedRisks.filter(predicate).length;
+    }
+  }
+  return count;
+}

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -1,0 +1,67 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ResolvedAuth } from '../../../../lib/auth-resolver';
+import { CLI_DIR } from '../../../../lib/config-constants';
+import logger, { getLogLevelConfig } from '../../../../lib/logger';
+import { type SonarQubeClient } from '../../../../sonarqube/client';
+import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
+import { assertScaAvailable } from '../../_common/sca-availability';
+import { parseAnalysisProperties } from './analysis-properties';
+import {
+  type AnalyzeProjectResponse,
+  type ScaScannerInvocation,
+  ScaScannerRunner,
+} from './sca-scanner';
+import type { ScaScannerSpawner } from './sca-scanner-spawner';
+import { buildScaUrls } from './sca-urls';
+
+export class ScaScanOrchestrator {
+  constructor(
+    private readonly client: SonarQubeClient,
+    private readonly installer: ScaScannerInstaller,
+    private readonly spawner: ScaScannerSpawner,
+  ) {}
+
+  async run(auth: ResolvedAuth, projectKey: string): Promise<AnalyzeProjectResponse> {
+    await assertScaAvailable(this.client, auth);
+    const settings = await this.client.getProjectSettings(projectKey);
+    const properties = parseAnalysisProperties(settings);
+    logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
+    const { apiBaseUrl, downloadBaseUrl } = buildScaUrls(auth);
+    const invocation: ScaScannerInvocation = {
+      baseDir: process.cwd(),
+      apiBaseUrl,
+      downloadBaseUrl,
+      sonarToken: auth.token,
+      projectKey,
+      cacheDir: join(CLI_DIR, 'sca-scanner-cache'),
+      workDir: join(tmpdir(), `sonar-sca-${Date.now()}`),
+      scannerProperties: properties.scaProperties,
+      excludedPaths: properties.exclusions,
+      includeGitIgnoredPaths: properties.includeGitIgnoredPaths,
+      debug: getLogLevelConfig() === 'DEBUG',
+    };
+    return new ScaScannerRunner(this.installer, this.spawner).run(invocation);
+  }
+}

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.ts
@@ -1,0 +1,60 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import picomatch from 'picomatch';
+
+import logger from '../../../../lib/logger';
+import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
+import type { ScaScannerSpawner } from './sca-scanner-spawner';
+
+interface WatchPatternsPayload {
+  patterns?: unknown;
+}
+
+export class ScaWatchPatternsRunner {
+  constructor(
+    private readonly installer: ScaScannerInstaller,
+    private readonly spawner: ScaScannerSpawner,
+  ) {}
+
+  async run(): Promise<string[]> {
+    try {
+      const binaryPath = await this.installer.install();
+      const result = await this.spawner.spawn(binaryPath, ['watch-patterns']);
+      if ((result.exitCode ?? 1) !== 0) {
+        logger.debug(`watch-patterns exited with code ${String(result.exitCode)}`);
+        return [];
+      }
+      const parsed: WatchPatternsPayload = JSON.parse(result.stdout) as WatchPatternsPayload;
+      if (!Array.isArray(parsed.patterns)) return [];
+      return parsed.patterns.filter((p): p is string => typeof p === 'string');
+    } catch (err) {
+      logger.debug(`watch-patterns failed: ${(err as Error).message}`);
+      return [];
+    }
+  }
+}
+
+export function anyFileMatches(files: readonly string[], patterns: readonly string[]): boolean {
+  if (patterns.length === 0 || files.length === 0) return false;
+  const normalizedPatterns = patterns.map((p) => (p.includes('/') ? p : `**/${p}`));
+  const match = picomatch(normalizedPatterns, { dot: true, nocase: process.platform === 'win32' });
+  return files.some((file) => match(file));
+}

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -18,37 +18,26 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import { type ResolvedAuth } from '../../../lib/auth-resolver';
-import { CLI_DIR } from '../../../lib/config-constants';
-import logger, { getLogLevelConfig } from '../../../lib/logger';
-import { fetchServerVersion, isAtLeast } from '../../../lib/server-info';
 import { SonarQubeClient } from '../../../sonarqube/client';
 import { error, print, warn } from '../../../ui';
-import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
+import { InvalidOptionError } from '../_common/error.js';
 import { DefaultScaScannerInstaller } from '../_common/install/sca-scanner.ts';
-import { parseAnalysisProperties } from './dependency-risk-helpers/analysis-properties.ts';
+import { countSelectedRisks } from './dependency-risk-helpers/count-selected-risks.ts';
 import { DefaultScaScannerSpawner } from './dependency-risk-helpers/default-sca-scanner-spawner.ts';
 import { formatDependencyRisksJson } from './dependency-risk-helpers/format-dependency-risks-json.ts';
 import { buildRiskFilter } from './dependency-risk-helpers/risk-filter.ts';
-import {
-  type ScaScannerInvocation,
-  ScaScannerRunner,
-} from './dependency-risk-helpers/sca-scanner.ts';
-import { buildScaUrls } from './dependency-risk-helpers/sca-urls.ts';
+import { ScaScanOrchestrator } from './dependency-risk-helpers/sca-scan-orchestrator.ts';
 import { formatDependencyRisksTable } from './dependency-risk-helpers/table';
 import type { DependencyRisksViewModel } from './dependency-risk-helpers/view-model';
 import { buildDependencyRisksViewModel } from './dependency-risk-helpers/view-model/build';
 
 export const VALID_FORMATS = ['json', 'table'];
 
+export const EXIT_CODE_UNRESOLVED_RISKS = 51;
+
 const EXIT_CODE_OK = 0;
 const EXIT_CODE_ERRORS_ONLY = 1;
-const EXIT_CODE_UNRESOLVED_RISKS = 51;
-
-const MIN_SCA_SQS_VERSION = '2026.4';
 
 export interface AnalyzeDependencyRisksOptions {
   project: string;
@@ -66,32 +55,11 @@ export async function analyzeDependencyRisks(
   }
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
-  await assertServerSupportsLocalSca(auth, client);
-
-  const settings = await client.getProjectSettings(options.project);
-  const properties = parseAnalysisProperties(settings);
-  logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
-
-  const { apiBaseUrl, downloadBaseUrl } = buildScaUrls(auth);
-
-  const invocation: ScaScannerInvocation = {
-    baseDir: process.cwd(),
-    apiBaseUrl,
-    downloadBaseUrl,
-    sonarToken: auth.token,
-    projectKey: options.project,
-    cacheDir: join(CLI_DIR, 'sca-scanner-cache'),
-    workDir: join(tmpdir(), `sonar-sca-${Date.now()}`),
-    scannerProperties: properties.scaProperties,
-    excludedPaths: properties.exclusions,
-    includeGitIgnoredPaths: properties.includeGitIgnoredPaths,
-    debug: getLogLevelConfig() === 'DEBUG',
-  };
-
-  const result = await new ScaScannerRunner(
+  const result = await new ScaScanOrchestrator(
+    client,
     new DefaultScaScannerInstaller(),
     new DefaultScaScannerSpawner(),
-  ).run(invocation);
+  ).run(auth, options.project);
 
   const viewModel = buildDependencyRisksViewModel(result, filter);
   if (options.format === 'json') {
@@ -129,46 +97,5 @@ function pluralize(count: number, singular: string): string {
 }
 
 export function countUnresolvedIssues(vm: DependencyRisksViewModel): number {
-  const isUnresolved = buildRiskFilter('active')!.predicate;
-  let count = 0;
-  for (const pkg of vm.packages) {
-    for (const group of pkg.groups) {
-      for (const risk of group.selectedRisks) {
-        if (isUnresolved(risk)) count += 1;
-      }
-    }
-  }
-  return count;
-}
-
-async function assertServerSupportsLocalSca(
-  auth: ResolvedAuth,
-  client: SonarQubeClient,
-): Promise<void> {
-  if (auth.connectionType !== 'cloud') {
-    let serverVersion: string;
-    try {
-      serverVersion = await fetchServerVersion(auth.serverUrl);
-    } catch (err) {
-      throw new CommandFailedError(
-        `Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
-        { cause: err },
-      );
-    }
-    if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
-      throw new CommandFailedError(
-        `Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
-      );
-    }
-  }
-  const enabled = await client.checkScaEnabled(auth.connectionType, auth.orgKey);
-  if (!enabled) {
-    throw new CommandFailedError(
-      'Software Composition Analysis is not available for the current connection.',
-      {
-        remediationHint:
-          'Software Composition Analysis must be enabled by an administrator and requires an eligible SonarQube plan. Learn more: https://docs.sonarsource.com/sonarqube-cli/analysis/sca',
-      },
-    );
-  }
+  return countSelectedRisks(vm, buildRiskFilter('active')!.predicate);
 }

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -32,10 +32,7 @@ import {
 } from '../cli/commands/integrate/_common/registry';
 import { CLAUDE_INTEGRATION_ID } from '../cli/commands/integrate/claude/declaration';
 import { installHooks } from '../cli/commands/integrate/claude/hooks.js';
-import {
-  SCA_SCANNER_BINARY_NAME,
-  SECRETS_BINARY_NAME,
-} from './install-types.js';
+import { SCA_SCANNER_BINARY_NAME, SECRETS_BINARY_NAME } from './install-types.js';
 import logger from './logger';
 import {
   cleanObsoleteFromState,

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -23,6 +23,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { version as CURRENT_VERSION } from '../../package.json';
+import { installScaScannerBinary } from '../cli/commands/_common/install/sca-scanner';
 import { installSecretsBinary } from '../cli/commands/_common/install/secrets';
 import { supportedIntegrations } from '../cli/commands/integrate';
 import {
@@ -31,7 +32,10 @@ import {
 } from '../cli/commands/integrate/_common/registry';
 import { CLAUDE_INTEGRATION_ID } from '../cli/commands/integrate/claude/declaration';
 import { installHooks } from '../cli/commands/integrate/claude/hooks.js';
-import { SECRETS_BINARY_NAME } from './install-types.js';
+import {
+  SCA_SCANNER_BINARY_NAME,
+  SECRETS_BINARY_NAME,
+} from './install-types.js';
 import logger from './logger';
 import {
   cleanObsoleteFromState,
@@ -83,6 +87,7 @@ async function runActions(_previousVersion: string, _currentVersion: string): Pr
   await migrateDeclarativeIntegrations();
   await migrateClaudeCodeHooks();
   await updateSecretsBinaryIfNeeded();
+  await updateScaScannerBinaryIfNeeded();
 }
 
 export async function migrateDeclarativeIntegrations(
@@ -174,6 +179,21 @@ export async function updateSecretsBinaryIfNeeded(): Promise<void> {
 
 function hasPreviousSecretsInstallation(state: CliState): boolean {
   return hasBinaryInState(state, SECRETS_BINARY_NAME);
+}
+
+/**
+ * Update the sca-scanner-cli binary if it is already installed but targets a different version
+ * than the one bundled with this CLI release.
+ */
+export async function updateScaScannerBinaryIfNeeded(): Promise<void> {
+  const state = loadState();
+
+  if (!hasBinaryInState(state, SCA_SCANNER_BINARY_NAME)) {
+    logger.debug('sca-scanner-cli not installed — skipping binary update');
+    return;
+  }
+
+  await installScaScannerBinary();
 }
 
 function hasBinaryInState(state: CliState, binaryName: string): boolean {

--- a/tests/unit/cli/commands/_common/sonar-command.test.ts
+++ b/tests/unit/cli/commands/_common/sonar-command.test.ts
@@ -40,7 +40,7 @@ const FAKE_AUTH: ResolvedAuth = {
 
 describe('SonarCommand', () => {
   let resolveAuthSpy: ReturnType<typeof spyOn>;
-  let originalExitCode: number | string | undefined;
+  let originalExitCode: number | string | null | undefined;
 
   beforeEach(() => {
     setMockUi(true);

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
@@ -1,0 +1,95 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+
+import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error.ts';
+import type { ScaScannerInstaller } from '../../../../../../src/cli/commands/_common/install/sca-scanner.ts';
+import { ScaScanOrchestrator } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts';
+import type { ScaScannerSpawner } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-spawner.ts';
+import type { ResolvedAuth } from '../../../../../../src/lib/auth-resolver.ts';
+import type { SonarQubeClient } from '../../../../../../src/sonarqube/client.ts';
+import type { SettingsValue } from '../../../../../../src/sonarqube/settings-value.ts';
+
+const CLOUD_AUTH: ResolvedAuth = {
+  connectionType: 'cloud',
+  serverUrl: 'https://sonarcloud.io',
+  token: 'test-token',
+  orgKey: 'my-org',
+};
+
+const EMPTY_RESPONSE = { releases: [], parsedFiles: [], errors: [] };
+
+function makeClient(
+  overrides: {
+    checkScaEnabled?: () => Promise<boolean>;
+    getProjectSettings?: () => Promise<SettingsValue[]>;
+  } = {},
+): SonarQubeClient {
+  return {
+    checkScaEnabled: overrides.checkScaEnabled ?? (() => Promise.resolve(true)),
+    getProjectSettings: overrides.getProjectSettings ?? (() => Promise.resolve([])),
+  } as unknown as SonarQubeClient;
+}
+
+const okInstaller: ScaScannerInstaller = { install: () => Promise.resolve('/bin/sca') };
+
+function spawnerReturning(payload: unknown): ScaScannerSpawner {
+  return {
+    spawn: () => Promise.resolve({ exitCode: 0, stdout: JSON.stringify(payload), stderr: '' }),
+  };
+}
+
+describe('ScaScanOrchestrator', () => {
+  it('returns the scanner response on a successful scan', async () => {
+    const orchestrator = new ScaScanOrchestrator(
+      makeClient(),
+      okInstaller,
+      spawnerReturning(EMPTY_RESPONSE),
+    );
+
+    const result = await orchestrator.run(CLOUD_AUTH, 'my-project');
+
+    expect(result).toEqual(EMPTY_RESPONSE);
+  });
+
+  it('throws when SCA is not available for the connection', () => {
+    const orchestrator = new ScaScanOrchestrator(
+      makeClient({ checkScaEnabled: () => Promise.resolve(false) }),
+      okInstaller,
+      spawnerReturning(EMPTY_RESPONSE),
+    );
+
+    expect(orchestrator.run(CLOUD_AUTH, 'my-project')).rejects.toBeInstanceOf(CommandFailedError);
+  });
+
+  it('passes projectKey and token from auth into the scanner invocation', async () => {
+    const spawn = mock((_binaryPath: string, _args: string[]) =>
+      Promise.resolve({ exitCode: 0, stdout: JSON.stringify(EMPTY_RESPONSE), stderr: '' }),
+    );
+    const orchestrator = new ScaScanOrchestrator(makeClient(), okInstaller, { spawn });
+
+    await orchestrator.run(CLOUD_AUTH, 'my-project');
+
+    const [, args] = spawn.mock.calls[0];
+    expect(args).toContain('--project-key=my-project');
+    expect(args).toContain('--sonar-token=test-token');
+  });
+});

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.test.ts
@@ -1,0 +1,150 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import type { ScaScannerInstaller } from '../../../../../../src/cli/commands/_common/install/sca-scanner.ts';
+import type { ScaScannerSpawner } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-spawner.ts';
+import {
+  anyFileMatches,
+  ScaWatchPatternsRunner,
+} from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns';
+
+const okInstaller: ScaScannerInstaller = { install: () => Promise.resolve('/bin/sca') };
+
+function spawnerReturning(exitCode: number, stdout: string): ScaScannerSpawner {
+  return { spawn: () => Promise.resolve({ exitCode, stdout, stderr: '' }) };
+}
+
+function watchPatternsPayload(patterns: unknown): string {
+  return JSON.stringify({ patterns });
+}
+
+describe('ScaWatchPatternsRunner', () => {
+  it('returns parsed patterns from a valid response', async () => {
+    const runner = new ScaWatchPatternsRunner(
+      okInstaller,
+      spawnerReturning(0, watchPatternsPayload(['package.json', '*.csproj'])),
+    );
+    expect(await runner.run()).toEqual(['package.json', '*.csproj']);
+  });
+
+  it('returns [] on non-zero exit', async () => {
+    const runner = new ScaWatchPatternsRunner(okInstaller, spawnerReturning(1, ''));
+    expect(await runner.run()).toEqual([]);
+  });
+
+  it('returns [] when stdout contains no JSON', async () => {
+    const runner = new ScaWatchPatternsRunner(okInstaller, spawnerReturning(0, 'no json here'));
+    expect(await runner.run()).toEqual([]);
+  });
+
+  it('returns [] when patterns is not an array', async () => {
+    const runner = new ScaWatchPatternsRunner(
+      okInstaller,
+      spawnerReturning(0, watchPatternsPayload('not-an-array')),
+    );
+    expect(await runner.run()).toEqual([]);
+  });
+
+  it('returns [] when the spawner throws', async () => {
+    const throwing: ScaScannerSpawner = {
+      spawn: () => Promise.reject(new Error('spawn failed')),
+    };
+    const runner = new ScaWatchPatternsRunner(okInstaller, throwing);
+    expect(await runner.run()).toEqual([]);
+  });
+});
+
+describe('anyFileMatches', () => {
+  it('returns false for empty inputs', () => {
+    expect(anyFileMatches([], ['package.json'])).toBe(false);
+    expect(anyFileMatches(['package.json'], [])).toBe(false);
+  });
+
+  it('matches bare filenames against any path', () => {
+    expect(anyFileMatches(['frontend/package.json'], ['package.json'])).toBe(true);
+    expect(anyFileMatches(['package.json'], ['package.json'])).toBe(true);
+  });
+
+  it('matches *.ext patterns', () => {
+    expect(anyFileMatches(['App.csproj'], ['*.csproj'])).toBe(true);
+    expect(anyFileMatches(['src/App.csproj'], ['*.csproj'])).toBe(true);
+    expect(anyFileMatches(['App.txt'], ['*.csproj'])).toBe(false);
+  });
+
+  it('matches path-style **/ globs', () => {
+    expect(anyFileMatches(['obj/project.assets.json'], ['**/obj/project.assets.json'])).toBe(true);
+    expect(anyFileMatches(['a/b/obj/project.assets.json'], ['**/obj/project.assets.json'])).toBe(
+      true,
+    );
+    expect(anyFileMatches(['project.assets.json'], ['**/obj/project.assets.json'])).toBe(false);
+  });
+
+  it('matches bare filename patterns against files in subdirectories', () => {
+    expect(anyFileMatches(['frontend/package.json'], ['package.json'])).toBe(true);
+    expect(anyFileMatches(['a/b/c/package.json'], ['package.json'])).toBe(true);
+    expect(anyFileMatches(['src/App.csproj'], ['*.csproj'])).toBe(true);
+  });
+
+  it('matches dotfiles and files inside hidden directories', () => {
+    expect(anyFileMatches(['.package-lock.json'], ['*.json'])).toBe(true);
+    expect(anyFileMatches(['src/.hidden/package.json'], ['package.json'])).toBe(true);
+  });
+
+  it('matches path-prefix patterns like requirements/*.txt', () => {
+    expect(anyFileMatches(['requirements/dev.txt'], ['requirements/*.txt'])).toBe(true);
+    expect(anyFileMatches(['requirements/sub/dev.txt'], ['requirements/*.txt'])).toBe(false);
+  });
+
+  it('expands {xml,json} brace lists', () => {
+    expect(anyFileMatches(['cyclonedx.xml'], ['cyclonedx.{xml,json}'])).toBe(true);
+    expect(anyFileMatches(['cyclonedx.json'], ['cyclonedx.{xml,json}'])).toBe(true);
+    expect(anyFileMatches(['cyclonedx.yaml'], ['cyclonedx.{xml,json}'])).toBe(false);
+  });
+
+  it.skipIf(process.platform !== 'win32')('matches case-insensitively on Windows', () => {
+    expect(anyFileMatches(['Frontend\\Package.json'], ['package.json'])).toBe(true);
+  });
+
+  it('matches prefix-with-star like req*.txt', () => {
+    expect(anyFileMatches(['requirements.txt'], ['req*.txt'])).toBe(true);
+    expect(anyFileMatches(['req-dev.txt'], ['req*.txt'])).toBe(true);
+    expect(anyFileMatches(['notrequirements.txt'], ['req*.txt'])).toBe(false);
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    'matches Windows backslash paths against bare filename patterns',
+    () => {
+      expect(anyFileMatches(['frontend\\package.json'], ['package.json'])).toBe(true);
+      expect(anyFileMatches(['a\\b\\c\\package.json'], ['package.json'])).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'matches Windows backslash paths against path-style globs',
+    () => {
+      expect(anyFileMatches(['obj\\project.assets.json'], ['**/obj/project.assets.json'])).toBe(
+        true,
+      );
+      expect(anyFileMatches(['requirements\\dev.txt'], ['requirements/*.txt'])).toBe(true);
+    },
+  );
+});

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -25,6 +25,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
 
 import { version as CURRENT_VERSION } from '../../../../../package.json';
+import * as scaScannerInstall from '../../../../../src/cli/commands/_common/install/sca-scanner';
 import * as secretsInstall from '../../../../../src/cli/commands/_common/install/secrets';
 import {
   type DependencyDeclaration,
@@ -33,11 +34,13 @@ import {
   wholeFile,
 } from '../../../../../src/cli/commands/integrate/_common/registry';
 import * as hooks from '../../../../../src/cli/commands/integrate/claude/hooks';
+import { SCA_SCANNER_BINARY_NAME } from '../../../../../src/lib/install-types';
 import * as migration from '../../../../../src/lib/migration';
 import {
   migrateClaudeCodeHooks,
   migrateDeclarativeIntegrations,
   runPostUpdateActions,
+  updateScaScannerBinaryIfNeeded,
   updateSecretsBinaryIfNeeded,
 } from '../../../../../src/lib/post-update';
 import * as stateRepository from '../../../../../src/lib/repository/state-repository';
@@ -140,19 +143,21 @@ describe('runPostUpdateActions', () => {
   });
 
   it('saves the reloaded state, not the pre-runActions snapshot', async () => {
-    // loadState is called 5 times:
+    // loadState is called 6 times:
     //   1. version check in runPostUpdateActions
     //   2. inside migrateDeclarativeIntegrations
     //   3. inside migrateClaudeCodeHooks
     //   4. inside updateSecretsBinaryIfNeeded
-    //   5. the reload after runActions (the fix being tested)
+    //   5. inside updateScaScannerBinaryIfNeeded
+    //   6. the reload after runActions (the fix being tested)
     const reloadedState = makeState();
     loadStateSpy
       .mockReturnValueOnce(makeState()) // call 1: version check
       .mockReturnValueOnce(makeState()) // call 2: migrateDeclarativeIntegrations
       .mockReturnValueOnce(makeState()) // call 3: migrateClaudeCodeHooks
       .mockReturnValueOnce(makeState()) // call 4: updateSecretsBinaryIfNeeded
-      .mockReturnValueOnce(reloadedState); // call 5: reload
+      .mockReturnValueOnce(makeState()) // call 5: updateScaScannerBinaryIfNeeded
+      .mockReturnValueOnce(reloadedState); // call 6: reload
 
     await runPostUpdateActions();
 
@@ -777,3 +782,57 @@ describe('updateSecretsBinaryIfNeeded', () => {
     expect(updateSecretsBinaryIfNeeded()).rejects.toThrow('download failed');
   });
 });
+
+function makeStateWithScaScanner(): CliState {
+  const state = makeState();
+  state.tools = {
+    installed: [
+      {
+        name: SCA_SCANNER_BINARY_NAME,
+        version: '0.0.0.1',
+        path: '/fake/bin/sca-scanner-cli-0.0.0.1-linux-x86-64',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        installedByCliVersion: '1.0.0',
+      },
+    ],
+  };
+  return state;
+}
+
+describe('updateScaScannerBinaryIfNeeded', () => {
+  let loadStateSpy: Mock<typeof stateRepository.loadState>;
+  let installScaScannerBinarySpy: Mock<typeof scaScannerInstall.installScaScannerBinary>;
+
+  beforeEach(() => {
+    loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeStateWithScaScanner());
+    installScaScannerBinarySpy = spyOn(
+      scaScannerInstall,
+      'installScaScannerBinary',
+    ).mockResolvedValue('/fake/bin/sca-scanner-cli');
+  });
+
+  afterEach(() => {
+    loadStateSpy.mockRestore();
+    installScaScannerBinarySpy.mockRestore();
+  });
+
+  it('does nothing when no previous binary is recorded in state', async () => {
+    loadStateSpy.mockReturnValue(makeState()); // tools.installed is empty
+
+    await updateScaScannerBinaryIfNeeded();
+
+    expect(installScaScannerBinarySpy).not.toHaveBeenCalled();
+  });
+
+  it('calls installScaScannerBinary when a previous installation is recorded in state', async () => {
+    await updateScaScannerBinaryIfNeeded();
+
+    expect(installScaScannerBinarySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors from installScaScannerBinary to the caller', () => {
+    installScaScannerBinarySpy.mockRejectedValue(new Error('download failed'));
+
+    expect(updateScaScannerBinaryIfNeeded()).rejects.toThrow('download failed');
+  });
+})

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -835,4 +835,4 @@ describe('updateScaScannerBinaryIfNeeded', () => {
 
     expect(updateScaScannerBinaryIfNeeded()).rejects.toThrow('download failed');
   });
-})
+});


### PR DESCRIPTION
Part of CLI-541

----
## Summary by Gitar

- **SCA orchestration:**
  - Added `ScaScanOrchestrator` to coordinate SCA scanner execution with project settings.
  - Added `assertScaAvailable` for server version and feature flag enforcement.
- **Dependency analysis:**
  - Added `countSelectedRisks` to tally risks in the analysis view model.
  - Added `ScaWatchPatternsRunner` to retrieve and match file patterns for analysis.
- **Binary lifecycle:**
  - Integrated `updateScaScannerBinaryIfNeeded` into post-update hooks to ensure binary currency.
  - Added `ScaScannerNoopInstaller` for internal service reuse.
- **Error handling:**
  - Defined `EXIT_CODE_UNRESOLVED_RISKS` (51) to identify scan results containing risks.
- **Dependencies:**
  - Added `picomatch` to support advanced file pattern matching.


<sub>This will update automatically on new commits.</sub>