### PR TITLE
CLI-544 Create PostToolUse hook for Codex

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -58,6 +58,10 @@ import {
 } from './commands/hook/agent-post-tool-use';
 import { agentPromptSubmit } from './commands/hook/agent-prompt-submit';
 import { claudePreToolUse } from './commands/hook/claude-pre-tool-use';
+import {
+  codexPostToolUse,
+  type CodexPostToolUseOptions,
+} from './commands/hook/codex-post-tool-use';
 import { codexPromptSubmit } from './commands/hook/codex-prompt-submit';
 import { copilotPreToolUse } from './commands/hook/copilot-pre-tool-use';
 import { gitPreCommit } from './commands/hook/git-pre-commit';
@@ -479,6 +483,14 @@ hookCommand
   .description('PostToolUse handler: run Agentic Analysis after agent edits or writes a file')
   .requiredOption('--project <key>', 'SonarQube Cloud project key')
   .anonymousAction((options: AgentPostToolUseOptions) => agentPostToolUse(options));
+
+hookCommand
+  .command('codex-post-tool-use')
+  .description(
+    'PostToolUse handler for Codex: run Agentic Analysis on the git change set after apply_patch',
+  )
+  .requiredOption('--project <key>', 'SonarQube Cloud project key')
+  .anonymousAction((options: CodexPostToolUseOptions) => codexPostToolUse(options));
 
 hookCommand
   .command('git-pre-commit')

--- a/src/cli/commands/hook/agent-post-tool-use.ts
+++ b/src/cli/commands/hook/agent-post-tool-use.ts
@@ -26,8 +26,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolveAuth } from '../../../lib/auth-resolver';
 import { toRelativePosixPath } from '../../../lib/fs-utils';
 import logger from '../../../lib/logger';
-import type { SqaaIssue } from '../../../sonarqube/client';
 import { SonarQubeClient } from '../../../sonarqube/client';
+import { formatSqaaIssuesForHook, writePostToolUseHookOutput } from './format-sqaa-hook-context';
 import { readStdinJson } from './stdin';
 
 interface PostToolUsePayload {
@@ -76,37 +76,9 @@ export async function agentPostToolUse(options: AgentPostToolUseOptions): Promis
       fileContent,
     });
 
-    const text = formatSqaaResult(response.issues, response.errors);
-    process.stdout.write(
-      JSON.stringify({
-        hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext: text },
-      }) + '\n',
-    );
+    const text = formatSqaaIssuesForHook(response.issues, response.errors);
+    writePostToolUseHookOutput(text);
   } catch (err) {
     logger.debug(`PostToolUse SQAA analysis failed: ${(err as Error).message}`);
   }
-}
-
-function formatSqaaResult(
-  issues: SqaaIssue[],
-  errors?: Array<{ code: string; message: string }> | null,
-): string {
-  const lines: string[] = [];
-
-  if (issues.length === 0) {
-    lines.push('Agentic Analysis completed — no issues found.');
-  } else {
-    lines.push(`Agentic Analysis found ${issues.length} issue${issues.length === 1 ? '' : 's'}:`);
-    issues.forEach((issue, idx) => {
-      const location = issue.textRange ? ` (line ${issue.textRange.startLine})` : '';
-      lines.push(`  [${idx + 1}] ${issue.message}${location} [${issue.rule}]`);
-    });
-  }
-
-  if (errors && errors.length > 0) {
-    lines.push('Agentic Analysis errors:');
-    errors.forEach((e) => lines.push(`  [${e.code}] ${e.message}`));
-  }
-
-  return lines.join('\n');
 }

--- a/src/cli/commands/hook/codex-post-tool-use.ts
+++ b/src/cli/commands/hook/codex-post-tool-use.ts
@@ -1,0 +1,56 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// PostToolUse callback handler for Codex — runs git change-set SQAA after apply_patch.
+
+import { resolveAuth } from '../../../lib/auth-resolver';
+import logger from '../../../lib/logger';
+import { buildSqaaJsonReport } from '../analyze/sqaa';
+import {
+  formatSqaaJsonReportForHook,
+  writePostToolUseHookOutput,
+} from './format-sqaa-hook-context';
+
+export interface CodexPostToolUseOptions {
+  project?: string;
+}
+
+export async function codexPostToolUse(options: CodexPostToolUseOptions): Promise<void> {
+  const projectKey = options.project;
+  if (!projectKey) return;
+
+  const auth = await resolveAuth().catch(() => null);
+  if (auth?.connectionType !== 'cloud' || !auth.orgKey) return;
+
+  try {
+    const report = await buildSqaaJsonReport(
+      { project: projectKey, force: true, format: 'json' },
+      auth,
+    );
+    if (!report) return;
+
+    const text = formatSqaaJsonReportForHook(report);
+    if (text) {
+      writePostToolUseHookOutput(text);
+    }
+  } catch (err) {
+    logger.debug(`Codex PostToolUse SQAA analysis failed: ${(err as Error).message}`);
+  }
+}

