### PR TITLE
CLI-593 Use git remote URL to auto-discover project binding when no local config is found

### DIFF
--- a/src/cli/commands/integrate/_common/agent-integrate-prelude.ts
+++ b/src/cli/commands/integrate/_common/agent-integrate-prelude.ts
@@ -55,8 +55,10 @@ export function introAgentIntegration(agentDisplayName: string): void {
   intro(`SonarQube Integration Setup for ${agentDisplayName}`);
 }
 
-export async function discoverIntegrateProject(): Promise<DiscoveredProject> {
-  return withSpinner('Discovering project...', () => discoverProject(process.cwd(), true));
+export async function discoverIntegrateProject(auth: ResolvedAuth): Promise<DiscoveredProject> {
+  return withSpinner('Discovering project...', () =>
+    discoverProject(process.cwd(), true, { auth }),
+  );
 }
 
 export function warnAuthProjectMismatches(auth: ResolvedAuth, project: DiscoveredProject): void {
@@ -124,7 +126,7 @@ export async function displayAgentIntegratePrelude(
 ): Promise<AgentIntegrateContext> {
   assertIntegrateScopeOptions(options);
   introAgentIntegration(agentDisplayName);
-  const project = await discoverIntegrateProject();
+  const project = await discoverIntegrateProject(auth);
   warnAuthProjectMismatches(auth, project);
   const projectKey = options.project || project.projectKey;
   assertSonarCloudOrganization(auth.serverUrl, auth.orgKey);

--- a/src/cli/commands/remediate/index.ts
+++ b/src/cli/commands/remediate/index.ts
@@ -100,7 +100,7 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
 
   let projectKey = options.project;
   if (!projectKey) {
-    const discovered = await discoverProject(process.cwd());
+    const discovered = await discoverProject(process.cwd(), false, { auth });
     projectKey = discovered.projectKey;
   }
   if (!projectKey) {

--- a/src/cli/commands/run/mcp.ts
+++ b/src/cli/commands/run/mcp.ts
@@ -27,7 +27,7 @@ import type { ResolvedAuth } from '../../../lib/auth-resolver.js';
 import { canonicalizePath } from '../../../lib/fs-utils.js';
 import logger from '../../../lib/logger';
 import { getMcpContainerCommand, type McpServerContext } from '../../../lib/mcp/mcp-helper.js';
-import { discoverProject } from '../../../lib/project-workspace/project-info.js';
+import { discoverProject } from '../../../lib/project-workspace';
 import { detectContainerRuntime } from '../../../lib/tool-detector.js';
 import { warn } from '../../../ui';
 import { CommandFailedError } from '../_common/error.js';
@@ -54,7 +54,7 @@ export async function runMcp(auth: ResolvedAuth, options: McpRunOptions = {}): P
 
   const cwd = process.cwd();
   const cwdIsHomeDir = canonicalizePath(cwd) === canonicalizePath(homedir());
-  const discovered = cwdIsHomeDir ? undefined : await discoverProject(cwd, true);
+  const discovered = cwdIsHomeDir ? undefined : await discoverProject(cwd, true, { auth });
   const projectKey = options.project || discovered?.projectKey;
   if (!projectKey) {
     warn(

--- a/src/lib/project-workspace/discover-project-by-remote.ts
+++ b/src/lib/project-workspace/discover-project-by-remote.ts
@@ -1,0 +1,55 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { SonarQubeClient } from '../../sonarqube/client';
+import type { ResolvedAuth } from '../auth-resolver';
+import logger from '../logger';
+
+export const GIT_REMOTE_BINDING_SOURCE = 'git remote (origin)';
+
+export interface GitRemoteBindingDiscovery {
+  projectKey: string;
+  serverUrl: string;
+  organization?: string;
+}
+
+/**
+ * Resolves a SonarQube project key from the git origin remote URL via the server project-bindings API
+ */
+export async function discoverProjectKeyByGitRemote(
+  auth: ResolvedAuth,
+  gitRemote: string,
+): Promise<GitRemoteBindingDiscovery | null> {
+  try {
+    const client = new SonarQubeClient(auth.serverUrl, auth.token);
+    const projectKey = await client.getProjectKeyByGitRemote(gitRemote, auth.orgKey);
+    if (!projectKey) {
+      return null;
+    }
+    return {
+      projectKey,
+      serverUrl: auth.serverUrl,
+      organization: auth.orgKey,
+    };
+  } catch (error) {
+    logger.debug(`Git remote project binding lookup failed: ${(error as Error).message}`);
+    return null;
+  }
+}

--- a/src/lib/project-workspace/project-info.ts
+++ b/src/lib/project-workspace/project-info.ts
@@ -24,9 +24,15 @@ import { existsSync, statSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 
 import { print } from '../../ui';
+import type { ResolvedAuth } from '../auth-resolver';
+import { resolveAuth } from '../auth-resolver';
 import { canonicalizePath } from '../fs-utils';
 import logger from '../logger';
 import { spawnProcess } from '../process';
+import {
+  discoverProjectKeyByGitRemote,
+  GIT_REMOTE_BINDING_SOURCE,
+} from './discover-project-by-remote';
 import { loadSonarLintConfig, type SonarLintConfig } from './sonarlint-connected-mode';
 
 export interface ProjectInfo {
@@ -50,6 +56,13 @@ export interface DiscoveredProject {
   projectKey?: string;
   /** Config files that contributed to the discovered project, in order found. */
   configSources: string[];
+}
+
+export interface DiscoverProjectOptions {
+  /** When set, used for git-remote binding lookup instead of resolving auth again. */
+  auth?: ResolvedAuth | null;
+  /** When false, skips server lookup even if a git remote is present. Defaults to true. */
+  tryGitRemoteBinding?: boolean;
 }
 
 export interface SonarProperties {
@@ -140,6 +153,7 @@ export async function discoverProjectInfo(startDir: string): Promise<ProjectInfo
 export async function discoverProject(
   startDir: string,
   silent = false,
+  options: DiscoverProjectOptions = {},
 ): Promise<DiscoveredProject> {
   const projectInfo = await discoverProjectInfo(startDir);
   const config: DiscoveredProject = {
@@ -182,7 +196,45 @@ export async function discoverProject(
     }
   }
 
+  await applyGitRemoteBindingFromRemote(config, projectInfo, options, silent);
+
   return config;
+}
+
+async function applyGitRemoteBindingFromRemote(
+  config: DiscoveredProject,
+  projectInfo: ProjectInfo,
+  options: DiscoverProjectOptions,
+  silent: boolean,
+): Promise<void> {
+  const tryGitRemoteBinding = options.tryGitRemoteBinding !== false;
+  if (!tryGitRemoteBinding || config.projectKey || !projectInfo.gitRemote) {
+    return;
+  }
+
+  const auth = options.auth === undefined ? await resolveAuth() : options.auth;
+  if (!auth) {
+    return;
+  }
+
+  const remoteBinding = await discoverProjectKeyByGitRemote(auth, projectInfo.gitRemote);
+  if (!remoteBinding) {
+    return;
+  }
+
+  config.configSources.push(GIT_REMOTE_BINDING_SOURCE);
+  config.serverUrl = config.serverUrl || remoteBinding.serverUrl;
+  config.projectKey = remoteBinding.projectKey;
+  config.organization = config.organization || remoteBinding.organization;
+
+  if (silent) {
+    return;
+  }
+
+  const fields = formatConfigFields(config.serverUrl, config.projectKey, config.organization);
+  if (fields) {
+    print(`Found ${GIT_REMOTE_BINDING_SOURCE}: ${fields}`);
+  }
 }
 
 function formatConfigFields(

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -518,7 +518,12 @@ export class SonarQubeClient {
     if (!result.response.ok) {
       return null;
     }
-    return result.value?.components[0]?.key ?? null;
+    const components = result.value?.components;
+    if (!Array.isArray(components) || components.length === 0) {
+      return null;
+    }
+    const projectKey = components[0].key;
+    return projectKey || null;
   }
 
   /**

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -25,6 +25,7 @@ import { isSonarQubeCloud, resolveFromEndpoint } from '../lib/auth-resolver';
 import logger from '../lib/logger';
 import { print } from '../ui';
 import { RateLimitError, ServiceUnavailableError } from './errors';
+import { stripGitRemoteUrlUserinfo } from './git-remote-url';
 import type { SettingsValue } from './settings-value';
 
 const GET_REQUEST_TIMEOUT_MS = 30000; // 30 seconds
@@ -454,6 +455,73 @@ export class SonarQubeClient {
   }
 
   /**
+   * Resolve a project key from a git repository remote URL using server-side bindings.
+   * SonarQube Server: GET /api/v2/dop-translation/project-bindings
+   * SonarQube Cloud: GET /dop-translation/project-bindings, then search_projects by project id.
+   */
+  async getProjectKeyByGitRemote(remoteUrl: string, orgKey?: string): Promise<string | null> {
+    const sanitizedRemoteUrl = stripGitRemoteUrlUserinfo(remoteUrl);
+    if (this.isCloud) {
+      if (!orgKey) {
+        return null;
+      }
+      const projectId = await this.getSqcProjectIdByRemoteUrl(sanitizedRemoteUrl);
+      if (!projectId) {
+        return null;
+      }
+      return this.getSonarCloudProjectKeyById(projectId, orgKey);
+    }
+    const binding = await this.getSqsProjectBindingByRemoteUrl(sanitizedRemoteUrl);
+    return binding?.projectKey ?? null;
+  }
+
+  private async getSqsProjectBindingByRemoteUrl(
+    remoteUrl: string,
+  ): Promise<{ projectKey: string } | null> {
+    const endpoint = `/api/v2/dop-translation/project-bindings?repositoryUrl=${encodeURIComponent(remoteUrl)}`;
+    const result = await this.getSafe<{
+      projectBindings: Array<{ projectId: string; projectKey: string }>;
+    }>(endpoint);
+    if (!result.response.ok) {
+      return null;
+    }
+    const binding = requireSingleBinding(
+      result.value?.projectBindings,
+      'git remote on SonarQube Server',
+    );
+    return binding?.projectKey ? { projectKey: binding.projectKey } : null;
+  }
+
+  private async getSqcProjectIdByRemoteUrl(remoteUrl: string): Promise<string | null> {
+    const endpoint = `/dop-translation/project-bindings?url=${encodeURIComponent(remoteUrl)}`;
+    const apiHost = resolveFromEndpoint(this.serverURL, endpoint);
+    const result = await this.getSafe<{ bindings: Array<{ projectId: string }> }>(
+      endpoint,
+      undefined,
+      apiHost,
+    );
+    if (!result.response.ok) {
+      return null;
+    }
+    const binding = requireSingleBinding(result.value?.bindings, 'git remote on SonarQube Cloud');
+    return binding?.projectId ?? null;
+  }
+
+  private async getSonarCloudProjectKeyById(
+    projectId: string,
+    orgKey: string,
+  ): Promise<string | null> {
+    const result = await this.getSafe<{ components: Array<{ key: string }> }>(
+      '/api/components/search_projects',
+      { projectIds: projectId, organization: orgKey },
+    );
+    if (!result.response.ok) {
+      return null;
+    }
+    return result.value?.components[0]?.key ?? null;
+  }
+
+  /**
    * Check if component (project) exists
    */
   async checkComponent(projectKey: string): Promise<boolean> {
@@ -539,6 +607,20 @@ export class SonarQubeClient {
       resolveFromEndpoint(this.serverURL, endpoint),
     );
   }
+}
+
+/** Returns the sole binding, or null when there are none or more than one (ambiguous). */
+function requireSingleBinding<T>(bindings: T[] | undefined, context: string): T | null {
+  if (!bindings?.length) {
+    return null;
+  }
+  if (bindings.length > 1) {
+    logger.debug(
+      `Multiple project bindings (${bindings.length}) for ${context}; skipping ambiguous git remote auto-discovery`,
+    );
+    return null;
+  }
+  return bindings[0];
 }
 
 function redactSensitiveHeaders(headers: Record<string, string>): Record<string, string> {

--- a/src/sonarqube/git-remote-url.ts
+++ b/src/sonarqube/git-remote-url.ts
@@ -18,21 +18,22 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export {
-  discoverProjectKeyByGitRemote,
-  GIT_REMOTE_BINDING_SOURCE,
-  type GitRemoteBindingDiscovery,
-} from './discover-project-by-remote';
-export {
-  type DiscoveredProject,
-  discoverOrganization,
-  discoverProject,
-  discoverProjectInfo,
-  type DiscoverProjectOptions,
-  discoverServer,
-  findGitRoot,
-  type ProjectInfo,
-  type SonarLintConfig,
-  type SonarProperties,
-} from './project-info';
-export { loadSonarLintConfig, type ResolvedSonarLintConfig } from './sonarlint-connected-mode';
+/**
+ * Strip embedded credentials from a git remote URL before sending it to SonarQube.
+ * HTTPS remotes may include userinfo (e.g. https://user:token@host/...); those must not
+ * appear in server request logs.
+ */
+export function stripGitRemoteUrlUserinfo(remoteUrl: string): string {
+  try {
+    const parsed = new URL(remoteUrl);
+    if (!parsed.username && !parsed.password) {
+      return remoteUrl;
+    }
+    parsed.username = '';
+    parsed.password = '';
+    return parsed.toString();
+  } catch {
+    // SCP-style remotes (git@host:path) and other non-URL forms are returned unchanged.
+    return remoteUrl;
+  }
+}

--- a/tests/unit/lib/project-workspace/project-info.test.ts
+++ b/tests/unit/lib/project-workspace/project-info.test.ts
@@ -33,7 +33,9 @@ import {
   discoverProject,
   discoverProjectInfo,
   discoverServer,
+  GIT_REMOTE_BINDING_SOURCE,
 } from '../../../../src/lib/project-workspace';
+import * as discoverByRemote from '../../../../src/lib/project-workspace/discover-project-by-remote';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../src/ui';
 
 async function withCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
@@ -343,6 +345,81 @@ describe('discoverProject', () => {
       'sonar-project.properties',
       join('.sonarlint', 'connectedMode.json'),
     ]);
+  });
+
+  it('resolves projectKey from git remote when authenticated and no local project key', async () => {
+    mkdirSync(join(testDir, '.git'), { recursive: true });
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
+      exitCode: 0,
+      stdout: 'https://github.com/example/remote-bound.git',
+      stderr: '',
+    });
+    const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+      projectKey: 'from-remote',
+      serverUrl: 'https://sonarcloud.io',
+      organization: 'my-org',
+    });
+
+    try {
+      const result = await discoverProject(testDir, false, {
+        auth: {
+          token: 'token',
+          serverUrl: 'https://sonarcloud.io',
+          orgKey: 'my-org',
+          connectionType: 'cloud',
+        },
+      });
+      expect(result.projectKey).toBe('from-remote');
+      expect(result.organization).toBe('my-org');
+      expect(result.configSources).toEqual([GIT_REMOTE_BINDING_SOURCE]);
+      expect(remoteSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ orgKey: 'my-org' }),
+        'https://github.com/example/remote-bound.git',
+      );
+    } finally {
+      spawnSpy.mockRestore();
+      remoteSpy.mockRestore();
+    }
+  });
+
+  it('does not call git remote lookup when projectKey is already in local config', async () => {
+    mkdirSync(join(testDir, '.git'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=local_key\n',
+    );
+    const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+      projectKey: 'from-remote',
+      serverUrl: 'https://sonarcloud.io',
+    });
+
+    try {
+      const result = await discoverProject(testDir, false, {
+        auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+      });
+      expect(result.projectKey).toBe('local_key');
+      expect(remoteSpy).not.toHaveBeenCalled();
+    } finally {
+      remoteSpy.mockRestore();
+    }
+  });
+
+  it('skips git remote lookup when tryGitRemoteBinding is false', async () => {
+    mkdirSync(join(testDir, '.git'), { recursive: true });
+    const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+      projectKey: 'from-remote',
+      serverUrl: 'https://sonarcloud.io',
+    });
+
+    try {
+      await discoverProject(testDir, true, {
+        auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+        tryGitRemoteBinding: false,
+      });
+      expect(remoteSpy).not.toHaveBeenCalled();
+    } finally {
+      remoteSpy.mockRestore();
+    }
   });
 });
 

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -1189,6 +1189,7 @@ describe('SonarQubeClient', () => {
         '/api/components/search_projects?',
       );
       expect((fetchSpy.mock.calls[1][0] as URL).toString()).toContain('organization=my-org');
+      expect((fetchSpy.mock.calls[1][0] as URL).toString()).toContain('projectIds=proj%3Aabc');
     });
 
     it('returns null on SonarCloud when organization is missing', async () => {
@@ -1254,6 +1255,26 @@ describe('SonarQubeClient', () => {
           status: 403,
           statusText: 'Forbidden',
           json: () => Promise.resolve({ message: 'Insufficient privileges' }),
+        } as Response);
+
+      expect(await cloudClient.getProjectKeyByGitRemote(remoteUrl, 'my-org')).toBeNull();
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns null when SonarCloud search_projects omits components', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ bindings: [{ projectId: 'proj:abc' }] }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({}),
         } as Response);
 
       expect(await cloudClient.getProjectKeyByGitRemote(remoteUrl, 'my-org')).toBeNull();

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -1108,4 +1108,156 @@ describe('SonarQubeClient', () => {
       ).rejects.toThrow('403');
     });
   });
