### PR TITLE
CLI-563 SCA hook: add integrate git option

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "js-yaml": "^4.1.1",
         "openpgp": "^6.0.0",
         "picocolors": "^1.1.1",
+        "picomatch": "^4.0.3",
         "smol-toml": "^1.6.1",
       },
       "devDependencies": {
@@ -23,6 +24,7 @@
         "@types/istanbul-lib-report": "3.0.3",
         "@types/istanbul-reports": "3.0.4",
         "@types/js-yaml": "^4.0.9",
+        "@types/picomatch": "^4.0.2",
         "@typescript-eslint/eslint-plugin": "^8.59.0",
         "@typescript-eslint/parser": "^8.59.0",
         "ajv": "^8.18.0",
@@ -229,6 +231,8 @@
     "@types/pg": ["@types/pg@8.15.6", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/pg/-/pg-8.15.6.tgz", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
 
     "@types/pg-pool": ["@types/pg-pool@2.0.7", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/pg-pool/-/pg-pool-2.0.7.tgz", { "dependencies": { "@types/pg": "*" } }, "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng=="],
+
+    "@types/picomatch": ["@types/picomatch@4.0.3", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/picomatch/-/picomatch-4.0.3.tgz", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
     "@types/tedious": ["@types/tedious@4.0.14", "https://repox.jfrog.io/artifactory/api/npm/npm/@types/tedious/-/tedious-4.0.14.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "js-yaml": "^4.1.1",
     "openpgp": "^6.0.0",
     "picocolors": "^1.1.1",
-    "smol-toml": "^1.6.1"
+    "smol-toml": "^1.6.1",
+    "picomatch": "^4.0.3"
   },
   "devDependencies": {
     "@sentry/cli": "3.4.2",
@@ -117,6 +118,7 @@
     "@types/istanbul-lib-report": "3.0.3",
     "@types/istanbul-reports": "3.0.4",
     "@types/js-yaml": "^4.0.9",
+    "@types/picomatch": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "ajv": "^8.18.0",

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -182,11 +182,11 @@ integrateCommand
 integrateCommand
   .command('git')
   .description(
-    'Install a git hook that scans staged files for secrets before each commit (pre-commit) or scans committed files for secrets before each push (pre-push).',
+    'Install a git hook that scans staged files for secrets before each commit (pre-commit) or scans committed files for secrets and analyzes dependency risks before each push (pre-push).',
   )
   .option(
     '--hook <type>',
-    'Hook to install: pre-commit (scan staged files) or pre-push (scan files in unpushed commits)',
+    'Hook to install: pre-commit (scan staged files) or pre-push (scan files in unpushed commits + dependency risks analysis)',
   )
   .option('--force', 'Overwrite existing hook if it is not from sonar integrate git')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -61,7 +61,7 @@ import { claudePreToolUse } from './commands/hook/claude-pre-tool-use';
 import { codexPromptSubmit } from './commands/hook/codex-prompt-submit';
 import { copilotPreToolUse } from './commands/hook/copilot-pre-tool-use';
 import { gitPreCommit } from './commands/hook/git-pre-commit';
-import { gitPrePush } from './commands/hook/git-pre-push';
+import { gitPrePush, type GitPrePushOptions } from './commands/hook/git-pre-push';
 import type { IntegrateAgentOptions } from './commands/integrate/_common/types';
 import { integrateClaude } from './commands/integrate/claude';
 import { integrateCodex } from './commands/integrate/codex';
@@ -471,8 +471,15 @@ hookCommand
 
 hookCommand
   .command('git-pre-push')
-  .description('git pre-push handler: scan files in new commits for secrets')
-  .anonymousAction(() => gitPrePush());
+  .description(
+    'git pre-push handler: scan files in new commits for secrets, optionally scan dependency manifests for risks',
+  )
+  .option('-p, --project <project>', 'Project key (required when --dependency-risks is set)')
+  .option(
+    '--dependency-risks',
+    'Also run a dependency-risks scan after the secrets scan (requires -p)',
+  )
+  .anonymousAction((options: GitPrePushOptions) => gitPrePush(options));
 
 // Hidden flush command — only registered when running as a telemetry worker.
 if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -160,23 +160,6 @@ const integrateCommand = COMMAND_TREE.command('integrate').description(
   'Setup SonarQube integration for AI coding agents, git and others.',
 );
 
-integrateCommand
-  .command('git')
-  .description(
-    'Install a Git pre-commit hook that scans staged files for secrets before each commit, or a Git pre-push hook that scans committed files for secrets before each push.',
-  )
-  .option(
-    '--hook <type>',
-    'Hook to install: pre-commit (scan staged files) or pre-push (scan files in unpushed commits)',
-  )
-  .option('--force', 'Overwrite existing hook if it is not from sonar integrate git')
-  .option('--non-interactive', 'Non-interactive mode (no prompts)')
-  .option(
-    '--global',
-    'Install hook globally for all repositories (sets git config --global core.hooksPath)',
-  )
-  .authenticatedAction((_auth, options: IntegrateGitOptions) => integrateGit(options));
-
 const projectKeyExtraHelp = `
 Instead of providing an explicit --project, you can add sonar.projectKey to sonar-project.properties at the repository root.
 Alternatively, add SonarQube for IDE shared binding JSON under .sonarlint/ (for example .sonarlint/connectedMode.json) that includes projectKey.
@@ -195,6 +178,28 @@ integrateCommand
   .option('--skip-context', 'Skip the sonar-context-augmentation install/init/skill step')
   .addHelpText('after', projectKeyExtraHelp)
   .authenticatedAction((auth, options: IntegrateAgentOptions) => integrateClaude(options, auth));
+
+integrateCommand
+  .command('git')
+  .description(
+    'Install a git hook that scans staged files for secrets before each commit (pre-commit) or scans committed files for secrets before each push (pre-push).',
+  )
+  .option(
+    '--hook <type>',
+    'Hook to install: pre-commit (scan staged files) or pre-push (scan files in unpushed commits)',
+  )
+  .option('--force', 'Overwrite existing hook if it is not from sonar integrate git')
+  .option('--non-interactive', 'Non-interactive mode (no prompts)')
+  .option(
+    '--global',
+    'Install hook globally for all repositories (sets git config --global core.hooksPath)',
+  )
+  .option('-p, --project <project>', 'Project key for dependency-risks scanning')
+  .option(
+    '--with-dependency-risks',
+    'Also install a pre-push dependency-risks scan (requires --hook pre-push and -p <project>)',
+  )
+  .authenticatedAction((auth, options: IntegrateGitOptions) => integrateGit(auth, options));
 
 integrateCommand
   .command('copilot')

--- a/src/cli/commands/_common/install/sca-scanner.ts
+++ b/src/cli/commands/_common/install/sca-scanner.ts
@@ -28,7 +28,12 @@ import {
   SONARSOURCE_PUBLIC_KEY,
 } from '../../../../lib/signatures';
 import { success } from '../../../../ui';
-import { type BinarySpec, buildLocalBinaryName as buildBinaryName, installBinary } from './binary';
+import {
+  type BinarySpec,
+  buildLocalBinaryName as buildBinaryName,
+  installBinary,
+  resolveBinaryPath,
+} from './binary';
 
 export const SCA_SCANNER_SPEC: BinarySpec = {
   name: SCA_SCANNER_BINARY_NAME,
@@ -50,6 +55,14 @@ export function buildLocalBinaryName(platformInfo: PlatformInfo): string {
   return buildBinaryName(SCA_SCANNER_SPEC, platformInfo);
 }
 
+/**
+ * Returns the path to the installed sca-scanner binary, or null if not present.
+ * Never downloads — use this where silent operation is required (e.g. hook handlers).
+ */
+export function resolveScaScannerBinaryPath(): string | null {
+  return resolveBinaryPath(SCA_SCANNER_SPEC);
+}
+
 export interface ScaScannerInstaller {
   install(): Promise<string>;
 }
@@ -57,5 +70,12 @@ export interface ScaScannerInstaller {
 export class DefaultScaScannerInstaller implements ScaScannerInstaller {
   install(): Promise<string> {
     return installScaScannerBinary();
+  }
+}
+
+export class ScaScannerNoopInstaller implements ScaScannerInstaller {
+  constructor(private readonly binaryPath: string) {}
+  install(): Promise<string> {
+    return Promise.resolve(this.binaryPath);
   }
 }

--- a/src/cli/commands/_common/sca-availability.ts
+++ b/src/cli/commands/_common/sca-availability.ts
@@ -1,0 +1,58 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { fetchServerVersion, isAtLeast } from '../../../lib/server-info';
+import type { SonarQubeClient } from '../../../sonarqube/client';
+import { CommandFailedError } from './error';
+
+export const MIN_SCA_SQS_VERSION = '2026.4';
+
+export async function assertScaAvailable(
+  client: Pick<SonarQubeClient, 'checkScaEnabled'>,
+  auth: Pick<ResolvedAuth, 'connectionType' | 'serverUrl' | 'orgKey'>,
+): Promise<void> {
+  if (auth.connectionType !== 'cloud') {
+    let serverVersion: string;
+    try {
+      serverVersion = await fetchServerVersion(auth.serverUrl);
+    } catch (err) {
+      throw new CommandFailedError(
+        `Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
+        { cause: err },
+      );
+    }
+    if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
+      throw new CommandFailedError(
+        `Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
+      );
+    }
+  }
+  const enabled = await client.checkScaEnabled(auth.connectionType, auth.orgKey);
+  if (!enabled) {
+    throw new CommandFailedError(
+      'Software Composition Analysis is not available for the current connection.',
+      {
+        remediationHint:
+          'Software Composition Analysis must be enabled by an administrator and requires an eligible SonarQube plan. Learn more: https://docs.sonarsource.com/sonarqube-cli/analysis/sca',
+      },
+    );
+  }
+}

--- a/src/cli/commands/analyze/dependency-risk-helpers/count-selected-risks.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/count-selected-risks.ts
@@ -1,0 +1,35 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { DependencyRisksViewModel } from './view-model';
+import type { RiskVM } from './view-model/risk';
+
+export function countSelectedRisks(
+  vm: DependencyRisksViewModel,
+  predicate: (risk: RiskVM) => boolean = () => true,
+): number {
+  let count = 0;
+  for (const pkg of vm.packages) {
+    for (const group of pkg.groups) {
+      count += group.selectedRisks.filter(predicate).length;
+    }
+  }
+  return count;
+}

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -1,0 +1,67 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ResolvedAuth } from '../../../../lib/auth-resolver';
+import { CLI_DIR } from '../../../../lib/config-constants';
+import logger, { getLogLevelConfig } from '../../../../lib/logger';
+import { type SonarQubeClient } from '../../../../sonarqube/client';
+import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
+import { assertScaAvailable } from '../../_common/sca-availability';
+import { parseAnalysisProperties } from './analysis-properties';
+import {
+  type AnalyzeProjectResponse,
+  type ScaScannerInvocation,
+  ScaScannerRunner,
+} from './sca-scanner';
+import type { ScaScannerSpawner } from './sca-scanner-spawner';
+import { buildScaUrls } from './sca-urls';
+
+export class ScaScanOrchestrator {
+  constructor(
+    private readonly client: SonarQubeClient,
+    private readonly installer: ScaScannerInstaller,
+    private readonly spawner: ScaScannerSpawner,
+  ) {}
+
+  async run(auth: ResolvedAuth, projectKey: string): Promise<AnalyzeProjectResponse> {
+    await assertScaAvailable(this.client, auth);
+    const settings = await this.client.getProjectSettings(projectKey);
+    const properties = parseAnalysisProperties(settings);
+    logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
+    const { apiBaseUrl, downloadBaseUrl } = buildScaUrls(auth);
+    const invocation: ScaScannerInvocation = {
+      baseDir: process.cwd(),
+      apiBaseUrl,
+      downloadBaseUrl,
+      sonarToken: auth.token,
+      projectKey,
+      cacheDir: join(CLI_DIR, 'sca-scanner-cache'),
+      workDir: join(tmpdir(), `sonar-sca-${Date.now()}`),
+      scannerProperties: properties.scaProperties,
+      excludedPaths: properties.exclusions,
+      includeGitIgnoredPaths: properties.includeGitIgnoredPaths,
+      debug: getLogLevelConfig() === 'DEBUG',
+    };
+    return new ScaScannerRunner(this.installer, this.spawner).run(invocation);
+  }
+}

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.ts
@@ -1,0 +1,60 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import picomatch from 'picomatch';
+
+import logger from '../../../../lib/logger';
+import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
+import type { ScaScannerSpawner } from './sca-scanner-spawner';
+
+interface WatchPatternsPayload {
+  patterns?: unknown;
+}
+
+export class ScaWatchPatternsRunner {
+  constructor(
+    private readonly installer: ScaScannerInstaller,
+    private readonly spawner: ScaScannerSpawner,
+  ) {}
+
+  async run(): Promise<string[]> {
+    try {
+      const binaryPath = await this.installer.install();
+      const result = await this.spawner.spawn(binaryPath, ['watch-patterns']);
+      if ((result.exitCode ?? 1) !== 0) {
+        logger.debug(`watch-patterns exited with code ${String(result.exitCode)}`);
+        return [];
+      }
+      const parsed: WatchPatternsPayload = JSON.parse(result.stdout) as WatchPatternsPayload;
+      if (!Array.isArray(parsed.patterns)) return [];
+      return parsed.patterns.filter((p): p is string => typeof p === 'string');
+    } catch (err) {
+      logger.debug(`watch-patterns failed: ${(err as Error).message}`);
+      return [];
+    }
+  }
+}
+
+export function anyFileMatches(files: readonly string[], patterns: readonly string[]): boolean {
+  if (patterns.length === 0 || files.length === 0) return false;
+  const normalizedPatterns = patterns.map((p) => (p.includes('/') ? p : `**/${p}`));
+  const match = picomatch(normalizedPatterns, { dot: true, nocase: process.platform === 'win32' });
+  return files.some((file) => match(file));
+}

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -18,37 +18,26 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import { type ResolvedAuth } from '../../../lib/auth-resolver';
-import { CLI_DIR } from '../../../lib/config-constants';
-import logger, { getLogLevelConfig } from '../../../lib/logger';
-import { fetchServerVersion, isAtLeast } from '../../../lib/server-info';
 import { SonarQubeClient } from '../../../sonarqube/client';
 import { error, print, warn } from '../../../ui';
-import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
+import { InvalidOptionError } from '../_common/error.js';
 import { DefaultScaScannerInstaller } from '../_common/install/sca-scanner.ts';
-import { parseAnalysisProperties } from './dependency-risk-helpers/analysis-properties.ts';
+import { countSelectedRisks } from './dependency-risk-helpers/count-selected-risks.ts';
 import { DefaultScaScannerSpawner } from './dependency-risk-helpers/default-sca-scanner-spawner.ts';
 import { formatDependencyRisksJson } from './dependency-risk-helpers/format-dependency-risks-json.ts';
 import { buildRiskFilter } from './dependency-risk-helpers/risk-filter.ts';
-import {
-  type ScaScannerInvocation,
-  ScaScannerRunner,
-} from './dependency-risk-helpers/sca-scanner.ts';
-import { buildScaUrls } from './dependency-risk-helpers/sca-urls.ts';
+import { ScaScanOrchestrator } from './dependency-risk-helpers/sca-scan-orchestrator.ts';
 import { formatDependencyRisksTable } from './dependency-risk-helpers/table';
 import type { DependencyRisksViewModel } from './dependency-risk-helpers/view-model';
 import { buildDependencyRisksViewModel } from './dependency-risk-helpers/view-model/build';
 
 export const VALID_FORMATS = ['json', 'table'];
 
+export const EXIT_CODE_UNRESOLVED_RISKS = 51;
+
 const EXIT_CODE_OK = 0;
 const EXIT_CODE_ERRORS_ONLY = 1;
-const EXIT_CODE_UNRESOLVED_RISKS = 51;
-
-const MIN_SCA_SQS_VERSION = '2026.4';
 
 export interface AnalyzeDependencyRisksOptions {
   project: string;
@@ -66,32 +55,11 @@ export async function analyzeDependencyRisks(
   }
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
-  await assertServerSupportsLocalSca(auth, client);
-
-  const settings = await client.getProjectSettings(options.project);
-  const properties = parseAnalysisProperties(settings);
-  logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
-
-  const { apiBaseUrl, downloadBaseUrl } = buildScaUrls(auth);
-
-  const invocation: ScaScannerInvocation = {
-    baseDir: process.cwd(),
-    apiBaseUrl,
-    downloadBaseUrl,
-    sonarToken: auth.token,
-    projectKey: options.project,
-    cacheDir: join(CLI_DIR, 'sca-scanner-cache'),
-    workDir: join(tmpdir(), `sonar-sca-${Date.now()}`),
-    scannerProperties: properties.scaProperties,
-    excludedPaths: properties.exclusions,
-    includeGitIgnoredPaths: properties.includeGitIgnoredPaths,
-    debug: getLogLevelConfig() === 'DEBUG',
-  };
-
-  const result = await new ScaScannerRunner(
+  const result = await new ScaScanOrchestrator(
+    client,
     new DefaultScaScannerInstaller(),
     new DefaultScaScannerSpawner(),
-  ).run(invocation);
+  ).run(auth, options.project);
 
   const viewModel = buildDependencyRisksViewModel(result, filter);
   if (options.format === 'json') {
@@ -129,46 +97,5 @@ function pluralize(count: number, singular: string): string {
 }
 
 export function countUnresolvedIssues(vm: DependencyRisksViewModel): number {
-  const isUnresolved = buildRiskFilter('active')!.predicate;
-  let count = 0;
-  for (const pkg of vm.packages) {
-    for (const group of pkg.groups) {
-      for (const risk of group.selectedRisks) {
-        if (isUnresolved(risk)) count += 1;
-      }
-    }
-  }
-  return count;
-}
-
-async function assertServerSupportsLocalSca(
-  auth: ResolvedAuth,
-  client: SonarQubeClient,
-): Promise<void> {
-  if (auth.connectionType !== 'cloud') {
-    let serverVersion: string;
-    try {
-      serverVersion = await fetchServerVersion(auth.serverUrl);
-    } catch (err) {
-      throw new CommandFailedError(
-        `Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
-        { cause: err },
-      );
-    }
-    if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
-      throw new CommandFailedError(
-        `Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
-      );
-    }
-  }
-  const enabled = await client.checkScaEnabled(auth.connectionType, auth.orgKey);
-  if (!enabled) {
-    throw new CommandFailedError(
-      'Software Composition Analysis is not available for the current connection.',
-      {
-        remediationHint:
-          'Software Composition Analysis must be enabled by an administrator and requires an eligible SonarQube plan. Learn more: https://docs.sonarsource.com/sonarqube-cli/analysis/sca',
-      },
-    );
-  }
+  return countSelectedRisks(vm, buildRiskFilter('active')!.predicate);
 }

--- a/src/cli/commands/hook/git-pre-push-dependency-risks.ts
+++ b/src/cli/commands/hook/git-pre-push-dependency-risks.ts
@@ -1,0 +1,115 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Dependency-risks stage of the git pre-push hook. Invoked after the secrets
+// stage when the user opted in via `--dependency-risks` and `-p <projectKey>`. Skips
+// silently when no manifests changed, fails-open on infra errors (auth/binary
+// missing, scanner failure), and blocks the push only when risks matching the
+// configured filter are found.
+
+import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import logger from '../../../lib/logger';
+import { SonarQubeClient } from '../../../sonarqube/client';
+import { print, success, warn } from '../../../ui';
+import { CommandFailedError } from '../_common/error';
+import {
+  resolveScaScannerBinaryPath,
+  ScaScannerNoopInstaller,
+} from '../_common/install/sca-scanner';
+import { countSelectedRisks } from '../analyze/dependency-risk-helpers/count-selected-risks';
+import { DefaultScaScannerSpawner } from '../analyze/dependency-risk-helpers/default-sca-scanner-spawner';
+import { buildRiskFilter } from '../analyze/dependency-risk-helpers/risk-filter';
+import { ScaScanOrchestrator } from '../analyze/dependency-risk-helpers/sca-scan-orchestrator';
+import {
+  anyFileMatches,
+  ScaWatchPatternsRunner,
+} from '../analyze/dependency-risk-helpers/sca-watch-patterns';
+import { formatDependencyRisksTable } from '../analyze/dependency-risk-helpers/table';
+import { buildDependencyRisksViewModel } from '../analyze/dependency-risk-helpers/view-model/build';
+import { hasUncommittedChanges } from './git-pre-push';
+
+const HOOK_STATUS_FILTER = 'new';
+
+export interface DepRisksStageOptions {
+  project: string;
+  changedFiles: string[];
+  auth: ResolvedAuth;
+}
+
+export async function runDepRisksStage(options: DepRisksStageOptions): Promise<void> {
+  const binaryPath = resolveScaScannerBinaryPath();
+  if (!binaryPath) {
+    logger.debug('Dependency-risks hook: sca-scanner binary not installed, skipping.');
+    return;
+  }
+
+  const patterns = await new ScaWatchPatternsRunner(
+    new ScaScannerNoopInstaller(binaryPath),
+    new DefaultScaScannerSpawner(),
+  ).run();
+  if (patterns.length === 0) {
+    logger.debug('Dependency-risks hook: no watch patterns returned, skipping.');
+    return;
+  }
+
+  if (!anyFileMatches(options.changedFiles, patterns)) {
+    success('No dependency manifests changed in this push — skipping dependency-risks scan.');
+    return;
+  }
+
+  if (await hasUncommittedChanges()) {
+    warn(
+      'Uncommitted changes detected — they are not part of this push, but will be included in the dependency-risks scan.',
+    );
+  }
+
+  const filter = buildRiskFilter(HOOK_STATUS_FILTER);
+  if (!filter) {
+    warn(
+      `Dependency-risks hook: invalid filter (statuses='${HOOK_STATUS_FILTER}'); push not blocked.`,
+    );
+    return;
+  }
+
+  let viewModel;
+  try {
+    const client = new SonarQubeClient(options.auth.serverUrl, options.auth.token);
+    const result = await new ScaScanOrchestrator(
+      client,
+      new ScaScannerNoopInstaller(binaryPath),
+      new DefaultScaScannerSpawner(),
+    ).run(options.auth, options.project);
+    viewModel = buildDependencyRisksViewModel(result, filter);
+  } catch (err) {
+    warn(`Dependency-risks scan failed; push not blocked. Reason: ${(err as Error).message}`);
+    return;
+  }
+
+  const matchedCount = countSelectedRisks(viewModel);
+  if (matchedCount === 0) return;
+
+  print(formatDependencyRisksTable(viewModel));
+  throw new CommandFailedError(
+    `Dependency risks detected in this push (${matchedCount} matching the configured filter).`,
+    {
+      remediationHint: `Run 'sonar analyze dependency-risks -p ${options.project}' to inspect, fix or accept the risks, then retry the push.`,
+    },
+  );
+}

--- a/src/cli/commands/hook/git-pre-push-secrets.ts
+++ b/src/cli/commands/hook/git-pre-push-secrets.ts
@@ -1,0 +1,58 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { CommandFailedError } from '../_common/error';
+import { resolveSecretsBinaryPath } from '../_common/install/secrets';
+import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
+import { GIT_NULL_OID } from './git-pre-push';
+import type { HookDependencies } from './hook-dependencies';
+import { handleScanError } from './hook-dependencies';
+import type { PushRef } from './stdin';
+
+export async function runSecretsStage(
+  filesByRef: Map<PushRef, string[]>,
+  auth: ResolvedAuth,
+): Promise<void> {
+  const binaryPath = resolveSecretsBinaryPath();
+  if (!binaryPath) return;
+  const deps: HookDependencies = { auth, binaryPath };
+
+  for (const [ref, files] of filesByRef) {
+    if (ref.localSha === GIT_NULL_OID) continue;
+    if (files.length === 0) continue;
+    await scanRef(files, deps);
+  }
+}
+
+async function scanRef(files: string[], deps: HookDependencies): Promise<void> {
+  try {
+    const result = await runSecretsBinary(deps.binaryPath, files, deps.auth);
+    if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
+      throw new CommandFailedError('Secrets detected in pushed commits.', {
+        remediationHint:
+          'Remove the reported secret, amend the commit if needed, then retry the push.',
+      });
+    }
+  } catch (err) {
+    if (err instanceof CommandFailedError) throw err;
+    handleScanError('Push', err as Error);
+  }
+}

--- a/src/cli/commands/hook/git-pre-push.ts
+++ b/src/cli/commands/hook/git-pre-push.ts
@@ -18,50 +18,44 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// git pre-push callback handler — scans files in new commits for secrets before push.
+// git pre-push callback handler — scans files in new commits for secrets and,
+// when --dependency-risks is set, runs a dependency-risks scan as a follow-up stage.
 // Replaces the shell logic that was previously embedded in the git hook script.
 
+import { resolveAuth } from '../../../lib/auth-resolver';
 import { spawnProcess } from '../../../lib/process';
-import { CommandFailedError } from '../_common/error';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
-import type { HookDependencies } from './hook-dependencies';
-import { handleScanError, resolveAuthAndSecrets } from './hook-dependencies';
+import { InvalidOptionError } from '../_common/error';
+import { runDepRisksStage } from './git-pre-push-dependency-risks.ts';
+import { runSecretsStage } from './git-pre-push-secrets.ts';
 import type { PushRef } from './stdin';
 import { readGitPushRefs } from './stdin';
 
-const GIT_NULL_OID = '0000000000000000000000000000000000000000';
+export const GIT_NULL_OID = '0000000000000000000000000000000000000000';
 
-export async function gitPrePush(): Promise<void> {
+export interface GitPrePushOptions {
+  project?: string;
+  dependencyRisks?: boolean;
+}
+
+export async function gitPrePush(options: GitPrePushOptions = {}): Promise<void> {
+  if (options.dependencyRisks && !options.project) {
+    throw new InvalidOptionError('--dependency-risks requires -p <projectKey>.');
+  }
+
+  const auth = await resolveAuth().catch(() => null);
+  if (!auth) return;
+
   const refs = await readGitPushRefs();
   if (refs.length === 0) return;
 
-  const deps = await resolveAuthAndSecrets();
-  if (!deps) return;
-
   const emptyTree = await getEmptyTree();
+  const filesByRef = await collectFilesForRefs(refs, emptyTree);
 
-  for (const ref of refs) {
-    await scanRef(ref, emptyTree, deps);
-  }
-}
+  await runSecretsStage(filesByRef, auth);
 
-async function scanRef(ref: PushRef, emptyTree: string, deps: HookDependencies): Promise<void> {
-  if (ref.localSha === GIT_NULL_OID) return; // branch deletion — nothing to scan
-
-  const files = await getFilesForRef(ref, emptyTree);
-  if (files.length === 0) return;
-
-  try {
-    const result = await runSecretsBinary(deps.binaryPath, files, deps.auth);
-    if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
-      throw new CommandFailedError('Secrets detected in pushed commits.', {
-        remediationHint:
-          'Remove the reported secret, amend the commit if needed, then retry the push.',
-      });
-    }
-  } catch (err) {
-    if (err instanceof CommandFailedError) throw err;
-    handleScanError('Push', err as Error);
+  if (options.dependencyRisks && options.project) {
+    const changedFiles = Array.from(filesByRef.values()).flat();
+    await runDepRisksStage({ project: options.project, changedFiles, auth });
   }
 }
 
@@ -72,6 +66,21 @@ async function getEmptyTree(): Promise<string> {
   } catch {
     return GIT_NULL_OID;
   }
+}
+
+async function collectFilesForRefs(
+  refs: PushRef[],
+  emptyTree: string,
+): Promise<Map<PushRef, string[]>> {
+  const out = new Map<PushRef, string[]>();
+  for (const ref of refs) {
+    if (ref.localSha === GIT_NULL_OID) {
+      out.set(ref, []);
+      continue;
+    }
+    out.set(ref, await getFilesForRef(ref, emptyTree));
+  }
+  return out;
 }
 
 async function getFilesForRef(ref: PushRef, emptyTree: string): Promise<string[]> {
@@ -118,7 +127,6 @@ async function getFilesForNewBranch(localSha: string, emptyTree: string): Promis
       return Array.from(fileSet);
     }
 
-    // No other remotes — diff full branch against empty tree
     const result = await spawnProcess('git', [
       'diff',
       '--name-only',
@@ -129,5 +137,14 @@ async function getFilesForNewBranch(localSha: string, emptyTree: string): Promis
     return result.stdout.trim().split('\n').filter(Boolean);
   } catch {
     return [];
+  }
+}
+
+export async function hasUncommittedChanges(): Promise<boolean> {
+  try {
+    const result = await spawnProcess('git', ['status', '--porcelain']);
+    return result.stdout.trim().length > 0;
+  } catch {
+    return false;
   }
 }

--- a/src/cli/commands/integrate/_common/registry/dependencies/sonarsource-binary.ts
+++ b/src/cli/commands/integrate/_common/registry/dependencies/sonarsource-binary.ts
@@ -18,9 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { SONAR_SECRETS_DIST_PREFIX } from '../../../../../../lib/config-constants';
-import { SECRETS_BINARY_NAME } from '../../../../../../lib/install-types';
 import {
+  SCA_SCANNER_CLI_DIST_PREFIX,
+  SONAR_SECRETS_DIST_PREFIX,
+} from '../../../../../../lib/config-constants';
+import { SCA_SCANNER_BINARY_NAME, SECRETS_BINARY_NAME } from '../../../../../../lib/install-types';
+import {
+  SCA_SCANNER_CLI_SIGNATURES,
+  SCA_SCANNER_CLI_VERSION,
   SONAR_SECRETS_SIGNATURES,
   SONAR_SECRETS_VERSION,
   SONARSOURCE_PUBLIC_KEY,
@@ -46,6 +51,16 @@ export const SonarSourceBinary = {
       version: SONAR_SECRETS_VERSION,
       distPrefix: SONAR_SECRETS_DIST_PREFIX,
       signatures: SONAR_SECRETS_SIGNATURES,
+      publicKey: SONARSOURCE_PUBLIC_KEY,
+    },
+  },
+  ScaScanner: {
+    id: SCA_SCANNER_BINARY_NAME,
+    spec: {
+      name: SCA_SCANNER_BINARY_NAME,
+      version: SCA_SCANNER_CLI_VERSION,
+      distPrefix: SCA_SCANNER_CLI_DIST_PREFIX,
+      signatures: SCA_SCANNER_CLI_SIGNATURES,
       publicKey: SONARSOURCE_PUBLIC_KEY,
     },
   },
@@ -92,4 +107,10 @@ export const sonarSecretsBinaryDependency = sonarSourceBinary({
   id: 'sonar-secrets',
   displayName: 'sonar-secrets binary',
   binary: SonarSourceBinary.SonarSecrets,
+});
+
+export const sonarScaScannerBinaryDependency = sonarSourceBinary({
+  id: SCA_SCANNER_BINARY_NAME,
+  displayName: 'sca-scanner binary',
+  binary: SonarSourceBinary.ScaScanner,
 });

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -21,6 +21,7 @@
 export { createIntegrationRegistry, IntegrationRegistry, registerIntegrations } from './core';
 export {
   type DependencyDeclaration,
+  sonarScaScannerBinaryDependency,
   sonarSecretsBinaryDependency,
   SonarSourceBinary,
   sonarSourceBinary,

--- a/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
@@ -75,26 +75,22 @@ export class TextSnippet implements ResourceDeclaration {
   private async renderContent(path: string, context: IntegrationContext): Promise<string> {
     const existing = (await readTextFile(path)) ?? '';
     const managedBlock = this.renderManagedBlock(context);
-    const pattern = new RegExp(
-      String.raw`${escapeRegExp(this.startMarker)}[\s\S]*?${escapeRegExp(this.endMarker)}`,
-    );
-    if (pattern.test(existing)) {
-      return existing.replace(pattern, managedBlock);
+    const startIndex = findFirstIndex(existing, [
+      this.startMarker,
+      ...(this.options.legacyStartMarkers ?? []),
+    ]);
+
+    if (startIndex < 0) {
+      return appendBlock(existing, managedBlock);
     }
 
-    const startMarkerIndex = existing.indexOf(this.startMarker);
-    if (startMarkerIndex >= 0) {
-      return `${existing.slice(0, startMarkerIndex)}${managedBlock}\n`;
+    const endIndex = existing.indexOf(this.endMarker, startIndex);
+    if (endIndex >= 0) {
+      const blockEnd = endIndex + this.endMarker.length;
+      return `${existing.slice(0, startIndex)}${managedBlock}${existing.slice(blockEnd)}`;
     }
 
-    for (const legacyMarker of this.options.legacyStartMarkers ?? []) {
-      const legacyIndex = existing.indexOf(legacyMarker);
-      if (legacyIndex >= 0) {
-        return `${existing.slice(0, legacyIndex)}${managedBlock}\n`;
-      }
-    }
-
-    return appendBlock(existing, managedBlock);
+    return `${existing.slice(0, startIndex)}${managedBlock}\n`;
   }
 
   private renderManagedBlock(context: IntegrationContext): string {
@@ -121,6 +117,12 @@ function appendBlock(existing: string, block: string): string {
   return `${existing.trimEnd()}\n\n${block}\n`;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+function findFirstIndex(haystack: string, needles: string[]): number {
+  for (const needle of needles) {
+    const index = haystack.indexOf(needle);
+    if (index >= 0) {
+      return index;
+    }
+  }
+  return -1;
 }

--- a/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
@@ -30,10 +30,11 @@ import {
 
 export interface TextSnippetResourceOptions extends BaseResourceOptions {
   targetPath: PathResolver;
-  content: string;
+  content: string | ((context: IntegrationContext) => string);
   executable?: boolean;
   startMarker: string;
   endMarker?: string;
+  legacyStartMarkers?: string[];
 }
 
 export function textSnippet(options: TextSnippetResourceOptions): ResourceDeclaration {
@@ -54,7 +55,11 @@ export class TextSnippet implements ResourceDeclaration {
 
   async apply(context: IntegrationContext): Promise<AppliedResource> {
     const path = await resolvePath(context, this.options.targetPath);
-    await writeFileIfChanged(path, await this.renderContent(path), this.options.executable);
+    await writeFileIfChanged(
+      path,
+      await this.renderContent(path, context),
+      this.options.executable,
+    );
     return { id: this.id, resourceType: this.resourceType, version: this.version, path };
   }
 
@@ -64,12 +69,12 @@ export class TextSnippet implements ResourceDeclaration {
     if (existing === undefined) {
       return false;
     }
-    return existing.includes(this.renderManagedBlock());
+    return existing.includes(this.renderManagedBlock(context));
   }
 
-  private async renderContent(path: string): Promise<string> {
+  private async renderContent(path: string, context: IntegrationContext): Promise<string> {
     const existing = (await readTextFile(path)) ?? '';
-    const managedBlock = this.renderManagedBlock();
+    const managedBlock = this.renderManagedBlock(context);
     const pattern = new RegExp(
       String.raw`${escapeRegExp(this.startMarker)}[\s\S]*?${escapeRegExp(this.endMarker)}`,
     );
@@ -82,11 +87,22 @@ export class TextSnippet implements ResourceDeclaration {
       return `${existing.slice(0, startMarkerIndex)}${managedBlock}\n`;
     }
 
+    for (const legacyMarker of this.options.legacyStartMarkers ?? []) {
+      const legacyIndex = existing.indexOf(legacyMarker);
+      if (legacyIndex >= 0) {
+        return `${existing.slice(0, legacyIndex)}${managedBlock}\n`;
+      }
+    }
+
     return appendBlock(existing, managedBlock);
   }
 
-  private renderManagedBlock(): string {
-    return `${this.startMarker}\n${this.options.content.trimEnd()}\n${this.endMarker}`;
+  private renderManagedBlock(context: IntegrationContext): string {
+    const content =
+      typeof this.options.content === 'function'
+        ? this.options.content(context)
+        : this.options.content;
+    return `${this.startMarker}\n${content.trimEnd()}\n${this.endMarker}`;
   }
 
   private get startMarker(): string {

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -343,6 +343,12 @@ export async function integrateGit(
   const depRisksEnabled = features.dependencyRisks;
   const projectKey = depRisksEnabled ? await resolveProjectKey(options) : undefined;
 
+  if (depRisksEnabled && projectKey == null) {
+    throw new CommandFailedError(
+      'Installation cancelled: a project key is required for dependency-risks scanning.'
+    );
+  }
+
   const installDepRisks = depRisksEnabled && projectKey != null;
 
   if (installDepRisks) {
@@ -351,9 +357,6 @@ export async function integrateGit(
       throw new CommandFailedError(`Project '${projectKey}' not found on the connected server.`);
     }
     await assertScaAvailable(client, auth);
-  }
-
-  if (installDepRisks) {
     text(`Dependency-risks scanning: enabled for project '${projectKey}'`);
     blank();
   }

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -24,17 +24,31 @@ import { existsSync, readFileSync } from 'node:fs';
 import { platform } from 'node:os';
 import { join } from 'node:path';
 
+import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { GLOBAL_HOOKS_DIR } from '../../../../lib/config-constants';
 import { normalizePath } from '../../../../lib/fs-utils';
+import { isValidProjectKey, PROJECT_KEY_VALIDATION_ERROR } from '../../../../lib/project-key.ts';
 import { findGitRoot } from '../../../../lib/project-workspace';
-import { blank, confirmPrompt, info, intro, note, selectPrompt, text, warn } from '../../../../ui';
+import { SonarQubeClient } from '../../../../sonarqube/client';
+import {
+  blank,
+  confirmPrompt,
+  info,
+  intro,
+  note,
+  promptUntilValid,
+  selectPrompt,
+  text,
+  warn,
+} from '../../../../ui';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
+import { assertScaAvailable } from '../../_common/sca-availability';
 import { installIntegration } from '../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from './options';
 import {
   hasSonarHookInPreCommitConfig,
-  HOOK_MARKER,
+  hasSonarHookMarker,
   HUSKY_INTEGRATION_ID,
   NATIVE_GIT_INTEGRATION_ID,
   PRE_COMMIT_CONFIG_FILE,
@@ -55,7 +69,7 @@ export function isGitHookType(s: string): s is GitHookType {
 // ---------------------------------------------------------------------------
 
 export function hasMarker(filePath: string): boolean {
-  return existsSync(filePath) && readFileSync(filePath, 'utf-8').includes(HOOK_MARKER);
+  return existsSync(filePath) && hasSonarHookMarker(readFileSync(filePath, 'utf-8'));
 }
 
 interface HookInstallation {
@@ -98,10 +112,77 @@ export function validateHookOption(hook: string | undefined): void {
   }
 }
 
+/** Rejects an invalid project key for the given option name */
+export function validateProjectKeyOption(optionName: string, key: string | undefined): void {
+  if (key === undefined) return;
+  if (!isValidProjectKey(key.trim())) {
+    throw new InvalidOptionError(`${optionName}: ${PROJECT_KEY_VALIDATION_ERROR}`);
+  }
+}
+
+/** `--with-dependency-risks` requires `--project` in non-interactive mode and is only meaningful for the pre-push hook. */
+export function validateDependencyRisksOption(options: IntegrateGitOptions): void {
+  if (!options.withDependencyRisks) return;
+  if (options.nonInteractive && !options.project) {
+    throw new InvalidOptionError('--with-dependency-risks requires -p <project>');
+  }
+  if (options.hook !== undefined && options.hook !== 'pre-push') {
+    throw new InvalidOptionError(
+      '--with-dependency-risks can only be combined with --hook pre-push',
+    );
+  }
+}
+
+export interface OptionalFeatures {
+  dependencyRisks: boolean;
+}
+
+/**
+ * Resolves which optional pre-push features to install. Uses the `--with-dependency-risks` flag
+ * when set; otherwise confirms with the user in interactive mode.
+ */
+export async function resolveOptionalFeatures(
+  options: IntegrateGitOptions,
+  hook: GitHookType,
+): Promise<OptionalFeatures> {
+  if (hook !== 'pre-push') return { dependencyRisks: false };
+  if (options.withDependencyRisks) return { dependencyRisks: true };
+  if (options.nonInteractive) return { dependencyRisks: false };
+
+  const enable = await confirmPrompt(
+    'Also install pre-push dependency-risks scanning? (Requires SCA-enabled SonarQube project)',
+    false,
+  );
+  return { dependencyRisks: enable === true };
+}
+
+/**
+ * Resolves the project key needed by analysis features. Uses `--project` if provided and valid;
+ * otherwise prompts once with a generic message.
+ */
+export async function resolveProjectKey(options: IntegrateGitOptions): Promise<string | null> {
+  if (options.project !== undefined && isValidProjectKey(options.project.trim())) {
+    return options.project.trim();
+  }
+  if (options.project !== undefined) {
+    warn(`Invalid project key '${options.project}': ${PROJECT_KEY_VALIDATION_ERROR}`);
+  }
+  text('A project key is required to run analysis.');
+  const value = await promptUntilValid(
+    'Project key:',
+    (v) => isValidProjectKey(v.trim()),
+    PROJECT_KEY_VALIDATION_ERROR,
+  );
+  return value?.trim() ?? null;
+}
+
 /**
  * Validates and returns explicit `--hook`, or `pre-commit` when non-interactive with no hook, or prompts to select.
  */
-export async function resolveHookType(options: IntegrateGitOptions): Promise<GitHookType> {
+export async function resolveHookType(
+  options: IntegrateGitOptions,
+  prePushLabel = 'pre-push (scan files in unpushed commits)',
+): Promise<GitHookType> {
   if (options.hook !== undefined) {
     return options.hook;
   }
@@ -117,7 +198,7 @@ export async function resolveHookType(options: IntegrateGitOptions): Promise<Git
       },
       {
         value: 'pre-push' as const,
-        label: 'pre-push (scan files in unpushed commits)',
+        label: prePushLabel,
       },
     ],
   );
@@ -176,6 +257,12 @@ export async function showInstallationStatus(root: string): Promise<void> {
 
 async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   validateHookOption(options.hook);
+  if (options.nonInteractive) validateProjectKeyOption('--project', options.project);
+  if (options.withDependencyRisks) {
+    throw new InvalidOptionError(
+      '--with-dependency-risks is not supported with --global; install per project instead',
+    );
+  }
 
   warn('Global hook installation');
   text('  Git prioritizes local repository settings over global ones.');
@@ -197,6 +284,10 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   }
   blank();
 
+  warn('Dependency risks analysis is not available with the global hook.');
+  text('  To run dependency risks analysis, install a repository-based pre-push hook instead.');
+  blank();
+
   const hook = await resolveHookType(options);
   text(`Hook: ${hook}`);
   blank();
@@ -206,8 +297,13 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   showVerificationGuide(hook);
 }
 
-export async function integrateGit(options: IntegrateGitOptions): Promise<void> {
+export async function integrateGit(
+  auth: ResolvedAuth,
+  options: IntegrateGitOptions,
+): Promise<void> {
   validateHookOption(options.hook);
+  if (options.nonInteractive) validateProjectKeyOption('--project', options.project);
+  validateDependencyRisksOption(options);
 
   intro('SonarQube Git integration (secrets scanning)');
   blank();
@@ -235,11 +331,43 @@ export async function integrateGit(options: IntegrateGitOptions): Promise<void> 
   }
   blank();
 
-  const hook = await resolveHookType(options);
+  const hook = await resolveHookType(
+    options,
+    'pre-push (scan files in unpushed commits, supports analysis of dependency risks)',
+  );
   text(`Hook: ${hook}`);
   blank();
 
-  await installGitFeatures({ ...options, hook }, gitRoot, 'project');
+  const features = await resolveOptionalFeatures(options, hook);
+
+  const depRisksEnabled = features.dependencyRisks;
+  const projectKey = depRisksEnabled ? await resolveProjectKey(options) : undefined;
+
+  const installDepRisks = depRisksEnabled && projectKey != null;
+
+  if (installDepRisks) {
+    const client = new SonarQubeClient(auth.serverUrl, auth.token);
+    if (!(await client.checkComponent(projectKey))) {
+      throw new CommandFailedError(`Project '${projectKey}' not found on the connected server.`);
+    }
+    await assertScaAvailable(client, auth);
+  }
+
+  if (installDepRisks) {
+    text(`Dependency-risks scanning: enabled for project '${projectKey}'`);
+    blank();
+  }
+
+  await installGitFeatures(
+    {
+      ...options,
+      hook,
+      withDependencyRisks: installDepRisks,
+      project: projectKey ?? undefined,
+    },
+    gitRoot,
+    'project',
+  );
 
   showPostInstallInfo(hook);
   await showInstallationStatus(gitRoot);
@@ -252,15 +380,17 @@ async function installGitFeatures(
   scope: 'project' | 'global',
 ): Promise<void> {
   const integrationId = await resolveGitIntegrationId(targetRoot, scope);
+  const attrs: Record<string, string> = { hook: options.hook };
+  if (options.withDependencyRisks && options.project && options.hook === 'pre-push') {
+    attrs.dependencyRisksProject = options.project;
+  }
   await installIntegration({
     integrationId,
     options,
     targetRoot,
     scope,
     force: options.force,
-    attrs: {
-      hook: options.hook,
-    },
+    attrs,
   });
 }
 

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -333,7 +333,7 @@ export async function integrateGit(
 
   const hook = await resolveHookType(
     options,
-    'pre-push (scan files in unpushed commits, supports analysis of dependency risks)',
+    'pre-push (scan files in unpushed commits + dependency risks analysis)',
   );
   text(`Hook: ${hook}`);
   blank();
@@ -374,6 +374,11 @@ export async function integrateGit(
 
   showPostInstallInfo(hook);
   await showInstallationStatus(gitRoot);
+  if (hook === 'pre-commit') {
+    info('Dependency risk analysis requires the pre-push hook.');
+    text('   Run `sonar integrate git` again to add it.');
+    blank();
+  }
   showVerificationGuide(hook);
 }
 

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -345,7 +345,7 @@ export async function integrateGit(
 
   if (depRisksEnabled && projectKey == null) {
     throw new CommandFailedError(
-      'Installation cancelled: a project key is required for dependency-risks scanning.'
+      'Installation cancelled: a project key is required for dependency-risks scanning.',
     );
   }
 

--- a/src/cli/commands/integrate/git/options.ts
+++ b/src/cli/commands/integrate/git/options.ts
@@ -25,4 +25,6 @@ export interface IntegrateGitOptions {
   force?: boolean;
   nonInteractive?: boolean;
   global?: boolean;
+  project?: string;
+  withDependencyRisks?: boolean;
 }

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -20,11 +20,14 @@
 
 import { join } from 'node:path';
 
-import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
+import {
+  sonarScaScannerBinaryDependency,
+  sonarSecretsBinaryDependency,
+} from '../../../_common/registry/dependencies';
 import { textSnippet } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { HOOK_MARKER } from '../shared';
+import { HOOK_MARKER, LEGACY_HOOK_MARKERS } from '../shared';
 import { getHuskySnippetContent } from './shell-fragments';
 
 export const HUSKY_INTEGRATION_ID = 'husky';
@@ -32,7 +35,16 @@ export const HUSKY_INTEGRATION_ID = 'husky';
 export const huskyIntegration: IntegrationDeclaration<IntegrateGitOptions> = {
   id: HUSKY_INTEGRATION_ID,
   displayName: 'Husky integration',
-  features: [createHuskyFeature('pre-commit'), createHuskyFeature('pre-push')],
+  features: [
+    createHuskyFeature('pre-commit'),
+    createHuskyFeature('pre-push'),
+    {
+      id: 'pre-push-sca-scanner',
+      displayName: 'SCA scanner binary',
+      when: ({ options }) => options.hook === 'pre-push' && options.withDependencyRisks === true,
+      dependencies: [sonarScaScannerBinaryDependency],
+    },
+  ],
 };
 
 function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitOptions> {
@@ -50,7 +62,15 @@ function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitO
         executable: true,
         startMarker: `# ${HOOK_MARKER}`,
         endMarker: `# sonar:end husky-${hook}`,
-        content: getHuskySnippetContent(hook).trimEnd(),
+        legacyStartMarkers: LEGACY_HOOK_MARKERS.map((m) => `# ${m}`),
+        content: (context) => {
+          const depsProject = context.attrs?.dependencyRisksProject;
+          const options =
+            typeof depsProject === 'string' && depsProject.length > 0
+              ? { dependencyRisksProject: depsProject }
+              : {};
+          return getHuskySnippetContent(hook, options).trimEnd();
+        },
       }),
     ],
   };