--- a/src/cli/commands/hook/format-sqaa-hook-context.ts
+++ b/src/cli/commands/hook/format-sqaa-hook-context.ts
@@ -1,0 +1,134 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Text formatting for PostToolUse hook additionalContext (Claude + Codex).
+
+import type { SqaaIssue } from '../../../sonarqube/client';
+import type { SqaaJsonReport } from '../analyze/sqaa-display';
+
+export function formatSqaaIssuesForHook(
+  issues: SqaaIssue[],
+  errors?: Array<{ code: string; message: string }> | null,
+): string {
+  const lines: string[] = [];
+
+  if (issues.length === 0) {
+    lines.push('Agentic Analysis completed — no issues found.');
+  } else {
+    lines.push(`Agentic Analysis found ${issues.length} issue${issues.length === 1 ? '' : 's'}:`);
+    issues.forEach((issue, idx) => {
+      const location = issue.textRange ? ` (line ${issue.textRange.startLine})` : '';
+      lines.push(`  [${idx + 1}] ${issue.message}${location} [${issue.rule}]`);
+    });
+  }
+
+  if (errors && errors.length > 0) {
+    lines.push('Agentic Analysis errors:');
+    errors.forEach((e) => lines.push(`  [${e.code}] ${e.message}`));
+  }
+
+  return lines.join('\n');
+}
+
+function appendIgnoredLines(lines: string[], ignored: SqaaJsonReport['ignored']): void {
+  if (ignored.length === 0) {
+    return;
+  }
+  lines.push(`Excluded ${ignored.length} file(s) from analysis (binary or oversized):`);
+  for (const file of ignored) {
+    lines.push(`  ${file.path} (${file.reason})`);
+  }
+}
+
+/**
+ * Format a change-set SQAA JSON report for hook additionalContext.
+ * Returns null when there is nothing useful to surface (empty change set).
+ */
+export function formatSqaaJsonReportForHook(report: SqaaJsonReport): string | null {
+  if (
+    report.files.length === 0 &&
+    report.ignored.length === 0 &&
+    report.failures.length === 0 &&
+    report.skipped.length === 0
+  ) {
+    return null;
+  }
+
+  const lines: string[] = [];
+  const totalIssues = report.summary.totalIssues;
+  const hasFileErrors = report.files.some((f) => (f.errors?.length ?? 0) > 0);
+  const hasAnalyzedContent = totalIssues > 0 || report.failures.length > 0 || hasFileErrors;
+
+  if (!hasAnalyzedContent) {
+    if (report.skipped.length > 0) {
+      lines.push(`Skipped ${report.skipped.length} file(s) (analysis not completed).`);
+    } else if (report.ignored.length > 0 && report.files.length === 0) {
+      lines.push(
+        'Agentic Analysis: no files to analyze — all change set files were excluded (binary or oversized).',
+      );
+    } else {
+      lines.push('Agentic Analysis completed — no issues found.');
+    }
+    appendIgnoredLines(lines, report.ignored);
+    return lines.join('\n');
+  }
+
+  if (totalIssues > 0) {
+    lines.push(`Agentic Analysis found ${totalIssues} issue${totalIssues === 1 ? '' : 's'}:`);
+  }
+
+  let issueIndex = 0;
+  for (const file of report.files) {
+    if (file.issues.length === 0 && !(file.errors && file.errors.length > 0)) {
+      continue;
+    }
+    lines.push(`── ${file.path}`);
+    for (const issue of file.issues) {
+      issueIndex += 1;
+      const location = issue.textRange ? ` (line ${issue.textRange.startLine})` : '';
+      lines.push(`  [${issueIndex}] ${issue.message}${location} [${issue.rule}]`);
+    }
+    if (file.errors && file.errors.length > 0) {
+      lines.push('  Analysis errors:');
+      file.errors.forEach((e) => lines.push(`  [${e.code}] ${e.message}`));
+    }
+  }
+
+  if (report.failures.length > 0) {
+    lines.push('Agentic Analysis failures:');
+    report.failures.forEach((f) => lines.push(`  ${f.path}: ${f.message}`));
+  }
+
+  if (report.skipped.length > 0) {
+    lines.push(`Skipped ${report.skipped.length} file(s) (analysis not completed).`);
+  }
+
+  appendIgnoredLines(lines, report.ignored);
+
+  return lines.join('\n');
+}
+
+export function writePostToolUseHookOutput(additionalContext: string): void {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: { hookEventName: 'PostToolUse', additionalContext },
+    }) + '\n',
+  );
+}

--- a/src/cli/commands/integrate/_common/hooks.ts
+++ b/src/cli/commands/integrate/_common/hooks.ts
@@ -98,6 +98,53 @@ export async function readOrInitJson<T>(path: string, defaultValue: T): Promise<
 export const HOOK_TIMEOUT_SEC = 60;
 export const HOOKS_DIR = 'hooks';
 
+/** SonarQube project keys allowed when using a key into a generated hook shell script. */
+export const SONAR_PROJECT_KEY_SAFE_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+
+/**
+ * Reject project keys that cannot be safely embedded in hook scripts (command
+ * substitution, quotes, spaces, etc.).
+ */
+export function assertSafeSonarProjectKeyForHookScript(projectKey: string): void {
+  if (!SONAR_PROJECT_KEY_SAFE_PATTERN.test(projectKey)) {
+    throw new Error(
+      `SonarQube project key "${projectKey}" cannot be embedded in a hook script. Use only letters, digits, and _ . : -`,
+    );
+  }
+}
+
+/** Bash idiom to embed `'` inside a single-quoted string: close `'`, add `'`, reopen `'`. */
+const BASH_EMBEDDED_SINGLE_QUOTE = String.raw`'\''`;
+
+/** PowerShell escapes `'` inside a single-quoted string by doubling it. */
+const POWERSHELL_EMBEDDED_SINGLE_QUOTE = "''";
+
+/** Single-quoted Bash literal: no expansion of $, `, or command substitution. */
+export function shellQuoteBash(value: string): string {
+  return "'" + value.replaceAll("'", BASH_EMBEDDED_SINGLE_QUOTE) + "'";
+}
+
+/** Single-quoted PowerShell literal (double single-quotes escape embedded quotes). */
+export function shellQuotePowerShell(value: string): string {
+  return "'" + value.replaceAll("'", POWERSHELL_EMBEDDED_SINGLE_QUOTE) + "'";
+}
+
+export function formatSqaaPostToolHookCommandUnix(
+  hookSubcommand: 'claude-post-tool-use' | 'codex-post-tool-use',
+  projectKey: string,
+): string {
+  assertSafeSonarProjectKeyForHookScript(projectKey);
+  return `sonar hook ${hookSubcommand} --project ${shellQuoteBash(projectKey)}`;
+}
+
+export function formatSqaaPostToolHookCommandWindows(
+  hookSubcommand: 'claude-post-tool-use' | 'codex-post-tool-use',
+  projectKey: string,
+): string {
+  assertSafeSonarProjectKeyForHookScript(projectKey);
+  return `sonar hook ${hookSubcommand} --project ${shellQuotePowerShell(projectKey)}`;
+}
+
 /** Absolute path to the platform-specific hook script under `<targetRoot>/<configDir>/hooks/`. */
 export function resolveAgentHookScriptPath(
   context: IntegrationContext,

--- a/src/cli/commands/integrate/claude/hook-templates.ts
+++ b/src/cli/commands/integrate/claude/hook-templates.ts
@@ -20,7 +20,12 @@
 
 // Hook script templates for Claude Code integration
 
-import { unixTemplate, windowsTemplate } from '../_common/hooks';
+import {
+  formatSqaaPostToolHookCommandUnix,
+  formatSqaaPostToolHookCommandWindows,
+  unixTemplate,
+  windowsTemplate,
+} from '../_common/hooks';
 
 export function getSecretPreToolTemplateUnix(): string {
   return unixTemplate('sonar hook claude-pre-tool-use');
@@ -39,9 +44,9 @@ export function getSecretPromptTemplateWindows(): string {
 }
 
 export function getSqaaPostToolTemplateUnix(projectKey: string): string {
-  return unixTemplate(`sonar hook claude-post-tool-use --project ${projectKey}`);
+  return unixTemplate(formatSqaaPostToolHookCommandUnix('claude-post-tool-use', projectKey));
 }
 
 export function getSqaaPostToolTemplateWindows(projectKey: string): string {
-  return windowsTemplate(`sonar hook claude-post-tool-use --project ${projectKey}`);
+  return windowsTemplate(formatSqaaPostToolHookCommandWindows('claude-post-tool-use', projectKey));
 }

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -26,33 +26,44 @@ import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
-  buildSqaaSectionBody,
-  sonarBeginMarker,
-  sonarEndMarker,
-  SQAA_MISSING_PROJECT_KEY_MESSAGE,
-  SQAA_PROMOTION_MESSAGE,
-} from '../_common/instructions-templates';
+  createAgentHookEntry,
+  removeAgentHooks,
+  resolveAgentHookScriptPath,
+  upsertAgentHooks,
+} from '../_common/hooks';
+import { sonarBeginMarker, sonarEndMarker } from '../_common/instructions-templates';
 import { removeCodexMcpServer } from '../_common/mcp-config';
