### PR TITLE
CLI-587 Split agent instructions feature into separate sqaa/secrets features

### DIFF
--- a/src/cli/commands/integrate/_common/attrs.ts
+++ b/src/cli/commands/integrate/_common/attrs.ts
@@ -1,0 +1,48 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { SUPPORT_URL } from '../../../../lib/config-constants';
+import { CommandFailedError } from '../../_common/error';
+import type { IntegrationContext } from './registry/types';
+
+export function getOptionalStringAttr(
+  context: IntegrationContext,
+  key: string,
+): string | undefined {
+  const value = context.attrs?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function getRequiredStringAttr(
+  context: IntegrationContext,
+  key: string,
+  integrationDisplayName: string,
+): string {
+  const value = getOptionalStringAttr(context, key);
+  if (value === undefined) {
+    throw new CommandFailedError(
+      `Could not complete the ${integrationDisplayName} integration: missing required data '${key}'.`,
+      {
+        remediationHint: `Report this issue: ${SUPPORT_URL}`,
+      },
+    );
+  }
+  return value;
+}

--- a/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
+++ b/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
@@ -21,6 +21,7 @@
 import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../../../lib/install-types';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../../../lib/signatures';
 import { CommandFailedError } from '../../../_common/error';
+import { getOptionalStringAttr } from '../attrs';
 import { printContextAugmentationSkill, runToolIntegrateCommand } from '../context-augmentation';
 import { contextAugmentationBinaryDependency } from '../registry/dependencies';
 import { wholeFile } from '../registry/resources';
@@ -83,11 +84,6 @@ function resolveContextAugmentationBinaryPath(context: IntegrationContext): stri
     throw new CommandFailedError('Context Augmentation binary path is unavailable.');
   }
   return binaryPath;
