### PR TITLE
CLI-592 Wire Copilot CLI integration to interactive feature selection

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -206,6 +206,7 @@ integrateCommand
     'Install hooks and config globally to ~/.copilot instead of project directory',
   )
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
+  .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .option('--skip-context', 'Skip the sonar-context-augmentation install/init/skill step')
   .addHelpText('after', projectKeyExtraHelp)
   .authenticatedAction((auth, options: IntegrateAgentOptions) => integrateCopilot(auth, options));
@@ -235,6 +236,7 @@ integrateCommand
     'Install hook and config globally to ~/.codex instead of project directory',
   )
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
+  .option('--non-interactive', 'Non-interactive mode (no prompts)')
   .option('--skip-context', 'Skip the sonar-context-augmentation install/init/skill step')
   .addHelpText('after', projectKeyExtraHelp)
   .authenticatedAction((auth, options: IntegrateAgentOptions) => integrateCodex(options, auth));

--- a/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
+++ b/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
@@ -25,6 +25,7 @@ import { getOptionalStringAttr } from '../attrs';
 import { printContextAugmentationSkill, runToolIntegrateCommand } from '../context-augmentation';
 import { contextAugmentationBinaryDependency } from '../registry/dependencies';
 import { wholeFile } from '../registry/resources';
+import { askUser, skip } from '../registry/selection';
 import type { FeatureDeclaration, IntegrationContext } from '../registry/types';
 
 export const CONTEXT_AUGMENTATION_FEATURE_ID = 'context-augmentation';
@@ -44,7 +45,7 @@ export function createContextAugmentationFeature<
     id: CONTEXT_AUGMENTATION_FEATURE_ID,
     displayName: `${options.agentDisplayName} Context Augmentation`,
     shouldInstall: ({ options: integrationOptions }) =>