-import { isFeatureInstalledGloballyForProject } from '../_common/registry/installation-recorder';
-import { textSnippet, tomlPatch } from '../_common/registry/resources';
-import { askUser, skip } from '../_common/registry/selection';
-import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
+import {
+  askUser,
+  isFeatureInstalledGloballyForProject,
+  jsonPatch,
+  skip,
+  textSnippet,
+  tomlPatch,
+  wholeFile,
+} from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
-import { getSecretPromptTemplateUnix, getSecretPromptTemplateWindows } from './hook-templates';
+import {
+  getSecretPromptTemplateUnix,
+  getSecretPromptTemplateWindows,
+  getSqaaPostToolTemplateUnix,
+  getSqaaPostToolTemplateWindows,
+} from './hook-templates';
 import { SECRETS_ON_READ_BODY } from './instructions-templates';
 
 const CODEX_CONFIG_DIR = '.codex';
 const HOOKS_FILE = 'hooks.json';
 const AGENTS_MD_FILE = 'AGENTS.md';
 const PROMPT_SCRIPT_REL = 'sonar-secrets/build-scripts/prompt-secrets';
+const POSTTOOL_SQAA_SCRIPT_REL = 'sonar-sqaa/build-scripts/posttool-sqaa';
 
 export const CODEX_INTEGRATION_ID = 'codex';
 
 export interface CodexIntegrationOptions extends IntegrateAgentOptions {
   globalSecretsHookExists?: boolean;
-  /** Write the SQAA marker block into `.codex/AGENTS.md`. */
-  installSqaaInstructions?: boolean;
-  sqaaEntitled?: boolean;
+  /** Install PostToolUse SQAA hook on apply_patch (project scope). */
+  installSqaaHook?: boolean;
   installContextAugmentation?: boolean;
 }
 
@@ -87,6 +98,54 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       ],
     }),
     {
+      id: 'sonar-sqaa-hook',
+      displayName: 'SonarQube Agentic Analysis hook',
+      shouldInstall: ({ options }) => {
+        if (options.installSqaaHook === true) {
+          return askUser();
+        }
+        return skip();
+      },
+      scope: 'project',
+      resources: [
+        wholeFile({
+          id: 'posttool-sqaa-script',
+          displayName: 'Codex PostToolUse hook script',
+          targetPath: (context) =>
+            resolveAgentHookScriptPath(context, CODEX_CONFIG_DIR, POSTTOOL_SQAA_SCRIPT_REL),
+          content: (context) => {
+            const projectKey = getRequiredStringAttr(
+              context,
+              'projectKey',
+              codexIntegration.displayName,
+            );
+            return process.platform === 'win32'
+              ? getSqaaPostToolTemplateWindows(projectKey)
+              : getSqaaPostToolTemplateUnix(projectKey);
+          },
+          executable: true,
+        }),
+        jsonPatch({
+          id: 'codex-hooks-sqaa-hook',
+          displayName: 'Codex SQAA hook configuration',
+          targetPath: resolveCodexHooksPath,
+          defaultValue: { hooks: {} },
+          patch: (document, context) =>
+            upsertAgentHooks(document, [
+              createAgentHookEntry(
+                context,
+                CODEX_CONFIG_DIR,
+                'PostToolUse',
+                'apply_patch',
+                'sonar-sqaa',
+                POSTTOOL_SQAA_SCRIPT_REL,
+              ),
+            ]),
+          removePatch: (document) => removeAgentHooks(document, ['sonar-sqaa']),
+        }),
+      ],
+    },
+    {
       id: 'secrets-instructions',
       displayName: 'secrets-on-read instructions',
       shouldInstall: ({ scope, state }) =>
@@ -108,31 +167,6 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
           startMarker: sonarBeginMarker('codex-secrets-on-read'),
           endMarker: sonarEndMarker('codex-secrets-on-read'),
           content: SECRETS_ON_READ_BODY,
-        }),
-      ],
-    },
-    {
-      id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis instructions',
-      shouldInstall: ({ options }) => {
-        if (options.installSqaaInstructions === true) {
-          return askUser();
-        }
-        return skip(
-          options.sqaaEntitled === true ? SQAA_MISSING_PROJECT_KEY_MESSAGE : SQAA_PROMOTION_MESSAGE,
-        );
-      },
-      resources: [
-        textSnippet({
-          id: 'codex-sqaa-instructions',
-          displayName: 'Codex AGENTS.md SQAA instructions',
-          targetPath: resolveCodexAgentsMdPath,
-          startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
-          endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),
-          content: (context) =>
-            buildSqaaSectionBody(
-              getRequiredStringAttr(context, 'projectKey', codexIntegration.displayName),
-            ),
         }),
       ],
     },