+
+  describe('getProjectKeyByGitRemote', () => {
+    const remoteUrl = 'https://github.com/foo/bar.git';
+
+    it('returns projectKey from SQS project-bindings API', async () => {
+      fetchSpy = mockFetch({
+        projectBindings: [{ projectId: 'proj:123', projectKey: 'my-project' }],
+      });
+      const key = await client.getProjectKeyByGitRemote(remoteUrl);
+      expect(key).toBe('my-project');
+      expect(lastFetchUrl(fetchSpy)).toBe(
+        `${SERVER_URL}/api/v2/dop-translation/project-bindings?repositoryUrl=${encodeURIComponent(remoteUrl)}`,
+      );
+    });
+
+    it('returns null when SQS has no bindings', async () => {
+      fetchSpy = mockFetch({ projectBindings: [] });
+      expect(await client.getProjectKeyByGitRemote(remoteUrl)).toBeNull();
+    });
+
+    it('returns null when SQS has multiple bindings', async () => {
+      fetchSpy = mockFetch({
+        projectBindings: [
+          { projectId: 'proj:1', projectKey: 'project-a' },
+          { projectId: 'proj:2', projectKey: 'project-b' },
+        ],
+      });
+      expect(await client.getProjectKeyByGitRemote(remoteUrl)).toBeNull();
+    });
+
+    it('strips embedded credentials from the remote before calling SQS', async () => {
+      const remoteWithCredentials = 'https://user:token@github.com/foo/bar.git';
+      const sanitizedRemote = 'https://github.com/foo/bar.git';
+      fetchSpy = mockFetch({
+        projectBindings: [{ projectId: 'proj:123', projectKey: 'my-project' }],
+      });
+      const key = await client.getProjectKeyByGitRemote(remoteWithCredentials);
+      expect(key).toBe('my-project');
+      expect(lastFetchUrl(fetchSpy)).toBe(
+        `${SERVER_URL}/api/v2/dop-translation/project-bindings?repositoryUrl=${encodeURIComponent(sanitizedRemote)}`,
+      );
+    });
+
+    it('returns null when SQS project-bindings request fails', async () => {
+      fetchSpy = mockFetch({ message: 'not found' }, false, 404);
+      expect(await client.getProjectKeyByGitRemote(remoteUrl)).toBeNull();
+    });
+
+    it('returns null when SQS binding has no projectKey', async () => {
+      fetchSpy = mockFetch({
+        projectBindings: [{ projectId: 'proj:123', projectKey: '' }],
+      });
+      expect(await client.getProjectKeyByGitRemote(remoteUrl)).toBeNull();
+    });
+
+    it('resolves SonarCloud project key via bindings then search_projects', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ bindings: [{ projectId: 'proj:abc' }] }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () =>
+            Promise.resolve({ components: [{ key: 'cloud-project-key', name: 'Cloud Project' }] }),
+        } as Response);
+
+      const key = await cloudClient.getProjectKeyByGitRemote(remoteUrl, 'my-org');
+      expect(key).toBe('cloud-project-key');
+      expect((fetchSpy.mock.calls[0][0] as URL).toString()).toBe(
+        `${SONARCLOUD_API_URL}/dop-translation/project-bindings?url=${encodeURIComponent(remoteUrl)}`,
+      );
+      expect((fetchSpy.mock.calls[1][0] as URL).toString()).toContain(
+        '/api/components/search_projects?',
+      );
+      expect((fetchSpy.mock.calls[1][0] as URL).toString()).toContain('organization=my-org');
+    });
+
+    it('returns null on SonarCloud when organization is missing', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = mockFetch({ bindings: [{ projectId: 'proj:abc' }] });
+      expect(await cloudClient.getProjectKeyByGitRemote(remoteUrl)).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns null when SonarCloud has multiple bindings', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = mockFetch({
+        bindings: [{ projectId: 'proj:a' }, { projectId: 'proj:b' }],
+      });
+      expect(await cloudClient.getProjectKeyByGitRemote(remoteUrl, 'my-org')).toBeNull();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('strips embedded credentials from the remote before calling SonarCloud', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      const remoteWithCredentials = 'https://user:token@github.com/foo/bar.git';
+      const sanitizedRemote = 'https://github.com/foo/bar.git';
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ bindings: [{ projectId: 'proj:abc' }] }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () =>
+            Promise.resolve({ components: [{ key: 'cloud-project-key', name: 'Cloud Project' }] }),
+        } as Response);
+
+      const key = await cloudClient.getProjectKeyByGitRemote(remoteWithCredentials, 'my-org');
+      expect(key).toBe('cloud-project-key');
+      expect((fetchSpy.mock.calls[0][0] as URL).toString()).toBe(
+        `${SONARCLOUD_API_URL}/dop-translation/project-bindings?url=${encodeURIComponent(sanitizedRemote)}`,
+      );
+    });
+
+    it('returns null when SonarCloud project-bindings request fails', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = mockFetch({ message: 'not found' }, false, 404);
+      expect(await cloudClient.getProjectKeyByGitRemote(remoteUrl, 'my-org')).toBeNull();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns null when SonarCloud search_projects request fails', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: () => Promise.resolve({ bindings: [{ projectId: 'proj:abc' }] }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          json: () => Promise.resolve({ message: 'Insufficient privileges' }),
+        } as Response);
+
+      expect(await cloudClient.getProjectKeyByGitRemote(remoteUrl, 'my-org')).toBeNull();
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/tests/unit/sonarqube/git-remote-url.test.ts
+++ b/tests/unit/sonarqube/git-remote-url.test.ts
@@ -1,0 +1,47 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { stripGitRemoteUrlUserinfo } from '../../../src/sonarqube/git-remote-url.js';
+
+describe('stripGitRemoteUrlUserinfo', () => {
+  it('removes username and password from https remotes', () => {
+    expect(stripGitRemoteUrlUserinfo('https://user:token@github.com/foo/bar.git')).toBe(
+      'https://github.com/foo/bar.git',
+    );
+  });
+
+  it('removes username-only userinfo from https remotes', () => {
+    expect(stripGitRemoteUrlUserinfo('https://user@github.com/foo/bar.git')).toBe(
+      'https://github.com/foo/bar.git',
+    );
+  });
+
+  it('returns the original string when there is no userinfo', () => {
+    const remote = 'https://github.com/foo/bar.git';
+    expect(stripGitRemoteUrlUserinfo(remote)).toBe(remote);
+  });
+
+  it('returns scp-style remotes unchanged', () => {
+    const remote = 'git@github.com:foo/bar.git';
+    expect(stripGitRemoteUrlUserinfo(remote)).toBe(remote);
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Project discovery:**
  - Added auto-discovery of project keys via git remote URL when local configuration is missing.
  - Implemented logic to query SonarQube Server and SonarCloud for repository-to-project bindings.
- **API client changes:**
  - Added `getProjectKeyByGitRemote` to `SonarQubeClient` to handle binding lookups.
  - Implemented `stripGitRemoteUrlUserinfo` to sanitize remote URLs before sending them to the server.
- **Refactoring:**
  - Updated CLI commands (`integrate`, `remediate`, `mcp`) to pass authentication state into `discoverProject`.
  - Added `DiscoverProjectOptions` to control git remote lookup behavior.


<sub>This will update automatically on new commits.</sub>