-}
-
-function getOptionalStringAttr(context: IntegrationContext, key: string): string | undefined {
-  const value = context.attrs?.[key];
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 function getRequiredAuth(context: IntegrationContext) {

--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -45,10 +45,6 @@ export function sonarEndMarker(id: string): string {
   return `<!-- sonar:end:${id} -->`;
 }
 
-export function buildSqaaSection(projectKey: string): string {
-  return withSonarMarkers('sonarqube-agentic-analysis-protocol', buildSqaaSectionBody(projectKey));
-}
-
 export function buildSqaaSectionBody(projectKey: string): string {
   return `# SonarQube Agentic Analysis protocol
 

--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -46,7 +46,7 @@ export function sonarEndMarker(id: string): string {
 }
 
 export function buildSqaaSection(projectKey: string): string {
-  return withSonarMarkers('sqaa-protocol', buildSqaaSectionBody(projectKey));
+  return withSonarMarkers('sonarqube-agentic-analysis-protocol', buildSqaaSectionBody(projectKey));
 }
 
 export function buildSqaaSectionBody(projectKey: string): string {

--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -34,13 +34,23 @@
  * for finding and replacing the managed region later.
  */
 export function withSonarMarkers(id: string, body: string): string {
-  return `<!-- sonar:begin:${id} -->\n${body.trimEnd()}\n<!-- sonar:end:${id} -->\n`;
+  return `${sonarBeginMarker(id)}\n${body.trimEnd()}\n${sonarEndMarker(id)}\n`;
+}
+
+export function sonarBeginMarker(id: string): string {
+  return `<!-- sonar:begin:${id} -->`;
+}
+
+export function sonarEndMarker(id: string): string {
+  return `<!-- sonar:end:${id} -->`;
 }
 
 export function buildSqaaSection(projectKey: string): string {
-  return withSonarMarkers(
-    'sqaa-protocol',
-    `# SonarQube Agentic Analysis protocol
+  return withSonarMarkers('sqaa-protocol', buildSqaaSectionBody(projectKey));
+}
+
+export function buildSqaaSectionBody(projectKey: string): string {
+  return `# SonarQube Agentic Analysis protocol
 
 SonarQube Agentic Analysis is the final confirmation layer at the end of every turn in which you wrote to one or more files in the workspace (create, edit, patch, format — any tool call that changed file contents on disk).
 
@@ -62,6 +72,5 @@ Non-negotiable rules:
 3. If SonarQube Agentic Analysis reports issues on lines you touched in this turn, fix them, then re-run SonarQube Agentic Analysis on that file. Repeat until the file is clean (or only pre-existing findings on lines you did not touch remain). Pre-existing findings on untouched lines are out of scope — do not "fix" them unless the user asked.
 4. If SonarQube Agentic Analysis is skipped (no SonarQube Cloud connection, or no project configured), state the skip reason to the user once and continue — do not retry.
 5. Do not suppress, summarize away, or omit SonarQube Agentic Analysis findings from your reply. Surface them verbatim.
-`,
-  );
+`;
 }

--- a/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { AppliedResource, IntegrationContext } from '../types';
+import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
   type BaseResourceOptions,
   type PathResolver,
@@ -30,7 +30,7 @@ import {
 
 export interface TextSnippetResourceOptions extends BaseResourceOptions {
   targetPath: PathResolver;
-  content: string;
+  content: string | ((context: IntegrationContext) => MaybePromise<string>);
   executable?: boolean;
   startMarker: string;
   endMarker?: string;
@@ -54,7 +54,12 @@ export class TextSnippet implements ResourceDeclaration {
 
   async apply(context: IntegrationContext): Promise<AppliedResource> {
     const path = await resolvePath(context, this.options.targetPath);
-    await writeFileIfChanged(path, await this.renderContent(path), this.options.executable);
+    const content = await this.resolveContent(context);
+    await writeFileIfChanged(
+      path,
+      await this.renderContent(path, content),
+      this.options.executable,
+    );
     return { id: this.id, resourceType: this.resourceType, version: this.version, path };
   }
 
@@ -64,7 +69,7 @@ export class TextSnippet implements ResourceDeclaration {
     if (existing === undefined) {
       return false;
     }
-    return existing.includes(this.renderManagedBlock());
+    return existing.includes(this.renderManagedBlock(await this.resolveContent(context)));
   }
 
   async remove(context: IntegrationContext): Promise<void> {
@@ -81,9 +86,14 @@ export class TextSnippet implements ResourceDeclaration {
     await writeFileIfChanged(path, existing.replaceAll(pattern, ''));
   }
 
-  private async renderContent(path: string): Promise<string> {
+  private async resolveContent(context: IntegrationContext): Promise<string> {
+    const { content } = this.options;
+    return typeof content === 'function' ? content(context) : content;
+  }
+
+  private async renderContent(path: string, content: string): Promise<string> {
     const existing = (await readTextFile(path)) ?? '';
-    const managedBlock = this.renderManagedBlock();
+    const managedBlock = this.renderManagedBlock(content);
     const pattern = new RegExp(
       String.raw`${escapeRegExp(this.startMarker)}[\s\S]*?${escapeRegExp(this.endMarker)}`,
     );
@@ -99,8 +109,8 @@ export class TextSnippet implements ResourceDeclaration {
     return appendBlock(existing, managedBlock);
   }
 
-  private renderManagedBlock(): string {
-    return `${this.startMarker}\n${this.options.content.trimEnd()}\n${this.endMarker}`;
+  private renderManagedBlock(content: string): string {
+    return `${this.startMarker}\n${content.trimEnd()}\n${this.endMarker}`;
   }
 
   private get startMarker(): string {

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -22,6 +22,7 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
@@ -119,7 +120,11 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
               'sonar-sqaa/build-scripts/posttool-sqaa',
             ),
           content: (context) => {
-            const projectKey = getRequiredStringAttr(context, 'projectKey');
+            const projectKey = getRequiredStringAttr(
+              context,
+              'projectKey',
+              claudeIntegration.displayName,
+            );
             return process.platform === 'win32'
               ? getSqaaPostToolTemplateWindows(projectKey)
               : getSqaaPostToolTemplateUnix(projectKey);
@@ -227,17 +232,4 @@ function toMcpSettings(document: unknown): {
         ? { ...(settings.mcpServers as Record<string, unknown>) }
         : {},
   };
-}
-
-function getOptionalStringAttr(context: IntegrationContext, key: string): string | undefined {
-  const value = context.attrs?.[key];
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function getRequiredStringAttr(context: IntegrationContext, key: string): string {
-  const value = getOptionalStringAttr(context, key);
-  if (!value) {
-    throw new Error(`Missing integration attribute: ${key}`);
-  }
-  return value;
 }

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -106,7 +106,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
           id: 'codex-sqaa-instructions',
           displayName: 'Codex AGENTS.md SQAA instructions',
           targetPath: resolveCodexAgentsMdPath,
-          startMarker: sonarBeginMarker('sqaa-protocol'),
+          startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
           endMarker: sonarEndMarker('sqaa-protocol'),
           content: (context) => buildSqaaSectionBody(getRequiredStringAttr(context, 'projectKey')),
         }),

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -107,7 +107,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
           displayName: 'Codex AGENTS.md SQAA instructions',
           targetPath: resolveCodexAgentsMdPath,
           startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
-          endMarker: sonarEndMarker('sqaa-protocol'),
+          endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),
           content: (context) => buildSqaaSectionBody(getRequiredStringAttr(context, 'projectKey')),
         }),
       ],

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -22,13 +22,19 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { CommandFailedError } from '../../_common/error';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
-import { tomlPatch, wholeFile } from '../_common/registry/resources';
+import {
+  buildSqaaSectionBody,
+  sonarBeginMarker,
+  sonarEndMarker,
+} from '../_common/instructions-templates';
+import { textSnippet, tomlPatch } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPromptTemplateUnix, getSecretPromptTemplateWindows } from './hook-templates';
-import { buildAgentsMdContent } from './instructions-templates';
+import { SECRETS_ON_READ_BODY } from './instructions-templates';
 
 const CODEX_CONFIG_DIR = '.codex';
 const HOOKS_FILE = 'hooks.json';
@@ -39,9 +45,9 @@ export const CODEX_INTEGRATION_ID = 'codex';
 
 export interface CodexIntegrationOptions extends IntegrateAgentOptions {
   installSecretsHooks?: boolean;
-  /** Render the pre-tool secrets-on-read section into `.codex/AGENTS.md`. */
+  /** Write the secrets-on-read marker block into `.codex/AGENTS.md`. */
   installSecretsInstructions?: boolean;
-  /** Render the post-tool SQAA section into `.codex/AGENTS.md`. */
+  /** Write the SQAA marker block into `.codex/AGENTS.md`. */
   installSqaaInstructions?: boolean;
   installMcp?: boolean;
   installContextAugmentation?: boolean;
@@ -77,25 +83,32 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       ],
     }),
     {
-      id: 'agents-md-instructions',
-      displayName: 'Codex AGENTS.md instructions',
-      // Fires whenever at least one section is enabled. Each section's
-      // inclusion is then decided from attrs by the content function, so the
-      // two flags act as independent toggles even though both sections share
-      // a single file.
-      shouldInstall: ({ options }) =>
-        options.installSecretsInstructions === true || options.installSqaaInstructions === true,
+      id: 'secrets-instructions',
+      displayName: 'secrets-on-read instructions',
+      shouldInstall: ({ options }) => options.installSecretsInstructions === true,
       resources: [
-        wholeFile({
-          id: 'codex-agents-md',
-          displayName: 'Codex AGENTS.md',
+        textSnippet({
+          id: 'codex-secrets-instructions',
+          displayName: 'Codex AGENTS.md secrets instructions',
           targetPath: resolveCodexAgentsMdPath,
-          content: (context) =>
-            buildAgentsMdContent({
-              includeSecrets: getOptionalBoolAttr(context, 'includeSecretsSection'),
-              includeSqaa: getOptionalBoolAttr(context, 'includeSqaa'),
-              projectKey: getOptionalStringAttr(context, 'projectKey'),
-            }),
+          startMarker: sonarBeginMarker('codex-secrets-on-read'),
+          endMarker: sonarEndMarker('codex-secrets-on-read'),
+          content: SECRETS_ON_READ_BODY,
+        }),
+      ],
+    },
+    {
+      id: 'sqaa-instructions',
+      displayName: 'SonarQube Agentic Analysis instructions',
+      shouldInstall: ({ options }) => options.installSqaaInstructions === true,
+      resources: [
+        textSnippet({
+          id: 'codex-sqaa-instructions',
+          displayName: 'Codex AGENTS.md SQAA instructions',
+          targetPath: resolveCodexAgentsMdPath,
+          startMarker: sonarBeginMarker('sqaa-protocol'),
+          endMarker: sonarEndMarker('sqaa-protocol'),
+          content: (context) => buildSqaaSectionBody(getRequiredStringAttr(context, 'projectKey')),
         }),
       ],
     },
@@ -170,6 +183,10 @@ function getOptionalStringAttr(context: IntegrationContext, key: string): string
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
-function getOptionalBoolAttr(context: IntegrationContext, key: string): boolean {
-  return context.attrs?.[key] === true;
+function getRequiredStringAttr(context: IntegrationContext, key: string): string {
+  const value = context.attrs?.[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new CommandFailedError(`Missing required integration attribute: ${key}`);
+  }
+  return value;
 }

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -22,7 +22,7 @@ import { join } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
-import { CommandFailedError } from '../../_common/error';
+import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
@@ -108,7 +108,10 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
           targetPath: resolveCodexAgentsMdPath,
           startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
           endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),
-          content: (context) => buildSqaaSectionBody(getRequiredStringAttr(context, 'projectKey')),
+          content: (context) =>
+            buildSqaaSectionBody(
+              getRequiredStringAttr(context, 'projectKey', codexIntegration.displayName),
+            ),
         }),
       ],
     },
@@ -176,17 +179,4 @@ function toRecord(value: unknown): Record<string, unknown> {
     return {};
   }
   return { ...(value as Record<string, unknown>) };
-}
-
-function getOptionalStringAttr(context: IntegrationContext, key: string): string | undefined {
-  const value = context.attrs?.[key];
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function getRequiredStringAttr(context: IntegrationContext, key: string): string {
-  const value = context.attrs?.[key];
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new CommandFailedError(`Missing required integration attribute: ${key}`);
-  }
-  return value;
 }

--- a/src/cli/commands/integrate/codex/instructions-templates.ts
+++ b/src/cli/commands/integrate/codex/instructions-templates.ts
@@ -18,16 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Markdown sections rendered into `.codex/AGENTS.md`. The file is CLI-owned;
-// each run overwrites the whole document with the composition of the
-// applicable sections. The SQAA section is shared with the Copilot
-// integration so the wording stays consistent across agents.
+// Markdown sections rendered into `.codex/AGENTS.md`. Each section is written
+// into its own marker block by an independent `textSnippet` feature, so the
+// secrets and SQAA sections can be toggled independently while sharing the
+// file. The SQAA section is shared with the Copilot integration so the
+// wording stays consistent across agents.
 
-import { buildSqaaSection, withSonarMarkers } from '../_common/instructions-templates';
-
-const SECRETS_ON_READ_SECTION = withSonarMarkers(
-  'codex-secrets-on-read',
-  `# SonarQube secrets scanning for files protocol
+export const SECRETS_ON_READ_BODY = `# SonarQube secrets scanning for files protocol
 
 Before reading any file in this workspace, scan it for secrets with the deterministic scanner:
 
@@ -40,22 +37,4 @@ If the command reports that the file contains a secret, **do not read the file**
 1. Inform the user that the file appears to contain a secret or credential and that reading it would expose the value in chat history, logs, and any downstream telemetry.
 2. Advise them to rotate the leaked credential at its source of truth and remove it from the file.
 3. Do not proceed with the original request until the secret has been removed.
-`,
-);
-
-export interface AgentsMdSections {
-  includeSecrets: boolean;
-  includeSqaa: boolean;
-  projectKey?: string;
-}
-
-export function buildAgentsMdContent(sections: AgentsMdSections): string {
-  const parts: string[] = [];
-  if (sections.includeSecrets) {
-    parts.push(SECRETS_ON_READ_SECTION);
-  }
-  if (sections.includeSqaa && sections.projectKey) {
-    parts.push(buildSqaaSection(sections.projectKey));
-  }
-  return `${parts.join('\n').trimEnd()}\n`;
-}
+`;

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -22,7 +22,7 @@ import { join, relative } from 'node:path';
 
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
-import { CommandFailedError } from '../../_common/error';
+import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { secretsScanningExample } from '../_common/features/sonar-secrets-hooks-feature';
 import {
@@ -120,7 +120,10 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
           targetPath: resolveInstructionsPath,
           startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
           endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),
-          content: (context) => buildSqaaSectionBody(getRequiredStringAttr(context, 'projectKey')),
+          content: (context) =>
+            buildSqaaSectionBody(
+              getRequiredStringAttr(context, 'projectKey', copilotIntegration.displayName),
+            ),
         }),
       ],
     },
@@ -237,22 +240,9 @@ function getDesiredCopilotMcpConfig(context: IntegrationContext) {
       : {
           withFsMount: true,
           projectRoot: context.targetRoot,
-          projectKey: getOptionalProjectKey(context),
+          projectKey: getOptionalStringAttr(context, 'projectKey'),
         },
   );
-}
-
-function getOptionalProjectKey(context: IntegrationContext): string | undefined {
-  const value = context.attrs?.projectKey;
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
-function getRequiredStringAttr(context: IntegrationContext, key: string): string {
-  const value = context.attrs?.[key];
-  if (typeof value !== 'string' || value.length === 0) {
-    throw new CommandFailedError(`Missing required integration attribute: ${key}`);
-  }
-  return value;
 }
 
 function toJsonObject(document: unknown): Record<string, unknown> {

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -25,8 +25,13 @@ import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-help
 import { CommandFailedError } from '../../_common/error';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { secretsScanningExample } from '../_common/features/sonar-secrets-hooks-feature';
+import {
+  buildSqaaSectionBody,
+  sonarBeginMarker,
+  sonarEndMarker,
+} from '../_common/instructions-templates';
 import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
-import { jsonPatch, wholeFile } from '../_common/registry/resources';
+import { jsonPatch, textSnippet, wholeFile } from '../_common/registry/resources';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
@@ -41,10 +46,9 @@ import {
   SCRIPT_REL_DIR,
 } from './hooks';
 import {
-  buildInstructionsBody,
-  buildSqaaInstructionsBody,
   INSTRUCTIONS_FILENAME,
   PROJECT_INSTRUCTIONS_REL_DIR,
+  PROMPT_SECRETS_BODY,
 } from './instructions';
 
 export const COPILOT_INTEGRATION_ID = 'copilot-cli';
@@ -93,31 +97,30 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       displayName: 'prompt-secrets instructions',
       shouldInstall: ({ options }) => options.installInstructions === true,
       resources: [
-        wholeFile({
+        textSnippet({
           id: 'prompt-secrets-instructions-file',
           displayName: 'Copilot prompt-secrets instructions',
           targetPath: resolveInstructionsPath,
-          content: (context) =>
-            context.scope === 'project' && getBooleanAttr(context, 'sqaaEnabled')
-              ? buildInstructionsBody(getRequiredStringAttr(context, 'projectKey'))
-              : buildInstructionsBody(),
+          startMarker: sonarBeginMarker('copilot-prompt-secrets'),
+          endMarker: sonarEndMarker('copilot-prompt-secrets'),
+          content: PROMPT_SECRETS_BODY,
         }),
       ],
     },
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      shouldInstall: ({ options, scope }) =>
-        scope === 'global' && options.installSqaaInstructions === true,
+      shouldInstall: ({ options }) => options.installSqaaInstructions === true,
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [
-        wholeFile({
+        textSnippet({
           id: 'sqaa-instructions-file',
           displayName: 'Copilot SQAA instructions',
           targetPath: resolveInstructionsPath,
-          content: (context) =>
-            buildSqaaInstructionsBody(getRequiredStringAttr(context, 'projectKey')),
+          startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
+          endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),
+          content: (context) => buildSqaaSectionBody(getRequiredStringAttr(context, 'projectKey')),
         }),
       ],
     },
@@ -250,10 +253,6 @@ function getRequiredStringAttr(context: IntegrationContext, key: string): string
     throw new CommandFailedError(`Missing required integration attribute: ${key}`);
   }
   return value;
-}
-
-function getBooleanAttr(context: IntegrationContext, key: string): boolean {
-  return context.attrs?.[key] === true;
 }
 
 function toJsonObject(document: unknown): Record<string, unknown> {

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -90,7 +90,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     auth,
     nonInteractive: options.nonInteractive,
     attrs: {
-      ...buildIntegrationAttrs(projectKey, sqaaProjectKey !== undefined),
+      ...buildIntegrationAttrs(projectKey),
       ...(contextAugmentation
         ? buildContextAugmentationAttrs(auth.serverUrl, auth.orgKey, contextAugmentation.scaEnabled)
         : {}),
@@ -100,10 +100,8 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
 
 function buildIntegrationAttrs(
   projectKey: string | undefined,
-  sqaaEnabled: boolean,
 ): Record<string, IntegrationStateAttribute> {
   return {
     projectKey: projectKey ?? null,
-    sqaaEnabled,
   };
 }

--- a/src/cli/commands/integrate/copilot/instructions.ts
+++ b/src/cli/commands/integrate/copilot/instructions.ts
@@ -32,15 +32,12 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { warn } from '../../../../ui';
-import { buildSqaaSection, withSonarMarkers } from '../_common/instructions-templates';
 
 export const INSTRUCTIONS_FILENAME = 'sonarqube.instructions.md';
 export const PROJECT_INSTRUCTIONS_REL_DIR = join('.github', 'instructions');
 export const GLOBAL_INSTRUCTIONS_DIR = join(homedir(), '.copilot', 'instructions');
 
-const PROMPT_SECRETS_SECTION = withSonarMarkers(
-  'copilot-prompt-secrets',
-  `# SonarQube secrets scanning for prompts protocol
+export const PROMPT_SECRETS_BODY = `# SonarQube secrets scanning for prompts protocol
 
 Before acting on any user prompt, scan the prompt text for secrets or credentials. Treat the following as secrets (non-exhaustive):
 
@@ -61,20 +58,7 @@ If the prompt appears to contain any such secret (either by your judgement or th
 
 1. Inform the user that their prompt appears to contain a secret or credential and that it may now be exposed in chat history, logs, and any downstream telemetry.
 2. Advise them to rotate the leaked credential immediately at its source of truth.
-`,
-);
-
-export function buildInstructionsBody(projectKey?: string): string {
-  const sections = [PROMPT_SECRETS_SECTION];
-  if (projectKey) {
-    sections.push(buildSqaaSection(projectKey));
-  }
-  return `${sections.join('\n\n').trimEnd()}\n`;
-}
-
-export function buildSqaaInstructionsBody(projectKey: string): string {
-  return `${buildSqaaSection(projectKey).trimEnd()}\n`;
-}
+`;
 
 export function warnIfProjectInstructionsShadowGlobal(): void {
   const filePath = join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME);

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -110,6 +110,7 @@ export const AI_REMEDIATION_DOCS_URL =
   'https://docs.sonarsource.com/sonarqube-cloud/administering-sonarcloud/ai-features/sonarqube-remediation-agent';
 export const SERVER_API_DOCS_URL =
   'https://docs.sonarsource.com/sonarqube-server/extension-guide/web-api';
+export const SUPPORT_URL = 'https://community.sonarsource.com';
 
 // ---------------------------------------------------------------------------
 // Application paths

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -396,8 +396,8 @@ describe('integrate codex', () => {
         expect(body).toContain('<!-- sonar:begin:codex-secrets-on-read -->');
         expect(body).toContain('<!-- sonar:end:codex-secrets-on-read -->');
         expect(body).toContain(SECRETS_HEADING);
-        expect(body).toContain('<!-- sonar:begin:sqaa-protocol -->');
-        expect(body).toContain('<!-- sonar:end:sqaa-protocol -->');
+        expect(body).toContain('<!-- sonar:begin:sonarqube-agentic-analysis-protocol -->');
+        expect(body).toContain('<!-- sonar:end:sonarqube-agentic-analysis-protocol -->');
         expect(body).toContain(SQAA_HEADING);
         expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
       },

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -324,10 +324,10 @@ describe('integrate copilot', () => {
     );
 
     it(
-      'overwrites pre-existing global instructions (CLI-owned file)',
+      'preserves pre-existing global instructions and appends the managed prompt-secrets block',
       async () => {
-        // sonarqube.instructions.md is CLI-owned, so any pre-existing content
-        // is replaced with the freshly rendered prompt-secrets section.
+        // sonarqube.instructions.md is marker-managed: the CLI only owns
+        // its sonar:begin/end block and preserves any surrounding content.
         harness.userHome.writeFile(
           '.copilot/instructions/sonarqube.instructions.md',
           '# pre-existing\n',
@@ -337,7 +337,7 @@ describe('integrate copilot', () => {
 
         expect(result.exitCode).toBe(0);
         const body = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
-        expect(body).not.toContain('# pre-existing');
+        expect(body).toContain('# pre-existing');
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
       },
       { timeout: 30000 },
@@ -646,7 +646,7 @@ describe('integrate copilot', () => {
     }
 
     it(
-      'merges the SQAA section into the project file when org is entitled, project scope, and project key is provided',
+      'writes secrets and SQAA as independent marker blocks in the project file when org is entitled, project scope, and project key is provided',
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
@@ -661,14 +661,9 @@ describe('integrate copilot', () => {
         // Project key is baked into the example command.
         expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
 
-        // Project-scope installs keep SQAA in the prompt instructions feature.
         const promptSecrets = findCopilotFeature(harness, 'prompt-secrets-instructions');
         expect(promptSecrets?.scope).toBe('project');
-        expect(promptSecrets?.attrs).toMatchObject({
-          projectKey: TEST_PROJECT,
-          sqaaEnabled: true,
-        });
-        expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
+        expect(findCopilotFeature(harness, 'sqaa-instructions')?.scope).toBe('project');
       },
       { timeout: 30000 },
     );

--- a/tests/unit/cli/commands/integrate/_common/attrs.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/attrs.test.ts
@@ -1,0 +1,75 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error';
+import {
+  getOptionalStringAttr,
+  getRequiredStringAttr,
+} from '../../../../../../src/cli/commands/integrate/_common/attrs';
+import type { IntegrationContext } from '../../../../../../src/cli/commands/integrate/_common/registry/types';
+import { SUPPORT_URL } from '../../../../../../src/lib/config-constants';
+
+function makeContext(attrs?: IntegrationContext['attrs']): IntegrationContext {
+  return { attrs } as IntegrationContext;
+}
+
+describe('integrate attrs helpers', () => {
+  it('getOptionalStringAttr returns the value only for non-empty string attributes', () => {
+    expect(getOptionalStringAttr(makeContext({ projectKey: 'my-project' }), 'projectKey')).toBe(
+      'my-project',
+    );
+    expect(getOptionalStringAttr(makeContext({}), 'projectKey')).toBeUndefined();
+    expect(getOptionalStringAttr(makeContext(), 'projectKey')).toBeUndefined();
+    expect(getOptionalStringAttr(makeContext({ projectKey: '' }), 'projectKey')).toBeUndefined();
+    expect(getOptionalStringAttr(makeContext({ projectKey: 42 }), 'projectKey')).toBeUndefined();
+    expect(getOptionalStringAttr(makeContext({ projectKey: true }), 'projectKey')).toBeUndefined();
+    expect(getOptionalStringAttr(makeContext({ projectKey: null }), 'projectKey')).toBeUndefined();
+  });
+
+  it('getRequiredStringAttr returns the value for a non-empty string attribute', () => {
+    expect(
+      getRequiredStringAttr(makeContext({ projectKey: 'my-project' }), 'projectKey', 'Codex'),
+    ).toBe('my-project');
+  });
+
+  it('getRequiredStringAttr throws a CommandFailedError naming the integration for missing or invalid attributes', () => {
+    const invalidAttrs: IntegrationContext['attrs'][] = [{}, { projectKey: '' }, { projectKey: 7 }];
+    for (const attrs of invalidAttrs) {
+      expect(() => getRequiredStringAttr(makeContext(attrs), 'projectKey', 'Codex')).toThrow(
+        CommandFailedError,
+      );
+    }
+
+    try {
+      getRequiredStringAttr(makeContext({}), 'projectKey', 'Codex');
+      throw new Error('expected getRequiredStringAttr to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(CommandFailedError);
+      const cliError = error as CommandFailedError;
+      expect(cliError.message).toBe(
+        "Could not complete the Codex integration: missing required data 'projectKey'.",
+      );
+      expect(cliError.remediationHint).toContain(SUPPORT_URL);
+      expect(cliError.exitCode).toBe(1);
+    }
+  });
+});

--- a/tests/unit/cli/commands/integrate/_common/instructions-templates.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/instructions-templates.test.ts
@@ -1,0 +1,44 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildSqaaSectionBody,
+  sonarBeginMarker,
+  sonarEndMarker,
+  withSonarMarkers,
+} from '../../../../../../src/cli/commands/integrate/_common/instructions-templates';
+
+describe('instructions-templates', () => {
+  it('withSonarMarkers wraps the body in begin/end markers, trims trailing whitespace, and ends with a newline', () => {
+    const result = withSonarMarkers('my-id', 'body line\n\n  ');
+
+    expect(result).toBe(`${sonarBeginMarker('my-id')}\nbody line\n${sonarEndMarker('my-id')}\n`);
+    expect(result.endsWith('\n')).toBe(true);
+  });
+
+  it('buildSqaaSectionBody renders the SQAA protocol body with the analyze command for the project', () => {
+    const result = buildSqaaSectionBody('my-project');
+
+    expect(result).toContain('# SonarQube Agentic Analysis protocol');
+    expect(result).toContain('sonar analyze agentic --project my-project --file');
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored instruction management:**
  - Decoupled `secrets-on-read` and `sqaa` instructions into independent features by splitting their `textSnippet` resources.
  - Updated `textSnippet` resource to support dynamic content resolution via a function callback.
  - Replaced monolithic file rendering with marker-based block injection to allow independent toggling of sections within `.codex/AGENTS.md`.
- **Updated CLI commands:**
  - Migrated `Codex` integration to use separate IDs and logic for `secrets-instructions` and `sqaa-instructions`.
  - Enforced `projectKey` as a required attribute for SQAA instructions, throwing `CommandFailedError` if missing.
- **Internal utilities:**
  - Refactored `withSonarMarkers` into granular `sonarBeginMarker` and `sonarEndMarker` helpers.
  - Exposed `buildSqaaSectionBody` for direct use in snippet rendering.
- **Testing:**
  - Added unit tests in `instructions-templates.test.ts` for marker generation and SQAA body rendering.
  - Updated integration tests to reflect marker-managed instruction files that preserve pre-existing content.


<sub>This will update automatically on new commits.</sub>