@@ -159,6 +193,10 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
 
 function resolveCodexAgentsMdPath(context: IntegrationContext): string {
   return join(context.targetRoot, CODEX_CONFIG_DIR, AGENTS_MD_FILE);
+}
+
+function resolveCodexHooksPath(context: IntegrationContext): string {
+  return join(context.targetRoot, CODEX_CONFIG_DIR, HOOKS_FILE);
 }
 
 function resolveCodexMcpConfigPath(context: IntegrationContext): string {

--- a/src/cli/commands/integrate/codex/hook-templates.ts
+++ b/src/cli/commands/integrate/codex/hook-templates.ts
@@ -20,7 +20,12 @@
 
 // Hook script templates for Codex integration.
 
-import { unixTemplate, windowsTemplate } from '../_common/hooks';
+import {
+  formatSqaaPostToolHookCommandUnix,
+  formatSqaaPostToolHookCommandWindows,
+  unixTemplate,
+  windowsTemplate,
+} from '../_common/hooks';
 
 export function getSecretPromptTemplateUnix(): string {
   return unixTemplate('sonar hook codex-prompt-submit');
@@ -28,4 +33,12 @@ export function getSecretPromptTemplateUnix(): string {
 
 export function getSecretPromptTemplateWindows(): string {
   return windowsTemplate('sonar hook codex-prompt-submit');
+}
+
+export function getSqaaPostToolTemplateUnix(projectKey: string): string {
+  return unixTemplate(formatSqaaPostToolHookCommandUnix('codex-post-tool-use', projectKey));
+}
+
+export function getSqaaPostToolTemplateWindows(projectKey: string): string {
+  return windowsTemplate(formatSqaaPostToolHookCommandWindows('codex-post-tool-use', projectKey));
 }

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -44,7 +44,7 @@ export async function integrateCodex(
 
   // SQAA is always project-scoped. resolveSqaaSetup returns false (and surfaces
   // the consistent skip notice when the org is entitled) on a global install, so
-  // here we only include the SQAA section for a project install with a known key.
+  // here we only install the PostToolUse hook for a project install with a known key.
   const sqaaEligible = await resolveSqaaSetup({
     serverURL: ctx.serverUrl,
     token: ctx.token,
@@ -66,8 +66,7 @@ export async function integrateCodex(
       });
   const integrationOptions = {
     ...options,
-    installSqaaInstructions: includeSqaa,
-    sqaaEntitled: sqaaEligible,
+    installSqaaHook: includeSqaa,
     installContextAugmentation: contextAugmentation !== null,
   } satisfies CodexIntegrationOptions;
 

--- a/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
@@ -1,0 +1,104 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) 2026 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integration tests for `sonar hook codex-post-tool-use`.
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { TestHarness } from '../../harness';
+import { commitFile, initGitRepo } from './git-test-helpers';
+
+const VALID_TOKEN = 'integration-test-token';
+const TEST_ORG = 'my-org';
+const TEST_PROJECT = 'my-project';
+
+describe('sonar hook codex-post-tool-use', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+    initGitRepo(harness.cwd.path);
+    commitFile(harness.cwd.path, 'README.md', 'baseline');
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'exits 0 and outputs Agentic Analysis JSON when the git change set is clean',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+      harness.cwd.writeFile('src/main.ts', 'const x = 1;');
+
+      const result = await harness.run(`hook codex-post-tool-use --project ${TEST_PROJECT}`);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout.trim());
+      expect(output.hookSpecificOutput.hookEventName).toBe('PostToolUse');
+      expect(output.hookSpecificOutput.additionalContext).toContain('no issues');
+      const sqaaCalls = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/a3s-analysis/analyses');
+      expect(sqaaCalls.length).toBeGreaterThan(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'exits 0 and outputs no hook response when not authenticated',
+    async () => {
+      harness.cwd.writeFile('src/main.ts', 'const x = 1;');
+
+      const result = await harness.run(`hook codex-post-tool-use --project ${TEST_PROJECT}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'exits 0 with empty stdout when the git change set is empty',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      const result = await harness.run(`hook codex-post-tool-use --project ${TEST_PROJECT}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe('');
+      const sqaaCalls = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/a3s-analysis/analyses');
+      expect(sqaaCalls).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+});

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -32,6 +32,7 @@ import { hookScriptName, hookScriptPath, normalizePath, TestHarness } from '../.
 import { findInstalledFeature } from './state-helpers';
 
 const PROMPT_SCRIPT_DIRS = ['.codex', 'hooks', 'sonar-secrets', 'build-scripts'];
+const SQAA_SCRIPT_DIRS = ['.codex', 'hooks', 'sonar-sqaa', 'build-scripts'];
 const HOOKS_JSON_DIRS = ['.codex', 'hooks.json'];
 const AGENTS_MD_DIRS = ['.codex', 'AGENTS.md'];
 const CONFIG_TOML_DIRS = ['.codex', 'config.toml'];
@@ -41,6 +42,10 @@ const SQAA_HEADING = '# SonarQube Agentic Analysis protocol';
 interface CodexHooksFile {
   hooks?: {
     UserPromptSubmit?: Array<{
+      matcher?: string;
+      hooks?: Array<{ type?: string; command?: string; timeout?: number }>;
+    }>;
+    PostToolUse?: Array<{
       matcher?: string;
       hooks?: Array<{ type?: string; command?: string; timeout?: number }>;
     }>;
@@ -404,7 +409,7 @@ describe('integrate codex', () => {
     );
 
     it(
-      'appends the SQAA section with the project key baked in when the org is entitled',
+      'installs PostToolUse SQAA hook on apply_patch and omits AGENTS.md SQAA protocol when entitled',
       async () => {
         const server = await harness
           .newFakeServer()
@@ -429,12 +434,119 @@ describe('integrate codex', () => {
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...AGENTS_MD_DIRS).asText();
         expect(body).toContain('<!-- sonar:begin:codex-secrets-on-read -->');
-        expect(body).toContain('<!-- sonar:end:codex-secrets-on-read -->');
-        expect(body).toContain(SECRETS_HEADING);
-        expect(body).toContain('<!-- sonar:begin:sonarqube-agentic-analysis-protocol -->');
-        expect(body).toContain('<!-- sonar:end:sonarqube-agentic-analysis-protocol -->');
-        expect(body).toContain(SQAA_HEADING);
-        expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --file`);
+        expect(body).not.toContain('<!-- sonar:begin:sonarqube-agentic-analysis-protocol -->');
+        expect(body).not.toContain(SQAA_HEADING);
+        expect(body).not.toContain('sonar analyze agentic');
+
+        const sqaaScript = harness.cwd.file(...SQAA_SCRIPT_DIRS, hookScriptName('posttool-sqaa'));
+        expect(sqaaScript.exists()).toBe(true);
+        expect(sqaaScript.isExecutable).toBe(true);
+        expect(sqaaScript.asText()).toContain('codex-post-tool-use');
+        expect(sqaaScript.asText()).toContain(`--project '${TEST_PROJECT}'`);
+
+        const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
+        const postTool = hooks.hooks?.PostToolUse?.find((e) =>
+          e.hooks?.some((h) => h.command?.includes('sonar-sqaa')),
+        );
+        expect(postTool?.matcher).toBe('apply_patch');
+        expect(postTool?.hooks?.[0]?.command).toContain('sonar-sqaa');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'does not install PostToolUse SQAA hook when the org has no entitlement',
+      async () => {
+        const result = await harness.run('integrate codex');
+
+        expect(result.exitCode).toBe(0);
+        const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
+        expect(hooks.hooks?.PostToolUse).toBeUndefined();
+        const body = harness.cwd.file(...AGENTS_MD_DIRS).asText();
+        expect(body).not.toContain('sonarqube-agentic-analysis-protocol');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      're-running does not duplicate the PostToolUse SQAA entry when entitled',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('cloud-token')
+          .withOrganizations([{ key: TEST_ORG, name: 'My Org' }])
+          .withSqaaEntitlement(TEST_ORG, 'test-uuid-1234')
+          .withProject(TEST_PROJECT)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
+
+        await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
+          extraEnv: {
+            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+          },
+        });
+        const result = await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
+          extraEnv: {
+            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+          },
+        });
+
+        expect(result.exitCode).toBe(0);
+        const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
+        const sqaaEntries = hooks.hooks?.PostToolUse?.filter((e) =>
+          e.hooks?.some((h) => h.command?.includes('sonar-sqaa')),
+        );
+        expect(sqaaEntries).toHaveLength(1);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'preserves pre-existing non-Sonar PostToolUse entries when adding SQAA hook',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('cloud-token')
+          .withOrganizations([{ key: TEST_ORG, name: 'My Org' }])
+          .withSqaaEntitlement(TEST_ORG, 'test-uuid-1234')
+          .withProject(TEST_PROJECT)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
+
+        harness.cwd.writeFile(
+          '.codex/hooks.json',
+          JSON.stringify({
+            hooks: {
+              PostToolUse: [
+                {
+                  matcher: 'other_tool',
+                  hooks: [
+                    { type: 'command', command: '.codex/hooks/other-tool/run.sh', timeout: 30 },
+                  ],
+                },
+              ],
+            },
+          }),
+        );
+
+        const result = await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
+          extraEnv: {
+            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+          },
+        });
+
+        expect(result.exitCode).toBe(0);
+        const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
+        const commands = hooks.hooks?.PostToolUse?.flatMap(
+          (entry) => entry.hooks?.map((hook) => hook.command) ?? [],
+        );
+        expect(commands?.some((command) => command?.includes('other-tool'))).toBe(true);
+        expect(commands?.some((command) => command?.includes('sonar-sqaa'))).toBe(true);
       },
       { timeout: 30000 },
     );
@@ -496,10 +608,9 @@ describe('integrate codex', () => {
       'prompts per feature, installs accepted features, and shows the SQAA promotion when not entitled',
       async () => {
         // Default beforeEach is on-premise auth with no org, so SQAA and
-        // Context Augmentation are not available: SQAA is skipped with the
-        // promotion line and CAG is skipped silently. The three remaining
-        // features (hook, secrets instructions, MCP) each ask. The leading
-        // '\r' selects project scope before the per-feature prompts.
+        // Context Augmentation are not available. The three remaining features
+        // (secrets hook, secrets instructions, MCP) each ask. The leading '\r'
+        // selects project scope before the per-feature prompts.
         const result = await harness.run('integrate codex', {
           stdinChunks: ['\r', '\r', '\r', '\r'],
         });
@@ -510,11 +621,8 @@ describe('integrate codex', () => {
         expect(output).toContain('Install secret scanning hooks?');
         expect(output).toContain('Install secrets-on-read instructions?');
         expect(output).toContain('Install MCP server?');
-        // SQAA is skipped with the shared promotion message + docs link.
-        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
-        expect(output).toContain(
-          'docs.sonarsource.com/agent-centric-development-cycle/features/agentic-analysis',
-        );
+        // SQAA is not eligible, so it is skipped silently without a prompt.
+        expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
         // Accepted features are installed on disk.
         expect(
           harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),
@@ -529,7 +637,7 @@ describe('integrate codex', () => {
         expect(findCodexFeature(harness, 'sonar-secrets-hooks')).toBeDefined();
         expect(findCodexFeature(harness, 'secrets-instructions')).toBeDefined();
         expect(findCodexFeature(harness, 'mcp-server')).toBeDefined();
-        expect(findCodexFeature(harness, 'sqaa-instructions')).toBeUndefined();
+        expect(findCodexFeature(harness, 'sonar-sqaa-hook')).toBeUndefined();
       },
       { timeout: 30000 },
     );
@@ -580,6 +688,40 @@ describe('integrate codex', () => {
         // Accepting writes the project-local copy and records the project-scope feature.
         expect(harness.cwd.file(...AGENTS_MD_DIRS).asText()).toContain(SECRETS_HEADING);
         expect(findCodexFeature(harness, 'secrets-instructions', 'project')).toBeDefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'asks before installing the SQAA hook when the org is entitled and a project key is known',
+      async () => {
+        const testOrg = 'my-org';
+        const testProject = 'my-project';
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('cloud-token')
+          .withOrganizations([{ key: testOrg, name: 'My Org' }])
+          .withSqaaEntitlement(testOrg, 'test-uuid-1234')
+          .withProject(testProject)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'cloud-token', testOrg);
+
+        const result = await harness.run(`integrate codex --project ${testProject}`, {
+          stdinChunks: ['\r', '\r', '\r', '\r', '\r'],
+          extraEnv: {
+            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+          },
+        });
+
+        expect(result.exitCode).toBe(0);
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(output).toContain('Install SonarQube Agentic Analysis hook?');
+        expect(
+          harness.cwd.file(...SQAA_SCRIPT_DIRS, hookScriptName('posttool-sqaa')).exists(),
+        ).toBe(true);
+        expect(findCodexFeature(harness, 'sonar-sqaa-hook')).toBeDefined();
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -457,7 +457,7 @@ describe('integrate codex', () => {
     it(
       'does not install PostToolUse SQAA hook when the org has no entitlement',
       async () => {
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
@@ -481,18 +481,21 @@ describe('integrate codex', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
 
-        await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
+        await harness.run(`integrate codex --project ${TEST_PROJECT} --non-interactive`, {
           extraEnv: {
             SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
             SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
           },
         });
-        const result = await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
-          extraEnv: {
-            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
-            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        const result = await harness.run(
+          `integrate codex --project ${TEST_PROJECT} --non-interactive`,
+          {
+            extraEnv: {
+              SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+              SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+            },
           },
-        });
+        );
 
         expect(result.exitCode).toBe(0);
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
@@ -533,12 +536,15 @@ describe('integrate codex', () => {
           }),
         );
 
-        const result = await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
-          extraEnv: {
-            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
-            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        const result = await harness.run(
+          `integrate codex --project ${TEST_PROJECT} --non-interactive`,
+          {
+            extraEnv: {
+              SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+              SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+            },
           },
-        });
+        );
 
         expect(result.exitCode).toBe(0);
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -38,8 +38,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { nativeGitIntegration } from '../../../../src/cli/commands/integrate/git/tools/native';
 import { SCA_SCANNER_CACHE_DIR } from '../../../../src/lib/config-constants';
 import { generateKeychainAccount } from '../../../../src/lib/keychain';
-import { TestHarness } from '../../harness';
+import { hookScriptName, TestHarness } from '../../harness';
 import { buildHomeEnv, IS_WINDOWS } from '../../harness/platform';
+
+const CODEX_SQAA_SCRIPT_DIRS = ['.codex', 'hooks', 'sonar-sqaa', 'build-scripts'];
 
 /** Unix-only: verify chmod 555 actually blocks recursive removal on this host. */
 function unixChmodBlocksDirectoryRemoval(): boolean {
@@ -619,6 +621,84 @@ describe('system reset --force', () => {
       expect(readState(harness.stateJsonFile.path).integrations.installed).toHaveLength(1);
     },
     { timeout: 15000 },
+  );
+
+  it(
+    'undoes a Codex sonar-sqaa-hook integration and preserves unrelated PostToolUse entries',
+    async () => {
+      const testOrg = 'my-org';
+      const testProject = 'my-project';
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('cloud-token')
+        .withOrganizations([{ key: testOrg, name: 'My Org' }])
+        .withSqaaEntitlement(testOrg, 'test-uuid-1234')
+        .withProject(testProject)
+        .start();
+      const serverUrl = server.baseUrl();
+      harness.state().withSecretsBinaryInstalled();
+      harness.withAuth(serverUrl, 'cloud-token', testOrg);
+
+      harness.cwd.writeFile(
+        '.codex/hooks.json',
+        JSON.stringify({
+          hooks: {
+            PostToolUse: [
+              {
+                matcher: 'other_tool',
+                hooks: [
+                  { type: 'command', command: '.codex/hooks/other-tool/run.sh', timeout: 30 },
+                ],
+              },
+            ],
+          },
+        }),
+      );
+
+      const integrateResult = await harness.run(
+        `integrate codex --project ${testProject} --non-interactive`,
+        {
+          extraEnv: {
+            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+          },
+        },
+      );
+
+      expect(integrateResult.exitCode).toBe(0);
+      expect(
+        harness.cwd.file(...CODEX_SQAA_SCRIPT_DIRS, hookScriptName('posttool-sqaa')).exists(),
+      ).toBe(true);
+      expect(readState(harness.stateJsonFile.path).integrations.installed.length).toBeGreaterThan(
+        0,
+      );
+
+      // harness.run() re-seeds state.json from the env builder before each subprocess;
+      // preserve the post-integrate snapshot so reset sees the installed features.
+      const stateAfterIntegrate = readFileSync(harness.stateJsonFile.path, 'utf-8');
+      harness.state().withRawState(stateAfterIntegrate);
+
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/Integrations:.*Removed/);
+      expect(readState(harness.stateJsonFile.path).integrations.installed).toHaveLength(0);
+      expect(
+        harness.cwd.file(...CODEX_SQAA_SCRIPT_DIRS, hookScriptName('posttool-sqaa')).exists(),
+      ).toBe(false);
+
+      const hooks = harness.cwd.file('.codex', 'hooks.json').asJson() as {
+        hooks?: {
+          PostToolUse?: Array<{ hooks?: Array<{ command?: string }> }>;
+        };
+      };
+      const commands = hooks.hooks?.PostToolUse?.flatMap(
+        (entry) => entry.hooks?.map((hook) => hook.command) ?? [],
+      );
+      expect(commands?.some((command) => command?.includes('other-tool'))).toBe(true);
+      expect(commands?.some((command) => command?.includes('sonar-sqaa'))).toBe(false);
+    },
+    { timeout: 30000 },
   );
 
   it(

--- a/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
@@ -23,10 +23,10 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import { agentPostToolUse } from '../../src/cli/commands/hook/agent-post-tool-use';
-import * as stdinModule from '../../src/cli/commands/hook/stdin';
-import * as authResolver from '../../src/lib/auth-resolver';
-import * as clientModule from '../../src/sonarqube/client';
+import { agentPostToolUse } from '../../../../../src/cli/commands/hook/agent-post-tool-use';
+import * as stdinModule from '../../../../../src/cli/commands/hook/stdin';
+import * as authResolver from '../../../../../src/lib/auth-resolver';
+import * as clientModule from '../../../../../src/sonarqube/client';
 
 // Real path inside cwd so realpathSync resolves consistently for file and cwd.
 const TEST_FILE = join(process.cwd(), 'src/index.ts');

--- a/tests/unit/cli/commands/hook/agent-prompt-submit.test.ts
+++ b/tests/unit/cli/commands/hook/agent-prompt-submit.test.ts
@@ -24,11 +24,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import * as installSecrets from '../../src/cli/commands/_common/install/secrets';
-import * as analyzeSecrets from '../../src/cli/commands/analyze/secrets';
-import { agentPromptSubmit } from '../../src/cli/commands/hook/agent-prompt-submit';
-import * as stdinModule from '../../src/cli/commands/hook/stdin';
-import * as authResolver from '../../src/lib/auth-resolver';
+import * as installSecrets from '../../../../../src/cli/commands/_common/install/secrets';
+import * as analyzeSecrets from '../../../../../src/cli/commands/analyze/secrets';
+import { agentPromptSubmit } from '../../../../../src/cli/commands/hook/agent-prompt-submit';
+import * as stdinModule from '../../../../../src/cli/commands/hook/stdin';
+import * as authResolver from '../../../../../src/lib/auth-resolver';
 
 describe('agentPromptSubmit (unit — impractical-via-e2e paths)', () => {
   let stdoutSpy: ReturnType<typeof spyOn>;

--- a/tests/unit/cli/commands/hook/claude-pre-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/claude-pre-tool-use.test.ts
@@ -22,11 +22,11 @@ import * as fs from 'node:fs';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import * as installSecrets from '../../src/cli/commands/_common/install/secrets';
-import * as analyzeSecrets from '../../src/cli/commands/analyze/secrets';
-import { claudePreToolUse } from '../../src/cli/commands/hook/claude-pre-tool-use';
-import * as stdinModule from '../../src/cli/commands/hook/stdin';
-import * as authResolver from '../../src/lib/auth-resolver';
+import * as installSecrets from '../../../../../src/cli/commands/_common/install/secrets';
+import * as analyzeSecrets from '../../../../../src/cli/commands/analyze/secrets';
+import { claudePreToolUse } from '../../../../../src/cli/commands/hook/claude-pre-tool-use';
+import * as stdinModule from '../../../../../src/cli/commands/hook/stdin';
+import * as authResolver from '../../../../../src/lib/auth-resolver';
 
 const TEST_FILE = '/sonar-test/test.ts';
 const { EXIT_CODE_SECRETS_FOUND } = analyzeSecrets;

--- a/tests/unit/cli/commands/hook/codex-post-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/codex-post-tool-use.test.ts
@@ -1,0 +1,168 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import * as sqaaModule from '../../../../../src/cli/commands/analyze/sqaa';
+import { codexPostToolUse } from '../../../../../src/cli/commands/hook/codex-post-tool-use';
+import * as authResolver from '../../../../../src/lib/auth-resolver';
+
+describe('codexPostToolUse', () => {
+  let stdoutSpy: ReturnType<typeof spyOn>;
+  let resolveAuthSpy: ReturnType<typeof spyOn>;
+  let buildSqaaJsonReportSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    resolveAuthSpy = spyOn(authResolver, 'resolveAuth').mockResolvedValue({
+      token: 'tok',
+      serverUrl: 'https://sonarcloud.io',
+      connectionType: 'cloud',
+      orgKey: 'myorg',
+    });
+    buildSqaaJsonReportSpy = spyOn(sqaaModule, 'buildSqaaJsonReport').mockResolvedValue({
+      files: [{ path: 'src/foo.ts', issues: [], errors: null }],
+      ignored: [],
+      failures: [],
+      skipped: [],
+      summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
+    });
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    resolveAuthSpy.mockRestore();
+    buildSqaaJsonReportSpy.mockRestore();
+  });
+
+  it('writes additionalContext when change-set analysis finds no issues', async () => {
+    await codexPostToolUse({ project: 'my-project' });
+
+    expect(buildSqaaJsonReportSpy).toHaveBeenCalledWith(
+      { project: 'my-project', force: true, format: 'json' },
+      expect.objectContaining({ connectionType: 'cloud' }),
+    );
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    const output = JSON.parse((stdoutSpy.mock.calls[0][0] as string).trim());
+    expect(output.hookSpecificOutput.hookEventName).toBe('PostToolUse');
+    expect(output.hookSpecificOutput.additionalContext).toContain('no issues');
+  });
+
+  it('surfaces per-file analysis errors when totalIssues is zero', async () => {
+    buildSqaaJsonReportSpy.mockResolvedValue({
+      files: [
+        {
+          path: 'src/foo.ts',
+          issues: [],
+          errors: [{ code: 'FILE_NOT_FOUND', message: 'File not indexed' }],
+        },
+      ],
+      ignored: [],
+      failures: [],
+      skipped: [],
+      summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
+    });
+
+    await codexPostToolUse({ project: 'my-project' });
+
+    const output = JSON.parse((stdoutSpy.mock.calls[0][0] as string).trim());
+    expect(output.hookSpecificOutput.additionalContext).not.toContain('no issues found');
+    expect(output.hookSpecificOutput.additionalContext).toContain('FILE_NOT_FOUND');
+  });
+
+  it('includes multi-file issue details in additionalContext', async () => {
+    buildSqaaJsonReportSpy.mockResolvedValue({
+      files: [
+        {
+          path: 'src/a.ts',
+          issues: [
+            {
+              rule: 'typescript:S1234',
+              message: 'Fix this',
+              textRange: { startLine: 3, endLine: 3, startOffset: 0, endOffset: 1 },
+            },
+          ],
+          errors: null,
+        },
+      ],
+      ignored: [],
+      failures: [],
+      skipped: [],
+      summary: { totalIssues: 1, totalFailures: 0, totalSkipped: 0 },
+    });
+
+    await codexPostToolUse({ project: 'my-project' });
+
+    const output = JSON.parse((stdoutSpy.mock.calls[0][0] as string).trim());
+    expect(output.hookSpecificOutput.additionalContext).toContain('Fix this');
+    expect(output.hookSpecificOutput.additionalContext).toContain('typescript:S1234');
+    expect(output.hookSpecificOutput.additionalContext).toContain('src/a.ts');
+  });
+
+  it('skips output when project key is missing', async () => {
+    await codexPostToolUse({});
+
+    expect(buildSqaaJsonReportSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips output when auth is not Cloud', async () => {
+    resolveAuthSpy.mockResolvedValue({
+      token: 'tok',
+      serverUrl: 'https://sonar.example.com',
+      connectionType: 'server',
+    });
+
+    await codexPostToolUse({ project: 'my-project' });
+
+    expect(buildSqaaJsonReportSpy).not.toHaveBeenCalled();
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips output on empty change set', async () => {
+    buildSqaaJsonReportSpy.mockResolvedValue({
+      files: [],
+      ignored: [],
+      failures: [],
+      skipped: [],
+      summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
+    });
+
+    await codexPostToolUse({ project: 'my-project' });
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when buildSqaaJsonReport fails', async () => {
+    buildSqaaJsonReportSpy.mockRejectedValue(new Error('git failed'));
+
+    await codexPostToolUse({ project: 'my-project' });
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+
+  it('skips output when buildSqaaJsonReport returns null', async () => {
+    buildSqaaJsonReportSpy.mockResolvedValue(null);
+
+    await codexPostToolUse({ project: 'my-project' });
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/cli/commands/hook/format-sqaa-hook-context.test.ts
+++ b/tests/unit/cli/commands/hook/format-sqaa-hook-context.test.ts
@@ -1,0 +1,100 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { formatSqaaJsonReportForHook } from '../../../../../src/cli/commands/hook/format-sqaa-hook-context';
+
+describe('formatSqaaJsonReportForHook', () => {
+  it('returns null for an empty change set', () => {
+    expect(
+      formatSqaaJsonReportForHook({
+        files: [],
+        ignored: [],
+        failures: [],
+        skipped: [],
+        summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
+      }),
+    ).toBeNull();
+  });
+
+  it('surfaces skipped files when analysis did not complete any file', () => {
+    expect(
+      formatSqaaJsonReportForHook({
+        files: [],
+        ignored: [],
+        failures: [],
+        skipped: ['src/a.ts', 'src/b.ts'],
+        summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 2 },
+      }),
+    ).toBe('Skipped 2 file(s) (analysis not completed).');
+  });
+
+  it('surfaces per-file analysis errors when totalIssues is zero', () => {
+    const text = formatSqaaJsonReportForHook({
+      files: [
+        {
+          path: 'src/foo.ts',
+          issues: [],
+          errors: [{ code: 'FILE_NOT_FOUND', message: 'File not indexed' }],
+        },
+      ],
+      ignored: [],
+      failures: [],
+      skipped: [],
+      summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
+    });
+
+    expect(text).not.toContain('no issues found');
+    expect(text).toContain('src/foo.ts');
+    expect(text).toContain('FILE_NOT_FOUND');
+    expect(text).toContain('File not indexed');
+  });
+
+  it('surfaces ignored-only change sets without claiming no issues found', () => {
+    const text = formatSqaaJsonReportForHook({
+      files: [],
+      ignored: [{ path: 'image.png', reason: 'binary' }],
+      failures: [],
+      skipped: [],
+      summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
+    });
+
+    expect(text).not.toContain('no issues found');
+    expect(text).toContain('excluded (binary or oversized)');
+    expect(text).toContain('image.png');
+    expect(text).toContain('binary');
+  });
+
+  it('appends excluded files when analysis completed with no issues', () => {
+    const text = formatSqaaJsonReportForHook({
+      files: [{ path: 'src/a.ts', issues: [], errors: null }],
+      ignored: [{ path: 'large.bin', reason: 'oversized' }],
+      failures: [],
+      skipped: [],
+      summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
+    });
+
+    expect(text).toContain('no issues found');
+    expect(text).toContain('Excluded 1 file(s)');
+    expect(text).toContain('large.bin');
+    expect(text).toContain('oversized');
+  });
+});

--- a/tests/unit/cli/commands/hook/git.test.ts
+++ b/tests/unit/cli/commands/hook/git.test.ts
@@ -20,14 +20,14 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import { CommandFailedError } from '../../src/cli/commands/_common/error';
-import * as installSecrets from '../../src/cli/commands/_common/install/secrets';
-import * as analyzeSecrets from '../../src/cli/commands/analyze/secrets';
-import { gitPreCommit } from '../../src/cli/commands/hook/git-pre-commit';
-import { gitPrePush } from '../../src/cli/commands/hook/git-pre-push';
-import * as stdinModule from '../../src/cli/commands/hook/stdin';
-import * as authResolver from '../../src/lib/auth-resolver';
-import * as processLib from '../../src/lib/process';
+import { CommandFailedError } from '../../../../../src/cli/commands/_common/error';
+import * as installSecrets from '../../../../../src/cli/commands/_common/install/secrets';
+import * as analyzeSecrets from '../../../../../src/cli/commands/analyze/secrets';
+import { gitPreCommit } from '../../../../../src/cli/commands/hook/git-pre-commit';
+import { gitPrePush } from '../../../../../src/cli/commands/hook/git-pre-push';
+import * as stdinModule from '../../../../../src/cli/commands/hook/stdin';
+import * as authResolver from '../../../../../src/lib/auth-resolver';
+import * as processLib from '../../../../../src/lib/process';
 
 const { EXIT_CODE_SECRETS_FOUND } = analyzeSecrets;
 

--- a/tests/unit/cli/commands/hook/stdin.test.ts
+++ b/tests/unit/cli/commands/hook/stdin.test.ts
@@ -20,7 +20,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import { readGitPushRefs, readStdinJson } from '../../src/cli/commands/hook/stdin';
+import { readGitPushRefs, readStdinJson } from '../../../../../src/cli/commands/hook/stdin';
 
 describe('readStdinJson', () => {
   type StdinListener = (...args: any[]) => void;

--- a/tests/unit/cli/commands/integrate/_common/hooks.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/hooks.test.ts
@@ -25,7 +25,10 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import {
+  assertSafeSonarProjectKeyForHookScript,
+  formatSqaaPostToolHookCommandUnix,
   readOrInitJson,
+  shellQuoteBash,
   UNIX_SONAR_COMMAND_GUARD,
   unixTemplate,
   WINDOWS_SONAR_COMMAND_GUARD,
@@ -93,6 +96,34 @@ describe('writeHookScript', () => {
     // Mask out file-type bits; only the permission bits matter.
     const mode = statSync(written).mode & 0o777;
     expect(mode).toBe(0o755);
+  });
+});
+
+describe('assertSafeSonarProjectKeyForHookScript', () => {
+  it('accepts typical SonarQube project keys', () => {
+    expect(() => assertSafeSonarProjectKeyForHookScript('SonarSource_sonarqube-cli')).not.toThrow();
+  });
+
+  it('rejects keys with shell metacharacters', () => {
+    expect(() => assertSafeSonarProjectKeyForHookScript('$(id)')).toThrow();
+    expect(() => assertSafeSonarProjectKeyForHookScript('my project')).toThrow();
+  });
+});
+
+describe('formatSqaaPostToolHookCommandUnix', () => {
+  it('single-quotes the project key so Bash does not expand metacharacters', () => {
+    const command = formatSqaaPostToolHookCommandUnix('codex-post-tool-use', 'my-org_my-project');
+    expect(command).toBe("sonar hook codex-post-tool-use --project 'my-org_my-project'");
+  });
+
+  it('escapes embedded single quotes in the project key', () => {
+    expect(() => formatSqaaPostToolHookCommandUnix('codex-post-tool-use', "bad'key")).toThrow();
+  });
+});
+
+describe('shellQuoteBash', () => {
+  it('wraps values in single quotes', () => {
+    expect(shellQuoteBash('a:b')).toBe("'a:b'");
   });
 });
 

--- a/tests/unit/cli/commands/integrate/claude/hook-templates.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/hook-templates.test.ts
@@ -88,7 +88,7 @@ describe('SQAA PostToolUse Hook Templates', () => {
 
     expect(template.startsWith('#!/bin/bash')).toBe(true);
     expect(template.includes('sonar hook claude-post-tool-use')).toBe(true);
-    expect(template.includes('--project my-project')).toBe(true);
+    expect(template.includes("--project 'my-project'")).toBe(true);
     expect(template.includes(UNIX_SONAR_COMMAND_GUARD)).toBe(true);
   });
 
@@ -104,7 +104,7 @@ describe('SQAA PostToolUse Hook Templates', () => {
     const template = getSqaaPostToolTemplateWindows('my-project');
 
     expect(template.includes('sonar hook claude-post-tool-use')).toBe(true);
-    expect(template.includes('--project my-project')).toBe(true);
+    expect(template.includes("--project 'my-project'")).toBe(true);
     expect(template.includes(WINDOWS_SONAR_COMMAND_GUARD)).toBe(true);
   });
 

--- a/tests/unit/cli/commands/integrate/codex/hook-templates.test.ts
+++ b/tests/unit/cli/commands/integrate/codex/hook-templates.test.ts
@@ -1,0 +1,51 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  UNIX_SONAR_COMMAND_GUARD,
+  WINDOWS_SONAR_COMMAND_GUARD,
+} from '../../../../../../src/cli/commands/integrate/_common/hooks';
+import {
+  getSqaaPostToolTemplateUnix,
+  getSqaaPostToolTemplateWindows,
+} from '../../../../../../src/cli/commands/integrate/codex/hook-templates';
+
+describe('Codex SQAA PostToolUse Hook Templates', () => {
+  it('PostTool Unix hook: delegates to codex-post-tool-use with project key', () => {
+    const template = getSqaaPostToolTemplateUnix('my-project');
+
+    expect(template.startsWith('#!/bin/bash')).toBe(true);
+    expect(template.includes('sonar hook codex-post-tool-use')).toBe(true);
+    expect(template.includes("--project 'my-project'")).toBe(true);
+    expect(template.includes(UNIX_SONAR_COMMAND_GUARD)).toBe(true);
+    expect(template.includes('sonar analyze agentic')).toBe(false);
+  });
+
+  it('PostTool Windows hook: delegates to codex-post-tool-use with project key', () => {
+    const template = getSqaaPostToolTemplateWindows('my-project');
+
+    expect(template.includes('sonar hook codex-post-tool-use')).toBe(true);
+    expect(template.includes("--project 'my-project'")).toBe(true);
+    expect(template.includes(WINDOWS_SONAR_COMMAND_GUARD)).toBe(true);
+    expect(template.includes('sonar analyze agentic')).toBe(false);
+  });
+});


### PR DESCRIPTION
Shipped the Codex PostToolUse SQAA hook as proposed:

- sonar hook codex-post-tool-use — runs after apply_patch, uses the same git change-set path as sonar analyze agentic (git diff HEAD + untracked), and writes findings to Codex via additionalContext JSON on stdout.

- sonar integrate codex — when the org is SQAA-entitled and a project key is known (project scope), installs .codex/hooks.json PostToolUse on apply_patch plus the hook script; does not write the AGENTS.md SQAA protocol block anymore (hook replaces it). Global integrate still skips SQAA and points users to project-scoped integrate codex --project.

- Shared with Claude — hook output formatting and project-key shell quoting live in _common/hooks.ts / format-sqaa-hook-context.ts; Claude’s post-tool handler was refactored to use the same helpers (behavior unchanged).

Also covered: safe embedding of project keys in generated scripts; hook output for skipped / failed / ignored (binary/oversized) files; unit + integration tests.

Intentional choices (from discovery): full change-set re-analysis per patch (not single-file / not parsing tool_response), aligned with analyze agentic and Claude’s “analyze after edit” model, with a different granularity for Codex.

<img width="628" height="158" alt="image" src="https://github.com/user-attachments/assets/3fb678a1-8b06-4a19-9c52-0dcf29d7691b" />

codex/hooks.json
```
    "PostToolUse": [
      {
        "matcher": "apply_patch",
        "hooks": [
          {
            "type": "command",
            "command": ".codex/hooks/sonar-sqaa/build-scripts/posttool-sqaa.sh",
            "timeout": 60
          }
        ]
      }
    ]
```
posttool-sqaa.sh
```
#!/bin/bash
if ! command -v sonar &> /dev/null; then
  exit 0
fi
sonar hook codex-post-tool-use --project SonarSource_sonarqube-cli

```

----
## Summary by Gitar

- **CLI command and integration:**
  - Added `codex-post-tool-use` command for running Agentic Analysis on git change sets after `apply_patch`.
  - Configured `PostToolUse` hook in `.codex/hooks.json` and implemented automated installation during Codex integration.
- **Hook output and formatting:**
  - Added `format-sqaa-hook-context.ts` to structure analysis findings, errors, and failures for tool output.
  - Updated `agent-post-tool-use.ts` to utilize the new formatting logic.
- **Security enhancements:**
  - Implemented shell-quote protection for project keys in generated hook scripts (Bash/PowerShell).
  - Added safety validation for project keys to prevent injection in generated hook scripts.
- **Test suite updates:**
  - Added unit tests for `codex-post-tool-use` and hook script safety utilities.
  - Updated integration tests to verify SQAA hook installation, idempotency, and non-interference with existing hooks.


<sub>This will update automatically on new commits.</sub>