### PR TITLE
CLI-590 Interactive integrate: feature selection framework

### DIFF
--- a/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
+++ b/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
@@ -42,7 +42,7 @@ export function createContextAugmentationFeature<
   return {
     id: CONTEXT_AUGMENTATION_FEATURE_ID,
     displayName: `${options.agentDisplayName} Context Augmentation`,
-    when: ({ options: integrationOptions }) =>
+    shouldInstall: ({ options: integrationOptions }) =>
       integrationOptions.installContextAugmentation === true,
     dependencies: [contextAugmentationBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -78,7 +78,7 @@ export function createSonarSecretsHooksFeature<TOptions extends SonarSecretsHook
   return {
     id: 'sonar-secrets-hooks',
     displayName: 'secret scanning hooks',
-    when: ({ options }) => options.installSecretsHooks === true,
+    shouldInstall: ({ options }) => options.installSecretsHooks === true,
     postInstallExample: secretsScanningExample(config.agentDisplayName),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -53,6 +53,7 @@ export {
   yamlPatch,
   type YamlPatchOptions,
 } from './resources';
+export { askUser, install, type InstallDecision, skip } from './selection';
 export type {
   AppliedFeature,
   AppliedOperation,

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -71,7 +71,7 @@ export async function installIntegration<TOptions>({
   const invocation = makeInvocation(options, targetRoot, scope, auth, force, attrs);
   const features =
     featureIds === undefined
-      ? integrationInstaller.selectFeaturesForInvocation(integration, invocation)
+      ? await integrationInstaller.selectFeaturesForInvocation(integration, invocation)
       : integrationInstaller.selectFeatures(integration, featureIds);
   if (features.length === 0) {
     throw new CommandFailedError(`No feature selected for ${integration.displayName}`);

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -54,6 +54,7 @@ export interface InstallIntegrationOptions<TOptions> {
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
   featureIds?: string[];
+  nonInteractive?: boolean;
 }
 
 export async function installIntegration<TOptions>({
@@ -66,9 +67,10 @@ export async function installIntegration<TOptions>({
   force,
   attrs,
   featureIds,
+  nonInteractive,
 }: InstallIntegrationOptions<TOptions>): Promise<InstalledIntegrationFeature[]> {
   const integration = getIntegrationDeclaration<TOptions>(registry, integrationId);
-  const invocation = makeInvocation(options, targetRoot, scope, auth, force, attrs);
+  const invocation = makeInvocation(options, targetRoot, scope, auth, force, attrs, nonInteractive);
   const features =
     featureIds === undefined
       ? await integrationInstaller.selectFeaturesForInvocation(integration, invocation)
@@ -195,8 +197,9 @@ function makeInvocation<TOptions>(
   auth: ResolvedAuth | undefined,
   force: boolean | undefined,
   attrs: Record<string, IntegrationStateAttribute> | undefined,
+  nonInteractive: boolean | undefined,
 ): IntegrationInvocation<TOptions> {
-  return { options, targetRoot, scope, auth, force, attrs };
+  return { options, targetRoot, scope, auth, force, attrs, nonInteractive };
 }
 
 async function resolveFeatureContext<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -135,11 +135,7 @@ export class IntegrationInstaller {
         }
         return false;
       case 'ask': {
-        const nonInteractive =
-          Boolean((invocation.options as { nonInteractive?: boolean }).nonInteractive) ||
-          process.env.CI === 'true' ||
-          !process.stdin.isTTY;
-        if (nonInteractive) {
+        if ((invocation.options as { nonInteractive?: boolean }).nonInteractive) {
           return true;
         }
         const confirmed = await confirmPrompt(

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -27,9 +27,11 @@ import type {
   IntegrationScope,
   IntegrationStateAttribute,
 } from '../../../../../lib/state';
+import { confirmPrompt, info } from '../../../../../ui';
 import type { DependencyDeclaration } from './dependencies';
 import { recordInstalledFeature } from './installation-recorder';
 import type { ResourceDeclaration } from './resources';
+import { normalizeDecision } from './selection';
 import type {
   AppliedFeature,
   AppliedOperation,
@@ -105,11 +107,43 @@ export class IntegrationInstaller {
     });
   }
 
-  selectFeaturesForInvocation<TOptions>(
+  async selectFeaturesForInvocation<TOptions>(
     integration: IntegrationDeclaration<TOptions>,
     invocation: IntegrationInvocation<TOptions>,
-  ): FeatureDeclaration<TOptions>[] {
-    return integration.features.filter((feature) => !feature.when || feature.when(invocation));
+  ): Promise<FeatureDeclaration<TOptions>[]> {
+    const selected: FeatureDeclaration<TOptions>[] = [];
+    for (const feature of integration.features) {
+      if (await this.shouldInstallFeature(feature, invocation)) {
+        selected.push(feature);
+      }
+    }
+    return selected;
+  }
+
+  private async shouldInstallFeature<TOptions>(
+    feature: FeatureDeclaration<TOptions>,
+    invocation: IntegrationInvocation<TOptions>,
+  ): Promise<boolean> {
+    const decision = normalizeDecision(await feature.shouldInstall?.(invocation));
+    switch (decision.action) {
+      case 'install':
+        return true;
+      case 'skip':
+        if (decision.message) {
+          info(decision.message);
+        }
+        return false;
+      case 'ask': {
+        if ((invocation.options as { nonInteractive?: boolean }).nonInteractive) {
+          return true;
+        }
+        const confirmed = await confirmPrompt(
+          decision.message ?? `Install ${feature.displayName}?`,
+          true,
+        );
+        return confirmed === true;
+      }
+    }
   }
 
   findInstalledFeature<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -139,7 +139,7 @@ export class IntegrationInstaller {
           return true;
         }
         const confirmed = await confirmPrompt(
-          decision.message ?? `Install ${feature.displayName}?`,
+          decision.question ?? `Install ${feature.displayName}?`,
           true,
         );
         if (confirmed === null) {

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -135,7 +135,7 @@ export class IntegrationInstaller {
         }
         return false;
       case 'ask': {
-        if ((invocation.options as { nonInteractive?: boolean }).nonInteractive) {
+        if (invocation.nonInteractive) {
           return true;
         }
         const confirmed = await confirmPrompt(

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -28,6 +28,7 @@ import type {
   IntegrationStateAttribute,
 } from '../../../../../lib/state';
 import { confirmPrompt, info } from '../../../../../ui';
+import { CommandFailedError } from '../../../_common/error';
 import type { DependencyDeclaration } from './dependencies';
 import { recordInstalledFeature } from './installation-recorder';
 import type { ResourceDeclaration } from './resources';
@@ -134,14 +135,21 @@ export class IntegrationInstaller {
         }
         return false;
       case 'ask': {
-        if ((invocation.options as { nonInteractive?: boolean }).nonInteractive) {
+        const nonInteractive =
+          Boolean((invocation.options as { nonInteractive?: boolean }).nonInteractive) ||
+          process.env.CI === 'true' ||
+          !process.stdin.isTTY;
+        if (nonInteractive) {
           return true;
         }
         const confirmed = await confirmPrompt(
           decision.message ?? `Install ${feature.displayName}?`,
           true,
         );
-        return confirmed === true;
+        if (confirmed === null) {
+          throw new CommandFailedError('Installation cancelled');
+        }
+        return confirmed;
       }
     }
   }

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -1,0 +1,63 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * Outcome of a feature's `shouldInstall` evaluation. Integrations declare the
+ * intent; the installer resolves it (prompting / skip messaging) centrally.
+ */
+export type InstallDecision =
+  | { action: 'install' }
+  | { action: 'skip'; message?: string }
+  | { action: 'ask'; message?: string };
+
+/** Install the feature without asking. */
+export function install(): InstallDecision {
+  return { action: 'install' };
+}
+
+/** Skip the feature, optionally explaining why. */
+export function skip(message?: string): InstallDecision {
+  return { action: 'skip', message };
+}
+
+/** Ask the user whether to install the feature, with an optional custom prompt. */
+export function askUser(message?: string): InstallDecision {
+  return { action: 'ask', message };
+}
+
+/**
+ * Coerce a `shouldInstall` result into an {@link InstallDecision}.
+ *
+ * A missing predicate defaults to asking the user (opt-in). An explicit `true`
+ * installs without asking, `false` skips silently, and an explicit
+ * {@link InstallDecision} passes through unchanged.
+ */
+export function normalizeDecision(result: boolean | InstallDecision | undefined): InstallDecision {
+  if (result === undefined) {
+    return askUser();
+  }
+  if (result === true) {
+    return install();
+  }
+  if (result === false) {
+    return skip();
+  }
+  return result;
+}

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -25,7 +25,7 @@
 export type InstallDecision =
   | { action: 'install' }
   | { action: 'skip'; message?: string }
-  | { action: 'ask'; message?: string };
+  | { action: 'ask'; question?: string };
 
 /** Install the feature without asking. */
 export function install(): InstallDecision {
@@ -38,8 +38,8 @@ export function skip(message?: string): InstallDecision {
 }
 
 /** Ask the user whether to install the feature, with an optional custom prompt. */
-export function askUser(message?: string): InstallDecision {
-  return { action: 'ask', message };
+export function askUser(question?: string): InstallDecision {
+  return { action: 'ask', question };
 }
 
 /**

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -49,6 +49,7 @@ export interface IntegrationInvocation<TOptions = Record<string, unknown>> {
   auth?: ResolvedAuth;
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
+  nonInteractive?: boolean;
 }
 
 export type FeatureTargetRoot<TOptions = Record<string, unknown>> =

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -26,6 +26,7 @@ import type {
 } from '../../../../../lib/state';
 import type { DependencyDeclaration } from './dependencies';
 import type { ResourceDeclaration } from './resources';
+import type { InstallDecision } from './selection';
 
 export type MaybePromise<T> = T | Promise<T>;
 export type IntegrationExecutionMode = 'install' | 'update';
@@ -79,7 +80,9 @@ export interface PostInstallExample {
 export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
   id: string;
   displayName: string;
-  when?: (invocation: IntegrationInvocation<TOptions>) => boolean;
+  shouldInstall?: (
+    invocation: IntegrationInvocation<TOptions>,
+  ) => MaybePromise<boolean | InstallDecision>;
   targetRoot?: FeatureTargetRoot<TOptions>;
   scope?: FeatureScope<TOptions>;
   dependencies?: DependencyDeclaration[];

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -105,7 +105,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     {
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
-      when: ({ options }) => options.installSqaaHook === true,
+      shouldInstall: ({ options }) => options.installSqaaHook === true,
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [
@@ -148,7 +148,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      when: ({ options }) => options.installMcp === true,
+      shouldInstall: ({ options }) => options.installMcp === true,
       resources: [
         jsonPatch({
           id: 'claude-mcp-config',

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -82,6 +82,8 @@ export async function integrateClaude(
 
   let token = config.token;
 
+  const isNonInteractive = !!options.nonInteractive || isEnvBasedAuth();
+
   blank();
   text('Phase 2/3: Health Check & Repair');
   blank();
@@ -101,8 +103,6 @@ export async function integrateClaude(
     for (const msg of healthResult.errors) {
       text(`  - ${msg}`);
     }
-
-    const isNonInteractive = !!options.nonInteractive || isEnvBasedAuth();
 
     if (!isNonInteractive && !healthResult.tokenValid) {
       blank();
@@ -154,6 +154,7 @@ export async function integrateClaude(
       scope: installScope,
       auth: { ...auth, token },
       attrs: featureAttrs,
+      nonInteractive: isNonInteractive,
     });
   } catch (error) {
     installError = error instanceof Error ? error : new Error(String(error));

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -83,7 +83,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       // inclusion is then decided from attrs by the content function, so the
       // two flags act as independent toggles even though both sections share
       // a single file.
-      when: ({ options }) =>
+      shouldInstall: ({ options }) =>
         options.installSecretsInstructions === true || options.installSqaaInstructions === true,
       resources: [
         wholeFile({
@@ -102,7 +102,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      when: ({ options }) => options.installMcp === true,
+      shouldInstall: ({ options }) => options.installMcp === true,
       resources: [
         tomlPatch({
           id: 'codex-mcp-config',

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -91,6 +91,7 @@ export async function integrateCodex(
     targetRoot: installRoot,
     scope: installScope,
     auth,
+    nonInteractive: options.nonInteractive,
     attrs: {
       ...buildAttrs({
         includeSecretsSection: true,

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -65,7 +65,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'pre-tool-use-hook',
       displayName: 'pre-tool-use hook',
-      when: ({ options }) => options.installHook === true,
+      shouldInstall: ({ options }) => options.installHook === true,
       postInstallExample: secretsScanningExample('Copilot'),
       dependencies: [sonarSecretsBinaryDependency],
       resources: [
@@ -91,7 +91,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'prompt-secrets-instructions',
       displayName: 'prompt-secrets instructions',
-      when: ({ options }) => options.installInstructions === true,
+      shouldInstall: ({ options }) => options.installInstructions === true,
       resources: [
         wholeFile({
           id: 'prompt-secrets-instructions-file',
@@ -107,7 +107,8 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      when: ({ options, scope }) => scope === 'global' && options.installSqaaInstructions === true,
+      shouldInstall: ({ options, scope }) =>
+        scope === 'global' && options.installSqaaInstructions === true,
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [
@@ -123,7 +124,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      when: ({ options }) => options.installMcp === true,
+      shouldInstall: ({ options }) => options.installMcp === true,
       resources: [
         jsonPatch({
           id: 'copilot-mcp-config',

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -88,6 +88,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     targetRoot,
     scope,
     auth,
+    nonInteractive: options.nonInteractive,
     attrs: {
       ...buildIntegrationAttrs(projectKey, sqaaProjectKey !== undefined),
       ...(contextAugmentation

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -203,6 +203,7 @@ async function installGitFeatures(
     targetRoot,
     scope,
     force: options.force,
+    nonInteractive: options.nonInteractive,
     attrs: {
       hook: options.hook,
     },

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -39,7 +39,7 @@ function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitO
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    when: ({ options }) => options.hook === hook,
+    shouldInstall: ({ options }) => options.hook === hook,
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -41,7 +41,7 @@ function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    when: ({ options }) => options.hook === hook,
+    shouldInstall: ({ options }) => options.hook === hook,
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -45,7 +45,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    when: ({ options }) => options.hook === hook,
+    shouldInstall: ({ options }) => options.hook === hook,
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -124,7 +124,7 @@ describe('generic integration installer', () => {
       {
         id: 'main',
         displayName: 'Main feature',
-        when: ({ options }) => options.installMain === true,
+        shouldInstall: ({ options }) => options.installMain === true,
         resources: [
           wholeFile({
             id: 'main-file',
@@ -137,7 +137,7 @@ describe('generic integration installer', () => {
       {
         id: 'project',
         displayName: 'Project feature',
-        when: ({ options }) => options.installProject === true,
+        shouldInstall: ({ options }) => options.installProject === true,
         targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
         scope: 'project',
         resources: [
@@ -179,7 +179,7 @@ describe('generic integration installer', () => {
         {
           id: 'main',
           displayName: 'Main feature',
-          when: ({ options }) => options.installMain === true,
+          shouldInstall: ({ options }) => options.installMain === true,
           resources: [
             wholeFile({
               id: 'main-file',
@@ -192,7 +192,7 @@ describe('generic integration installer', () => {
         {
           id: 'context-skill',
           displayName: 'Context skill',
-          when: () => false,
+          shouldInstall: () => false,
           resources: [
             wholeFile({
               id: 'skill-file',
@@ -405,7 +405,7 @@ describe('generic integration installer', () => {
         {
           id: 'feature',
           displayName: 'Feature',
-          when: ({ options }) => options.enabled === true,
+          shouldInstall: ({ options }) => options.enabled === true,
         },
       ],
     );

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -389,9 +389,10 @@ describe('declarative integration framework', () => {
     });
 
     const selected = await installer.selectFeaturesForInvocation(integration, {
-      options: { nonInteractive: true },
+      options: {},
       targetRoot: tempDir,
       scope: 'project',
+      nonInteractive: true,
     });
 
     expect(selected.map((feature) => feature.id)).toEqual(['asked', 'defaulted']);

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -38,10 +38,13 @@ void mock.module('../../../../../../src/cli/commands/_common/install/binary', ()
 }));
 
 const {
+  askUser,
   createIntegrationRegistry,
+  install,
   IntegrationInstaller,
   IntegrationRegistry,
   jsonPatch,
+  skip,
   SonarSourceBinary,
   sonarSourceBinary,
   textSnippet,
@@ -51,6 +54,10 @@ const {
 } = await import('../../../../../../src/cli/commands/integrate/_common/registry');
 
 type Installer = InstanceType<typeof IntegrationInstaller>;
+
+const { findMockUiCall, getMockUiCalls, queueMockResponse, setMockUi } = await import(
+  '../../../../../../src/ui'
+);
 
 describe('declarative integration framework', () => {
   const installer = new IntegrationInstaller();
@@ -70,6 +77,7 @@ describe('declarative integration framework', () => {
   afterEach(() => {
     installBinarySpy.mockRestore();
     resolveBinaryPathSpy.mockRestore();
+    setMockUi(false);
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -259,7 +267,7 @@ describe('declarative integration framework', () => {
     );
   });
 
-  it('selects features matching an invocation', () => {
+  it('selects features matching an invocation, honoring boolean and decision results', async () => {
     interface GitOptions {
       hook?: 'pre-commit' | 'pre-push';
     }
@@ -268,38 +276,127 @@ describe('declarative integration framework', () => {
         {
           id: 'pre-commit',
           displayName: 'Pre-commit',
-          when: ({ options }) => !options.hook || options.hook === 'pre-commit',
+          shouldInstall: ({ options }) => !options.hook || options.hook === 'pre-commit',
         },
         {
           id: 'pre-push',
           displayName: 'Pre-push',
-          when: ({ options }) => options.hook === 'pre-push',
+          shouldInstall: ({ options }) => options.hook === 'pre-push',
         },
         {
           id: 'always',
           displayName: 'Always',
+          shouldInstall: () => install(),
+        },
+        {
+          id: 'never',
+          displayName: 'Never',
+          shouldInstall: () => skip(),
         },
       ],
     });
 
     expect(
-      installer
-        .selectFeaturesForInvocation(integration, {
+      (
+        await installer.selectFeaturesForInvocation(integration, {
           options: {},
           targetRoot: tempDir,
           scope: 'project',
         })
-        .map((feature) => feature.id),
+      ).map((feature) => feature.id),
     ).toEqual(['pre-commit', 'always']);
     expect(
-      installer
-        .selectFeaturesForInvocation(integration, {
+      (
+        await installer.selectFeaturesForInvocation(integration, {
           options: { hook: 'pre-push' },
           targetRoot: tempDir,
           scope: 'project',
         })
-        .map((feature) => feature.id),
+      ).map((feature) => feature.id),
     ).toEqual(['pre-push', 'always']);
+  });
+
+  it('reports an optional reason when a feature is skipped, and stays silent otherwise', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({
+      features: [
+        { id: 'with-reason', displayName: 'With reason', shouldInstall: () => skip('covered') },
+        { id: 'silent', displayName: 'Silent', shouldInstall: () => skip() },
+      ],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(integration, {
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(selected).toEqual([]);
+    expect(findMockUiCall('info', 'covered')).toBeDefined();
+    expect(getMockUiCalls().filter((call) => call.method === 'info')).toHaveLength(1);
+  });
+
+  it('prompts the user when a feature asks, installing on confirm and skipping on decline', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({
+      features: [
+        { id: 'accepted', displayName: 'Accepted', shouldInstall: () => askUser() },
+        {
+          id: 'declined',
+          displayName: 'Declined',
+          shouldInstall: () => askUser('Install the thing?'),
+        },
+      ],
+    });
+    queueMockResponse(true);
+    queueMockResponse(false);
+
+    const selected = await installer.selectFeaturesForInvocation(integration, {
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(selected.map((feature) => feature.id)).toEqual(['accepted']);
+    const confirmCalls = getMockUiCalls().filter((call) => call.method === 'confirmPrompt');
+    expect(confirmCalls).toHaveLength(2);
+    expect(confirmCalls[1]?.args[0]).toBe('Install the thing?');
+  });
+
+  it('defaults to asking the user when a feature omits shouldInstall', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({
+      features: [{ id: 'feature', displayName: 'Feature' }],
+    });
+    queueMockResponse(false);
+
+    const selected = await installer.selectFeaturesForInvocation(integration, {
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(selected).toEqual([]);
+    expect(getMockUiCalls().filter((call) => call.method === 'confirmPrompt')).toHaveLength(1);
+  });
+
+  it('auto-confirms ask decisions in non-interactive mode without prompting', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({
+      features: [
+        { id: 'asked', displayName: 'Asked', shouldInstall: () => askUser() },
+        { id: 'defaulted', displayName: 'Defaulted' },
+      ],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(integration, {
+      options: { nonInteractive: true },
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(selected.map((feature) => feature.id)).toEqual(['asked', 'defaulted']);
+    expect(getMockUiCalls().filter((call) => call.method === 'confirmPrompt')).toHaveLength(0);
   });
 
   it('applies declared resources and records the feature once', async () => {

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -55,9 +55,8 @@ const {
 
 type Installer = InstanceType<typeof IntegrationInstaller>;
 
-const { findMockUiCall, getMockUiCalls, queueMockResponse, setMockUi } = await import(
-  '../../../../../../src/ui'
-);
+const { findMockUiCall, getMockUiCalls, queueMockResponse, setMockUi } =
+  await import('../../../../../../src/ui');
 
 describe('declarative integration framework', () => {
   const installer = new IntegrationInstaller();


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored feature selection:**
  - Replaced the boolean `when` property with a flexible `shouldInstall` function returning `InstallDecision`.
  - Added `askUser`, `install`, and `skip` helpers to manage interactive installation flow.
- **Implemented interactive support:**
  - Added `selection.ts` to normalize installation decisions and handle `confirmPrompt` logic.
  - Updated `IntegrationInstaller` to support asynchronous feature evaluation and non-interactive mode auto-confirmation.
- **Updated integrations:**
  - Refactored `sonar-secrets-hooks-feature` and other declaration files to migrate from `when` to `shouldInstall`.
- **Added unit tests:**
  - Included comprehensive test coverage for conditional skipping, user prompts, non-interactive mode, and default behaviors.

<sub>This will update automatically on new commits.</sub>