### PR TITLE
CLI-598 Git hook pre-commit framework delegates to sonar hook subcommands

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -495,7 +495,8 @@ hookCommand
 hookCommand
   .command('git-pre-commit')
   .description('git pre-commit handler: scan staged files for secrets')
-  .anonymousAction(() => gitPreCommit());
+  .argument('[files...]', 'Changed files passed by pre-commit (pass_filenames: true)')
+  .anonymousAction((files: string[]) => gitPreCommit(files));
 
 hookCommand
   .command('git-pre-push')
@@ -507,7 +508,8 @@ hookCommand
     '--dependency-risks',
     'Also run a dependency-risks scan after the secrets scan (requires -p)',
   )
-  .anonymousAction((options: GitPrePushOptions) => gitPrePush(options));
+  .argument('[files...]', 'Changed files passed by pre-commit (pass_filenames: true)')
+  .anonymousAction((files: string[], options: GitPrePushOptions) => gitPrePush(options, files));
 
 // Hidden flush command — only registered when running as a telemetry worker.
 if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {

--- a/src/cli/commands/hook/git-pre-commit.ts
+++ b/src/cli/commands/hook/git-pre-commit.ts
@@ -27,8 +27,8 @@ import { CommandFailedError } from '../_common/error';
 import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
 import { handleScanError, resolveAuthAndSecrets } from './hook-dependencies';
 
-export async function gitPreCommit(): Promise<void> {
-  const stagedFiles = await getStagedFiles();
+export async function gitPreCommit(files: string[] = []): Promise<void> {
+  const stagedFiles = files.length > 0 ? files : await getStagedFiles();
   if (stagedFiles.length === 0) return;
 
   const deps = await resolveAuthAndSecrets();

--- a/src/cli/commands/hook/git-pre-push-secrets.ts
+++ b/src/cli/commands/hook/git-pre-push-secrets.ts
@@ -22,29 +22,14 @@ import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import { CommandFailedError } from '../_common/error';
 import { resolveSecretsBinaryPath } from '../_common/install/secrets';
 import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
-import { GIT_NULL_OID } from './git-pre-push';
-import type { HookDependencies } from './hook-dependencies';
 import { handleScanError } from './hook-dependencies';
-import type { PushRef } from './stdin';
 
-export async function runSecretsStage(
-  filesByRef: Map<PushRef, string[]>,
-  auth: ResolvedAuth,
-): Promise<void> {
+export async function runSecretsStage(files: string[], auth: ResolvedAuth): Promise<void> {
   const binaryPath = resolveSecretsBinaryPath();
   if (!binaryPath) return;
-  const deps: HookDependencies = { auth, binaryPath };
-
-  for (const [ref, files] of filesByRef) {
-    if (ref.localSha === GIT_NULL_OID) continue;
-    if (files.length === 0) continue;
-    await scanRef(files, deps);
-  }
-}
-
-async function scanRef(files: string[], deps: HookDependencies): Promise<void> {
+  if (files.length === 0) return;
   try {
-    const result = await runSecretsBinary(deps.binaryPath, files, deps.auth);
+    const result = await runSecretsBinary(binaryPath, files, auth);
     if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
       throw new CommandFailedError('Secrets detected in pushed commits.', {
         remediationHint:

--- a/src/cli/commands/hook/git-pre-push.ts
+++ b/src/cli/commands/hook/git-pre-push.ts
@@ -49,8 +49,8 @@ export async function gitPrePush(
   const auth = await resolveAuth().catch(() => null);
   if (!auth) return;
 
-  const changedFiles = await getFilesToScan(files);
-  if (changedFiles === null) return;
+  const fileGroups = await getFileGroupsToScan(files);
+  if (fileGroups === null) return;
 
   if (await hasUncommittedChanges()) {
     warn(
@@ -58,25 +58,35 @@ export async function gitPrePush(
     );
   }
 
-  await runSecretsStage(changedFiles, auth);
+  for (const group of fileGroups) {
+    await runSecretsStage(group, auth);
+  }
 
   if (options.dependencyRisks && options.project) {
+    const changedFiles = [...new Set(fileGroups.flat())];
     await runDepRisksStage({ project: options.project, changedFiles, auth });
   }
 }
 
-async function getFilesToScan(files: string[]) {
+async function getFileGroupsToScan(files: string[]): Promise<string[][] | null> {
   if (files.length > 0) {
-    return files;
-  } else {
-    const refs = await readGitPushRefs();
-    if (refs.length === 0) return null;
-
-    const emptyTree = await getEmptyTree();
-    const nonDeletionRefs = refs.filter((ref) => ref.localSha !== GIT_NULL_OID);
-    const filesByRef = await collectFilesForRefs(nonDeletionRefs, emptyTree);
-    return [...new Set(Array.from(filesByRef.values()).flat())];
+    /*
+     * pre-commit framework pre-chunks files before calling our tool in parallel.
+     * This is suboptimal for SCA analysis, as it may be triggered multiple times for the same changes.
+     * However, there's no easy solution, as the pre-commit framework can't pass all files at once due to ARG_MAX limits
+     * and there's no support for stdin.
+     */
+    return [files];
   }
+
+  const refs = await readGitPushRefs();
+  if (refs.length === 0) return null;
+
+  const emptyTree = await getEmptyTree();
+  const nonDeletionRefs = refs.filter((ref) => ref.localSha !== GIT_NULL_OID);
+  const filesByRef = await collectFilesForRefs(nonDeletionRefs, emptyTree);
+  const groups = Array.from(filesByRef.values()).filter((g) => g.length > 0);
+  return groups.length > 0 ? groups : null;
 }
 
 async function getEmptyTree(): Promise<string> {

--- a/src/cli/commands/hook/git-pre-push.ts
+++ b/src/cli/commands/hook/git-pre-push.ts
@@ -38,7 +38,10 @@ export interface GitPrePushOptions {
   dependencyRisks?: boolean;
 }
 
-export async function gitPrePush(options: GitPrePushOptions = {}): Promise<void> {
+export async function gitPrePush(
+  options: GitPrePushOptions = {},
+  files: string[] = [],
+): Promise<void> {
   if (options.dependencyRisks && !options.project) {
     throw new InvalidOptionError('--dependency-risks requires -p <projectKey>.');
   }
@@ -46,11 +49,8 @@ export async function gitPrePush(options: GitPrePushOptions = {}): Promise<void>
   const auth = await resolveAuth().catch(() => null);
   if (!auth) return;
 
-  const refs = await readGitPushRefs();
-  if (refs.length === 0) return;
-
-  const emptyTree = await getEmptyTree();
-  const filesByRef = await collectFilesForRefs(refs, emptyTree);
+  const changedFiles = await getFilesToScan(files);
+  if (changedFiles === null) return;
 
   if (await hasUncommittedChanges()) {
     warn(
@@ -58,11 +58,24 @@ export async function gitPrePush(options: GitPrePushOptions = {}): Promise<void>
     );
   }
 
-  await runSecretsStage(filesByRef, auth);
+  await runSecretsStage(changedFiles, auth);
 
   if (options.dependencyRisks && options.project) {
-    const changedFiles = Array.from(filesByRef.values()).flat();
     await runDepRisksStage({ project: options.project, changedFiles, auth });
+  }
+}
+
+async function getFilesToScan(files: string[]) {
+  if (files.length > 0) {
+    return files;
+  } else {
+    const refs = await readGitPushRefs();
+    if (refs.length === 0) return null;
+
+    const emptyTree = await getEmptyTree();
+    const nonDeletionRefs = refs.filter((ref) => ref.localSha !== GIT_NULL_OID);
+    const filesByRef = await collectFilesForRefs(nonDeletionRefs, emptyTree);
+    return [...new Set(Array.from(filesByRef.values()).flat())];
   }
 }
 
@@ -81,10 +94,6 @@ async function collectFilesForRefs(
 ): Promise<Map<PushRef, string[]>> {
   const out = new Map<PushRef, string[]>();
   for (const ref of refs) {
-    if (ref.localSha === GIT_NULL_OID) {
-      out.set(ref, []);
-      continue;
-    }
     out.set(ref, await getFilesForRef(ref, emptyTree));
   }
   return out;
@@ -149,8 +158,8 @@ async function getFilesForNewBranch(localSha: string, emptyTree: string): Promis
 
 export async function hasUncommittedChanges(): Promise<boolean> {
   try {
-    const result = await spawnProcess('git', ['status', '--porcelain', '-uno']);
-    return result.stdout.trim().length > 0;
+    const result = await spawnProcess('git', ['diff', '--quiet', 'HEAD']);
+    return result.exitCode !== 0;
   } catch {
     return false;
   }

--- a/src/cli/commands/integrate/git/tools/pre-commit/config.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/config.ts
@@ -55,11 +55,11 @@ export interface PreCommitConfig {
   [key: string]: unknown;
 }
 
-function buildSonarPreCommitHook(stage: GitHookType): PreCommitHookEntry {
+function buildSonarHook(stage: GitHookType): PreCommitHookEntry {
   return {
     id: PRE_COMMIT_SONAR_HOOK_ID,
-    name: 'Sonar secrets scan',
-    entry: 'sonar analyze secrets --',
+    name: `Sonar ${stage} scan`,
+    entry: `sonar hook git-${stage}`,
     language: 'system',
     pass_filenames: true,
     stages: [stage],
@@ -127,16 +127,16 @@ export function removeSonarHooksFromPreCommitConfig(document: unknown): PreCommi
   return config;
 }
 
-/** Upserts the sonar-secrets hook into the local repo entry of a config object. */
+/** Upserts the sonar hook for the given stage into the local repo entry of a config object. */
 export function upsertSonarHook(config: PreCommitConfig, stage: GitHookType): void {
-  const sonarHook = buildSonarPreCommitHook(stage);
+  const hook = buildSonarHook(stage);
   const localRepo = findLocalRepo(config);
   if (localRepo) {
     const index = localRepo.hooks.findIndex(isSonarHookEntry);
     const idx = index >= 0 ? index : localRepo.hooks.length;
-    localRepo.hooks[idx] = sonarHook;
+    localRepo.hooks[idx] = hook;
   } else {
-    config.repos.push({ repo: 'local', hooks: [sonarHook] });
+    config.repos.push({ repo: 'local', hooks: [hook] });
   }
 }
 

--- a/tests/integration/specs/hook/hook-git-pre-push.test.ts
+++ b/tests/integration/specs/hook/hook-git-pre-push.test.ts
@@ -290,6 +290,110 @@ describe('sonar hook git-pre-push', () => {
     { timeout: 30000 },
   );
 
+  describe('files mode (pre-commit framework)', () => {
+    it(
+      'exits 0 when no files are passed',
+      async () => {
+        const result = await harness.run('hook git-pre-push');
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when not authenticated (graceful skip)',
+      async () => {
+        harness.state().withSecretsBinaryInstalled();
+        harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
+        const result = await harness.run('hook git-pre-push clean.js');
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when binary is not installed (graceful skip)',
+      async () => {
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN);
+        harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
+        const result = await harness.run('hook git-pre-push clean.js');
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits 0 when file is clean',
+      async () => {
+        harness.state().withSecretsBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN);
+        harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
+
+        const result = await harness.run('hook git-pre-push clean.js');
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'exits 1 when a passed file contains a secret',
+      async () => {
+        harness.state().withSecretsBinaryInstalled();
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN);
+        harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
+
+        const result = await harness.run('hook git-pre-push secret.js');
+        expect(result.exitCode).toBe(1);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'exits 1 when binary spawn fails with env-based auth (CI mode, fail hard)',
+      async () => {
+        const binaryName = buildLocalBinaryName(detectPlatform());
+        harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
+        chmodSync(harness.cliHome.file('bin', binaryName).path, NON_EXECUTABLE_MODE);
+
+        harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
+
+        const result = await harness.run('hook git-pre-push clean.js', {
+          extraEnv: { SONARQUBE_CLI_TOKEN: VALID_TOKEN, SONARQUBE_CLI_SERVER: FAKE_SERVER },
+        });
+
+        expect(result.exitCode).toBe(1);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'exits 0 when binary spawn fails with keychain auth (local mode, fail soft)',
+      async () => {
+        const binaryName = buildLocalBinaryName(detectPlatform());
+        harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
+        chmodSync(harness.cliHome.file('bin', binaryName).path, NON_EXECUTABLE_MODE);
+
+        harness.withAuth(FAKE_SERVER, VALID_TOKEN);
+        harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
+
+        const result = await harness.run('hook git-pre-push clean.js');
+        expect(result.exitCode).toBe(0);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'exits 2 when --dependency-risks is set without -p',
+      async () => {
+        harness.cwd.writeFile('package.json', PACKAGE_JSON_CONTENT);
+        const result = await harness.run('hook git-pre-push --dependency-risks package.json');
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain('-p');
+      },
+      { timeout: 15000 },
+    );
+  });
+
   describe('with --dependency-risks', () => {
     it(
       'exits 0 when stdin is empty (no refs)',

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -146,7 +146,7 @@ type InstalledFeatureJson = InstalledIntegrationJson['features'][number];
 type PreCommitYamlConfig = {
   repos: Array<{
     repo: string;
-    hooks: Array<{ id: string; stages?: string[] }>;
+    hooks: Array<{ id: string; stages?: string[]; entry?: string; pass_filenames?: boolean }>;
   }>;
 };
 
@@ -822,6 +822,8 @@ describe('integrate git (pre-commit framework)', () => {
       const localRepo = config.repos.find((repo) => repo.repo === 'local');
       const sonarHook = localRepo?.hooks.find((hook) => hook.id === 'sonar-secrets');
       expect(sonarHook?.stages).toEqual(['pre-push']);
+      expect(sonarHook?.entry).toBe('sonar hook git-pre-push');
+      expect(sonarHook?.pass_filenames).toBe(true);
       expect(readCommandLog(preCommitLog)).toEqual([
         'uninstall',
         'clean',

--- a/tests/unit/cli/commands/hook/git.test.ts
+++ b/tests/unit/cli/commands/hook/git.test.ts
@@ -277,14 +277,15 @@ describe('gitPrePush', () => {
     await gitPrePush(); // must not throw
   });
 
-  it('continues scanning remaining refs after crash with keychain auth (fail soft)', async () => {
+  it('merges files from multiple refs into a single secrets binary invocation', async () => {
     const secondRef = { ...FAKE_REF, localSha: 'def456' };
     readGitPushRefsSpy.mockResolvedValue([FAKE_REF, secondRef]);
-    runSecretsBinarySpy.mockRejectedValue(new Error('binary crashed'));
 
     await gitPrePush();
 
-    expect(runSecretsBinarySpy).toHaveBeenCalledTimes(2);
+    expect(runSecretsBinarySpy).toHaveBeenCalledTimes(1);
+    const [, files] = runSecretsBinarySpy.mock.calls[0] as [string, string[], unknown];
+    expect(files).toEqual(['src/foo.ts', 'src/bar.ts']);
   });
 
   it('proceeds normally when git mktree throws (falls back to null OID as empty tree)', async () => {

--- a/tests/unit/cli/commands/hook/git.test.ts
+++ b/tests/unit/cli/commands/hook/git.test.ts
@@ -277,15 +277,17 @@ describe('gitPrePush', () => {
     await gitPrePush(); // must not throw
   });
 
-  it('merges files from multiple refs into a single secrets binary invocation', async () => {
+  it('calls the secrets binary once per ref group', async () => {
     const secondRef = { ...FAKE_REF, localSha: 'def456' };
     readGitPushRefsSpy.mockResolvedValue([FAKE_REF, secondRef]);
 
     await gitPrePush();
 
-    expect(runSecretsBinarySpy).toHaveBeenCalledTimes(1);
-    const [, files] = runSecretsBinarySpy.mock.calls[0] as [string, string[], unknown];
-    expect(files).toEqual(['src/foo.ts', 'src/bar.ts']);
+    expect(runSecretsBinarySpy).toHaveBeenCalledTimes(2);
+    for (const call of runSecretsBinarySpy.mock.calls) {
+      const [, files] = call as [string, string[], unknown];
+      expect(files).toEqual(['src/foo.ts', 'src/bar.ts']);
+    }
   });
 
   it('proceeds normally when git mktree throws (falls back to null OID as empty tree)', async () => {

--- a/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
@@ -24,7 +24,9 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import yaml from 'js-yaml';
 
+import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error';
 import {
+  activatePreCommitFramework,
   hasSonarHookInPreCommitConfig,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,
@@ -92,29 +94,39 @@ describe('removeLegacyHook', () => {
 });
 
 describe('upsertSonarHook', () => {
+  it('writes the correct hook shape for pre-commit stage', () => {
+    const config: PreCommitConfig = { repos: [] };
+    upsertSonarHook(config, 'pre-commit');
+    const hook = config.repos.find((r) => r.repo === 'local')?.hooks[0];
+    expect(hook).toEqual({
+      id: 'sonar-secrets',
+      name: 'Sonar pre-commit scan',
+      entry: 'sonar hook git-pre-commit',
+      language: 'system',
+      pass_filenames: true,
+      stages: ['pre-commit'],
+    });
+  });
+
+  it('writes the correct hook shape for pre-push stage', () => {
+    const config: PreCommitConfig = { repos: [] };
+    upsertSonarHook(config, 'pre-push');
+    const hook = config.repos.find((r) => r.repo === 'local')?.hooks[0];
+    expect(hook).toEqual({
+      id: 'sonar-secrets',
+      name: 'Sonar pre-push scan',
+      entry: 'sonar hook git-pre-push',
+      language: 'system',
+      pass_filenames: true,
+      stages: ['pre-push'],
+    });
+  });
+
   it('creates a local repo with the sonar-secrets hook when no repos exist', () => {
     const config: PreCommitConfig = { repos: [] };
     upsertSonarHook(config, 'pre-commit');
     const localRepo = config.repos.find((r) => r.repo === 'local');
     expect(localRepo?.hooks.some((h) => h.id === 'sonar-secrets')).toBe(true);
-  });
-
-  it('sets stage to pre-commit', () => {
-    const config: PreCommitConfig = { repos: [] };
-    upsertSonarHook(config, 'pre-commit');
-    const hook = config.repos
-      .find((r) => r.repo === 'local')
-      ?.hooks.find((h) => h.id === 'sonar-secrets');
-    expect(hook?.stages).toEqual(['pre-commit']);
-  });
-
-  it('sets stage to pre-push', () => {
-    const config: PreCommitConfig = { repos: [] };
-    upsertSonarHook(config, 'pre-push');
-    const hook = config.repos
-      .find((r) => r.repo === 'local')
-      ?.hooks.find((h) => h.id === 'sonar-secrets');
-    expect(hook?.stages).toEqual(['pre-push']);
   });
 
   it('appends a local repo when only unrelated repos exist', () => {
@@ -163,6 +175,30 @@ describe('upsertSonarHook', () => {
     const sonarHooks = localRepo?.hooks.filter((h) => h.id === 'sonar-secrets');
     expect(sonarHooks).toHaveLength(1);
     expect(sonarHooks?.[0].stages).toEqual(['pre-commit']);
+  });
+
+  it('replaces the existing sonar-secrets hook in place for pre-push stage', () => {
+    const config: PreCommitConfig = {
+      repos: [
+        {
+          repo: 'local',
+          hooks: [
+            {
+              id: 'sonar-secrets',
+              name: 'old',
+              entry: 'old-entry',
+              language: 'system',
+              stages: ['pre-commit'],
+            },
+          ],
+        },
+      ],
+    };
+    upsertSonarHook(config, 'pre-push');
+    const localRepo = config.repos.find((r) => r.repo === 'local');
+    const hooks = localRepo?.hooks.filter((h) => h.id === 'sonar-secrets');
+    expect(hooks).toHaveLength(1);
+    expect(hooks?.[0].entry).toBe('sonar hook git-pre-push');
   });
 
   it('preserves top-level keys that are not repos', () => {
@@ -271,6 +307,62 @@ describe('runPreCommitInstall', () => {
       expect(runPreCommitInstall(TEMP_DIR, 'pre-commit')).rejects.toThrow(
         'pre-commit uninstall failed',
       );
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('throws CommandFailedError when spawnProcess rejects', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockRejectedValue(new Error('not found'));
+
+    try {
+      const err = await runPreCommitInstall(TEMP_DIR, 'pre-commit').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(CommandFailedError);
+      expect((err as CommandFailedError).message).toContain('Failed to run pre-commit [not found]');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+});
+
+describe('activatePreCommitFramework', () => {
+  it('succeeds when all pre-commit commands pass', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await activatePreCommitFramework(TEMP_DIR, 'pre-commit');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('throws CommandFailedError with remediation hint when commands fail (pre-commit stage)', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_FAIL);
+
+    try {
+      const err: unknown = await activatePreCommitFramework(TEMP_DIR, 'pre-commit').catch(
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(CommandFailedError);
+      expect((err as CommandFailedError).message).toContain(
+        'Updated .pre-commit-config.yaml but pre-commit commands failed.',
+      );
+      expect((err as CommandFailedError).remediationHint).toContain('pre-commit install');
+      expect((err as CommandFailedError).remediationHint).not.toContain('--hook-type pre-push');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('includes --hook-type pre-push in remediation hint for pre-push stage', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_FAIL);
+
+    try {
+      const err: unknown = await activatePreCommitFramework(TEMP_DIR, 'pre-push').catch(
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(CommandFailedError);
+      expect((err as CommandFailedError).remediationHint).toContain('--hook-type pre-push');
     } finally {
       spawnSpy.mockRestore();
     }


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **Pre-commit framework integration:**
  - Updated `upsertSonarHook` to delegate `pre-commit` and `pre-push` stages to specific `sonar hook` subcommands.
  - Configured `pass_filenames: true` for sonar hooks to allow direct file scanning via the framework.
- **CLI Command updates:**
  - Refactored `git-pre-commit` and `git-pre-push` to accept optional `[files...]` arguments for framework integration.
  - Added `getFilesToScan` logic to `git-pre-push` to support both explicit file lists and fallback git ref collection.
- **Logic refactoring:**
  - Optimized `hasUncommittedChanges` to use `git diff --quiet HEAD` instead of parsing `git status --porcelain`.
  - Consolidated file scanning for `git-pre-push` into a single binary invocation to improve performance.
- **Testing:**
  - Added comprehensive integration tests for `sonar hook git-pre-push` in file-scanning mode and unit tests for framework activation logic.

<sub>This will update automatically on new commits.</sub>