### PR TITLE
CLI-589 Fix release notes automation

### DIFF
--- a/.github/scripts/generate-release-notes.ts
+++ b/.github/scripts/generate-release-notes.ts
@@ -32,7 +32,8 @@
  *
  * The script:
  *   1. Resolves the previous release tag with `git describe`.
- *   2. Collects commit subjects between the previous tag and the released one.
+ *   2. Collects commit subjects between the previous tag and the released one
+ *      (or HEAD when the release tag has not been pushed yet).
  *   3. Send two GitHub releases as style examples (hardcoded).
  *   4. Extracts JIRA keys from commit subjects and fetches their title/description
  *      from the Atlassian REST API when JIRA_USER / JIRA_TOKEN are set.
@@ -189,23 +190,26 @@ function describeError(err: unknown): string {
   }
 }
 
-function assertTagExists(tag: string): void {
-  const resolved = tryRunCmd(`git rev-parse --verify --quiet "${tag}^{commit}"`);
-  if (!resolved) {
-    throw new Error(
-      `Tag "${tag}" is not in the local git repository. ` +
-        'Make sure to check out with fetch-depth: 0 and fetch-tags: true.',
-    );
+/** Return the tag if it exists in git, otherwise HEAD (pre-release / draft-notes mode). */
+function resolveUpperBound(tag: string): string {
+  if (tryRunCmd(`git rev-parse --verify --quiet "${tag}^{commit}"`)) {
+    return tag;
   }
+  console.error(
+    `Tag "${tag}" not found in local git; using HEAD as upper bound (pre-release mode).`,
+  );
+  return 'HEAD';
 }
 
-function resolvePreviousTag(tag: string): string | undefined {
-  const prev = tryRunCmd(`git describe --tags --abbrev=0 --match '${RELEASE_TAG_GLOB}' "${tag}^"`);
+function resolvePreviousTag(upper: string): string | undefined {
+  const prev = tryRunCmd(
+    `git describe --tags --abbrev=0 --match '${RELEASE_TAG_GLOB}' "${upper}^"`,
+  );
   return prev || undefined;
 }
 
-function listCommits(previousTag: string | undefined, tag: string): CommitEntry[] {
-  const range = previousTag ? `${previousTag}..${tag}` : tag;
+function listCommits(previousTag: string | undefined, endRef: string): CommitEntry[] {
+  const range = previousTag ? `${previousTag}..${endRef}` : endRef;
   const output = tryRunCmd(`git log ${range} --no-merges --pretty=format:%h%x09%s`);
   if (!output) return [];
   return output
@@ -514,18 +518,16 @@ async function main(): Promise<void> {
     process.exit(2);
   }
 
-  // Sanity check: we need the tag locally to compute the change set.
-  // `gh release list` does not need the tag locally and degrades gracefully if `gh` is missing.
-  assertTagExists(releasedVersion);
+  const upper = resolveUpperBound(releasedVersion);
 
-  const previousTag = resolvePreviousTag(releasedVersion);
+  const previousTag = resolvePreviousTag(upper);
   if (previousTag) {
     console.error(`Using previous tag: ${previousTag}`);
   } else {
-    console.error('No previous release tag found — using full history up to the released version.');
+    console.error('No previous release tag found — using full history up to the upper bound.');
   }
 
-  const commits = listCommits(previousTag, releasedVersion);
+  const commits = listCommits(previousTag, upper);
   console.error(`Collected ${commits.length} commit(s).`);
 
   const jiraTickets = await fetchJiraTickets(commits);

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -137,11 +137,18 @@ jobs:
           DRAFT_VERSION: ${{ needs.check-draft-exists.outputs.release-version }}
           RELEASED_VERSION: ${{ needs.release.outputs.released-version }}
         run: |
+          set -euo pipefail
           echo "Copying notes from draft '$DRAFT_VERSION' to published release '$RELEASED_VERSION'..."
           gh release view "$DRAFT_VERSION" --json body --jq '.body' > release-notes.md
           gh release edit "$RELEASED_VERSION" --notes-file release-notes.md
-          # Draft releases do not create a git tag (see https://github.com/orgs/community/discussions/24690),
-          # so --cleanup-tag is intentionally omitted.
-          echo "Deleting draft '$DRAFT_VERSION'..."
-          gh release delete "$DRAFT_VERSION" --yes
+
+          IS_DRAFT=$(gh release view "$DRAFT_VERSION" --json isDraft -q '.isDraft' 2>/dev/null || echo "missing")
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "Deleting draft release '$DRAFT_VERSION'..."
+            gh release delete "$DRAFT_VERSION" --yes
+          elif [ "$DRAFT_VERSION" = "$RELEASED_VERSION" ]; then
+            echo "Release '$RELEASED_VERSION' was published from the draft in place; notes copied, skipping delete."
+          else
+            echo "No draft release '$DRAFT_VERSION' to delete (isDraft=$IS_DRAFT)."
+          fi
           echo "Done."


### PR DESCRIPTION
Prepare release notes failed because the script required git tag 0.14.0.2224, which does not exist yet at draft time—only after publish.

Fix: If the release tag is missing, use HEAD for the commit range (same as sonar-mcp-server). Re-run the workflow after deploying the script change.

Also avoid deletion of non-draft release.

----
## Summary by Gitar

- **Release notes automation:**
  - Updated `generate-release-notes.ts` to allow `HEAD` as an upper bound when the release tag is missing.
- **Workflow cleanup:**
  - Modified `full-release.yml` to prevent accidental deletion of published releases by checking `isDraft` status before deletion.


<sub>This will update automatically on new commits.</sub>