### PR TITLE
CLI-604 Fix macOS code signing identifier to prevent Keychain prompts after update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,7 @@ jobs:
 
           codesign \
             --sign "Developer ID Application: SonarSource SA ($APPLE_TEAM_ID)" \
+            --identifier sonarqube-cli \
             --options runtime \
             --timestamp \
             dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Added `--identifier sonarqube-cli` to the `codesign` command in `.github/workflows/build.yml` to ensure consistent code signing on macOS.

<sub>This will update automatically on new commits.</sub>