### PR TITLE
CLI-561 SCA pre-push hook logic implementation

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -61,7 +61,7 @@ import { claudePreToolUse } from './commands/hook/claude-pre-tool-use';
 import { codexPromptSubmit } from './commands/hook/codex-prompt-submit';
 import { copilotPreToolUse } from './commands/hook/copilot-pre-tool-use';
 import { gitPreCommit } from './commands/hook/git-pre-commit';
-import { gitPrePush } from './commands/hook/git-pre-push';
+import { gitPrePush, type GitPrePushOptions } from './commands/hook/git-pre-push';
 import type { IntegrateAgentOptions } from './commands/integrate/_common/types';
 import { integrateClaude } from './commands/integrate/claude';
 import { integrateCodex } from './commands/integrate/codex';
@@ -471,8 +471,15 @@ hookCommand
 
 hookCommand
   .command('git-pre-push')
-  .description('git pre-push handler: scan files in new commits for secrets')
-  .anonymousAction(() => gitPrePush());
+  .description(
+    'git pre-push handler: scan files in new commits for secrets, optionally scan dependency manifests for risks',
+  )
+  .option('-p, --project <project>', 'Project key (required when --dependency-risks is set)')
+  .option(
+    '--dependency-risks',
+    'Also run a dependency-risks scan after the secrets scan (requires -p)',
+  )
+  .anonymousAction((options: GitPrePushOptions) => gitPrePush(options));
 
 // Hidden flush command — only registered when running as a telemetry worker.
 if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {

--- a/src/cli/commands/hook/git-pre-push-dependency-risks.ts
+++ b/src/cli/commands/hook/git-pre-push-dependency-risks.ts
@@ -43,7 +43,6 @@ import {
 } from '../analyze/dependency-risk-helpers/sca-watch-patterns';
 import { formatDependencyRisksTable } from '../analyze/dependency-risk-helpers/table';
 import { buildDependencyRisksViewModel } from '../analyze/dependency-risk-helpers/view-model/build';
-import { hasUncommittedChanges } from './git-pre-push';
 
 const HOOK_STATUS_FILTER = 'new';
 
@@ -62,12 +61,6 @@ export async function runDepRisksStage(options: DepRisksStageOptions): Promise<v
 
   if (!(await shouldRunDependencyRiskAnalysis(binaryPath, options.changedFiles))) {
     return;
-  }
-
-  if (await hasUncommittedChanges()) {
-    warn(
-      'Uncommitted changes detected — they are not part of this push, but will be included in the dependency-risks scan.',
-    );
   }
 
   const filter = buildRiskFilter(HOOK_STATUS_FILTER);
@@ -97,7 +90,7 @@ export async function runDepRisksStage(options: DepRisksStageOptions): Promise<v
 
   print(formatDependencyRisksTable(viewModel));
   throw new CommandFailedError(
-    `Dependency risks detected in this push (${matchedCount} matching the configured filter).`,
+    `Dependency risks detected (${matchedCount} matching the configured filter).`,
     {
       remediationHint: `Run 'sonar analyze dependency-risks -p ${options.project}' to inspect, fix or accept the risks, then retry the push.`,
     },

--- a/src/cli/commands/hook/git-pre-push-dependency-risks.ts
+++ b/src/cli/commands/hook/git-pre-push-dependency-risks.ts
@@ -92,7 +92,7 @@ export async function runDepRisksStage(options: DepRisksStageOptions): Promise<v
   throw new CommandFailedError(
     `Dependency risks detected (${matchedCount} matching the configured filter).`,
     {
-      remediationHint: `Run 'sonar analyze dependency-risks -p ${options.project}' to inspect, fix or accept the risks, then retry the push.`,
+      remediationHint: `Run 'sonar analyze dependency-risks -p ${options.project}' to inspect & fix the risks, then retry the push.`,
     },
   );
 }

--- a/src/cli/commands/hook/git-pre-push-dependency-risks.ts
+++ b/src/cli/commands/hook/git-pre-push-dependency-risks.ts
@@ -1,0 +1,123 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Dependency-risks stage of the git pre-push hook. Invoked after the secrets
+// stage when the user opted in via `--dependency-risks` and `-p <projectKey>`. Skips
+// silently when no manifests changed, fails-open on infra errors (auth/binary
+// missing, scanner failure), and blocks the push only when risks matching the
+// configured filter are found.
+
+import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import logger from '../../../lib/logger';
+import { SonarQubeClient } from '../../../sonarqube/client';
+import { print, success, warn } from '../../../ui';
+import { CommandFailedError } from '../_common/error';
+import {
+  resolveScaScannerBinaryPath,
+  ScaScannerNoopInstaller,
+} from '../_common/install/sca-scanner';
+import { countSelectedRisks } from '../analyze/dependency-risk-helpers/count-selected-risks';
+import { DefaultScaScannerSpawner } from '../analyze/dependency-risk-helpers/default-sca-scanner-spawner';
+import { buildRiskFilter } from '../analyze/dependency-risk-helpers/risk-filter';
+import { ScaScanOrchestrator } from '../analyze/dependency-risk-helpers/sca-scan-orchestrator';
+import {
+  anyFileMatches,
+  ScaWatchPatternsRunner,
+} from '../analyze/dependency-risk-helpers/sca-watch-patterns';
+import { formatDependencyRisksTable } from '../analyze/dependency-risk-helpers/table';
+import { buildDependencyRisksViewModel } from '../analyze/dependency-risk-helpers/view-model/build';
+import { hasUncommittedChanges } from './git-pre-push';
+
+const HOOK_STATUS_FILTER = 'new';
+
+export interface DepRisksStageOptions {
+  project: string;
+  changedFiles: string[];
+  auth: ResolvedAuth;
+}
+
+export async function runDepRisksStage(options: DepRisksStageOptions): Promise<void> {
+  const binaryPath = resolveScaScannerBinaryPath();
+  if (!binaryPath) {
+    logger.debug('Dependency-risks hook: sca-scanner binary not installed, skipping.');
+    return;
+  }
+
+  if (!(await shouldRunDependencyRiskAnalysis(binaryPath, options.changedFiles))) {
+    return;
+  }
+
+  if (await hasUncommittedChanges()) {
+    warn(
+      'Uncommitted changes detected — they are not part of this push, but will be included in the dependency-risks scan.',
+    );
+  }
+
+  const filter = buildRiskFilter(HOOK_STATUS_FILTER);
+  if (!filter) {
+    warn(
+      `Dependency-risks hook: invalid filter (statuses='${HOOK_STATUS_FILTER}'); push not blocked.`,
+    );
+    return;
+  }
+
+  let viewModel;
+  try {
+    const client = new SonarQubeClient(options.auth.serverUrl, options.auth.token);
+    const result = await new ScaScanOrchestrator(
+      client,
+      new ScaScannerNoopInstaller(binaryPath),
+      new DefaultScaScannerSpawner(),
+    ).run(options.auth, options.project);
+    viewModel = buildDependencyRisksViewModel(result, filter);
+  } catch (err) {
+    warn(`Dependency-risks scan failed; push not blocked. Reason: ${(err as Error).message}`);
+    return;
+  }
+
+  const matchedCount = countSelectedRisks(viewModel);
+  if (matchedCount === 0) return;
+
+  print(formatDependencyRisksTable(viewModel));
+  throw new CommandFailedError(
+    `Dependency risks detected in this push (${matchedCount} matching the configured filter).`,
+    {
+      remediationHint: `Run 'sonar analyze dependency-risks -p ${options.project}' to inspect, fix or accept the risks, then retry the push.`,
+    },
+  );
+}
+
+async function shouldRunDependencyRiskAnalysis(binaryPath: string, changedFiles: string[]) {
+  const patterns = await new ScaWatchPatternsRunner(
+    new ScaScannerNoopInstaller(binaryPath),
+    new DefaultScaScannerSpawner(),
+  ).run();
+  if (patterns.length === 0) {
+    logger.debug('Dependency-risks hook: no watch patterns returned, skipping.');
+    return false;
+  }
+
+  if (!anyFileMatches(changedFiles, patterns)) {
+    success('No dependency manifests changed in this push — skipping dependency-risks scan.');
+    return false;
+  }
+
+  return true;
+}

--- a/src/cli/commands/hook/git-pre-push-secrets.ts
+++ b/src/cli/commands/hook/git-pre-push-secrets.ts
@@ -1,0 +1,58 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { CommandFailedError } from '../_common/error';
+import { resolveSecretsBinaryPath } from '../_common/install/secrets';
+import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
+import { GIT_NULL_OID } from './git-pre-push';
+import type { HookDependencies } from './hook-dependencies';
+import { handleScanError } from './hook-dependencies';
+import type { PushRef } from './stdin';
+
+export async function runSecretsStage(
+  filesByRef: Map<PushRef, string[]>,
+  auth: ResolvedAuth,
+): Promise<void> {
+  const binaryPath = resolveSecretsBinaryPath();
+  if (!binaryPath) return;
+  const deps: HookDependencies = { auth, binaryPath };
+
+  for (const [ref, files] of filesByRef) {
+    if (ref.localSha === GIT_NULL_OID) continue;
+    if (files.length === 0) continue;
+    await scanRef(files, deps);
+  }
+}
+
+async function scanRef(files: string[], deps: HookDependencies): Promise<void> {
+  try {
+    const result = await runSecretsBinary(deps.binaryPath, files, deps.auth);
+    if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
+      throw new CommandFailedError('Secrets detected in pushed commits.', {
+        remediationHint:
+          'Remove the reported secret, amend the commit if needed, then retry the push.',
+      });
+    }
+  } catch (err) {
+    if (err instanceof CommandFailedError) throw err;
+    handleScanError('Push', err as Error);
+  }
+}

