### PR TITLE
CLI-594 Interactive integrate: wire codex to interactive feature selection

### DIFF
--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -20,13 +20,36 @@
 
 import { join } from 'node:path';
 
+import type { CliState, IntegrationScope } from '../../../../../lib/state';
 import { createAgentHookEntry, resolveAgentHookScriptPath, upsertAgentHooks } from '../hooks';
 import { sonarSecretsBinaryDependency } from '../registry/dependencies';
+import { isFeatureInstalledGloballyForProject } from '../registry/installation-recorder';
 import { jsonPatch, type PlatformSpecificContent, wholeFile } from '../registry/resources';
+import { askUser, skip } from '../registry/selection';
 import type { FeatureDeclaration, IntegrationContext, PostInstallExample } from '../registry/types';
 
+const SONAR_SECRETS_HOOKS_FEATURE_ID = 'sonar-secrets-hooks';
+
 export interface SonarSecretsHooksFeatureOptions {
-  installSecretsHooks?: boolean;
+  globalSecretsHookExists?: boolean;
+}
+
+/** True when a global secrets hook already exists, per the explicit option or, when unset, the recorded state. */
+function globalSecretsHookAlreadyConfigured(
+  integrationId: string,
+  options: SonarSecretsHooksFeatureOptions,
+  scope: IntegrationScope,
+  state: CliState | undefined,
+): boolean {
+  if (options.globalSecretsHookExists !== undefined) {
+    return options.globalSecretsHookExists;
+  }
+  return isFeatureInstalledGloballyForProject(
+    state,
+    scope,
+    integrationId,
+    SONAR_SECRETS_HOOKS_FEATURE_ID,
+  );
 }
 
 export function secretsScanningExample(agentDisplayName: string): PostInstallExample {
@@ -53,6 +76,7 @@ export interface SonarSecretsHookEntrySpec {
 
 export interface SonarSecretsHooksFeatureConfig {
   agentDisplayName: string;
+  integrationId: string;
   configDir: string;
   hooksConfigFileName: string;
   hooksPatchId: string;
@@ -76,9 +100,14 @@ export function createSonarSecretsHooksFeature<TOptions extends SonarSecretsHook
     resolveAgentHooksConfigPath(context, config.configDir, config.hooksConfigFileName);
 
   return {
-    id: 'sonar-secrets-hooks',
+    id: SONAR_SECRETS_HOOKS_FEATURE_ID,
     displayName: 'secret scanning hooks',
-    shouldInstall: ({ options }) => options.installSecretsHooks === true,
+    shouldInstall: ({ options, scope, state }) =>
+      globalSecretsHookAlreadyConfigured(config.integrationId, options, scope, state)
+        ? skip(
+            'Skipping the project-level secret scanning hooks because a global secrets scanning hook is already configured.',
+          )
+        : askUser(),
     postInstallExample: secretsScanningExample(config.agentDisplayName),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -39,7 +39,7 @@ function globalSecretsHookAlreadyConfigured(
   integrationId: string,
   options: SonarSecretsHooksFeatureOptions,
   scope: IntegrationScope,
-  state: CliState | undefined,
+  state: CliState,
 ): boolean {
   if (options.globalSecretsHookExists !== undefined) {
     return options.globalSecretsHookExists;

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -33,6 +33,7 @@ export {
   type InstallIntegrationOptions,
   makeContext,
 } from './install-integration';
+export { isFeatureInstalledGloballyForProject } from './installation-recorder';
 export {
   IntegrationInstaller,
   integrationInstaller,

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -70,7 +70,17 @@ export async function installIntegration<TOptions>({
   nonInteractive,
 }: InstallIntegrationOptions<TOptions>): Promise<InstalledIntegrationFeature[]> {
   const integration = getIntegrationDeclaration<TOptions>(registry, integrationId);
-  const invocation = makeInvocation(options, targetRoot, scope, auth, force, attrs, nonInteractive);
+  const state = loadStateForInstallation();
+  const invocation: IntegrationInvocation<TOptions> = {
+    options,
+    targetRoot,
+    scope,
+    auth,
+    force,
+    attrs,
+    nonInteractive,
+    state,
+  };
   const features =
     featureIds === undefined
       ? await integrationInstaller.selectFeaturesForInvocation(integration, invocation)
@@ -79,7 +89,6 @@ export async function installIntegration<TOptions>({
     throw new CommandFailedError(`No feature selected for ${integration.displayName}`);
   }
 
-  const state = loadStateForInstallation();
   const applications: FeatureApplication<TOptions>[] = [];
   for (const feature of features) {
     const context = await resolveFeatureContext(state, invocation, feature, 'install');
@@ -188,18 +197,6 @@ function loadStateForInstallation(): CliState {
     logger.warn(`Failed to read configuration state: ${msg}`);
     return getDefaultState(VERSION);
   }
-}
-
-function makeInvocation<TOptions>(
-  options: TOptions,
-  targetRoot: string,
-  scope: IntegrationScope,
-  auth: ResolvedAuth | undefined,
-  force: boolean | undefined,
-  attrs: Record<string, IntegrationStateAttribute> | undefined,
-  nonInteractive: boolean | undefined,
-): IntegrationInvocation<TOptions> {
-  return { options, targetRoot, scope, auth, force, attrs, nonInteractive };
 }
 
 async function resolveFeatureContext<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/installation-recorder.ts
+++ b/src/cli/commands/integrate/_common/registry/installation-recorder.ts
@@ -29,6 +29,7 @@ import type {
   InstalledIntegrationFeature,
   InstalledIntegrationOperation,
   InstalledIntegrationResource,
+  IntegrationScope,
 } from '../../../../../lib/state';
 import type {
   AppliedFeature,
@@ -105,6 +106,23 @@ export function collectReferencedDependencyIds(state: CliState): Set<string> {
         feature.dependencies.map((dependency) => dependency.id),
       ),
     ),
+  );
+}
+
+/** True for a project install whose `featureId` already has a recorded global install. */
+export function isFeatureInstalledGloballyForProject(
+  state: CliState | undefined,
+  scope: IntegrationScope,
+  integrationId: string,
+  featureId: string,
+): boolean {
+  return (
+    scope === 'project' &&
+    state !== undefined &&
+    (state.integrations.installed
+      .find((integration) => integration.integrationId === integrationId)
+      ?.features.some((feature) => feature.featureId === featureId && feature.scope === 'global') ??
+      false)
   );
 }
 

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -50,6 +50,7 @@ export interface IntegrationInvocation<TOptions = Record<string, unknown>> {
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
   nonInteractive?: boolean;
+  state?: CliState;
 }
 
 export type FeatureTargetRoot<TOptions = Record<string, unknown>> =

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -50,7 +50,7 @@ export interface IntegrationInvocation<TOptions = Record<string, unknown>> {
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
   nonInteractive?: boolean;
-  state?: CliState;
+  state: CliState;
 }
 
 export type FeatureTargetRoot<TOptions = Record<string, unknown>> =

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -51,7 +51,7 @@ export const CLAUDE_INTEGRATION_ID = 'claude-code';
 
 export interface ClaudeIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
-  installSecretsHooks?: boolean;
+  globalSecretsHookExists?: boolean;
   installSqaaHook?: boolean;
   installMcp?: boolean;
   installContextAugmentation?: boolean;
@@ -64,6 +64,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     {
       ...createSonarSecretsHooksFeature({
         agentDisplayName: 'Claude',
+        integrationId: CLAUDE_INTEGRATION_ID,
         configDir: CLAUDE_CONFIG_DIR,
         hooksConfigFileName: SETTINGS_FILE,
         hooksPatchId: 'claude-settings-secrets-hooks',

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -106,7 +106,7 @@ export async function integrateClaude(
   const integrationOptions = {
     ...options,
     projectRoot: ctx.project.rootDir,
-    installSecretsHooks: !skipSecretsHooks,
+    globalSecretsHookExists: skipSecretsHooks,
     installSqaaHook: sqaaEnabled && config.projectKey !== undefined,
     installMcp: true,
     installContextAugmentation: contextAugmentation !== null,

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -29,6 +29,8 @@ import {
   buildSqaaSectionBody,
   sonarBeginMarker,
   sonarEndMarker,
+  SQAA_MISSING_PROJECT_KEY_MESSAGE,
+  SQAA_PROMOTION_MESSAGE,
 } from '../_common/instructions-templates';
 import { isFeatureInstalledGloballyForProject } from '../_common/registry/installation-recorder';
 import { textSnippet, tomlPatch } from '../_common/registry/resources';
@@ -49,6 +51,7 @@ export interface CodexIntegrationOptions extends IntegrateAgentOptions {
   globalSecretsHookExists?: boolean;
   /** Write the SQAA marker block into `.codex/AGENTS.md`. */
   installSqaaInstructions?: boolean;
+  sqaaEntitled?: boolean;
   installContextAugmentation?: boolean;
 }
 
@@ -114,7 +117,9 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
         if (options.installSqaaInstructions === true) {
           return askUser();
         }
-        return skip();
+        return skip(
+          options.sqaaEntitled === true ? SQAA_MISSING_PROJECT_KEY_MESSAGE : SQAA_PROMOTION_MESSAGE,
+        );
       },
       resources: [
         textSnippet({

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -29,8 +29,6 @@ import {
   buildSqaaSectionBody,
   sonarBeginMarker,
   sonarEndMarker,
-  SQAA_MISSING_PROJECT_KEY_MESSAGE,
-  SQAA_PROMOTION_MESSAGE,
 } from '../_common/instructions-templates';
 import { isFeatureInstalledGloballyForProject } from '../_common/registry/installation-recorder';
 import { textSnippet, tomlPatch } from '../_common/registry/resources';
@@ -51,8 +49,6 @@ export interface CodexIntegrationOptions extends IntegrateAgentOptions {
   globalSecretsHookExists?: boolean;
   /** Write the SQAA marker block into `.codex/AGENTS.md`. */
   installSqaaInstructions?: boolean;
-  /** Whether the connection is entitled to SonarQube Agentic Analysis. */
-  sqaaEntitled?: boolean;
   installContextAugmentation?: boolean;
 }
 
@@ -118,9 +114,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
         if (options.installSqaaInstructions === true) {
           return askUser();
         }
-        return skip(
-          options.sqaaEntitled === true ? SQAA_MISSING_PROJECT_KEY_MESSAGE : SQAA_PROMOTION_MESSAGE,
-        );
+        return skip();
       },
       resources: [
         textSnippet({

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -29,8 +29,12 @@ import {
   buildSqaaSectionBody,
   sonarBeginMarker,
   sonarEndMarker,
+  SQAA_MISSING_PROJECT_KEY_MESSAGE,
+  SQAA_PROMOTION_MESSAGE,
 } from '../_common/instructions-templates';
+import { isFeatureInstalledGloballyForProject } from '../_common/registry/installation-recorder';
 import { textSnippet, tomlPatch } from '../_common/registry/resources';
+import { askUser, skip } from '../_common/registry/selection';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPromptTemplateUnix, getSecretPromptTemplateWindows } from './hook-templates';
@@ -44,12 +48,11 @@ const PROMPT_SCRIPT_REL = 'sonar-secrets/build-scripts/prompt-secrets';
 export const CODEX_INTEGRATION_ID = 'codex';
 
 export interface CodexIntegrationOptions extends IntegrateAgentOptions {
-  installSecretsHooks?: boolean;
-  /** Write the secrets-on-read marker block into `.codex/AGENTS.md`. */
-  installSecretsInstructions?: boolean;
+  globalSecretsHookExists?: boolean;
   /** Write the SQAA marker block into `.codex/AGENTS.md`. */
   installSqaaInstructions?: boolean;
-  installMcp?: boolean;
+  /** Whether the connection is entitled to SonarQube Agentic Analysis. */
+  sqaaEntitled?: boolean;
   installContextAugmentation?: boolean;
 }
 
@@ -59,6 +62,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
   features: [
     createSonarSecretsHooksFeature({
       agentDisplayName: 'Codex',
+      integrationId: CODEX_INTEGRATION_ID,
       configDir: CODEX_CONFIG_DIR,
       hooksConfigFileName: HOOKS_FILE,
       hooksPatchId: 'codex-hooks-secrets-hook',
@@ -85,7 +89,17 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     {
       id: 'secrets-instructions',
       displayName: 'secrets-on-read instructions',
-      shouldInstall: ({ options }) => options.installSecretsInstructions === true,
+      shouldInstall: ({ scope, state }) =>
+        isFeatureInstalledGloballyForProject(
+          state,
+          scope,
+          CODEX_INTEGRATION_ID,
+          'secrets-instructions',
+        )
+          ? askUser(
+              'Global Codex instructions already exist. Do you also want to create a project-local copy for this repo?',
+            )
+          : askUser(),
       resources: [
         textSnippet({
           id: 'codex-secrets-instructions',
@@ -100,7 +114,14 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      shouldInstall: ({ options }) => options.installSqaaInstructions === true,
+      shouldInstall: ({ options }) => {
+        if (options.installSqaaInstructions === true) {
+          return askUser();
+        }
+        return skip(
+          options.sqaaEntitled === true ? SQAA_MISSING_PROJECT_KEY_MESSAGE : SQAA_PROMOTION_MESSAGE,
+        );
+      },
       resources: [
         textSnippet({
           id: 'codex-sqaa-instructions',
@@ -118,7 +139,6 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      shouldInstall: ({ options }) => options.installMcp === true,
       resources: [
         tomlPatch({
           id: 'codex-mcp-config',

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -66,6 +66,7 @@ export async function integrateCodex(
   const integrationOptions = {
     ...options,
     installSqaaInstructions: includeSqaa,
+    sqaaEntitled: sqaaEligible,
     installContextAugmentation: contextAugmentation !== null,
   } satisfies CodexIntegrationOptions;
 

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -65,10 +65,8 @@ export async function integrateCodex(
       });
   const integrationOptions = {
     ...options,
-    installSecretsHooks: true,
-    installSecretsInstructions: true,
     installSqaaInstructions: includeSqaa,
-    installMcp: true,
+    sqaaEntitled: sqaaEligible,
     installContextAugmentation: contextAugmentation !== null,
   } satisfies CodexIntegrationOptions;
 

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -66,7 +66,6 @@ export async function integrateCodex(
   const integrationOptions = {
     ...options,
     installSqaaInstructions: includeSqaa,
-    sqaaEntitled: sqaaEligible,
     installContextAugmentation: contextAugmentation !== null,
   } satisfies CodexIntegrationOptions;
 

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -41,6 +41,8 @@ import { buildLocalCagBinaryName } from '../../../src/cli/commands/_common/insta
 import { SCA_SCANNER_SPEC } from '../../../src/cli/commands/_common/install/sca-scanner';
 import { SECRETS_SPEC } from '../../../src/cli/commands/_common/install/secrets';
 import { CONTEXT_AUGMENTATION_FEATURE_ID } from '../../../src/cli/commands/integrate/_common/features/context-augmentation-feature';
+import { recordInstalledFeature } from '../../../src/cli/commands/integrate/_common/registry/installation-recorder';
+import type { IntegrationDeclaration } from '../../../src/cli/commands/integrate/_common/registry/types';
 import { CLAUDE_INTEGRATION_ID } from '../../../src/cli/commands/integrate/claude/declaration';
 import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../src/lib/install-types.js';
 import { generateKeychainAccount } from '../../../src/lib/keychain';
@@ -51,6 +53,7 @@ import type {
   CliState,
   InstalledIntegrationDependency,
   InstalledTool,
+  IntegrationScope,
 } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import { IS_WINDOWS } from './platform';
@@ -144,6 +147,7 @@ export class EnvironmentBuilder {
   private readonly keychainTokens: Array<{ serverURL: string; token: string; org?: string }> = [];
   private readonly sqaaExtensions: SqaaExtensionConfig[] = [];
   private readonly contextAugmentationSkills: ContextAugmentationSkillConfig[] = [];
+  private readonly installedFeatureSeeds: Array<(state: CliState) => void> = [];
 
   withActiveConnection(
     url: string,
@@ -321,6 +325,33 @@ export class EnvironmentBuilder {
     return this;
   }
 
+  /**
+   * Seeds a previously-installed integration feature in the state file so
+   * `shouldInstall` state probes (e.g. `isFeatureInstalledGloballyForProject`) see it as
+   * already installed.
+   */
+  withInstalledIntegrationFeature<TOptions>(
+    integration: IntegrationDeclaration<TOptions>,
+    featureId: string,
+    scope: IntegrationScope = 'global',
+    targetRoot = '',
+  ): this {
+    this.installedFeatureSeeds.push((state) => {
+      const feature = integration.features.find((entry) => entry.id === featureId);
+      if (!feature) {
+        throw new Error(`Unknown feature ${integration.id}.${featureId}`);
+      }
+      recordInstalledFeature(
+        state,
+        { targetRoot, scope, executionMode: 'install', resolvedDependencies: new Map(), attrs: {} },
+        integration,
+        feature,
+        { dependencies: [], resources: [], operations: [] },
+      );
+    });
+    return this;
+  }
+
   build(binDir?: string): CliState {
     // Default to the current CLI version so post-update is a no-op. Tests that
     // need to exercise the upgrade migration inject a stale version via
@@ -444,6 +475,10 @@ export class EnvironmentBuilder {
         serverUrl: skill.serverUrl ?? this.activeConnectionUrl,
         scaEnabled: skill.scaEnabled ?? false,
       });
+    }
+
+    for (const seed of this.installedFeatureSeeds) {
+      seed(state);
     }
 
     return state;

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -722,7 +722,7 @@ describe('integrate claude — SQAA entitlement guard', () => {
       const serverUrl = server.baseUrl();
       harness.withAuth(serverUrl, 'cloud-token', 'my-org');
 
-      const result = await harness.run('integrate claude -g', {
+      const result = await harness.run('integrate claude -g --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -508,12 +508,11 @@ describe('integrate codex', () => {
 
   describe('interactive feature selection', () => {
     it(
-      'prompts per feature, installs accepted features, and shows the SQAA promotion when not entitled',
+      'prompts per feature, installs accepted features, and silently skips SQAA when not entitled',
       async () => {
         // Default beforeEach is on-premise auth with no org, so SQAA and
-        // Context Augmentation are not available: SQAA is skipped with the
-        // promotion line and CAG is skipped silently. The three remaining
-        // features (hook, secrets instructions, MCP) each ask.
+        // Context Augmentation are not available: both are skipped silently.
+        // The three remaining features (hook, secrets instructions, MCP) each ask.
         const result = await harness.run('integrate codex', {
           stdinChunks: ['\r', '\r', '\r'],
         });
@@ -524,8 +523,6 @@ describe('integrate codex', () => {
         expect(output).toContain('Install secret scanning hooks?');
         expect(output).toContain('Install secrets-on-read instructions?');
         expect(output).toContain('Install MCP server?');
-        // SQAA is skipped with the shared promotion message.
-        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
         // Accepted features are installed on disk.
         expect(
           harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -508,11 +508,12 @@ describe('integrate codex', () => {
 
   describe('interactive feature selection', () => {
     it(
-      'prompts per feature, installs accepted features, and silently skips SQAA when not entitled',
+      'prompts per feature, installs accepted features, and shows the SQAA promotion when not entitled',
       async () => {
         // Default beforeEach is on-premise auth with no org, so SQAA and
-        // Context Augmentation are not available: both are skipped silently.
-        // The three remaining features (hook, secrets instructions, MCP) each ask.
+        // Context Augmentation are not available: SQAA is skipped with the
+        // promotion line and CAG is skipped silently. The three remaining
+        // features (hook, secrets instructions, MCP) each ask.
         const result = await harness.run('integrate codex', {
           stdinChunks: ['\r', '\r', '\r'],
         });
@@ -523,6 +524,11 @@ describe('integrate codex', () => {
         expect(output).toContain('Install secret scanning hooks?');
         expect(output).toContain('Install secrets-on-read instructions?');
         expect(output).toContain('Install MCP server?');
+        // SQAA is skipped with the shared promotion message + docs link.
+        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
+        expect(output).toContain(
+          'docs.sonarsource.com/agent-centric-development-cycle/features/agentic-analysis',
+        );
         // Accepted features are installed on disk.
         expect(
           harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -27,6 +27,7 @@ import { isAbsolute } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
+import { codexIntegration } from '../../../../src/cli/commands/integrate/codex/declaration';
 import { hookScriptName, hookScriptPath, normalizePath, TestHarness } from '../../harness';
 
 const PROMPT_SCRIPT_DIRS = ['.codex', 'hooks', 'sonar-secrets', 'build-scripts'];
@@ -43,6 +44,26 @@ interface CodexHooksFile {
       hooks?: Array<{ type?: string; command?: string; timeout?: number }>;
     }>;
   };
+}
+
+interface InstalledCodexFeature {
+  featureId: string;
+  scope: string;
+}
+
+function findCodexFeature(
+  harness: TestHarness,
+  featureId: string,
+  scope?: string,
+): InstalledCodexFeature | undefined {
+  const state = harness.stateJsonFile.asJson();
+  const codex = state.integrations.installed.find(
+    (entry: { integrationId: string }) => entry.integrationId === 'codex',
+  );
+  return codex?.features?.find(
+    (feature: InstalledCodexFeature) =>
+      feature.featureId === featureId && (scope === undefined || feature.scope === scope),
+  ) as InstalledCodexFeature | undefined;
 }
 
 describe('integrate codex', () => {
@@ -63,7 +84,7 @@ describe('integrate codex', () => {
     it(
       'writes an executable prompt-submit script and a hooks.json entry under .codex/',
       async () => {
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
 
@@ -91,7 +112,7 @@ describe('integrate codex', () => {
     it(
       'uses a project-relative command path so the config is portable',
       async () => {
-        await harness.run('integrate codex');
+        await harness.run('integrate codex --non-interactive');
 
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
         const command = hookScriptPath(
@@ -106,8 +127,8 @@ describe('integrate codex', () => {
     it(
       're-running does not duplicate the UserPromptSubmit entry',
       async () => {
-        await harness.run('integrate codex');
-        const result = await harness.run('integrate codex');
+        await harness.run('integrate codex --non-interactive');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
@@ -135,7 +156,7 @@ describe('integrate codex', () => {
           }),
         );
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const hooks: CodexHooksFile = harness.cwd.file(...HOOKS_JSON_DIRS).asJson();
@@ -153,7 +174,7 @@ describe('integrate codex', () => {
     it(
       'writes script + hooks.json under $HOME/.codex/ with an absolute command path',
       async () => {
-        const result = await harness.run('integrate codex -g');
+        const result = await harness.run('integrate codex -g --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists('.codex')).toBe(false);
@@ -171,6 +192,32 @@ describe('integrate codex', () => {
       },
       { timeout: 30000 },
     );
+
+    it(
+      'skips the project-level secrets hook when a global Codex hook is already recorded',
+      async () => {
+        // Seed a previously-installed global secrets hook so the state probe
+        // (isFeatureInstalledGloballyForProject) fires for the project run.
+        harness
+          .state()
+          .withInstalledIntegrationFeature(codexIntegration, 'sonar-secrets-hooks', 'global');
+
+        const result = await harness.run('integrate codex --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+        expect(`${result.stdout}\n${result.stderr}`).toContain(
+          'Skipping the project-level secret scanning hooks because a global secrets scanning hook is already configured.',
+        );
+        // No project-level hook artifacts were written.
+        expect(harness.cwd.exists('.codex', 'hooks')).toBe(false);
+        expect(harness.cwd.exists(...HOOKS_JSON_DIRS)).toBe(false);
+        expect(findCodexFeature(harness, 'sonar-secrets-hooks', 'project')).toBeUndefined();
+        // The remaining project features still install.
+        expect(harness.cwd.file(...AGENTS_MD_DIRS).asText()).toContain(SECRETS_HEADING);
+        expect(harness.cwd.exists(...CONFIG_TOML_DIRS)).toBe(true);
+      },
+      { timeout: 30000 },
+    );
   });
 
   describe('MCP server config', () => {
@@ -179,7 +226,7 @@ describe('integrate codex', () => {
       async () => {
         harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=my-project\n');
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         // Assert on the result and the file contents
         expect(result.exitCode).toBe(0);
@@ -215,7 +262,7 @@ describe('integrate codex', () => {
     it(
       'writes the MCP config to $HOME/.codex/config.toml for global installs',
       async () => {
-        const result = await harness.run('integrate codex -g');
+        const result = await harness.run('integrate codex -g --non-interactive');
 
         // Assert on the result and the file contents
         expect(result.exitCode).toBe(0);
@@ -250,10 +297,10 @@ describe('integrate codex', () => {
     it(
       're-running does not change the config.toml or duplicate [mcp_servers.sonarqube]',
       async () => {
-        await harness.run('integrate codex');
+        await harness.run('integrate codex --non-interactive');
         const firstBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.file(...CONFIG_TOML_DIRS).asText()).toBe(firstBody);
@@ -270,7 +317,7 @@ describe('integrate codex', () => {
           '[mcp_servers.sonarqube]\ncommand = "custom-sonar"\nargs = ["custom", "args"]\n',
         );
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
@@ -286,7 +333,7 @@ describe('integrate codex', () => {
       async () => {
         harness.cwd.writeFile('.codex/config.toml', '= not valid toml =');
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(1);
         const output = `${result.stdout}\n${result.stderr}`;
@@ -299,7 +346,7 @@ describe('integrate codex', () => {
     it(
       'omits --project from the args array when no project key is known',
       async () => {
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
@@ -328,7 +375,7 @@ describe('integrate codex', () => {
           ].join('\n'),
         );
 
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
@@ -344,7 +391,7 @@ describe('integrate codex', () => {
 
   describe('option validation', () => {
     it('rejects --global combined with --project', async () => {
-      const result = await harness.run('integrate codex -g -p some-project');
+      const result = await harness.run('integrate codex -g -p some-project --non-interactive');
 
       expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain('mutually exclusive');
@@ -358,7 +405,7 @@ describe('integrate codex', () => {
     it(
       'writes the secrets-on-read section to <repo>/.codex/AGENTS.md at project scope (no SQAA without entitlement)',
       async () => {
-        const result = await harness.run('integrate codex');
+        const result = await harness.run('integrate codex --non-interactive');
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...AGENTS_MD_DIRS).asText();
@@ -384,12 +431,15 @@ describe('integrate codex', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
 
-        const result = await harness.run(`integrate codex --project ${TEST_PROJECT}`, {
-          extraEnv: {
-            SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
-            SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        const result = await harness.run(
+          `integrate codex --project ${TEST_PROJECT} --non-interactive`,
+          {
+            extraEnv: {
+              SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+              SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+            },
           },
-        });
+        );
 
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...AGENTS_MD_DIRS).asText();
@@ -407,7 +457,7 @@ describe('integrate codex', () => {
     it(
       'writes ~/.codex/AGENTS.md (and nothing project-side) at global scope without SQAA entitlement, and does NOT warn about SQAA',
       async () => {
-        const result = await harness.run('integrate codex -g');
+        const result = await harness.run('integrate codex -g --non-interactive');
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.exists(...AGENTS_MD_DIRS)).toBe(false);
@@ -434,7 +484,7 @@ describe('integrate codex', () => {
         harness.withAuth(serverUrl, 'cloud-token', TEST_ORG);
         harness.cwd.writeFile('sonar-project.properties', `sonar.projectKey=${TEST_PROJECT}\n`);
 
-        const result = await harness.run('integrate codex -g', {
+        const result = await harness.run('integrate codex -g --non-interactive', {
           extraEnv: {
             SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
             SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -451,6 +501,123 @@ describe('integrate codex', () => {
         const output = `${result.stdout}\n${result.stderr}`;
         expect(output).toContain('Skipping SonarQube Agentic Analysis');
         expect(output).toContain('not supported with --global');
+      },
+      { timeout: 30000 },
+    );
+  });
+
+  describe('interactive feature selection', () => {
+    it(
+      'prompts per feature, installs accepted features, and shows the SQAA promotion when not entitled',
+      async () => {
+        // Default beforeEach is on-premise auth with no org, so SQAA and
+        // Context Augmentation are not available: SQAA is skipped with the
+        // promotion line and CAG is skipped silently. The three remaining
+        // features (hook, secrets instructions, MCP) each ask.
+        const result = await harness.run('integrate codex', {
+          stdinChunks: ['\r', '\r', '\r'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        const output = `${result.stdout}\n${result.stderr}`;
+        // Each opted feature surfaced its confirm prompt.
+        expect(output).toContain('Install secret scanning hooks?');
+        expect(output).toContain('Install secrets-on-read instructions?');
+        expect(output).toContain('Install MCP server?');
+        // SQAA is skipped with the shared promotion message.
+        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
+        // Accepted features are installed on disk.
+        expect(
+          harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),
+        ).toBe(true);
+        expect(harness.cwd.exists(...HOOKS_JSON_DIRS)).toBe(true);
+        const agentsMd = harness.cwd.file(...AGENTS_MD_DIRS).asText();
+        expect(agentsMd).toContain(SECRETS_HEADING);
+        // No SQAA marker block was written (org not entitled).
+        expect(agentsMd).not.toContain(SQAA_HEADING);
+        expect(harness.cwd.exists(...CONFIG_TOML_DIRS)).toBe(true);
+        // Declarative state records only the accepted features.
+        expect(findCodexFeature(harness, 'sonar-secrets-hooks')).toBeDefined();
+        expect(findCodexFeature(harness, 'secrets-instructions')).toBeDefined();
+        expect(findCodexFeature(harness, 'mcp-server')).toBeDefined();
+        expect(findCodexFeature(harness, 'sqaa-instructions')).toBeUndefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'skips a feature when the user declines its prompt',
+      async () => {
+        // Decline the hook ('n'), accept secrets instructions and MCP ('\r').
+        const result = await harness.run('integrate codex', {
+          stdinChunks: ['n', '\r', '\r'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        // Hook was declined: no hook artifacts and no state entry.
+        expect(harness.cwd.exists('.codex', 'hooks')).toBe(false);
+        expect(harness.cwd.exists(...HOOKS_JSON_DIRS)).toBe(false);
+        expect(findCodexFeature(harness, 'sonar-secrets-hooks')).toBeUndefined();
+        // The accepted features are still installed.
+        expect(harness.cwd.file(...AGENTS_MD_DIRS).asText()).toContain(SECRETS_HEADING);
+        expect(harness.cwd.exists(...CONFIG_TOML_DIRS)).toBe(true);
+        expect(findCodexFeature(harness, 'secrets-instructions')).toBeDefined();
+        expect(findCodexFeature(harness, 'mcp-server')).toBeDefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'asks a custom question for secrets instructions when global instructions already exist',
+      async () => {
+        // Seed a previously-installed global secrets-instructions feature so the
+        // state probe (isFeatureInstalledGloballyForProject) fires for the project run.
+        harness
+          .state()
+          .withInstalledIntegrationFeature(codexIntegration, 'secrets-instructions', 'global');
+
+        // Project install hits the state-probe branch: the secrets-instructions
+        // feature asks a custom "project-local copy" question instead of the
+        // default one.
+        const result = await harness.run('integrate codex', {
+          stdinChunks: ['\r', '\r', '\r'],
+        });
+
+        expect(result.exitCode).toBe(0);
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(output).toContain(
+          'Global Codex instructions already exist. Do you also want to create a project-local copy for this repo?',
+        );
+        // Accepting writes the project-local copy and records the project-scope feature.
+        expect(harness.cwd.file(...AGENTS_MD_DIRS).asText()).toContain(SECRETS_HEADING);
+        expect(findCodexFeature(harness, 'secrets-instructions', 'project')).toBeDefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'env-based auth implies non-interactive: installs without prompting and without stdin',
+      async () => {
+        const server = await harness.newFakeServer().withAuthToken('env-tok').start();
+
+        // SONARQUBE_CLI_TOKEN + SONARQUBE_CLI_SERVER ⇒ isEnvBasedAuth() ⇒ the
+        // ask-features auto-install.
+        const result = await harness.run('integrate codex', {
+          extraEnv: {
+            SONARQUBE_CLI_TOKEN: 'env-tok',
+            SONARQUBE_CLI_SERVER: server.baseUrl(),
+          },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(`${result.stdout}\n${result.stderr}`).not.toContain(
+          'Install secret scanning hooks?',
+        );
+        expect(
+          harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),
+        ).toBe(true);
+        expect(harness.cwd.exists(...AGENTS_MD_DIRS)).toBe(true);
+        expect(harness.cwd.exists(...CONFIG_TOML_DIRS)).toBe(true);
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -594,32 +594,5 @@ describe('integrate codex', () => {
       },
       { timeout: 30000 },
     );
-
-    it(
-      'env-based auth implies non-interactive: installs without prompting and without stdin',
-      async () => {
-        const server = await harness.newFakeServer().withAuthToken('env-tok').start();
-
-        // SONARQUBE_CLI_TOKEN + SONARQUBE_CLI_SERVER ⇒ isEnvBasedAuth() ⇒ the
-        // ask-features auto-install.
-        const result = await harness.run('integrate codex', {
-          extraEnv: {
-            SONARQUBE_CLI_TOKEN: 'env-tok',
-            SONARQUBE_CLI_SERVER: server.baseUrl(),
-          },
-        });
-
-        expect(result.exitCode).toBe(0);
-        expect(`${result.stdout}\n${result.stderr}`).not.toContain(
-          'Install secret scanning hooks?',
-        );
-        expect(
-          harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),
-        ).toBe(true);
-        expect(harness.cwd.exists(...AGENTS_MD_DIRS)).toBe(true);
-        expect(harness.cwd.exists(...CONFIG_TOML_DIRS)).toBe(true);
-      },
-      { timeout: 30000 },
-    );
   });
 });

--- a/tests/integration/specs/integrate/context-augmentation.test.ts
+++ b/tests/integration/specs/integrate/context-augmentation.test.ts
@@ -756,7 +756,7 @@ describe('integrate codex — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate codex --skip-context', {
+      const result = await harness.run('integrate codex --non-interactive --skip-context', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -794,7 +794,7 @@ describe('integrate codex — Context Augmentation', () => {
         ].join('\n'),
       );
 
-      const result = await harness.run('integrate codex', {
+      const result = await harness.run('integrate codex --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -823,7 +823,7 @@ describe('integrate codex — Context Augmentation', () => {
       harness.state().withContextAugmentationBinaryInstalled();
       // No sonar-project.properties — projectKey is undefined.
 
-      const result = await harness.run('integrate codex', {
+      const result = await harness.run('integrate codex --non-interactive', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
@@ -855,7 +855,7 @@ describe('integrate <agent> --global — Context Augmentation', () => {
   it.each([
     ['claude', 'integrate claude -g --non-interactive'],
     ['copilot', 'integrate copilot -g --non-interactive'],
-    ['codex', 'integrate codex -g'],
+    ['codex', 'integrate codex -g --non-interactive'],
   ])(
     'skips CAG entirely on "integrate %s --global" and warns when the org is entitled',
     async (_agent, command) => {

--- a/tests/integration/specs/integrate/context-augmentation.test.ts
+++ b/tests/integration/specs/integrate/context-augmentation.test.ts
@@ -890,7 +890,7 @@ describe('integrate <agent> --global — Context Augmentation', () => {
   it.each([
     ['claude', 'integrate claude -g --non-interactive'],
     ['copilot', 'integrate copilot -g --non-interactive'],
-    ['codex', 'integrate codex -g'],
+    ['codex', 'integrate codex -g --non-interactive'],
   ])(
     'skips CAG entirely on "integrate %s --global" without warning when the org is not entitled',
     async (_agent, command) => {

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -301,6 +301,7 @@ describe('declarative integration framework', () => {
           options: {},
           targetRoot: tempDir,
           scope: 'project',
+          state: getDefaultState('test'),
         })
       ).map((feature) => feature.id),
     ).toEqual(['pre-commit', 'always']);
@@ -310,6 +311,7 @@ describe('declarative integration framework', () => {
           options: { hook: 'pre-push' },
           targetRoot: tempDir,
           scope: 'project',
+          state: getDefaultState('test'),
         })
       ).map((feature) => feature.id),
     ).toEqual(['pre-push', 'always']);
@@ -328,6 +330,7 @@ describe('declarative integration framework', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      state: getDefaultState('test'),
     });
 
     expect(selected).toEqual([]);
@@ -354,6 +357,7 @@ describe('declarative integration framework', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      state: getDefaultState('test'),
     });
 
     expect(selected.map((feature) => feature.id)).toEqual(['accepted']);
@@ -373,6 +377,7 @@ describe('declarative integration framework', () => {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
+      state: getDefaultState('test'),
     });
 
     expect(selected).toEqual([]);
@@ -393,6 +398,7 @@ describe('declarative integration framework', () => {
       targetRoot: tempDir,
       scope: 'project',
       nonInteractive: true,
+      state: getDefaultState('test'),
     });
 
     expect(selected.map((feature) => feature.id)).toEqual(['asked', 'defaulted']);

--- a/tests/unit/cli/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/integrate.test.ts
@@ -523,7 +523,7 @@ describe('integrateCommand', () => {
         auth: CLOUD_AUTH,
         projectRoot: '/project/root',
         projectKey: 'a-project',
-        installSecretsHooks: true,
+        globalSecretsHookExists: false,
         installSqaaHook: false,
       });
       expect(runMigrationsSpy).toHaveBeenLastCalledWith(

--- a/tests/unit/cli/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/integrate.test.ts
@@ -300,7 +300,7 @@ describe('integrateCommand', () => {
         auth: CLOUD_AUTH,
         options: expect.objectContaining({
           projectRoot: '/project/root',
-          installSecretsHooks: true,
+          globalSecretsHookExists: false,
           installSqaaHook: false,
           installMcp: true,
           installContextAugmentation: true,
@@ -433,7 +433,7 @@ describe('integrateCommand', () => {
         auth: SERVER_AUTH,
         projectRoot: '/project/root',
         projectKey: 'a-project',
-        installSecretsHooks: false,
+        globalSecretsHookExists: true,
         installSqaaHook: false,
       });
       expect(runMigrationsSpy).toHaveBeenCalledWith(
@@ -464,7 +464,7 @@ describe('integrateCommand', () => {
         auth: CLOUD_AUTH,
         projectRoot: '/project/root',
         projectKey: 'a-project',
-        installSecretsHooks: false,
+        globalSecretsHookExists: true,
         installSqaaHook: true,
       });
     });
@@ -486,7 +486,7 @@ describe('integrateCommand', () => {
         auth: SERVER_AUTH,
         projectRoot: '/project/root',
         projectKey: 'a-project',
-        installSecretsHooks: true,
+        globalSecretsHookExists: false,
         installSqaaHook: false,
       });
     });
@@ -592,7 +592,7 @@ describe('integrateCommand', () => {
       auth,
       projectRoot: projectRootDir,
       projectKey,
-      installSecretsHooks: !skipSecretsHooks,
+      globalSecretsHookExists: skipSecretsHooks,
       installSqaaHook: sqaaEnabled && projectKey !== undefined,
     });
 
@@ -612,7 +612,7 @@ describe('integrateCommand', () => {
     auth,
     projectRoot,
     projectKey,
-    installSecretsHooks,
+    globalSecretsHookExists,
     installSqaaHook,
   }: {
     targetRoot: string;
@@ -620,7 +620,7 @@ describe('integrateCommand', () => {
     auth: ResolvedAuth;
     projectRoot: string;
     projectKey?: string;
-    installSecretsHooks: boolean;
+    globalSecretsHookExists: boolean;
     installSqaaHook: boolean;
   }): void {
     const attrs = {
@@ -634,7 +634,7 @@ describe('integrateCommand', () => {
         auth,
         options: expect.objectContaining({
           projectRoot,
-          installSecretsHooks,
+          globalSecretsHookExists,
           installSqaaHook,
           installMcp: true,
         }),


### PR DESCRIPTION
----
## Summary by Gitar

- **Interactive integration:**
  - Wired Codex integration to the interactive feature selection flow, allowing users to choose features during installation.
- **State-aware installation:**
  - Added `isFeatureInstalledGloballyForProject` to detect and skip redundant project-level installations if a global hook already exists.
- **Refactored integration options:**
  - Replaced specific install boolean flags with `globalSecretsHookExists` and `sqaaEntitled` for more granular control over integration state.
- **Test coverage:**
  - Added comprehensive integration tests to verify interactive prompts, custom skip messages for existing global hooks, and conditional SQAA promotion messaging.
  - Updated existing integration tests to support `--non-interactive` execution for reliable CI verification.

<sub>This will update automatically on new commits.</sub>