--- a/src/cli/commands/integrate/git/tools/husky/shell-fragments.ts
+++ b/src/cli/commands/integrate/git/tools/husky/shell-fragments.ts
@@ -21,6 +21,11 @@
 import type { GitHookType } from '../../options';
 import { HOOK_MARKER, resolveSonarHookCommand, SONAR_HOOK_SKIP_SECRETS_MESSAGE } from '../shared';
 
+export interface HuskySnippetOptions {
+  /** When set on a pre-push snippet, also runs the dependency-risks scan for this project key. */
+  dependencyRisksProject?: string;
+}
+
 function huskyBinBlock(): string {
   return [
     String.raw`CLEAN_PATH=$(echo "$PATH" | tr ':' '\n' | grep -v node_modules | tr '\n' ':' | sed 's/:$//')`,
@@ -29,18 +34,32 @@ function huskyBinBlock(): string {
   ].join('\n');
 }
 
-export function getHuskySnippetContent(hook: GitHookType): string {
-  return [huskyBinBlock(), `"$SONAR_BIN" hook ${resolveSonarHookCommand(hook)}`, ''].join('\n');
+export function getHuskySnippetContent(
+  hook: GitHookType,
+  options: HuskySnippetOptions = {},
+): string {
+  const hookCommand = resolveSonarHookCommand(hook);
+  const flags =
+    hook === 'pre-push' && options.dependencyRisksProject
+      ? ` -p '${options.dependencyRisksProject}' --dependency-risks`
+      : '';
+  const lines: string[] = [
+    huskyBinBlock(),
+    `SONAR_HOOK_STDIN=$(cat)`,
+    `printf '%s' "$SONAR_HOOK_STDIN" | "$SONAR_BIN" hook ${hookCommand}${flags}`,
+    '',
+  ];
+  return lines.join('\n');
 }
 
-export function getHuskySnippet(hook: GitHookType): string {
-  return ['', `# ${HOOK_MARKER}`, getHuskySnippetContent(hook)].join('\n');
+export function getHuskySnippet(hook: GitHookType, options: HuskySnippetOptions = {}): string {
+  return ['', `# ${HOOK_MARKER}`, getHuskySnippetContent(hook, options)].join('\n');
 }
 
 export function getHuskyPreCommitSnippet(): string {
   return getHuskySnippet('pre-commit');
 }
 
-export function getHuskyPrePushSnippet(): string {
-  return getHuskySnippet('pre-push');
+export function getHuskyPrePushSnippet(options: HuskySnippetOptions = {}): string {
+  return getHuskySnippet('pre-push', options);
 }

--- a/src/cli/commands/integrate/git/tools/index.ts
+++ b/src/cli/commands/integrate/git/tools/index.ts
@@ -35,4 +35,4 @@ export {
   PRE_COMMIT_CONFIG_FILE,
   PRE_COMMIT_INTEGRATION_ID,
 } from './pre-commit';
-export { HOOK_MARKER } from './shared';
+export { hasSonarHookMarker, HOOK_MARKER } from './shared';

--- a/src/cli/commands/integrate/git/tools/native/hooks.ts
+++ b/src/cli/commands/integrate/git/tools/native/hooks.ts
@@ -25,8 +25,8 @@ import { dirname, join } from 'node:path';
 import { success, text, warn } from '../../../../../../ui';
 import { CommandFailedError } from '../../../../_common/error';
 import type { GitHookType } from '../../options';
-import { HOOK_MARKER } from '../shared';
-import { getHookScript } from './shell-fragments';
+import { hasSonarHookMarker } from '../shared';
+import { getHookScript, type HookScriptOptions } from './shell-fragments';
 
 const OVERWRITE_HOOK_REMEDIATION_HINT = 'Use --force to replace the existing hook.';
 
@@ -34,11 +34,12 @@ export async function writeManagedGitHook(
   hookPath: string,
   hook: GitHookType,
   force?: boolean,
+  scriptOptions: HookScriptOptions = {},
 ): Promise<void> {
   mkdirSync(dirname(hookPath), { recursive: true });
   if (existsSync(hookPath)) {
     const existing = await fs.readFile(hookPath, 'utf-8');
-    if (!existing.includes(HOOK_MARKER) && !force) {
+    if (!hasSonarHookMarker(existing) && !force) {
       warn(`A different ${hook} hook already exists at ${hookPath}.`);
       text('  Use --force to replace it.');
       throw new CommandFailedError(`Refusing to overwrite existing ${hook} hook at ${hookPath}.`, {
@@ -46,15 +47,16 @@ export async function writeManagedGitHook(
       });
     }
   }
-  await fs.writeFile(hookPath, getHookScript(hook), { mode: 0o755 });
+  await fs.writeFile(hookPath, getHookScript(hook, scriptOptions), { mode: 0o755 });
 }
 
 export async function installViaGitHooks(
   hooksDir: string,
   hook: GitHookType,
   force?: boolean,
+  scriptOptions: HookScriptOptions = {},
 ): Promise<void> {
   const hookPath = join(hooksDir, hook);
-  await writeManagedGitHook(hookPath, hook, force);
+  await writeManagedGitHook(hookPath, hook, force, scriptOptions);
   success(`${hook} hook installed at ${hookPath}`);
 }

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -21,7 +21,10 @@
 import { normalizePath } from '../../../../../../lib/fs-utils';
 import { spawnProcess } from '../../../../../../lib/process';
 import { CommandFailedError } from '../../../../_common/error';
-import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
+import {
+  sonarScaScannerBinaryDependency,
+  sonarSecretsBinaryDependency,
+} from '../../../_common/registry/dependencies';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { nativeGitHookResource } from './resource';
@@ -33,7 +36,16 @@ const GLOBAL_GIT_CONFIG_REMEDIATION_HINT =
 export const nativeGitIntegration: IntegrationDeclaration<IntegrateGitOptions> = {
   id: NATIVE_GIT_INTEGRATION_ID,
   displayName: 'Native Git integration',
-  features: [createNativeGitFeature('pre-commit'), createNativeGitFeature('pre-push')],
+  features: [
+    createNativeGitFeature('pre-commit'),
+    createNativeGitFeature('pre-push'),
+    {
+      id: 'pre-push-sca-scanner',
+      displayName: 'SCA scanner binary',
+      when: ({ options }) => options.hook === 'pre-push' && options.withDependencyRisks === true,
+      dependencies: [sonarScaScannerBinaryDependency],
+    },
+  ],
 };
 
 function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitOptions> {

--- a/src/cli/commands/integrate/git/tools/native/resource.ts
+++ b/src/cli/commands/integrate/git/tools/native/resource.ts
@@ -22,14 +22,11 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { resolveGitHooksDir } from '../../../../_common/git-repo';
-import type {
-  AppliedResource,
-  IntegrationContext,
-  ResourceDeclaration,
-} from '../../../_common/registry';
+import type { ResourceDeclaration } from '../../../_common/registry/resources';
+import type { AppliedResource, IntegrationContext } from '../../../_common/registry/types';
 import type { GitHookType } from '../../options';
 import { writeManagedGitHook } from './hooks';
-import { getHookScript } from './shell-fragments';
+import { getHookScript, type HookScriptOptions } from './shell-fragments';
 
 interface NativeGitHookResourceOptions {
   id: string;
@@ -53,7 +50,8 @@ class NativeGitHookResource implements ResourceDeclaration {
 
   async apply(context: IntegrationContext): Promise<AppliedResource> {
     const path = await resolveNativeGitHookPath(context, this.options.hook);
-    await writeManagedGitHook(path, this.options.hook, context.force === true);
+    const scriptOptions = hookScriptOptionsFromAttrs(context);
+    await writeManagedGitHook(path, this.options.hook, context.force === true, scriptOptions);
     return { id: this.id, resourceType: this.resourceType, path };
   }
 
@@ -61,13 +59,17 @@ class NativeGitHookResource implements ResourceDeclaration {
     const path = await resolveNativeGitHookPath(context, this.options.hook);
     try {
       const existing = await readFile(path, 'utf-8');
-      return (
-        normalizeLineEndings(existing) === normalizeLineEndings(getHookScript(this.options.hook))
-      );
+      const expected = getHookScript(this.options.hook, hookScriptOptionsFromAttrs(context));
+      return normalizeLineEndings(existing) === normalizeLineEndings(expected);
     } catch {
       return false;
     }
   }
+}
+
+function hookScriptOptionsFromAttrs(context: IntegrationContext): HookScriptOptions {
+  const value = context.attrs?.dependencyRisksProject;
+  return typeof value === 'string' && value.length > 0 ? { dependencyRisksProject: value } : {};
 }
 
 function normalizeLineEndings(content: string): string {

--- a/src/cli/commands/integrate/git/tools/native/shell-fragments.ts
+++ b/src/cli/commands/integrate/git/tools/native/shell-fragments.ts
@@ -21,6 +21,11 @@
 import type { GitHookType } from '../../options';
 import { HOOK_MARKER, resolveSonarHookCommand, SONAR_HOOK_SKIP_SECRETS_MESSAGE } from '../shared';
 
+export interface HookScriptOptions {
+  /** When set on a pre-push script, also runs the dependency-risks scan for this project key. */
+  dependencyRisksProject?: string;
+}
+
 function nativeBinBlock(): string {
   return [
     // `|| :` avoids exiting under `sh -e` when `command -v` fails (missing sonar).
@@ -29,20 +34,27 @@ function nativeBinBlock(): string {
   ].join('\n');
 }
 
-export function getHookScript(hook: GitHookType): string {
-  return [
+export function getHookScript(hook: GitHookType, options: HookScriptOptions = {}): string {
+  const hookCommand = resolveSonarHookCommand(hook);
+  const flags =
+    hook === 'pre-push' && options.dependencyRisksProject
+      ? ` -p '${options.dependencyRisksProject}' --dependency-risks`
+      : '';
+  const lines: string[] = [
     '#!/bin/sh',
     `# ${HOOK_MARKER}`,
     nativeBinBlock(),
-    `"$SONAR_BIN" hook ${resolveSonarHookCommand(hook)}`,
+    `SONAR_HOOK_STDIN=$(cat)`,
+    `printf '%s' "$SONAR_HOOK_STDIN" | "$SONAR_BIN" hook ${hookCommand}${flags}`,
     '',
-  ].join('\n');
+  ];
+  return lines.join('\n');
 }
 
 export function getPreCommitHookScript(): string {
   return getHookScript('pre-commit');
 }
 
-export function getPrePushHookScript(): string {
-  return getHookScript('pre-push');
+export function getPrePushHookScript(options: HookScriptOptions = {}): string {
+  return getHookScript('pre-push', options);
 }

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -20,8 +20,16 @@
 
 import type { GitHookType } from '../options';
 
-export const HOOK_MARKER = 'Sonar secrets scan - installed by sonar integrate git';
-export const SONAR_HOOK_SKIP_SECRETS_MESSAGE = 'sonarqube-cli not found, skipping secrets scan';
+export const HOOK_MARKER = 'Sonar git hook - installed by sonar integrate git';
+// Legacy marker from earlier CLI versions — kept so re-running `sonar integrate git`
+// recognises and upgrades hooks installed before the marker was generalised.
+export const LEGACY_HOOK_MARKERS = ['Sonar secrets scan - installed by sonar integrate git'];
+export const SONAR_HOOK_SKIP_SECRETS_MESSAGE = 'sonarqube-cli not found, skipping sonar hooks';
+
+export function hasSonarHookMarker(content: string): boolean {
+  if (content.includes(HOOK_MARKER)) return true;
+  return LEGACY_HOOK_MARKERS.some((m) => content.includes(m));
+}
 
 export function resolveSonarHookCommand(hook: GitHookType): string {
   return hook === 'pre-commit' ? 'git-pre-commit' : 'git-pre-push';

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 
 import { version as CURRENT_VERSION } from '../../package.json';
 import { installContextAugmentationBinary } from '../cli/commands/_common/install/context-augmentation';
+import { installScaScannerBinary } from '../cli/commands/_common/install/sca-scanner';
 import { installSecretsBinary } from '../cli/commands/_common/install/secrets';
 import { supportedIntegrations } from '../cli/commands/integrate';
 import {
@@ -38,7 +39,11 @@ import {
 } from '../cli/commands/integrate/_common/registry';
 import { CLAUDE_INTEGRATION_ID } from '../cli/commands/integrate/claude/declaration';
 import { installHooks } from '../cli/commands/integrate/claude/hooks.js';
-import { CONTEXT_AUGMENTATION_BINARY_NAME, SECRETS_BINARY_NAME } from './install-types.js';
+import {
+  CONTEXT_AUGMENTATION_BINARY_NAME,
+  SCA_SCANNER_BINARY_NAME,
+  SECRETS_BINARY_NAME,
+} from './install-types.js';
 import logger from './logger';
 import {
   cleanObsoleteFromState,
@@ -92,6 +97,7 @@ async function runActions(_previousVersion: string, _currentVersion: string): Pr
   await migrateDeclarativeIntegrations();
   await migrateClaudeCodeHooks();
   await updateSecretsBinaryIfNeeded();
+  await updateScaScannerBinaryIfNeeded();
   await updateContextAugmentationIfNeeded();
 }
 
@@ -169,6 +175,21 @@ export async function updateSecretsBinaryIfNeeded(): Promise<void> {
 
 function hasPreviousSecretsInstallation(state: CliState): boolean {
   return hasBinaryInState(state, SECRETS_BINARY_NAME);
+}
+
+/**
+ * Update the sca-scanner-cli binary if it is already installed but targets a different version
+ * than the one bundled with this CLI release.
+ */
+export async function updateScaScannerBinaryIfNeeded(): Promise<void> {
+  const state = loadState();
+
+  if (!hasBinaryInState(state, SCA_SCANNER_BINARY_NAME)) {
+    logger.debug('sca-scanner-cli not installed — skipping binary update');
+    return;
+  }
+
+  await installScaScannerBinary();
 }
 
 function hasBinaryInState(state: CliState, binaryName: string): boolean {

--- a/src/lib/project-key.ts
+++ b/src/lib/project-key.ts
@@ -18,13 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export type { BaseDependencyOptions, DependencyDeclaration } from './common';
-export {
-  sonarScaScannerBinaryDependency,
-  sonarSecretsBinaryDependency,
-  SonarSourceBinary,
-  sonarSourceBinary,
-  SonarSourceBinaryDependency,
-  type SonarSourceBinaryDependencyOptions,
-  type SonarSourceBinaryDescriptor,
-} from './sonarsource-binary';
+import { red } from '../ui/colors.ts';
+
+const PROJECT_KEY_REGEX = /^[a-zA-Z0-9\-_.:]{1,400}$/;
+
+export const PROJECT_KEY_VALIDATION_ERROR = red(
+  'Project key may only contain letters, digits, dash, underscore, period, or colon, and must be at most 400 characters.',
+);
+
+export function isValidProjectKey(key: string): boolean {
+  return PROJECT_KEY_REGEX.test(key);
+}

--- a/tests/integration/specs/hook/hook-git-pre-push.test.ts
+++ b/tests/integration/specs/hook/hook-git-pre-push.test.ts
@@ -28,7 +28,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { buildLocalBinaryName } from '../../../../src/cli/commands/_common/install/secrets';
 import { detectPlatform } from '../../../../src/lib/platform-detector';
 import { TestHarness } from '../../harness';
-import { commitFile, initGitRepo } from './git-test-helpers';
+import { commitFile, initGitRepo, stageFile } from './git-test-helpers';
 
 // Hardcoded test token — intentional fixture for secret detection, not a real credential
 // sonar-ignore-next-line S6769
@@ -39,6 +39,8 @@ const GIT_NULL_OID = '0000000000000000000000000000000000000000';
 // Unreachable but well-formed server URL: binary handles connection-refused gracefully.
 const FAKE_SERVER = 'http://localhost:19999';
 const VALID_TOKEN = 'integration-test-token';
+const TEST_ORG = 'my-org';
+const PACKAGE_JSON_CONTENT = '{"name":"demo","version":"1.0.0"}';
 const NON_EXECUTABLE_MODE = 0o644;
 
 function pushRefLine(localSha: string, remoteSha: string, branch = 'refs/heads/main'): string {
@@ -235,4 +237,164 @@ describe('sonar hook git-pre-push', () => {
     },
     { timeout: 30000 },
   );
+
+  it(
+    'exits 2 when --dependency-risks is set without -p',
+    async () => {
+      const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
+      const result = await harness.run('hook git-pre-push --dependency-risks', {
+        stdin: pushRefLine(sha, GIT_NULL_OID),
+      });
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('-p');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'exits 0 when -p is set without --dependency-risks (secrets-only, no dep-risks side effects)',
+    async () => {
+      initGitRepo(harness.cwd.path);
+      const sha = commitFile(harness.cwd.path, 'package.json', PACKAGE_JSON_CONTENT);
+
+      harness.state().withSecretsBinaryInstalled();
+      harness.withAuth(FAKE_SERVER, VALID_TOKEN);
+
+      const result = await harness.run('hook git-pre-push -p demo', {
+        stdin: pushRefLine(sha, GIT_NULL_OID),
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toContain('dependency manifests');
+    },
+    { timeout: 30000 },
+  );
+
+  describe('with --dependency-risks', () => {
+    it(
+      'exits 0 when stdin is empty (no refs)',
+      async () => {
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: '',
+        });
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when not authenticated (graceful skip)',
+      async () => {
+        harness.state().withScaScannerBinaryInstalled();
+        const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when sca-scanner binary is not installed (graceful skip)',
+      async () => {
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+        const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when pushed files contain no dependency manifests',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'index.ts', CLEAN_CONTENT);
+
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout + result.stderr).toContain(
+          'No dependency manifests changed in this push',
+        );
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'does not warn about uncommitted changes when no manifests changed',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'index.ts', CLEAN_CONTENT);
+        stageFile(harness.cwd.path, 'extra.ts', CLEAN_CONTENT);
+
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).not.toContain('Uncommitted changes detected');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'exits 0 (fail-open) when a manifest changed but the SCA backend is unavailable',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'package.json', PACKAGE_JSON_CONTENT);
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken(VALID_TOKEN)
+          .withScaEnabled(true)
+          .withProject('demo')
+          .withProjectSettings('demo', [])
+          .start();
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+          timeoutMs: 45_000,
+        });
+
+        // Hook is fail-open on scanner failure: warn on stderr, push not blocked.
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain('push not blocked');
+      },
+      { timeout: 60000 },
+    );
+
+    it(
+      'warns when the working tree has uncommitted changes',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        const sha = commitFile(harness.cwd.path, 'package.json', PACKAGE_JSON_CONTENT);
+        stageFile(harness.cwd.path, 'extra.ts', CLEAN_CONTENT);
+
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-push -p demo --dependency-risks', {
+          stdin: pushRefLine(sha, GIT_NULL_OID),
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain('Uncommitted changes detected');
+      },
+      { timeout: 30000 },
+    );
+  });
 });

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -109,6 +109,7 @@ function gitPush(
 }
 
 const INTEGRATION_TEST_TOKEN = 'test-token';
+const TEST_PROJECT_KEY = 'my-project';
 const LEGACY_PRE_COMMIT_REPO = 'https://github.com/SonarSource/sonar-secrets-pre-commit';
 
 type InstalledStateJson = {
@@ -196,13 +197,17 @@ function readYamlFile<T>(path: string): T {
   return yaml.load(readFileSync(path, 'utf-8')) as T;
 }
 
-type SetupAuthOptions = { withSecretsBinary?: boolean };
-
 async function setupAuthenticated(
   harness: TestHarness,
-  options: SetupAuthOptions = {},
+  options: { withSecretsBinary?: boolean } = {},
 ): Promise<void> {
-  const server = await harness.newFakeServer().withAuthToken(INTEGRATION_TEST_TOKEN).start();
+  const server = await harness
+    .newFakeServer()
+    .withAuthToken(INTEGRATION_TEST_TOKEN)
+    .withVersion('2026.4')
+    .withProject(TEST_PROJECT_KEY)
+    .withScaEnabled(true)
+    .start();
   const chain = harness
     .state()
     .withActiveConnection(server.baseUrl())
@@ -418,14 +423,51 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' confirms 'Install here?'; '\x1b[B' moves the selection down to pre-push; '\r' submits
+      // '\r' confirms 'Install here?'; '\x1b[B' moves the selection down to pre-push; '\r' submits; 'n' declines dep-risks prompt
       const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', '\x1b[B', '\r'],
+        stdinChunks: ['\r', '\x1b[B', '\r', 'n'],
       });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'prints dependency-risks project line when --with-dependency-risks is set',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      const result = await harness.run(
+        `integrate git --hook pre-push --with-dependency-risks -p ${TEST_PROJECT_KEY} --non-interactive`,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        `Dependency-risks scanning: enabled for project '${TEST_PROJECT_KEY}'`,
+      );
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'prints dependency-risks project line when confirmed via interactive prompts',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      // 'y' confirms 'Install here?'; '\x1b[B' + '\r' selects pre-push; 'y' confirms dep-risks; project key + '\r' enters project key
+      const result = await harness.run('integrate git', {
+        stdinChunks: ['y', '\x1b[B', '\r', 'y', `${TEST_PROJECT_KEY}\r`],
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        `Dependency-risks scanning: enabled for project '${TEST_PROJECT_KEY}'`,
+      );
     },
     { timeout: 15000 },
   );
@@ -563,6 +605,9 @@ describe('integrate git (husky)', () => {
       const hookContent = readFileSync(join(harness.cwd.path, '.husky', 'pre-commit'), 'utf-8');
       expect(
         countOccurrences(hookContent, '# Sonar secrets scan - installed by sonar integrate git'),
+      ).toBe(0);
+      expect(
+        countOccurrences(hookContent, '# Sonar git hook - installed by sonar integrate git'),
       ).toBe(1);
       expect(countOccurrences(hookContent, 'hook git-pre-commit')).toBe(1);
       expect(hookContent).toContain('# sonar:end husky-pre-commit');
@@ -815,6 +860,97 @@ describe('integrate git (pre-commit framework)', () => {
           hook: 'pre-commit',
         },
       });
+    },
+    { timeout: 15000 },
+  );
+});
+
+describe('integrate git (dependency-risks server checks)', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'fails when the project is not found on the server',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(INTEGRATION_TEST_TOKEN)
+        .withVersion('2026.4')
+        .withScaEnabled(true)
+        // no .withProject() — /api/components/show returns 404
+        .start();
+      harness
+        .state()
+        .withActiveConnection(server.baseUrl())
+        .withKeychainToken(server.baseUrl(), INTEGRATION_TEST_TOKEN);
+      initGitRepo(harness);
+
+      const result = await harness.run(
+        'integrate git --hook pre-push --with-dependency-risks --project missing-project --non-interactive',
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('not found on the connected server');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'fails when SCA is not available on the server',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(INTEGRATION_TEST_TOKEN)
+        .withVersion('2026.4')
+        .withProject('test-project')
+        .withScaEnabled(false)
+        .start();
+      harness
+        .state()
+        .withActiveConnection(server.baseUrl())
+        .withKeychainToken(server.baseUrl(), INTEGRATION_TEST_TOKEN);
+      initGitRepo(harness);
+
+      const result = await harness.run(
+        'integrate git --hook pre-push --with-dependency-risks --project test-project --non-interactive',
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain(
+        'Software Composition Analysis is not available',
+      );
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'fails when the SonarQube Server version is too old for SCA',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(INTEGRATION_TEST_TOKEN)
+        .withVersion('2026.3')
+        .withProject('test-project')
+        .start();
+      harness
+        .state()
+        .withActiveConnection(server.baseUrl())
+        .withKeychainToken(server.baseUrl(), INTEGRATION_TEST_TOKEN);
+      initGitRepo(harness);
+
+      const result = await harness.run(
+        'integrate git --hook pre-push --with-dependency-risks --project test-project --non-interactive',
+      );
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('requires SonarQube Server 2026.4 or later');
     },
     { timeout: 15000 },
   );

--- a/tests/unit/cli/commands/_common/sonar-command.test.ts
+++ b/tests/unit/cli/commands/_common/sonar-command.test.ts
@@ -40,7 +40,7 @@ const FAKE_AUTH: ResolvedAuth = {
 
 describe('SonarCommand', () => {
   let resolveAuthSpy: ReturnType<typeof spyOn>;
-  let originalExitCode: number | string | undefined;
+  let originalExitCode: number | string | null | undefined;
 
   beforeEach(() => {
     setMockUi(true);

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
@@ -1,0 +1,95 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it, mock } from 'bun:test';
+
+import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error.ts';
+import type { ScaScannerInstaller } from '../../../../../../src/cli/commands/_common/install/sca-scanner.ts';
+import { ScaScanOrchestrator } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts';
+import type { ScaScannerSpawner } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-spawner.ts';
+import type { ResolvedAuth } from '../../../../../../src/lib/auth-resolver.ts';
+import type { SonarQubeClient } from '../../../../../../src/sonarqube/client.ts';
+import type { SettingsValue } from '../../../../../../src/sonarqube/settings-value.ts';
+
+const CLOUD_AUTH: ResolvedAuth = {
+  connectionType: 'cloud',
+  serverUrl: 'https://sonarcloud.io',
+  token: 'test-token',
+  orgKey: 'my-org',
+};
+
+const EMPTY_RESPONSE = { releases: [], parsedFiles: [], errors: [] };
+
+function makeClient(
+  overrides: {
+    checkScaEnabled?: () => Promise<boolean>;
+    getProjectSettings?: () => Promise<SettingsValue[]>;
+  } = {},
+): SonarQubeClient {
+  return {
+    checkScaEnabled: overrides.checkScaEnabled ?? (() => Promise.resolve(true)),
+    getProjectSettings: overrides.getProjectSettings ?? (() => Promise.resolve([])),
+  } as unknown as SonarQubeClient;
+}
+
+const okInstaller: ScaScannerInstaller = { install: () => Promise.resolve('/bin/sca') };
+
+function spawnerReturning(payload: unknown): ScaScannerSpawner {
+  return {
+    spawn: () => Promise.resolve({ exitCode: 0, stdout: JSON.stringify(payload), stderr: '' }),
+  };
+}
+
+describe('ScaScanOrchestrator', () => {
+  it('returns the scanner response on a successful scan', async () => {
+    const orchestrator = new ScaScanOrchestrator(
+      makeClient(),
+      okInstaller,
+      spawnerReturning(EMPTY_RESPONSE),
+    );
+
+    const result = await orchestrator.run(CLOUD_AUTH, 'my-project');
+
+    expect(result).toEqual(EMPTY_RESPONSE);
+  });
+
+  it('throws when SCA is not available for the connection', () => {
+    const orchestrator = new ScaScanOrchestrator(
+      makeClient({ checkScaEnabled: () => Promise.resolve(false) }),
+      okInstaller,
+      spawnerReturning(EMPTY_RESPONSE),
+    );
+
+    expect(orchestrator.run(CLOUD_AUTH, 'my-project')).rejects.toBeInstanceOf(CommandFailedError);
+  });
+
+  it('passes projectKey and token from auth into the scanner invocation', async () => {
+    const spawn = mock((_binaryPath: string, _args: string[]) =>
+      Promise.resolve({ exitCode: 0, stdout: JSON.stringify(EMPTY_RESPONSE), stderr: '' }),
+    );
+    const orchestrator = new ScaScanOrchestrator(makeClient(), okInstaller, { spawn });
+
+    await orchestrator.run(CLOUD_AUTH, 'my-project');
+
+    const [, args] = spawn.mock.calls[0];
+    expect(args).toContain('--project-key=my-project');
+    expect(args).toContain('--sonar-token=test-token');
+  });
+});

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.test.ts
@@ -1,0 +1,150 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import type { ScaScannerInstaller } from '../../../../../../src/cli/commands/_common/install/sca-scanner.ts';
+import type { ScaScannerSpawner } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-spawner.ts';
+import {
+  anyFileMatches,
+  ScaWatchPatternsRunner,
+} from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns';
+
+const okInstaller: ScaScannerInstaller = { install: () => Promise.resolve('/bin/sca') };
+
+function spawnerReturning(exitCode: number, stdout: string): ScaScannerSpawner {
+  return { spawn: () => Promise.resolve({ exitCode, stdout, stderr: '' }) };
+}
+
+function watchPatternsPayload(patterns: unknown): string {
+  return JSON.stringify({ patterns });
+}
+
+describe('ScaWatchPatternsRunner', () => {
+  it('returns parsed patterns from a valid response', async () => {
+    const runner = new ScaWatchPatternsRunner(
+      okInstaller,
+      spawnerReturning(0, watchPatternsPayload(['package.json', '*.csproj'])),
+    );
+    expect(await runner.run()).toEqual(['package.json', '*.csproj']);
+  });
+
+  it('returns [] on non-zero exit', async () => {
+    const runner = new ScaWatchPatternsRunner(okInstaller, spawnerReturning(1, ''));
+    expect(await runner.run()).toEqual([]);
+  });
+
+  it('returns [] when stdout contains no JSON', async () => {
+    const runner = new ScaWatchPatternsRunner(okInstaller, spawnerReturning(0, 'no json here'));
+    expect(await runner.run()).toEqual([]);
+  });
+
+  it('returns [] when patterns is not an array', async () => {
+    const runner = new ScaWatchPatternsRunner(
+      okInstaller,
+      spawnerReturning(0, watchPatternsPayload('not-an-array')),
+    );
+    expect(await runner.run()).toEqual([]);
+  });
+
+  it('returns [] when the spawner throws', async () => {
+    const throwing: ScaScannerSpawner = {
+      spawn: () => Promise.reject(new Error('spawn failed')),
+    };
+    const runner = new ScaWatchPatternsRunner(okInstaller, throwing);
+    expect(await runner.run()).toEqual([]);
+  });
+});
+
+describe('anyFileMatches', () => {
+  it('returns false for empty inputs', () => {
+    expect(anyFileMatches([], ['package.json'])).toBe(false);
+    expect(anyFileMatches(['package.json'], [])).toBe(false);
+  });
+
+  it('matches bare filenames against any path', () => {
+    expect(anyFileMatches(['frontend/package.json'], ['package.json'])).toBe(true);
+    expect(anyFileMatches(['package.json'], ['package.json'])).toBe(true);
+  });
+
+  it('matches *.ext patterns', () => {
+    expect(anyFileMatches(['App.csproj'], ['*.csproj'])).toBe(true);
+    expect(anyFileMatches(['src/App.csproj'], ['*.csproj'])).toBe(true);
+    expect(anyFileMatches(['App.txt'], ['*.csproj'])).toBe(false);
+  });
+
+  it('matches path-style **/ globs', () => {
+    expect(anyFileMatches(['obj/project.assets.json'], ['**/obj/project.assets.json'])).toBe(true);
+    expect(anyFileMatches(['a/b/obj/project.assets.json'], ['**/obj/project.assets.json'])).toBe(
+      true,
+    );
+    expect(anyFileMatches(['project.assets.json'], ['**/obj/project.assets.json'])).toBe(false);
+  });
+
+  it('matches bare filename patterns against files in subdirectories', () => {
+    expect(anyFileMatches(['frontend/package.json'], ['package.json'])).toBe(true);
+    expect(anyFileMatches(['a/b/c/package.json'], ['package.json'])).toBe(true);
+    expect(anyFileMatches(['src/App.csproj'], ['*.csproj'])).toBe(true);
+  });
+
+  it('matches dotfiles and files inside hidden directories', () => {
+    expect(anyFileMatches(['.package-lock.json'], ['*.json'])).toBe(true);
+    expect(anyFileMatches(['src/.hidden/package.json'], ['package.json'])).toBe(true);
+  });
+
+  it('matches path-prefix patterns like requirements/*.txt', () => {
+    expect(anyFileMatches(['requirements/dev.txt'], ['requirements/*.txt'])).toBe(true);
+    expect(anyFileMatches(['requirements/sub/dev.txt'], ['requirements/*.txt'])).toBe(false);
+  });
+
+  it('expands {xml,json} brace lists', () => {
+    expect(anyFileMatches(['cyclonedx.xml'], ['cyclonedx.{xml,json}'])).toBe(true);
+    expect(anyFileMatches(['cyclonedx.json'], ['cyclonedx.{xml,json}'])).toBe(true);
+    expect(anyFileMatches(['cyclonedx.yaml'], ['cyclonedx.{xml,json}'])).toBe(false);
+  });
+
+  it.skipIf(process.platform !== 'win32')('matches case-insensitively on Windows', () => {
+    expect(anyFileMatches(['Frontend\\Package.json'], ['package.json'])).toBe(true);
+  });
+
+  it('matches prefix-with-star like req*.txt', () => {
+    expect(anyFileMatches(['requirements.txt'], ['req*.txt'])).toBe(true);
+    expect(anyFileMatches(['req-dev.txt'], ['req*.txt'])).toBe(true);
+    expect(anyFileMatches(['notrequirements.txt'], ['req*.txt'])).toBe(false);
+  });
+
+  it.skipIf(process.platform !== 'win32')(
+    'matches Windows backslash paths against bare filename patterns',
+    () => {
+      expect(anyFileMatches(['frontend\\package.json'], ['package.json'])).toBe(true);
+      expect(anyFileMatches(['a\\b\\c\\package.json'], ['package.json'])).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform !== 'win32')(
+    'matches Windows backslash paths against path-style globs',
+    () => {
+      expect(anyFileMatches(['obj\\project.assets.json'], ['**/obj/project.assets.json'])).toBe(
+        true,
+      );
+      expect(anyFileMatches(['requirements\\dev.txt'], ['requirements/*.txt'])).toBe(true);
+    },
+  );
+});

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -520,6 +520,44 @@ describe('declarative integration framework', () => {
     );
   });
 
+  it('upgrades legacy start markers in place when the end marker is still present', async () => {
+    const state = getDefaultState('test');
+    const context = makeContext(state, tempDir);
+    const targetPath = join(tempDir, 'legacy-with-end.txt');
+    await writeFile(
+      targetPath,
+      [
+        '#!/bin/sh',
+        '# sonar:begin legacy',
+        'old managed content',
+        '# sonar:end feature',
+        'npm test',
+        '',
+      ].join('\n'),
+    );
+    const resource = textSnippet({
+      id: 'feature',
+      targetPath,
+      content: 'new managed content',
+      startMarker: '# sonar:begin feature',
+      endMarker: '# sonar:end feature',
+      legacyStartMarkers: ['# sonar:begin legacy'],
+    });
+
+    await resource.apply(context);
+
+    expect(await readFile(targetPath, 'utf-8')).toBe(
+      [
+        '#!/bin/sh',
+        '# sonar:begin feature',
+        'new managed content',
+        '# sonar:end feature',
+        'npm test',
+        '',
+      ].join('\n'),
+    );
+  });
+
   it('replaces legacy text snippets that only contain the start marker', async () => {
     const state = getDefaultState('test');
     const context = makeContext(state, tempDir);

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -977,6 +977,17 @@ describe('integrateGit dep-risks server validation', () => {
     expect(getMockUiCalls().some((c) => c.method === 'warn')).toBe(false);
   });
 
+  it('cancels installation when project key prompt is cancelled', async () => {
+    queueMockResponse(true); // confirm "Install here?"
+    queueMockResponse(null); // cancel project key prompt
+    await expect(
+      integrateGit(DEP_RISKS_AUTH, { hook: 'pre-push', withDependencyRisks: true }),
+    ).rejects.toThrow('a project key is required for dependency-risks scanning');
+    expect(checkComponentSpy).not.toHaveBeenCalled();
+    expect(checkScaEnabledSpy).not.toHaveBeenCalled();
+    expect(state.integrations.installed).toHaveLength(0);
+  });
+
   it('throws CommandFailedError when project is not found on server', async () => {
     checkComponentSpy.mockResolvedValue(false);
     await expect(integrateGit(DEP_RISKS_AUTH, DEP_RISKS_OPTIONS)).rejects.toBeInstanceOf(

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -37,16 +37,22 @@ import {
   isGitHookType,
   resolveGitHooksDir,
   resolveHookType,
+  resolveOptionalFeatures,
+  resolveProjectKey,
   showInstallationStatus,
   showPostInstallInfo,
+  validateDependencyRisksOption,
+  validateProjectKeyOption,
 } from '../../../../../../src/cli/commands/integrate/git';
 import { PRE_COMMIT_CONFIG_FILE } from '../../../../../../src/cli/commands/integrate/git/tools/pre-commit';
 import { HOOK_MARKER } from '../../../../../../src/cli/commands/integrate/git/tools/shared';
+import type { ResolvedAuth } from '../../../../../../src/lib/auth-resolver.ts';
 import { GLOBAL_HOOKS_DIR } from '../../../../../../src/lib/config-constants';
 import * as processLib from '../../../../../../src/lib/process.js';
 import * as discovery from '../../../../../../src/lib/project-workspace';
 import * as stateRepository from '../../../../../../src/lib/repository/state-repository';
 import { type CliState, getDefaultState } from '../../../../../../src/lib/state';
+import { SonarQubeClient } from '../../../../../../src/sonarqube/client';
 import {
   clearMockUiCalls,
   getMockUiCalls,
@@ -59,12 +65,87 @@ const TEMP_DIR = join(process.cwd(), 'tests', 'unit', '.integrate-git-tmp');
 /** Simulate `git config core.hooksPath` returning "not set" (exit code 1). */
 const NO_HOOKS_PATH = { exitCode: 1, stdout: '', stderr: '' };
 
+const MOCK_AUTH: ResolvedAuth = {
+  connectionType: 'cloud',
+  serverUrl: 'https://sonarcloud.io',
+  token: 'mock-token',
+  orgKey: 'my-org',
+};
+
 describe('isGitHookType', () => {
   it('returns true for valid hook types and false otherwise', () => {
     expect(isGitHookType('pre-commit')).toBe(true);
     expect(isGitHookType('pre-push')).toBe(true);
     expect(isGitHookType('commit-msg')).toBe(false);
     expect(isGitHookType('')).toBe(false);
+  });
+});
+
+describe('validateProjectKeyOption', () => {
+  it('does nothing when key is undefined', () => {
+    expect(() => validateProjectKeyOption('--some-option', undefined)).not.toThrow();
+  });
+
+  it('throws when project key is empty', () => {
+    expect(() => validateProjectKeyOption('--some-option', '')).toThrow(InvalidOptionError);
+    expect(() => validateProjectKeyOption('--some-option', '   ')).toThrow(InvalidOptionError);
+  });
+
+  it('throws when project key contains invalid characters', () => {
+    expect(() => validateProjectKeyOption('--some-option', 'proj ect')).toThrow(InvalidOptionError);
+  });
+
+  it('throws when project key exceeds 400 characters', () => {
+    expect(() => validateProjectKeyOption('--some-option', 'a'.repeat(401))).toThrow(
+      InvalidOptionError,
+    );
+  });
+
+  it('accepts a valid project key', () => {
+    expect(() => validateProjectKeyOption('--some-option', 'my-project')).not.toThrow();
+  });
+});
+
+describe('validateDependencyRisksOption', () => {
+  it('does nothing when withDependencyRisks is false/undefined', () => {
+    expect(() => validateDependencyRisksOption({})).not.toThrow();
+    expect(() => validateDependencyRisksOption({ withDependencyRisks: false })).not.toThrow();
+  });
+
+  it('throws when project key is missing in non-interactive mode', () => {
+    expect(() =>
+      validateDependencyRisksOption({ withDependencyRisks: true, nonInteractive: true }),
+    ).toThrow(InvalidOptionError);
+  });
+
+  it('does nothing when project key is missing in interactive mode', () => {
+    expect(() => validateDependencyRisksOption({ withDependencyRisks: true })).not.toThrow();
+  });
+
+  it('throws when combined with a non-pre-push hook', () => {
+    expect(() =>
+      validateDependencyRisksOption({
+        withDependencyRisks: true,
+        project: 'my-project',
+        hook: 'pre-commit',
+      }),
+    ).toThrow(InvalidOptionError);
+  });
+
+  it('does nothing when hook is pre-push', () => {
+    expect(() =>
+      validateDependencyRisksOption({
+        withDependencyRisks: true,
+        project: 'my-project',
+        hook: 'pre-push',
+      }),
+    ).not.toThrow();
+  });
+
+  it('does nothing when hook is not set', () => {
+    expect(() =>
+      validateDependencyRisksOption({ withDependencyRisks: true, project: 'my-project' }),
+    ).not.toThrow();
   });
 });
 
@@ -377,6 +458,112 @@ describe('resolveHookType', () => {
   });
 });
 
+describe('resolveOptionalFeatures', () => {
+  beforeEach(() => {
+    setMockUi(true);
+  });
+
+  afterEach(() => {
+    setMockUi(false);
+  });
+
+  it('disables all features when hook is pre-commit (regardless of other options)', async () => {
+    const result = await resolveOptionalFeatures({}, 'pre-commit');
+    expect(result).toEqual({ dependencyRisks: false });
+  });
+
+  it('enables dependency-risks when --with-dependency-risks flag is set (no prompts)', async () => {
+    const result = await resolveOptionalFeatures(
+      { withDependencyRisks: true, nonInteractive: true },
+      'pre-push',
+    );
+    expect(result).toEqual({ dependencyRisks: true });
+  });
+
+  it('disables all features when non-interactive and no flag', async () => {
+    const result = await resolveOptionalFeatures({ nonInteractive: true }, 'pre-push');
+    expect(result).toEqual({ dependencyRisks: false });
+  });
+
+  it('disables dependency-risks when user declines the confirm prompt', async () => {
+    queueMockResponse(false);
+    const result = await resolveOptionalFeatures({}, 'pre-push');
+    expect(result).toEqual({ dependencyRisks: false });
+  });
+
+  it('enables dependency-risks when user accepts the confirm prompt', async () => {
+    queueMockResponse(true);
+    const result = await resolveOptionalFeatures({}, 'pre-push');
+    expect(result).toEqual({ dependencyRisks: true });
+  });
+
+  it('disables dependency-risks when user cancels the confirm prompt', async () => {
+    queueMockResponse(null);
+    const result = await resolveOptionalFeatures({}, 'pre-push');
+    expect(result).toEqual({ dependencyRisks: false });
+  });
+});
+
+describe('resolveProjectKey', () => {
+  beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
+  });
+
+  afterEach(() => {
+    setMockUi(false);
+  });
+
+  it('returns the option value silently when --project is valid', async () => {
+    const result = await resolveProjectKey({ project: 'my-project' });
+    expect(result).toBe('my-project');
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'text' && String(c.args[0]).includes('A project key is required'),
+      ),
+    ).toBe(false);
+  });
+
+  it('warns about invalid --project then shows message and prompts', async () => {
+    queueMockResponse('my-project');
+    const result = await resolveProjectKey({ project: 'invalid key!' });
+    expect(result).toBe('my-project');
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'warn' && String(c.args[0]).includes('invalid key!'),
+      ),
+    ).toBe(true);
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'text' && String(c.args[0]).includes('A project key is required'),
+      ),
+    ).toBe(true);
+  });
+
+  it('shows message and prompts when no --project is provided', async () => {
+    queueMockResponse('my-project');
+    const result = await resolveProjectKey({});
+    expect(result).toBe('my-project');
+    expect(
+      getMockUiCalls().some(
+        (c) => c.method === 'text' && String(c.args[0]).includes('A project key is required'),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns null when user cancels the prompt', async () => {
+    queueMockResponse(null);
+    const result = await resolveProjectKey({});
+    expect(result).toBeNull();
+  });
+
+  it('trims whitespace from the prompted value', async () => {
+    queueMockResponse('  my-project  ');
+    const result = await resolveProjectKey({});
+    expect(result).toBe('my-project');
+  });
+});
+
 describe('showPostInstallInfo', () => {
   beforeEach(() => {
     setMockUi(true);
@@ -555,23 +742,29 @@ describe('integrateGit', () => {
   /* eslint-disable @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable */
   it('throws InvalidOptionError when --hook is invalid before git checks', async () => {
     await expect(
-      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
+      integrateGit(MOCK_AUTH, {
+        nonInteractive: true,
+        hook: 'typo',
+      } as unknown as IntegrateGitOptions),
     ).rejects.toBeInstanceOf(InvalidOptionError);
     await expect(
-      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
+      integrateGit(MOCK_AUTH, {
+        nonInteractive: true,
+        hook: 'typo',
+      } as unknown as IntegrateGitOptions),
     ).rejects.toThrow('--hook must be pre-commit or pre-push');
   });
 
   it('throws InvalidOptionError for invalid --hook on global install before other work', async () => {
     await expect(
-      integrateGit({
+      integrateGit(MOCK_AUTH, {
         global: true,
         nonInteractive: true,
         hook: 'typo',
       } as unknown as IntegrateGitOptions),
     ).rejects.toBeInstanceOf(InvalidOptionError);
     await expect(
-      integrateGit({
+      integrateGit(MOCK_AUTH, {
         global: true,
         nonInteractive: true,
         hook: 'typo',
@@ -581,14 +774,16 @@ describe('integrateGit', () => {
 
   it('throws CommandFailedError when not inside a git repository', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: '/not-a-repo', isGit: false });
-    expect(integrateGit({ nonInteractive: true })).rejects.toThrow('No git repository found');
+    expect(integrateGit(MOCK_AUTH, { nonInteractive: true })).rejects.toThrow(
+      'No git repository found',
+    );
   });
 
   it('asks for confirmation showing the repository path when a git repo is found', async () => {
     findGitRootSpy.mockReturnValue({ gitRoot: '/my/project', isGit: true });
     queueMockResponse(null); // user cancels at the confirm prompt
     try {
-      await integrateGit({});
+      await integrateGit(MOCK_AUTH, {});
     } catch {
       // expected cancellation
     }
@@ -610,7 +805,7 @@ describe('integrateGit', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit(MOCK_AUTH, { nonInteractive: true, hook: 'pre-commit' });
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('husky');
       expect(feature).toMatchObject({
@@ -653,7 +848,7 @@ describe('integrateGit', () => {
       throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
     });
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit(MOCK_AUTH, { nonInteractive: true, hook: 'pre-commit' });
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('pre-commit');
       expect(feature).toMatchObject({
@@ -685,7 +880,7 @@ describe('integrateGit', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: TEMP_DIR, isGit: true });
     const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(NO_HOOKS_PATH);
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit(MOCK_AUTH, { nonInteractive: true, hook: 'pre-commit' });
       expect(existsSync(join(TEMP_DIR, '.git', 'hooks', 'pre-commit'))).toBe(true);
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('native-git');
@@ -711,6 +906,95 @@ describe('integrateGit', () => {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });
     }
+  });
+});
+
+describe('integrateGit dep-risks server validation', () => {
+  let findGitRootSpy: ReturnType<typeof spyOn>;
+  let installBinarySpy: ReturnType<typeof spyOn>;
+  let resolveBinaryPathSpy: ReturnType<typeof spyOn>;
+  let loadStateSpy: ReturnType<typeof spyOn>;
+  let saveStateSpy: ReturnType<typeof spyOn>;
+  let checkComponentSpy: ReturnType<typeof spyOn>;
+  let checkScaEnabledSpy: ReturnType<typeof spyOn>;
+  let spawnSpy: ReturnType<typeof spyOn>;
+  let state: CliState;
+
+  const DEP_RISKS_AUTH: ResolvedAuth = {
+    connectionType: 'cloud',
+    serverUrl: 'https://sonarcloud.io',
+    token: 'mock-token',
+    orgKey: 'my-org',
+  };
+
+  const DEP_RISKS_OPTIONS: IntegrateGitOptions = {
+    nonInteractive: true,
+    hook: 'pre-push',
+    withDependencyRisks: true,
+    project: 'my-project',
+  };
+
+  beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
+    mkdirSync(join(TEMP_DIR, '.git', 'hooks'), { recursive: true });
+    findGitRootSpy = spyOn(discovery, 'findGitRoot').mockReturnValue({
+      gitRoot: TEMP_DIR,
+      isGit: true,
+    });
+    installBinarySpy = spyOn(binaryInstall, 'installBinary').mockResolvedValue({
+      binaryPath: '/usr/local/bin/sonar-secrets',
+      freshlyInstalled: true,
+    });
+    resolveBinaryPathSpy = spyOn(binaryInstall, 'resolveBinaryPath').mockReturnValue(null);
+    state = getDefaultState('test');
+    loadStateSpy = spyOn(stateRepository, 'loadState').mockImplementation(() => state);
+    saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
+    spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(NO_HOOKS_PATH);
+    checkComponentSpy = spyOn(SonarQubeClient.prototype, 'checkComponent').mockResolvedValue(true);
+    checkScaEnabledSpy = spyOn(SonarQubeClient.prototype, 'checkScaEnabled').mockResolvedValue(
+      true,
+    );
+  });
+
+  afterEach(() => {
+    setMockUi(false);
+    findGitRootSpy.mockRestore();
+    installBinarySpy.mockRestore();
+    resolveBinaryPathSpy.mockRestore();
+    loadStateSpy.mockRestore();
+    saveStateSpy.mockRestore();
+    spawnSpy.mockRestore();
+    checkComponentSpy.mockRestore();
+    checkScaEnabledSpy.mockRestore();
+    rmSync(TEMP_DIR, { recursive: true, force: true });
+  });
+
+  it('installs dep-risks hook when project exists and SCA is enabled', async () => {
+    await integrateGit(DEP_RISKS_AUTH, DEP_RISKS_OPTIONS);
+    const feature = state.integrations.installed[0]?.features[0];
+    expect(feature?.attrs?.dependencyRisksProject).toBe('my-project');
+    expect(getMockUiCalls().some((c) => c.method === 'warn')).toBe(false);
+  });
+
+  it('throws CommandFailedError when project is not found on server', async () => {
+    checkComponentSpy.mockResolvedValue(false);
+    await expect(integrateGit(DEP_RISKS_AUTH, DEP_RISKS_OPTIONS)).rejects.toBeInstanceOf(
+      CommandFailedError,
+    );
+    await expect(integrateGit(DEP_RISKS_AUTH, DEP_RISKS_OPTIONS)).rejects.toThrow(
+      'not found on the connected server',
+    );
+  });
+
+  it('throws CommandFailedError when SCA is not enabled on server', async () => {
+    checkScaEnabledSpy.mockResolvedValue(false);
+    await expect(integrateGit(DEP_RISKS_AUTH, DEP_RISKS_OPTIONS)).rejects.toBeInstanceOf(
+      CommandFailedError,
+    );
+    await expect(integrateGit(DEP_RISKS_AUTH, DEP_RISKS_OPTIONS)).rejects.toThrow(
+      'Software Composition Analysis is not available',
+    );
   });
 });
 
@@ -746,7 +1030,7 @@ describe('integrateGitGlobal', () => {
     queueMockResponse(null);
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: false, hook: 'pre-commit' });
+      await integrateGit(MOCK_AUTH, { global: true, nonInteractive: false, hook: 'pre-commit' });
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -757,7 +1041,7 @@ describe('integrateGitGlobal', () => {
     installBinarySpy.mockRejectedValue(new Error('download failed'));
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit(MOCK_AUTH, { global: true, nonInteractive: true, hook: 'pre-commit' });
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -771,7 +1055,7 @@ describe('integrateGitGlobal', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit(MOCK_AUTH, { global: true, nonInteractive: true, hook: 'pre-commit' });
       const calls = getMockUiCalls();
       expect(
         calls.some(
@@ -799,7 +1083,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+        await integrateGit(MOCK_AUTH, { global: true, nonInteractive: true, hook: 'pre-commit' });
       } catch (e) {
         caughtError = e;
       }
@@ -821,7 +1105,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+        await integrateGit(MOCK_AUTH, { global: true, nonInteractive: true, hook: 'pre-commit' });
       } catch (e) {
         caughtError = e;
       }

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -26,6 +26,7 @@ import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:te
 
 import { version as CURRENT_VERSION } from '../../../../../package.json';
 import * as cagInstall from '../../../../../src/cli/commands/_common/install/context-augmentation';
+import * as scaScannerInstall from '../../../../../src/cli/commands/_common/install/sca-scanner';
 import * as secretsInstall from '../../../../../src/cli/commands/_common/install/secrets';
 import * as contextAugmentation from '../../../../../src/cli/commands/integrate/_common/context-augmentation';
 import {
@@ -33,13 +34,17 @@ import {
   wholeFile,
 } from '../../../../../src/cli/commands/integrate/_common/registry';
 import * as hooks from '../../../../../src/cli/commands/integrate/claude/hooks';
-import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../../../src/lib/install-types';
+import {
+  CONTEXT_AUGMENTATION_BINARY_NAME,
+  SCA_SCANNER_BINARY_NAME,
+} from '../../../../../src/lib/install-types';
 import * as migration from '../../../../../src/lib/migration';
 import {
   migrateClaudeCodeHooks,
   migrateDeclarativeIntegrations,
   runPostUpdateActions,
   updateContextAugmentationIfNeeded,
+  updateScaScannerBinaryIfNeeded,
   updateSecretsBinaryIfNeeded,
 } from '../../../../../src/lib/post-update';
 import * as stateRepository from '../../../../../src/lib/repository/state-repository';
@@ -167,21 +172,23 @@ describe('runPostUpdateActions', () => {
   });
 
   it('saves the reloaded state, not the pre-runActions snapshot', async () => {
-    // loadState is called 6 times:
+    // loadState is called 7 times:
     //   1. version check in runPostUpdateActions
     //   2. inside migrateDeclarativeIntegrations
     //   3. inside migrateClaudeCodeHooks
     //   4. inside updateSecretsBinaryIfNeeded
-    //   5. inside updateContextAugmentationIfNeeded
-    //   6. the reload after runActions (the fix being tested)
+    //   5. inside updateScaScannerBinaryIfNeeded
+    //   6. inside updateContextAugmentationIfNeeded
+    //   7. the reload after runActions (the fix being tested)
     const reloadedState = makeState();
     loadStateSpy
       .mockReturnValueOnce(makeState()) // call 1: version check
       .mockReturnValueOnce(makeState()) // call 2: migrateDeclarativeIntegrations
       .mockReturnValueOnce(makeState()) // call 3: migrateClaudeCodeHooks
       .mockReturnValueOnce(makeState()) // call 4: updateSecretsBinaryIfNeeded
-      .mockReturnValueOnce(makeState()) // call 5: updateContextAugmentationIfNeeded
-      .mockReturnValueOnce(reloadedState); // call 6: reload
+      .mockReturnValueOnce(makeState()) // call 5: updateScaScannerBinaryIfNeeded
+      .mockReturnValueOnce(makeState()) // call 6: updateContextAugmentationIfNeeded
+      .mockReturnValueOnce(reloadedState); // call 7: reload
 
     await runPostUpdateActions();
 
@@ -690,6 +697,60 @@ describe('updateSecretsBinaryIfNeeded', () => {
     installSecretsBinarySpy.mockRejectedValue(new Error('download failed'));
 
     expect(updateSecretsBinaryIfNeeded()).rejects.toThrow('download failed');
+  });
+});
+
+function makeStateWithScaScanner(): CliState {
+  const state = makeState();
+  state.tools = {
+    installed: [
+      {
+        name: SCA_SCANNER_BINARY_NAME,
+        version: '0.0.0.1',
+        path: '/fake/bin/sca-scanner-cli-0.0.0.1-linux-x86-64',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        installedByCliVersion: '1.0.0',
+      },
+    ],
+  };
+  return state;
+}
+
+describe('updateScaScannerBinaryIfNeeded', () => {
+  let loadStateSpy: Mock<typeof stateRepository.loadState>;
+  let installScaScannerBinarySpy: Mock<typeof scaScannerInstall.installScaScannerBinary>;
+
+  beforeEach(() => {
+    loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeStateWithScaScanner());
+    installScaScannerBinarySpy = spyOn(
+      scaScannerInstall,
+      'installScaScannerBinary',
+    ).mockResolvedValue('/fake/bin/sca-scanner-cli');
+  });
+
+  afterEach(() => {
+    loadStateSpy.mockRestore();
+    installScaScannerBinarySpy.mockRestore();
+  });
+
+  it('does nothing when no previous binary is recorded in state', async () => {
+    loadStateSpy.mockReturnValue(makeState()); // tools.installed is empty
+
+    await updateScaScannerBinaryIfNeeded();
+
+    expect(installScaScannerBinarySpy).not.toHaveBeenCalled();
+  });
+
+  it('calls installScaScannerBinary when a previous installation is recorded in state', async () => {
+    await updateScaScannerBinaryIfNeeded();
+
+    expect(installScaScannerBinarySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors from installScaScannerBinary to the caller', () => {
+    installScaScannerBinarySpy.mockRejectedValue(new Error('download failed'));
+
+    expect(updateScaScannerBinaryIfNeeded()).rejects.toThrow('download failed');
   });
 });
 

--- a/tests/unit/hook-stdin.test.ts
+++ b/tests/unit/hook-stdin.test.ts
@@ -23,7 +23,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { readGitPushRefs, readStdinJson } from '../../src/cli/commands/hook/stdin';
 
 describe('readStdinJson', () => {
-  type StdinListener = (...args: unknown[]) => void;
+  type StdinListener = (...args: any[]) => void;
   const listeners: Record<string, StdinListener[]> = {};
   let onSpy: ReturnType<typeof spyOn>;
 
@@ -43,9 +43,7 @@ describe('readStdinJson', () => {
     for (const key of Object.keys(listeners)) {
       delete listeners[key];
     }
-    onSpy = spyOn(process.stdin, 'on').mockImplementation(
-      captureListener as unknown as typeof process.stdin.on,
-    );
+    onSpy = spyOn(process.stdin, 'on').mockImplementation(captureListener);
   });
 
   afterEach(() => {
@@ -109,7 +107,7 @@ describe('readStdinJson', () => {
 });
 
 describe('readGitPushRefs', () => {
-  type StdinListener = (...args: unknown[]) => void;
+  type StdinListener = (...args: any[]) => void;
   const listeners: Record<string, StdinListener[]> = {};
   let onSpy: ReturnType<typeof spyOn>;
 
@@ -129,9 +127,7 @@ describe('readGitPushRefs', () => {
     for (const key of Object.keys(listeners)) {
       delete listeners[key];
     }
-    onSpy = spyOn(process.stdin, 'on').mockImplementation(
-      captureListener as unknown as typeof process.stdin.on,
-    );
+    onSpy = spyOn(process.stdin, 'on').mockImplementation(captureListener);
   });
 
   afterEach(() => {

--- a/tests/unit/lib/project-key.test.ts
+++ b/tests/unit/lib/project-key.test.ts
@@ -1,0 +1,49 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { isValidProjectKey } from '../../../src/lib/project-key';
+
+describe('isValidProjectKey', () => {
+  it('accepts valid keys', () => {
+    expect(isValidProjectKey('my-project')).toBe(true);
+    expect(isValidProjectKey('org:project')).toBe(true);
+    expect(isValidProjectKey('proj_1.0')).toBe(true);
+    expect(isValidProjectKey('A')).toBe(true);
+    expect(isValidProjectKey('a'.repeat(400))).toBe(true);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidProjectKey('')).toBe(false);
+  });
+
+  it('rejects keys exceeding 400 characters', () => {
+    expect(isValidProjectKey('a'.repeat(401))).toBe(false);
+  });
+
+  it('rejects keys with disallowed characters', () => {
+    expect(isValidProjectKey('proj ect')).toBe(false);
+    expect(isValidProjectKey('proj/ect')).toBe(false);
+    expect(isValidProjectKey('proj@ect')).toBe(false);
+    expect(isValidProjectKey('proj#ect')).toBe(false);
+    expect(isValidProjectKey("proj'ect")).toBe(false);
+  });
+});


### PR DESCRIPTION
Part of CLI-541

----
## Summary by Gitar

- **CLI enhancements:**
  - Added `--with-dependency-risks` and `-p, --project` options to `integrate git` command.
  - Restricted `--with-dependency-risks` to `pre-push` hooks and enforced project key validation.
- **Feature integration:**
  - Implemented `SCA scanner` binary installation for `pre-push` hooks.
  - Added mandatory server-side validation for project existence and SCA capability during `pre-push` setup.
- **Resource management:**
  - Updated `textSnippet` to support `legacyStartMarkers`, enabling smooth migration of existing hook markers.
- **New utilities:**
  - Added `project-key.ts` for standardized validation of project keys.

<sub>This will update automatically on new commits.</sub>