--- a/src/cli/commands/hook/git-pre-push.ts
+++ b/src/cli/commands/hook/git-pre-push.ts
@@ -149,7 +149,7 @@ async function getFilesForNewBranch(localSha: string, emptyTree: string): Promis
 
 export async function hasUncommittedChanges(): Promise<boolean> {
   try {
-    const result = await spawnProcess('git', ['status', '--porcelain']);
+    const result = await spawnProcess('git', ['status', '--porcelain', '-uno']);
     return result.stdout.trim().length > 0;
   } catch {
     return false;

--- a/src/cli/commands/hook/git-pre-push.ts
+++ b/src/cli/commands/hook/git-pre-push.ts
@@ -18,50 +18,44 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// git pre-push callback handler — scans files in new commits for secrets before push.
+// git pre-push callback handler — scans files in new commits for secrets and,
+// when --dependency-risks is set, runs a dependency-risks scan as a follow-up stage.
 // Replaces the shell logic that was previously embedded in the git hook script.
 
+import { resolveAuth } from '../../../lib/auth-resolver';
 import { spawnProcess } from '../../../lib/process';
-import { CommandFailedError } from '../_common/error';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
-import type { HookDependencies } from './hook-dependencies';
-import { handleScanError, resolveAuthAndSecrets } from './hook-dependencies';
+import { InvalidOptionError } from '../_common/error';
+import { runDepRisksStage } from './git-pre-push-dependency-risks.ts';
+import { runSecretsStage } from './git-pre-push-secrets.ts';
 import type { PushRef } from './stdin';
 import { readGitPushRefs } from './stdin';
 
-const GIT_NULL_OID = '0000000000000000000000000000000000000000';
+export const GIT_NULL_OID = '0000000000000000000000000000000000000000';
 
-export async function gitPrePush(): Promise<void> {
+export interface GitPrePushOptions {
+  project?: string;
+  dependencyRisks?: boolean;
+}
+
+export async function gitPrePush(options: GitPrePushOptions = {}): Promise<void> {
+  if (options.dependencyRisks && !options.project) {
+    throw new InvalidOptionError('--dependency-risks requires -p <projectKey>.');
+  }
+
+  const auth = await resolveAuth().catch(() => null);
+  if (!auth) return;
+
   const refs = await readGitPushRefs();
   if (refs.length === 0) return;
 
-  const deps = await resolveAuthAndSecrets();
-  if (!deps) return;
-
   const emptyTree = await getEmptyTree();
+  const filesByRef = await collectFilesForRefs(refs, emptyTree);
 
-  for (const ref of refs) {
-    await scanRef(ref, emptyTree, deps);
-  }
-}
+  await runSecretsStage(filesByRef, auth);
 
-async function scanRef(ref: PushRef, emptyTree: string, deps: HookDependencies): Promise<void> {
-  if (ref.localSha === GIT_NULL_OID) return; // branch deletion — nothing to scan
-
-  const files = await getFilesForRef(ref, emptyTree);
-  if (files.length === 0) return;
-
-  try {
-    const result = await runSecretsBinary(deps.binaryPath, files, deps.auth);
-    if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
-      throw new CommandFailedError('Secrets detected in pushed commits.', {
-        remediationHint:
-          'Remove the reported secret, amend the commit if needed, then retry the push.',
-      });
-    }
-  } catch (err) {
-    if (err instanceof CommandFailedError) throw err;
-    handleScanError('Push', err as Error);
+  if (options.dependencyRisks && options.project) {
+    const changedFiles = Array.from(filesByRef.values()).flat();
+    await runDepRisksStage({ project: options.project, changedFiles, auth });
   }
 }
 
@@ -72,6 +66,21 @@ async function getEmptyTree(): Promise<string> {
   } catch {
     return GIT_NULL_OID;
   }
+}
+
+async function collectFilesForRefs(
+  refs: PushRef[],
+  emptyTree: string,
+): Promise<Map<PushRef, string[]>> {
+  const out = new Map<PushRef, string[]>();
+  for (const ref of refs) {
+    if (ref.localSha === GIT_NULL_OID) {
+      out.set(ref, []);
+      continue;
+    }
+    out.set(ref, await getFilesForRef(ref, emptyTree));
+  }
+  return out;
 }
 
 async function getFilesForRef(ref: PushRef, emptyTree: string): Promise<string[]> {
@@ -118,7 +127,6 @@ async function getFilesForNewBranch(localSha: string, emptyTree: string): Promis
       return Array.from(fileSet);
     }
 
-    // No other remotes — diff full branch against empty tree
     const result = await spawnProcess('git', [
       'diff',
       '--name-only',
@@ -129,5 +137,14 @@ async function getFilesForNewBranch(localSha: string, emptyTree: string): Promis
     return result.stdout.trim().split('\n').filter(Boolean);
   } catch {
     return [];
+  }
+}
+
+export async function hasUncommittedChanges(): Promise<boolean> {
+  try {
+    const result = await spawnProcess('git', ['status', '--porcelain']);
+    return result.stdout.trim().length > 0;
+  } catch {
+    return false;
   }
 }

--- a/src/cli/commands/hook/git-pre-push.ts
+++ b/src/cli/commands/hook/git-pre-push.ts
@@ -24,6 +24,7 @@
 
 import { resolveAuth } from '../../../lib/auth-resolver';
 import { spawnProcess } from '../../../lib/process';
+import { warn } from '../../../ui';
 import { InvalidOptionError } from '../_common/error';
 import { runDepRisksStage } from './git-pre-push-dependency-risks.ts';
 import { runSecretsStage } from './git-pre-push-secrets.ts';
@@ -50,6 +51,12 @@ export async function gitPrePush(options: GitPrePushOptions = {}): Promise<void>
 
   const emptyTree = await getEmptyTree();
   const filesByRef = await collectFilesForRefs(refs, emptyTree);
+
+  if (await hasUncommittedChanges()) {
+    warn(
+      'Uncommitted changes detected — they are not part of this push but will be included in the scan.',
+    );
+  }
 
   await runSecretsStage(filesByRef, auth);
 

--- a/tests/integration/specs/hook/hook-git-pre-push.test.ts
+++ b/tests/integration/specs/hook/hook-git-pre-push.test.ts
@@ -252,6 +252,26 @@ describe('sonar hook git-pre-push', () => {
   );
 
   it(
+    'warns about uncommitted changes during a push',
+    async () => {
+      initGitRepo(harness.cwd.path);
+      const sha = commitFile(harness.cwd.path, 'clean.js', CLEAN_CONTENT);
+      stageFile(harness.cwd.path, 'extra.ts', CLEAN_CONTENT);
+
+      harness.state().withSecretsBinaryInstalled();
+      harness.withAuth(FAKE_SERVER, VALID_TOKEN);
+
+      const result = await harness.run('hook git-pre-push', {
+        stdin: pushRefLine(sha, GIT_NULL_OID),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('Uncommitted changes detected');
+    },
+    { timeout: 30000 },
+  );
+
+  it(
     'exits 0 when -p is set without --dependency-risks (secrets-only, no dep-risks side effects)',
     async () => {
       initGitRepo(harness.cwd.path);
@@ -330,26 +350,6 @@ describe('sonar hook git-pre-push', () => {
     );
 
     it(
-      'does not warn about uncommitted changes when no manifests changed',
-      async () => {
-        initGitRepo(harness.cwd.path);
-        const sha = commitFile(harness.cwd.path, 'index.ts', CLEAN_CONTENT);
-        stageFile(harness.cwd.path, 'extra.ts', CLEAN_CONTENT);
-
-        harness.state().withScaScannerBinaryInstalled();
-        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
-
-        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
-          stdin: pushRefLine(sha, GIT_NULL_OID),
-        });
-
-        expect(result.exitCode).toBe(0);
-        expect(result.stderr).not.toContain('Uncommitted changes detected');
-      },
-      { timeout: 30000 },
-    );
-
-    it(
       'exits 0 (fail-open) when a manifest changed but the SCA backend is unavailable',
       async () => {
         initGitRepo(harness.cwd.path);
@@ -375,26 +375,6 @@ describe('sonar hook git-pre-push', () => {
         expect(result.stderr).toContain('push not blocked');
       },
       { timeout: 60000 },
-    );
-
-    it(
-      'warns when the working tree has uncommitted changes',
-      async () => {
-        initGitRepo(harness.cwd.path);
-        const sha = commitFile(harness.cwd.path, 'package.json', PACKAGE_JSON_CONTENT);
-        stageFile(harness.cwd.path, 'extra.ts', CLEAN_CONTENT);
-
-        harness.state().withScaScannerBinaryInstalled();
-        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
-
-        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
-          stdin: pushRefLine(sha, GIT_NULL_OID),
-        });
-
-        expect(result.exitCode).toBe(0);
-        expect(result.stderr).toContain('Uncommitted changes detected');
-      },
-      { timeout: 30000 },
     );
   });
 });

--- a/tests/integration/specs/hook/hook-git-pre-push.test.ts
+++ b/tests/integration/specs/hook/hook-git-pre-push.test.ts
@@ -28,7 +28,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { buildLocalBinaryName } from '../../../../src/cli/commands/_common/install/secrets';
 import { detectPlatform } from '../../../../src/lib/platform-detector';
 import { TestHarness } from '../../harness';
-import { commitFile, initGitRepo } from './git-test-helpers';
+import { commitFile, initGitRepo, stageFile } from './git-test-helpers';
 
 // Hardcoded test token — intentional fixture for secret detection, not a real credential
 // sonar-ignore-next-line S6769
@@ -39,6 +39,8 @@ const GIT_NULL_OID = '0000000000000000000000000000000000000000';
 // Unreachable but well-formed server URL: binary handles connection-refused gracefully.
 const FAKE_SERVER = 'http://localhost:19999';
 const VALID_TOKEN = 'integration-test-token';
+const TEST_ORG = 'my-org';
+const PACKAGE_JSON_CONTENT = '{"name":"demo","version":"1.0.0"}';
 const NON_EXECUTABLE_MODE = 0o644;
 
 function pushRefLine(localSha: string, remoteSha: string, branch = 'refs/heads/main'): string {
@@ -235,4 +237,164 @@ describe('sonar hook git-pre-push', () => {
     },
     { timeout: 30000 },
   );
+
+  it(
+    'exits 2 when --dependency-risks is set without -p',
+    async () => {
+      const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
+      const result = await harness.run('hook git-pre-push --dependency-risks', {
+        stdin: pushRefLine(sha, GIT_NULL_OID),
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('-p');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'exits 0 when -p is set without --dependency-risks (secrets-only, no dep-risks side effects)',
+    async () => {
+      initGitRepo(harness.cwd.path);
+      const sha = commitFile(harness.cwd.path, 'package.json', PACKAGE_JSON_CONTENT);
+
+      harness.state().withSecretsBinaryInstalled();
+      harness.withAuth(FAKE_SERVER, VALID_TOKEN);
+
+      const result = await harness.run('hook git-pre-push -p demo', {
+        stdin: pushRefLine(sha, GIT_NULL_OID),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toContain('dependency manifests');
+    },
+    { timeout: 30000 },
+  );
+
+  describe('with --dependency-risks', () => {
+    it(
+      'exits 0 when stdin is empty (no refs)',
+      async () => {
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: '',
+        });
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when not authenticated (graceful skip)',
+      async () => {
+        harness.state().withScaScannerBinaryInstalled();
+        const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when sca-scanner binary is not installed (graceful skip)',
+      async () => {
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+        const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when pushed files contain no dependency manifests',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'index.ts', CLEAN_CONTENT);
+
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout + result.stderr).toContain(
+          'No dependency manifests changed in this push',
+        );
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'does not warn about uncommitted changes when no manifests changed',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'index.ts', CLEAN_CONTENT);
+        stageFile(harness.cwd.path, 'extra.ts', CLEAN_CONTENT);
+
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).not.toContain('Uncommitted changes detected');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'exits 0 (fail-open) when a manifest changed but the SCA backend is unavailable',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'package.json', PACKAGE_JSON_CONTENT);
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken(VALID_TOKEN)
+          .withScaEnabled(true)
+          .withProject('demo')
+          .withProjectSettings('demo', [])
+          .start();
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+          timeoutMs: 45_000,
+        });
+
+        // Hook is fail-open on scanner failure: warn on stderr, push not blocked.
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain('push not blocked');
+      },
+      { timeout: 60000 },
+    );
+
+    it(
+      'warns when the working tree has uncommitted changes',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'package.json', PACKAGE_JSON_CONTENT);
+        stageFile(harness.cwd.path, 'extra.ts', CLEAN_CONTENT);
+
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain('Uncommitted changes detected');
+      },
+      { timeout: 30000 },
+    );
+  });
 });