-      integrationOptions.installContextAugmentation === true,
+      integrationOptions.installContextAugmentation === true ? askUser() : skip(),
     dependencies: [contextAugmentationBinaryDependency],
     resources: [
       wholeFile({

--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -48,9 +48,13 @@ export function sonarEndMarker(id: string): string {
 }
 
 /**
- * Shown when SQAA cannot be set up for the current connection.
+ * Shown when SQAA is not available for the current connection.
  */
 export const SQAA_PROMOTION_MESSAGE = `SonarQube Agentic Analysis is available on SonarQube Cloud. Learn more: ${AGENTIC_ANALYSIS_DOCS_URL}`;
+
+/** Shown when SQAA is available for the connection but cannot be set up because no project key could be resolved. */
+export const SQAA_MISSING_PROJECT_KEY_MESSAGE =
+  'Skipping SonarQube Agentic Analysis instructions because no project key could be resolved. Re-run with --project <key> or from a directory with a configured project.';
 
 export function buildSqaaSectionBody(projectKey: string): string {
   return `# SonarQube Agentic Analysis protocol

--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -28,6 +28,8 @@
 // instructions file (i.e. without clobbering anything the user appended
 // around it).
 
+import { AGENTIC_ANALYSIS_DOCS_URL } from '../../../../lib/config-constants';
+
 /**
  * Wrap a markdown body in stable HTML-comment markers. The `id` must remain
  * unique and stable across CLI versions — it is the only identifier we have
@@ -44,6 +46,11 @@ export function sonarBeginMarker(id: string): string {
 export function sonarEndMarker(id: string): string {
   return `<!-- sonar:end:${id} -->`;
 }
+
+/**
+ * Shown when SQAA cannot be set up for the current connection.
+ */
+export const SQAA_PROMOTION_MESSAGE = `SonarQube Agentic Analysis is available on SonarQube Cloud. Learn more: ${AGENTIC_ANALYSIS_DOCS_URL}`;
 
 export function buildSqaaSectionBody(projectKey: string): string {
   return `# SonarQube Agentic Analysis protocol

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -22,7 +22,7 @@
 
 import { homedir } from 'node:os';
 
-import type { ResolvedAuth } from '../../../../lib/auth-resolver';
+import { isEnvBasedAuth, type ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
 import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
 import { intro, warn } from '../../../../ui';
@@ -91,7 +91,7 @@ export async function integrateCodex(
     targetRoot: installRoot,
     scope: installScope,
     auth,
-    nonInteractive: options.nonInteractive,
+    nonInteractive: !!options.nonInteractive || isEnvBasedAuth(),
     attrs: {
       ...buildAttrs({
         includeSecretsSection: true,

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -29,6 +29,7 @@ import {
   buildSqaaSectionBody,
   sonarBeginMarker,
   sonarEndMarker,
+  SQAA_MISSING_PROJECT_KEY_MESSAGE,
   SQAA_PROMOTION_MESSAGE,
 } from '../_common/instructions-templates';
 import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
@@ -60,6 +61,7 @@ export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
   installHook?: boolean;
   installSqaaInstructions?: boolean;
+  sqaaEntitled?: boolean;
   installContextAugmentation?: boolean;
 }
 
@@ -121,8 +123,14 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      shouldInstall: ({ options }) =>
-        options.installSqaaInstructions === true ? askUser() : skip(SQAA_PROMOTION_MESSAGE),
+      shouldInstall: ({ options }) => {
+        if (options.installSqaaInstructions === true) {
+          return askUser();
+        }
+        return skip(
+          options.sqaaEntitled === true ? SQAA_MISSING_PROJECT_KEY_MESSAGE : SQAA_PROMOTION_MESSAGE,
+        );
+      },
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -59,9 +59,7 @@ export const COPILOT_INTEGRATION_ID = 'copilot-cli';
 export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
   installHook?: boolean;
-  installInstructions?: boolean;
   installSqaaInstructions?: boolean;
-  installMcp?: boolean;
   installContextAugmentation?: boolean;
 }
 

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -59,7 +59,7 @@ export const COPILOT_INTEGRATION_ID = 'copilot-cli';
 
 export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
-  installHook?: boolean;
+  globalSecretsHookExists?: boolean;
   installSqaaInstructions?: boolean;
   sqaaEntitled?: boolean;
   installContextAugmentation?: boolean;
@@ -73,11 +73,11 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       id: 'pre-tool-use-hook',
       displayName: 'pre-tool-use hook',
       shouldInstall: ({ options }) =>
-        options.installHook === true
-          ? askUser()
-          : skip(
+        options.globalSecretsHookExists === true
+          ? skip(
               'Skipping the project-level pre-tool-use hook because a global secrets scanning hook is already configured.',
-            ),
+            )
+          : askUser(),
       postInstallExample: secretsScanningExample('Copilot'),
       dependencies: [sonarSecretsBinaryDependency],
       resources: [

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -29,9 +29,11 @@ import {
   buildSqaaSectionBody,
   sonarBeginMarker,
   sonarEndMarker,
+  SQAA_PROMOTION_MESSAGE,
 } from '../_common/instructions-templates';
 import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
 import { jsonPatch, textSnippet, wholeFile } from '../_common/registry/resources';
+import { askUser, skip } from '../_common/registry/selection';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
@@ -46,6 +48,7 @@ import {
   SCRIPT_REL_DIR,
 } from './hooks';
 import {
+  globalCopilotInstructionsExist,
   INSTRUCTIONS_FILENAME,
   PROJECT_INSTRUCTIONS_REL_DIR,
   PROMPT_SECRETS_BODY,
@@ -69,7 +72,12 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'pre-tool-use-hook',
       displayName: 'pre-tool-use hook',
-      shouldInstall: ({ options }) => options.installHook === true,
+      shouldInstall: ({ options }) =>
+        options.installHook === true
+          ? askUser()
+          : skip(
+              'Skipping the project-level pre-tool-use hook because a global secrets scanning hook is already configured.',
+            ),
       postInstallExample: secretsScanningExample('Copilot'),
       dependencies: [sonarSecretsBinaryDependency],
       resources: [
@@ -95,7 +103,12 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'prompt-secrets-instructions',
       displayName: 'prompt-secrets instructions',
-      shouldInstall: ({ options }) => options.installInstructions === true,
+      shouldInstall: ({ scope }) =>
+        scope === 'project' && globalCopilotInstructionsExist()
+          ? askUser(
+              'Global Copilot instructions already exist. Do you also want to create a project-local copy for this repo?',
+            )
+          : askUser(),
       resources: [
         textSnippet({
           id: 'prompt-secrets-instructions-file',
@@ -110,7 +123,8 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      shouldInstall: ({ options }) => options.installSqaaInstructions === true,
+      shouldInstall: ({ options }) =>
+        options.installSqaaInstructions === true ? askUser() : skip(SQAA_PROMOTION_MESSAGE),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [
@@ -130,7 +144,6 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      shouldInstall: ({ options }) => options.installMcp === true,
       resources: [
         jsonPatch({
           id: 'copilot-mcp-config',

--- a/src/cli/commands/integrate/copilot/hooks.ts
+++ b/src/cli/commands/integrate/copilot/hooks.ts
@@ -22,7 +22,7 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { info, warn } from '../../../../ui';
+import { warn } from '../../../../ui';
 import { readOrInitJson, SONAR_SECRETS_MARKER } from '../_common/hooks';
 
 export const SCRIPT_REL_DIR = join(SONAR_SECRETS_MARKER, 'build-scripts');
@@ -55,7 +55,7 @@ export interface HooksJson {
  * install is found (caller should skip project-level install to avoid
  * double-scanning), and `undefined` otherwise.
  *
- *  - Healthy global install → `info(...)` and return the script path.
+ *  - Healthy global install → return the script path.
  *  - Orphaned install (`hooks.json` references sonar-secrets but the backing
  *    script is missing) → `warn(...)` and return `undefined`.
  *  - No global install → silent, return `undefined`.
@@ -78,9 +78,6 @@ export async function detectGlobalSecretsHook(): Promise<string | undefined> {
     return undefined;
   }
 
-  info(
-    `A global secrets scanning hook is already configured at ${scriptPath}. Skipping project-level hook to avoid duplicate execution.`,
-  );
   return scriptPath;
 }
 

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -20,7 +20,7 @@
 
 import { homedir } from 'node:os';
 
-import type { ResolvedAuth } from '../../../../lib/auth-resolver';
+import { isEnvBasedAuth, type ResolvedAuth } from '../../../../lib/auth-resolver';
 import { discoverProject } from '../../../../lib/project-workspace';
 import type { IntegrationScope, IntegrationStateAttribute } from '../../../../lib/state';
 import { intro, warn } from '../../../../ui';
@@ -34,7 +34,6 @@ import { resolveSqaaEntitlement } from '../_common/sqaa-entitlement';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { COPILOT_INTEGRATION_ID, type CopilotIntegrationOptions } from './declaration';
 import { detectGlobalSecretsHook } from './hooks';
-import { warnIfProjectInstructionsShadowGlobal } from './instructions';
 
 export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAgentOptions) {
   if (options.global && options.project) {
@@ -61,9 +60,6 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
   const scope: IntegrationScope = isGlobal ? 'global' : 'project';
   const existingGlobalHookPath = isGlobal ? undefined : await detectGlobalSecretsHook();
   const installHook = existingGlobalHookPath === undefined;
-  if (!isGlobal) {
-    warnIfProjectInstructionsShadowGlobal();
-  }
 
   const contextAugmentation = options.skipContext
     ? null
@@ -88,7 +84,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     targetRoot,
     scope,
     auth,
-    nonInteractive: options.nonInteractive,
+    nonInteractive: !!options.nonInteractive || isEnvBasedAuth(),
     attrs: {
       ...buildIntegrationAttrs(projectKey),
       ...(contextAugmentation

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -73,6 +73,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     projectRoot: project.rootDir,
     installHook,
     installSqaaInstructions: sqaaProjectKey !== undefined,
+    sqaaEntitled: entitled,
     installContextAugmentation: contextAugmentation !== null,
   };
 

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -59,7 +59,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
   const targetRoot = isGlobal ? homedir() : project.rootDir;
   const scope: IntegrationScope = isGlobal ? 'global' : 'project';
   const existingGlobalHookPath = isGlobal ? undefined : await detectGlobalSecretsHook();
-  const installHook = existingGlobalHookPath === undefined;
+  const globalSecretsHookExists = existingGlobalHookPath !== undefined;
 
   const contextAugmentation = options.skipContext
     ? null
@@ -71,7 +71,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
   const integrationOptions: CopilotIntegrationOptions = {
     ...options,
     projectRoot: project.rootDir,
-    installHook,
+    globalSecretsHookExists,
     installSqaaInstructions: sqaaProjectKey !== undefined,
     sqaaEntitled: entitled,
     installContextAugmentation: contextAugmentation !== null,

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -72,9 +72,7 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     ...options,
     projectRoot: project.rootDir,
     installHook,
-    installInstructions: true,
     installSqaaInstructions: sqaaProjectKey !== undefined,
-    installMcp: true,
     installContextAugmentation: contextAugmentation !== null,
   };
 

--- a/src/cli/commands/integrate/copilot/instructions.ts
+++ b/src/cli/commands/integrate/copilot/instructions.ts
@@ -31,8 +31,6 @@ import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-import { warn } from '../../../../ui';
-
 export const INSTRUCTIONS_FILENAME = 'sonarqube.instructions.md';
 export const PROJECT_INSTRUCTIONS_REL_DIR = join('.github', 'instructions');
 export const GLOBAL_INSTRUCTIONS_DIR = join(homedir(), '.copilot', 'instructions');
@@ -60,12 +58,6 @@ If the prompt appears to contain any such secret (either by your judgement or th
 2. Advise them to rotate the leaked credential immediately at its source of truth.
 `;
 
-export function warnIfProjectInstructionsShadowGlobal(): void {
-  const filePath = join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME);
-  if (!existsSync(filePath)) {
-    return;
-  }
-  warn(
-    `Found existing Copilot instructions at '${filePath}'; this run only updates the project-level file. Remove the existing one if it is no longer needed.`,
-  );
+export function globalCopilotInstructionsExist(): boolean {
+  return existsSync(join(GLOBAL_INSTRUCTIONS_DIR, INSTRUCTIONS_FILENAME));
 }

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -111,6 +111,8 @@ export const AI_REMEDIATION_DOCS_URL =
 export const SERVER_API_DOCS_URL =
   'https://docs.sonarsource.com/sonarqube-server/extension-guide/web-api';
 export const SUPPORT_URL = 'https://community.sonarsource.com';
+export const AGENTIC_ANALYSIS_DOCS_URL =
+  'https://docs.sonarsource.com/agent-centric-development-cycle/features/agentic-analysis';
 
 // ---------------------------------------------------------------------------
 // Application paths

--- a/tests/integration/specs/integrate/context-augmentation.test.ts
+++ b/tests/integration/specs/integrate/context-augmentation.test.ts
@@ -629,7 +629,7 @@ describe('integrate copilot — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate copilot', {
+      const result = await harness.run('integrate copilot --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -700,7 +700,7 @@ describe('integrate codex — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate codex', {
+      const result = await harness.run('integrate codex --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -731,6 +731,54 @@ describe('integrate codex — Context Augmentation', () => {
         scaEnabled: false,
         serverUrl,
       });
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'env-based auth implies non-interactive: installs CAG without prompting or stdin',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(TOKEN)
+        .withProject(PROJECT_KEY)
+        .withCagEntitlement(ORG_KEY)
+        .withScaEnabled(false)
+        .start();
+      const serverUrl = server.baseUrl();
+      harness.withAuth(serverUrl, TOKEN, ORG_KEY);
+      harness.state().withContextAugmentationBinaryInstalled();
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [
+          `sonar.host.url=${serverUrl}`,
+          `sonar.projectKey=${PROJECT_KEY}`,
+          `sonar.organization=${ORG_KEY}`,
+        ].join('\n'),
+      );
+
+      // SONARQUBE_CLI_TOKEN + _SERVER + _ORG ⇒ isEnvBasedAuth() ⇒ the Context
+      // Augmentation ask auto-installs with no --non-interactive flag and no
+      // stdin.
+      const result = await harness.run('integrate codex', {
+        extraEnv: {
+          SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+          SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+          SONARQUBE_CLI_TOKEN: TOKEN,
+          SONARQUBE_CLI_SERVER: serverUrl,
+          SONARQUBE_CLI_ORG: ORG_KEY,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toContain('Install Codex Context Augmentation?');
+      expect(findToolInvocation(readInvocations(harness), 'integrate').argv).toEqual([
+        'tool',
+        'integrate',
+        '--invocation-prefix',
+        'sonar context',
+      ]);
+      expectSkillFile(harness, CODEX_SKILL_PATH, false);
     },
     { timeout: 30000 },
   );
@@ -854,7 +902,7 @@ describe('integrate <agent> --global — Context Augmentation', () => {
 
   it.each([
     ['claude', 'integrate claude -g --non-interactive'],
-    ['copilot', 'integrate copilot -g'],
+    ['copilot', 'integrate copilot -g --non-interactive'],
     ['codex', 'integrate codex -g'],
   ])(
     'skips CAG entirely on "integrate %s --global"',

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -65,7 +65,7 @@ describe('integrate copilot', () => {
     it(
       'writes hook script (executable), hooks.json, instructions, and .mcp.json under .github/',
       async () => {
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
 
@@ -103,7 +103,7 @@ describe('integrate copilot', () => {
     it(
       'writes a relative-path preToolUse entry in hooks.json with timeoutSec=60',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
         expect(json.hooks.preToolUse).toHaveLength(1);
@@ -123,7 +123,7 @@ describe('integrate copilot', () => {
     it(
       'does not touch ~/.copilot when running without --global',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         expect(harness.userHome.exists('.copilot')).toBe(false);
       },
@@ -133,7 +133,7 @@ describe('integrate copilot', () => {
     it(
       'records default project-scope features in integrations.installed',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         const copilotIntegration = getCopilotIntegration(harness);
         expect(copilotIntegration).toBeDefined();
@@ -151,7 +151,7 @@ describe('integrate copilot', () => {
     it(
       'records declarative Copilot features in integrations.installed for project installs',
       async () => {
-        await harness.run('integrate copilot --project my-project');
+        await harness.run('integrate copilot --project my-project --non-interactive');
 
         const state = harness.stateJsonFile.asJson();
         const copilotIntegration = state.integrations.installed.find(
@@ -188,8 +188,8 @@ describe('integrate copilot', () => {
     it(
       'running twice yields exactly one preToolUse entry in hooks.json',
       async () => {
-        await harness.run('integrate copilot');
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
+        await harness.run('integrate copilot --non-interactive');
 
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
         expect(json.hooks.preToolUse).toHaveLength(1);
@@ -200,7 +200,7 @@ describe('integrate copilot', () => {
     it(
       'appends --project <key> to the MCP server args when --project is provided',
       async () => {
-        await harness.run('integrate copilot --project my-project');
+        await harness.run('integrate copilot --project my-project --non-interactive');
 
         const mcp = harness.cwd.file('.mcp.json').asJson() as McpJson;
         const args = mcp.mcpServers?.sonarqube?.args ?? [];
@@ -214,7 +214,7 @@ describe('integrate copilot', () => {
     it(
       'pretool-secrets script uses the correct subcommand (sonar hook copilot-pre-tool-use)',
       async () => {
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         const content = harness.cwd.file(...PROJECT_HOOK_SCRIPT_PATH).asText();
         expect(content).toContain('sonar hook copilot-pre-tool-use');
@@ -236,7 +236,7 @@ describe('integrate copilot', () => {
           }),
         );
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
@@ -256,7 +256,7 @@ describe('integrate copilot', () => {
         // and without dropping the existing `version` field.
         harness.cwd.writeFile('.github/hooks/hooks.json', JSON.stringify({ version: 1 }));
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const json = harness.cwd.file(...PROJECT_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
@@ -275,7 +275,7 @@ describe('integrate copilot', () => {
     it(
       'writes hook script, hooks.json, instructions, and mcp-config.json under ~/.copilot/',
       async () => {
-        const result = await harness.run('integrate copilot -g');
+        const result = await harness.run('integrate copilot -g --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.userHome.exists(...GLOBAL_HOOK_SCRIPT_PATH)).toBe(true);
@@ -289,7 +289,7 @@ describe('integrate copilot', () => {
     it(
       'uses an absolute path in the hooks.json preToolUse entry under ~/.copilot/hooks/',
       async () => {
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot -g --non-interactive');
 
         const json = harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asJson() as CopilotHooksJson;
         const command = normalizePath(String(json.hooks.preToolUse?.[0]?.[HOOK_FIELD] ?? ''));
@@ -303,7 +303,7 @@ describe('integrate copilot', () => {
     it(
       'does not create .github/ inside the project directory when -g is set',
       async () => {
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot -g --non-interactive');
 
         expect(harness.cwd.exists('.github', 'hooks')).toBe(false);
         expect(harness.cwd.exists('.github', 'instructions')).toBe(false);
@@ -315,7 +315,7 @@ describe('integrate copilot', () => {
     it(
       'records hook and prompt instructions as global features in declarative state',
       async () => {
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot -g --non-interactive');
 
         expect(findCopilotFeature(harness, 'pre-tool-use-hook')?.scope).toBe('global');
         expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('global');
@@ -333,7 +333,7 @@ describe('integrate copilot', () => {
           '# pre-existing\n',
         );
 
-        const result = await harness.run('integrate copilot -g');
+        const result = await harness.run('integrate copilot -g --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const body = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
@@ -346,8 +346,8 @@ describe('integrate copilot', () => {
     it(
       'is idempotent: running -g twice yields exactly one prompt-secrets section',
       async () => {
-        await harness.run('integrate copilot -g');
-        await harness.run('integrate copilot -g');
+        await harness.run('integrate copilot -g --non-interactive');
+        await harness.run('integrate copilot -g --non-interactive');
 
         const body = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
         const headingCount =
@@ -366,7 +366,7 @@ describe('integrate copilot', () => {
       async () => {
         writeExistingGlobalHook(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists('.github', 'hooks', 'sonar-secrets')).toBe(false);
@@ -381,7 +381,7 @@ describe('integrate copilot', () => {
       async () => {
         writeExistingGlobalHook(harness);
 
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         expect(findCopilotFeature(harness, 'pre-tool-use-hook')).toBeUndefined();
         // Instructions are independent — the project-level instructions
@@ -397,7 +397,7 @@ describe('integrate copilot', () => {
         writeExistingGlobalHook(harness);
         const before = harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asText();
 
-        await harness.run('integrate copilot');
+        await harness.run('integrate copilot --non-interactive');
 
         expect(harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asText()).toBe(before);
       },
@@ -417,7 +417,7 @@ describe('integrate copilot', () => {
         };
         harness.userHome.writeFile('.copilot/hooks/hooks.json', JSON.stringify(orphanedJson));
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(result.stderr + result.stdout).toContain(
@@ -442,7 +442,7 @@ describe('integrate copilot', () => {
         harness.userHome.writeFile('.copilot/hooks/hooks.json', JSON.stringify(globalJson));
         const before = harness.userHome.file(...GLOBAL_HOOKS_JSON_PATH).asText();
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists('.github', 'hooks', 'hooks.json')).toBe(true);
@@ -466,12 +466,12 @@ describe('integrate copilot', () => {
 
   describe('project-level install when global Copilot instructions already exist', () => {
     it(
-      'writes the project-level instructions file, leaves the global file untouched, and warns about it',
+      'writes the project-level instructions file and leaves the global file untouched',
       async () => {
         writeExistingGlobalInstructions(harness);
         const before = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         // Project file is written despite the global file existing.
@@ -483,11 +483,6 @@ describe('integrate copilot', () => {
         expect(harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText()).toBe(before);
         // Declarative state records the project-scoped prompt-secrets feature.
         expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('project');
-        // Orphan warning surfaces the stale global file path.
-        expect(result.stderr + result.stdout).toContain('Found existing Copilot instructions at');
-        expect(normalizePath(result.stderr + result.stdout)).toContain(
-          '.copilot/instructions/sonarqube.instructions.md',
-        );
       },
       { timeout: 30000 },
     );
@@ -502,7 +497,7 @@ describe('integrate copilot', () => {
         writeExistingGlobalHook(harness);
         writeExistingGlobalInstructions(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(0);
         // Hook is short-circuited; no project-level hook artifacts.
@@ -542,7 +537,7 @@ describe('integrate copilot', () => {
       async () => {
         obstructHooksJson(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         expect(result.stdout + result.stderr).toContain('contains invalid JSON');
@@ -563,7 +558,7 @@ describe('integrate copilot', () => {
       async () => {
         obstructInstructionsFile(harness);
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         expect(harness.cwd.exists('.mcp.json')).toBe(false);
@@ -582,7 +577,7 @@ describe('integrate copilot', () => {
       async () => {
         harness.cwd.writeFile('.mcp.json', '{ invalid json\n');
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         expect(result.stdout + result.stderr).toContain('.mcp.json contains invalid JSON');
@@ -650,9 +645,12 @@ describe('integrate copilot', () => {
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
-          extraEnv,
-        });
+        const result = await harness.run(
+          `integrate copilot --project ${TEST_PROJECT} --non-interactive`,
+          {
+            extraEnv,
+          },
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -669,6 +667,27 @@ describe('integrate copilot', () => {
     );
 
     it(
+      'prompts to install SQAA and writes the section when accepted (entitled org, interactive)',
+      async () => {
+        const { extraEnv } = await setupCloudWithEntitlement();
+
+        // Interactive (no --non-interactive): the entitled org makes SQAA an ask.
+        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
+          extraEnv,
+          stdinChunks: ['\r', '\r', '\r', '\r'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('Install SonarQube Agentic Analysis instructions?');
+        const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
+        expect(body).toContain('# SonarQube Agentic Analysis protocol');
+        expect(findCopilotFeature(harness, 'sqaa-instructions')?.scope).toBe('project');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
       'writes the SQAA section to the project file under -g when org is entitled and a project key is discoverable from sonar-project.properties',
       async () => {
         // `--global` and `--project` are mutually exclusive on the CLI, so the
@@ -676,7 +695,7 @@ describe('integrate copilot', () => {
         const { extraEnv } = await setupCloudWithEntitlement();
         harness.cwd.writeFile('sonar-project.properties', `sonar.projectKey=${TEST_PROJECT}\n`);
 
-        const result = await harness.run('integrate copilot -g', { extraEnv });
+        const result = await harness.run('integrate copilot -g --non-interactive', { extraEnv });
 
         expect(result.exitCode).toBe(0);
 
@@ -703,7 +722,7 @@ describe('integrate copilot', () => {
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run('integrate copilot', { extraEnv });
+        const result = await harness.run('integrate copilot --non-interactive', { extraEnv });
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -721,9 +740,12 @@ describe('integrate copilot', () => {
           enabled: false,
         });
 
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
-          extraEnv,
-        });
+        const result = await harness.run(
+          `integrate copilot --project ${TEST_PROJECT} --non-interactive`,
+          {
+            extraEnv,
+          },
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -738,7 +760,7 @@ describe('integrate copilot', () => {
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run('integrate copilot -g', { extraEnv });
+        const result = await harness.run('integrate copilot -g --non-interactive', { extraEnv });
 
         expect(result.exitCode).toBe(0);
         // Without a project key the SQAA section cannot bake one in, so the
@@ -758,7 +780,9 @@ describe('integrate copilot', () => {
       async () => {
         // Default beforeEach sets up on-premise auth (no org). hasSqaaEntitlement
         // returns false fast without hitting the API in this case.
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`);
+        const result = await harness.run(
+          `integrate copilot --project ${TEST_PROJECT} --non-interactive`,
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
@@ -779,12 +803,15 @@ describe('integrate copilot', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
 
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
-          extraEnv: {
-            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
-            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        const result = await harness.run(
+          `integrate copilot --project ${TEST_PROJECT} --non-interactive`,
+          {
+            extraEnv: {
+              SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+              SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+            },
           },
-        });
+        );
 
         // Command must not abort — degraded success.
         expect(result.exitCode).toBe(0);
@@ -793,6 +820,127 @@ describe('integrate copilot', () => {
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
         expect(body).not.toContain('# SonarQube Agentic Analysis');
+      },
+      { timeout: 30000 },
+    );
+  });
+
+  // ─── Interactive feature selection ──────────────────────────────────────────
+  //
+  // Without --non-interactive each feature is gated by a prompt (ask) or an
+  // automatic skip. The harness drives the confirm prompts via stdin chunks
+  // (one keypress per prompt: '\r' accepts the default Yes, 'n' declines).
+
+  describe('interactive feature selection', () => {
+    it(
+      'prompts per feature, installs accepted features, and shows the SQAA promotion when not entitled',
+      async () => {
+        // Default beforeEach is on-premise auth with no org, so SQAA and
+        // Context Augmentation are not available: SQAA is skipped with the
+        // promotion line and CAG is skipped silently. The three remaining
+        // features (hook, prompt-secrets, MCP) each ask.
+        const result = await harness.run('integrate copilot', {
+          stdinChunks: ['\r', '\r', '\r'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        const output = result.stdout + result.stderr;
+        // Each opted feature surfaced its confirm prompt.
+        expect(output).toContain('Install pre-tool-use hook?');
+        expect(output).toContain('Install prompt-secrets instructions?');
+        expect(output).toContain('Install MCP server?');
+        // SQAA is skipped with the shared promotion message + docs link.
+        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
+        expect(output).toContain(
+          'docs.sonarsource.com/agent-centric-development-cycle/features/agentic-analysis',
+        );
+        // Accepted features are installed on disk.
+        expect(harness.cwd.file(...PROJECT_HOOK_SCRIPT_PATH).exists()).toBe(true);
+        expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(true);
+        expect(harness.cwd.exists('.mcp.json')).toBe(true);
+        // No SQAA marker block was written (org not entitled).
+        expect(harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText()).not.toContain(
+          '# SonarQube Agentic Analysis',
+        );
+        // Declarative state records only the accepted features.
+        expect(findCopilotFeature(harness, 'pre-tool-use-hook')).toBeDefined();
+        expect(findCopilotFeature(harness, 'prompt-secrets-instructions')).toBeDefined();
+        expect(findCopilotFeature(harness, 'mcp-server')).toBeDefined();
+        expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'skips a feature when the user declines its prompt',
+      async () => {
+        // Decline the hook ('n'), accept prompt-secrets and MCP ('\r').
+        const result = await harness.run('integrate copilot', {
+          stdinChunks: ['n', '\r', '\r'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        // Hook was declined: no project-level hook artifacts and no state entry.
+        expect(harness.cwd.exists('.github', 'hooks')).toBe(false);
+        expect(findCopilotFeature(harness, 'pre-tool-use-hook')).toBeUndefined();
+        // The accepted features are still installed.
+        expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(true);
+        expect(harness.cwd.exists('.mcp.json')).toBe(true);
+        expect(findCopilotFeature(harness, 'prompt-secrets-instructions')).toBeDefined();
+        expect(findCopilotFeature(harness, 'mcp-server')).toBeDefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'auto-skips the hook (with message) and asks a custom question when a global hook and global instructions both exist',
+      async () => {
+        writeExistingGlobalHook(harness);
+        writeExistingGlobalInstructions(harness);
+
+        const result = await harness.run('integrate copilot', {
+          stdinChunks: ['\r', '\r'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        const output = result.stdout + result.stderr;
+        // Hook: skipped with message, never prompted, nothing installed.
+        expect(output).toContain(
+          'Skipping the project-level pre-tool-use hook because a global secrets scanning hook is already configured.',
+        );
+        expect(output).not.toContain('Install pre-tool-use hook?');
+        expect(harness.cwd.exists('.github', 'hooks')).toBe(false);
+        expect(findCopilotFeature(harness, 'pre-tool-use-hook')).toBeUndefined();
+        // prompt-secrets instructions: custom question.
+        // accepting writes the project-local file.
+        expect(output).toContain(
+          'Global Copilot instructions already exist. Do you also want to create a project-local copy for this repo?',
+        );
+        expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(true);
+        expect(findCopilotFeature(harness, 'prompt-secrets-instructions')?.scope).toBe('project');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'env-based auth implies non-interactive: installs without prompting and without stdin',
+      async () => {
+        const server = await harness.newFakeServer().withAuthToken('env-tok').start();
+
+        // SONARQUBE_CLI_TOKEN + SONARQUBE_CLI_SERVER ⇒ isEnvBasedAuth() ⇒ the
+        // ask-features auto-install.
+        const result = await harness.run('integrate copilot', {
+          extraEnv: {
+            SONARQUBE_CLI_TOKEN: 'env-tok',
+            SONARQUBE_CLI_SERVER: server.baseUrl(),
+          },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout + result.stderr).not.toContain('Install pre-tool-use hook?');
+        expect(harness.cwd.file(...PROJECT_HOOK_SCRIPT_PATH).exists()).toBe(true);
+        expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(true);
+        expect(harness.cwd.exists('.mcp.json')).toBe(true);
       },
       { timeout: 30000 },
     );
@@ -808,7 +956,7 @@ describe('integrate copilot', () => {
         // unauthenticated path.
         harness.clearAuth();
 
-        const result = await harness.run('integrate copilot');
+        const result = await harness.run('integrate copilot --non-interactive');
 
         expect(result.exitCode).toBe(1);
         const output = result.stdout + result.stderr;

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -371,7 +371,9 @@ describe('integrate copilot', () => {
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists('.github', 'hooks', 'sonar-secrets')).toBe(false);
         expect(harness.cwd.exists('.github', 'hooks', 'hooks.json')).toBe(false);
-        expect(result.stdout).toContain('A global secrets scanning hook is already configured at');
+        expect(result.stdout).toContain(
+          'Skipping the project-level pre-tool-use hook because a global secrets scanning hook is already configured.',
+        );
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -773,6 +773,11 @@ describe('integrate copilot', () => {
         expect(body).not.toContain('# SonarQube Agentic Analysis');
         expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(false);
         expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
+        // The org IS entitled, so the skip reason must point at the missing
+        // project key rather than the Cloud promotion message.
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('no project key could be resolved');
+        expect(output).not.toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
       },
       { timeout: 30000 },
     );


### PR DESCRIPTION
----
## Summary by Gitar

- **Interactive feature selection:**
  - Integrated interactive prompts for feature installation across `Copilot`, `Codex`, and `Context Augmentation` commands.
  - Added `--non-interactive` flag to bypass prompts and allow automated usage.
- **Auth-based automation:**
  - Implemented auto-installation of features without prompts when `isEnvBasedAuth()` is detected.
- **User experience:**
  - Added `SQAA_PROMOTION_MESSAGE` to guide users toward SonarQube Cloud when agentic analysis is unavailable.
  - Streamlined CLI feedback by removing redundant warnings and info messages during integration hooks.

<sub>This will update automatically on new commits.</sub>