### PR TITLE
CLI-604 Fix macOS code signing identifier to prevent Keychain prompts after update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,7 @@ jobs:
 
           codesign \
             --sign "Developer ID Application: SonarSource SA ($APPLE_TEAM_ID)" \
+            --identifier sonarqube-cli \
             --options runtime \
             --timestamp \
             dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}


### PR DESCRIPTION
----
## Summary by Gitar

- **Code Signing:**
  - Added `--identifier sonarqube-cli` to the `codesign` command in `build.yml` to prevent macOS Keychain prompts.

<sub>This will update automatically on new commits.</sub>