--- a/tests/unit/hook-stdin.test.ts
+++ b/tests/unit/hook-stdin.test.ts
@@ -23,7 +23,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { readGitPushRefs, readStdinJson } from '../../src/cli/commands/hook/stdin';
 
 describe('readStdinJson', () => {
-  type StdinListener = (...args: unknown[]) => void;
+  type StdinListener = (...args: any[]) => void;
   const listeners: Record<string, StdinListener[]> = {};
   let onSpy: ReturnType<typeof spyOn>;
 
@@ -43,9 +43,7 @@ describe('readStdinJson', () => {
     for (const key of Object.keys(listeners)) {
       delete listeners[key];
     }
-    onSpy = spyOn(process.stdin, 'on').mockImplementation(
-      captureListener as unknown as typeof process.stdin.on,
-    );
+    onSpy = spyOn(process.stdin, 'on').mockImplementation(captureListener);
   });
 
   afterEach(() => {
@@ -109,7 +107,7 @@ describe('readStdinJson', () => {
 });
 
 describe('readGitPushRefs', () => {
-  type StdinListener = (...args: unknown[]) => void;
+  type StdinListener = (...args: any[]) => void;
   const listeners: Record<string, StdinListener[]> = {};
   let onSpy: ReturnType<typeof spyOn>;
 
@@ -129,9 +127,7 @@ describe('readGitPushRefs', () => {
     for (const key of Object.keys(listeners)) {
       delete listeners[key];
     }
-    onSpy = spyOn(process.stdin, 'on').mockImplementation(
-      captureListener as unknown as typeof process.stdin.on,
-    );
+    onSpy = spyOn(process.stdin, 'on').mockImplementation(captureListener);
   });
 
   afterEach(() => {


### PR DESCRIPTION
Part of CLI-541

----
## Summary by Gitar

- **New features:**
  - Implemented `git-pre-push` secondary stage for SCA dependency risk analysis via `--dependency-risks` flag.
  - Added `git-pre-push-dependency-risks.ts` to coordinate scanner execution and filter results.
  - Implemented `runSecretsStage` in `git-pre-push-secrets.ts` to modularize existing secret scanning logic.
- **CLI updates:**
  - Added `-p, --project` and `--dependency-risks` options to `hook git-pre-push` command.
  - Refactored `git-pre-push.ts` to support multi-stage hook execution (Secrets and SCA) and added uncommitted change detection.
- **Integration testing:**
  - Added comprehensive test suite in `hook-git-pre-push.test.ts` covering error handling, skip logic, and failure scenarios.
- **Improvements:**
  - Added `hasUncommittedChanges` check to notify users about local changes during the push process.


<sub>This will update automatically on new commits.</sub>