### PR TITLE
CLI-565 Declarative integration uninstall support

### DIFF
--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -20,10 +20,15 @@
 
 import { join } from 'node:path';
 
-import { createAgentHookEntry, resolveAgentHookScriptPath, upsertAgentHooks } from '../hooks';
-import { sonarSecretsBinaryDependency } from '../registry/dependencies';
-import { jsonPatch, type PlatformSpecificContent, wholeFile } from '../registry/resources';
-import type { FeatureDeclaration, IntegrationContext, PostInstallExample } from '../registry/types';
+import {
+  createAgentHookEntry,
+  removeAgentHooks,
+  resolveAgentHookScriptPath,
+  upsertAgentHooks,
+} from '../hooks';
+import type { FeatureDeclaration, IntegrationContext, PostInstallExample } from '../registry';
+import { sonarSecretsBinaryDependency } from '../registry';
+import { jsonPatch, type PlatformSpecificContent, wholeFile } from '../registry';
 
 export interface SonarSecretsHooksFeatureOptions {
   installSecretsHooks?: boolean;
@@ -110,6 +115,11 @@ export function createSonarSecretsHooksFeature<TOptions extends SonarSecretsHook
                 entry.scriptPath,
               ),
             ),
+          ),
+        removePatch: (document) =>
+          removeAgentHooks(
+            document,
+            config.hookEntries.map((entry) => entry.marker),
           ),
       }),
     ],

--- a/src/cli/commands/integrate/_common/hooks.ts
+++ b/src/cli/commands/integrate/_common/hooks.ts
@@ -173,6 +173,29 @@ export function upsertAgentHooks(document: unknown, entries: ManagedHookEntry[])
   return settings;
 }
 
+/**
+ * Remove hook entries whose commands contain any of the given markers.
+ * Idempotent inverse of {@link upsertAgentHooks} for the same markers.
+ */
+export function removeAgentHooks(document: unknown, markers: string[]): HooksDocument {
+  const settings = toHooksDocument(document);
+  if (!settings.hooks) {
+    return settings;
+  }
+
+  const hooks: NonNullable<HooksDocument['hooks']> = {};
+  for (const [eventType, entries] of Object.entries(settings.hooks)) {
+    const filtered = (entries ?? []).filter(
+      (hook) => !markers.some((marker) => ownsHookEntry(hook, marker)),
+    );
+    if (filtered.length > 0) {
+      hooks[eventType] = filtered;
+    }
+  }
+
+  return { ...settings, hooks };
+}
+
 function ownsHookEntry(entry: HookConfig, marker: string): boolean {
   return entry.hooks.some((hook) => hook.command.includes(marker));
 }

--- a/src/cli/commands/integrate/_common/mcp-config.ts
+++ b/src/cli/commands/integrate/_common/mcp-config.ts
@@ -1,0 +1,80 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/** Shared MCP config remove helpers for declarative integration patch resources. */
+
+export const SONARQUBE_MCP_SERVER_ID = 'sonarqube';
+
+function toRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return { ...(value as Record<string, unknown>) };
+}
+
+function toMcpSettings(document: unknown): {
+  mcpServers: Record<string, unknown>;
+  [key: string]: unknown;
+} {
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    return { mcpServers: {} };
+  }
+
+  const settings = document as { mcpServers?: unknown; [key: string]: unknown };
+  return {
+    ...settings,
+    mcpServers:
+      settings.mcpServers &&
+      typeof settings.mcpServers === 'object' &&
+      !Array.isArray(settings.mcpServers)
+        ? { ...(settings.mcpServers as Record<string, unknown>) }
+        : {},
+  };
+}
+
+/**
+ * Remove a server entry from JSON MCP config (`mcpServers` object), e.g. Claude/Copilot.
+ */
+export function removeJsonMcpServer(
+  document: unknown,
+  serverId: string = SONARQUBE_MCP_SERVER_ID,
+): Record<string, unknown> {
+  const settings = toMcpSettings(document);
+  const { [serverId]: _removed, ...remainingServers } = settings.mcpServers;
+  return {
+    ...settings,
+    mcpServers: remainingServers,
+  };
+}
+
+/**
+ * Remove a server entry from Codex TOML-backed config (`mcp_servers` table keys).
+ */
+export function removeCodexMcpServer(
+  document: Record<string, unknown>,
+  serverId: string = SONARQUBE_MCP_SERVER_ID,
+): Record<string, unknown> {
+  const servers = toRecord(document.mcp_servers);
+  const { [serverId]: _removed, ...remainingServers } = servers;
+  return {
+    ...document,
+    mcp_servers: remainingServers,
+  };
+}

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -31,7 +31,6 @@ import type {
 import { getDefaultState } from '../../../../../lib/state';
 import { discreetSuccess, info, text, warn } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
-import { supportedIntegrations } from '../../index';
 import { renderCompletionSummary } from './completion-summary';
 import type { IntegrationRegistry } from './core';
 import type { FeatureApplication } from './installer';
@@ -57,8 +56,18 @@ export interface InstallIntegrationOptions<TOptions> {
   nonInteractive?: boolean;
 }
 
+async function resolveIntegrationRegistry(
+  registry: IntegrationRegistry | undefined,
+): Promise<IntegrationRegistry> {
+  if (registry) {
+    return registry;
+  }
+  const { supportedIntegrations } = await import('../../index.js');
+  return supportedIntegrations;
+}
+
 export async function installIntegration<TOptions>({
-  registry = supportedIntegrations,
+  registry,
   integrationId,
   options,
   targetRoot,
@@ -69,7 +78,8 @@ export async function installIntegration<TOptions>({
   featureIds,
   nonInteractive,
 }: InstallIntegrationOptions<TOptions>): Promise<InstalledIntegrationFeature[]> {
-  const integration = getIntegrationDeclaration<TOptions>(registry, integrationId);
+  const resolvedRegistry = await resolveIntegrationRegistry(registry);
+  const integration = getIntegrationDeclaration<TOptions>(resolvedRegistry, integrationId);
   const invocation = makeInvocation(options, targetRoot, scope, auth, force, attrs, nonInteractive);
   const features =
     featureIds === undefined

--- a/src/cli/commands/integrate/_common/registry/resources/common.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/common.ts
@@ -80,7 +80,7 @@ export async function readTextFile(path: string): Promise<string | undefined> {
 export interface PatchResourceOptions<TDoc = unknown> extends BaseResourceOptions {
   targetPath: PathResolver;
   patch: (document: TDoc, context: IntegrationContext) => MaybePromise<unknown>;
-  removePatch?: (document: TDoc, context: IntegrationContext) => MaybePromise<unknown>;
+  removePatch: (document: TDoc, context: IntegrationContext) => MaybePromise<unknown>;
 }
 
 export abstract class PatchResource<
@@ -110,9 +110,6 @@ export abstract class PatchResource<
   }
 
   async remove(context: IntegrationContext): Promise<void> {
-    if (!this.options.removePatch) {
-      return;
-    }
     const path = await resolvePath(context, this.options.targetPath);
     if (!existsSync(path)) {
       return;

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -27,11 +27,13 @@ import { createContextAugmentationFeature } from '../_common/features/context-au
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
 import {
   createAgentHookEntry,
+  removeAgentHooks,
   resolveAgentHookScriptPath,
   upsertAgentHooks,
 } from '../_common/hooks';
-import { jsonPatch, wholeFile } from '../_common/registry/resources';
-import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
+import { removeJsonMcpServer } from '../_common/mcp-config';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
+import { jsonPatch, wholeFile } from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
 import {
   getSecretPreToolTemplateUnix,
@@ -147,6 +149,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
                 'sonar-sqaa/build-scripts/posttool-sqaa',
               ),
             ]),
+          removePatch: (document) => removeAgentHooks(document, ['sonar-sqaa']),
         }),
       ],
     },
@@ -162,6 +165,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
           defaultValue: {},
           patch: (document, context) =>
             upsertClaudeMcpServer(document, getDesiredClaudeMcpConfig(context)),
+          removePatch: (document) => removeJsonMcpServer(document),
         }),
       ],
     },

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -30,8 +30,9 @@ import {
   sonarBeginMarker,
   sonarEndMarker,
 } from '../_common/instructions-templates';
-import { textSnippet, tomlPatch } from '../_common/registry/resources';
-import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
+import { removeCodexMcpServer } from '../_common/mcp-config';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
+import { textSnippet, tomlPatch } from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPromptTemplateUnix, getSecretPromptTemplateWindows } from './hook-templates';
 import { SECRETS_ON_READ_BODY } from './instructions-templates';
@@ -126,6 +127,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
           targetPath: resolveCodexMcpConfigPath,
           defaultValue: {},
           patch: (document, context) => upsertCodexMcpServer(document, context),
+          removePatch: (document) => removeCodexMcpServer(document),
         }),
       ],
     },

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -32,10 +32,16 @@ import {
   SQAA_MISSING_PROJECT_KEY_MESSAGE,
   SQAA_PROMOTION_MESSAGE,
 } from '../_common/instructions-templates';
-import { sonarSecretsBinaryDependency } from '../_common/registry/dependencies';
-import { jsonPatch, textSnippet, wholeFile } from '../_common/registry/resources';
-import { askUser, skip } from '../_common/registry/selection';
-import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry/types';
+import { removeJsonMcpServer } from '../_common/mcp-config';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
+import {
+  askUser,
+  jsonPatch,
+  skip,
+  sonarSecretsBinaryDependency,
+  textSnippet,
+  wholeFile,
+} from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
 import { getSecretPreToolTemplateUnix, getSecretPreToolTemplateWindows } from './hook-templates';
 import {
@@ -46,6 +52,7 @@ import {
   hookScriptName,
   type HooksJson,
   PROJECT_HOOKS_REL_DIR,
+  removeCopilotHookConfig,
   SCRIPT_REL_DIR,
 } from './hooks';
 import {
@@ -97,6 +104,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
           targetPath: resolveHooksJsonPath,
           defaultValue: { version: 1, hooks: {} },
           patch: (document, context) => upsertHookConfig(document, context),
+          removePatch: (document) => removeCopilotHookConfig(document),
         }),
       ],
     },
@@ -158,6 +166,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
           defaultValue: {},
           patch: (document, context) =>
             upsertCopilotMcpServer(document, getDesiredCopilotMcpConfig(context)),
+          removePatch: (document) => removeJsonMcpServer(document),
         }),
       ],
     },

--- a/src/cli/commands/integrate/copilot/hooks.ts
+++ b/src/cli/commands/integrate/copilot/hooks.ts
@@ -87,6 +87,38 @@ export function entryReferencesSonarSecrets(entry: HookCommandEntry): boolean {
   );
 }
 
+function toHooksJson(document: unknown): HooksJson {
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    return { version: 1, hooks: {} };
+  }
+
+  const json = document as Partial<HooksJson>;
+  return {
+    version: typeof json.version === 'number' ? json.version : 1,
+    hooks: json.hooks ? { ...json.hooks } : {},
+  };
+}
+
+/** Idempotent inverse of Copilot pre-tool-use hook upsert for sonar-secrets. */
+export function removeCopilotHookConfig(document: unknown): HooksJson {
+  const hooksJson = toHooksJson(document);
+  if (!hooksJson.hooks?.preToolUse) {
+    return hooksJson;
+  }
+
+  const preToolUse = hooksJson.hooks.preToolUse.filter(
+    (entry) => !entryReferencesSonarSecrets(entry),
+  );
+  const hooks = { ...hooksJson.hooks };
+  if (preToolUse.length > 0) {
+    hooks.preToolUse = preToolUse;
+  } else {
+    delete hooks.preToolUse;
+  }
+
+  return { ...hooksJson, hooks };
+}
+
 export function hookScriptName(): string {
   return `${SCRIPT_BASENAME}${process.platform === 'win32' ? '.ps1' : '.sh'}`;
 }

--- a/src/cli/commands/integrate/git/tools/native/hooks.ts
+++ b/src/cli/commands/integrate/git/tools/native/hooks.ts
@@ -58,3 +58,25 @@ export async function installViaGitHooks(
   await writeManagedGitHook(hookPath, hook, force);
   discreetSuccess(`${hook} hook installed at ${hookPath}`);
 }
+
+function normalizeLineEndings(content: string): string {
+  return content.replaceAll('\r\n', '\n');
+}
+
+/**
+ * Remove a Sonar-managed native git hook file when it matches our install marker or content.
+ */
+export async function removeManagedGitHook(hookPath: string, hook: GitHookType): Promise<void> {
+  if (!existsSync(hookPath)) {
+    return;
+  }
+
+  const existing = await fs.readFile(hookPath, 'utf-8');
+  const managedContent = normalizeLineEndings(getHookScript(hook));
+  const normalizedExisting = normalizeLineEndings(existing);
+  if (normalizedExisting !== managedContent && !existing.includes(HOOK_MARKER)) {
+    return;
+  }
+
+  await fs.rm(hookPath, { force: true });
+}

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -21,8 +21,8 @@
 import { normalizePath } from '../../../../../../lib/fs-utils';
 import { spawnProcess } from '../../../../../../lib/process';
 import { CommandFailedError } from '../../../../_common/error';
-import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
-import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
+import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry';
+import { sonarSecretsBinaryDependency } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { gitHookExample } from '../shared';
 import { nativeGitHookResource } from './resource';
@@ -57,9 +57,34 @@ function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<Integrate
         displayName: 'global hooks path',
         shouldApply: ({ scope }) => scope === 'global',
         apply: ({ targetRoot }) => configureGlobalHooksPath(targetRoot),
+        undo: async ({ scope }) => {
+          if (scope === 'global') {
+            await unsetGlobalHooksPath();
+          }
+        },
       },
     ],
   };
+}
+
+async function unsetGlobalHooksPath(): Promise<void> {
+  let gitResult;
+  try {
+    gitResult = await spawnProcess('git', ['config', '--global', '--unset', 'core.hooksPath']);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CommandFailedError(`Failed to run git [${message}]`, {
+      remediationHint: GLOBAL_GIT_CONFIG_REMEDIATION_HINT,
+    });
+  }
+
+  if (gitResult.exitCode !== 0 && gitResult.exitCode !== 5) {
+    const detail = [gitResult.stderr, gitResult.stdout].filter(Boolean).join('\n');
+    throw new CommandFailedError(
+      `'git config --global --unset core.hooksPath' failed (exit code ${gitResult.exitCode}): ${detail}`,
+      { remediationHint: GLOBAL_GIT_CONFIG_REMEDIATION_HINT },
+    );
+  }
 }
 
 async function configureGlobalHooksPath(hooksDir: string): Promise<void> {

--- a/src/cli/commands/integrate/git/tools/native/resource.ts
+++ b/src/cli/commands/integrate/git/tools/native/resource.ts
@@ -28,7 +28,7 @@ import type {
   ResourceDeclaration,
 } from '../../../_common/registry';
 import type { GitHookType } from '../../options';
-import { writeManagedGitHook } from './hooks';
+import { removeManagedGitHook, writeManagedGitHook } from './hooks';
 import { getHookScript } from './shell-fragments';
 
 interface NativeGitHookResourceOptions {
@@ -67,6 +67,11 @@ class NativeGitHookResource implements ResourceDeclaration {
     } catch {
       return false;
     }
+  }
+
+  async remove(context: IntegrationContext): Promise<void> {
+    const path = await resolveNativeGitHookPath(context, this.options.hook);
+    await removeManagedGitHook(path, this.options.hook);
   }
 }
 

--- a/src/cli/commands/integrate/git/tools/pre-commit/config.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/config.ts
@@ -105,6 +105,28 @@ export function removeLegacyHook(config: PreCommitConfig): boolean {
   return config.repos.length < before;
 }
 
+/**
+ * Remove Sonar-managed hooks from a pre-commit config (inverse of install patch).
+ * Drops the legacy remote repo entry and local sonar-secrets hooks; removes an empty local repo.
+ */
+export function removeSonarHooksFromPreCommitConfig(document: unknown): PreCommitConfig {
+  const config = normalizePreCommitConfig(document);
+  removeLegacyHook(config);
+
+  for (const repo of config.repos) {
+    if (!Array.isArray(repo.hooks)) {
+      continue;
+    }
+    repo.hooks = repo.hooks.filter((hook) => !isSonarHookEntry(hook));
+  }
+
+  config.repos = config.repos.filter(
+    (repo) => repo.repo !== 'local' || (Array.isArray(repo.hooks) && repo.hooks.length > 0),
+  );
+
+  return config;
+}
+
 /** Upserts the sonar-secrets hook into the local repo entry of a config object. */
 export function upsertSonarHook(config: PreCommitConfig, stage: GitHookType): void {
   const sonarHook = buildSonarPreCommitHook(stage);
@@ -166,5 +188,15 @@ export async function activatePreCommitFramework(root: string, hook: GitHookType
         remediationHint: `Install the pre-commit framework (for example 'pip install pre-commit') and run: ${installCommands}`,
       },
     );
+  }
+}
+
+/** Best-effort pre-commit uninstall during factory reset; never throws. */
+export async function deactivatePreCommitFramework(root: string): Promise<void> {
+  try {
+    await runPreCommitCommand(['uninstall'], root);
+    await runPreCommitCommand(['clean'], root);
+  } catch {
+    // Missing framework or hook scripts — non-fatal for reset.
   }
 }

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -20,16 +20,17 @@
 
 import { join } from 'node:path';
 
-import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
-import { yamlPatch } from '../../../_common/registry/resources';
-import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
+import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry';
+import { sonarSecretsBinaryDependency, yamlPatch } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { gitHookExample } from '../shared';
 import {
   activatePreCommitFramework,
+  deactivatePreCommitFramework,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,
   removeLegacyHook,
+  removeSonarHooksFromPreCommitConfig,
   upsertSonarHook,
 } from './config';
 
@@ -60,6 +61,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
 
           return config;
         },
+        removePatch: (document) => removeSonarHooksFromPreCommitConfig(document),
       }),
     ],
     operations: [
@@ -67,6 +69,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
         id: 'activate-hook',
         displayName: `${hook} hook activation`,
         apply: ({ targetRoot }) => activatePreCommitFramework(targetRoot, hook),
+        undo: ({ targetRoot }) => deactivatePreCommitFramework(targetRoot),
       },
     ],
   };
@@ -74,12 +77,14 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
 
 export {
   activatePreCommitFramework,
+  deactivatePreCommitFramework,
   hasSonarHookInPreCommitConfig,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,
   PRE_COMMIT_LEGACY_REPO,
   type PreCommitConfig,
   removeLegacyHook,
+  removeSonarHooksFromPreCommitConfig,
   runPreCommitInstall,
   upsertSonarHook,
 } from './config';

--- a/src/cli/commands/integrate/index.ts
+++ b/src/cli/commands/integrate/index.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { createIntegrationRegistry } from './_common/registry/core';
+import { createIntegrationRegistry } from './_common/registry';
 import { claudeIntegration } from './claude/declaration';
 import { codexIntegration } from './codex/declaration';
 import { copilotIntegration } from './copilot/declaration';

--- a/tests/unit/cli/commands/integrate/_common/registry-remove.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry-remove.test.ts
@@ -56,6 +56,7 @@ describe('declarative integration framework - remove and undo', () => {
       targetPath: jsonPath,
       defaultValue: { fallback: true },
       patch: (document) => ({ ...(document as Record<string, unknown>), enabled: true }),
+      removePatch: (document) => document,
     });
 
     // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable
@@ -78,6 +79,7 @@ describe('declarative integration framework - remove and undo', () => {
       targetPath: tomlPath,
       defaultValue: {},
       patch: (document) => document,
+      removePatch: (document) => document,
     });
 
     // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable
@@ -99,6 +101,7 @@ describe('declarative integration framework - remove and undo', () => {
       id: 'yaml-invalid',
       targetPath: yamlPath,
       patch: (document) => ({ ...(document as Record<string, unknown>), enabled: true }),
+      removePatch: (document) => document,
     });
 
     await yamlResource.apply(context);
@@ -152,7 +155,7 @@ describe('declarative integration framework - remove and undo', () => {
       expect(JSON.parse(await readFile(jsonPath, 'utf-8'))).toEqual({ existing: 1 });
     });
 
-    it('json-patch: is a no-op without removePatch', async () => {
+    it('json-patch: identity removePatch leaves file unchanged', async () => {
       const state = getDefaultState('test');
       const context = makeContext(state, tempDir);
       const jsonPath = join(tempDir, 'settings.json');
@@ -161,11 +164,12 @@ describe('declarative integration framework - remove and undo', () => {
         id: 'r',
         targetPath: jsonPath,
         patch: (doc) => ({ ...(doc as object), sonar: true }),
+        removePatch: (doc) => doc,
       });
 
       await resource.remove!(context);
 
-      expect(await readFile(jsonPath, 'utf-8')).toBe('{"sonar":true}');
+      expect(JSON.parse(await readFile(jsonPath, 'utf-8'))).toEqual({ sonar: true });
     });
 
     it('json-patch: is a no-op when the file does not exist', async () => {
@@ -201,7 +205,7 @@ describe('declarative integration framework - remove and undo', () => {
       expect(await readFile(yamlPath, 'utf-8')).toBe('existing: 1\n');
     });
 
-    it('yaml-patch: is a no-op without removePatch', async () => {
+    it('yaml-patch: identity removePatch leaves file unchanged', async () => {
       const state = getDefaultState('test');
       const context = makeContext(state, tempDir);
       const yamlPath = join(tempDir, 'config.yml');
@@ -211,6 +215,7 @@ describe('declarative integration framework - remove and undo', () => {
         id: 'r',
         targetPath: yamlPath,
         patch: (doc) => doc,
+        removePatch: (doc) => doc,
       });
 
       await resource.remove!(context);
@@ -238,7 +243,7 @@ describe('declarative integration framework - remove and undo', () => {
       expect(await readFile(tomlPath, 'utf-8')).toBe('existing = 1\n');
     });
 
-    it('toml-patch: is a no-op without removePatch', async () => {
+    it('toml-patch: identity removePatch leaves file unchanged', async () => {
       const state = getDefaultState('test');
       const context = makeContext(state, tempDir);
       const tomlPath = join(tempDir, 'config.toml');
@@ -248,6 +253,7 @@ describe('declarative integration framework - remove and undo', () => {
         id: 'r',
         targetPath: tomlPath,
         patch: (doc) => doc,
+        removePatch: (doc) => doc,
       });
 
       await resource.remove!(context);

--- a/tests/unit/cli/commands/integrate/_common/registry-resources.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry-resources.test.ts
@@ -292,6 +292,7 @@ describe('declarative integration framework - resources and state recording', ()
           id: 'json',
           targetPath: join(tempDir, 'settings.json'),
           patch: () => ({ enabled: true }),
+          removePatch: (document) => document,
         }),
       ],
     };

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -423,16 +423,19 @@ describe('declarative integration framework', () => {
           id: 'json',
           targetPath: join(tempDir, 'settings.json'),
           patch: (document) => ({ ...(document as Record<string, unknown>), enabled: true }),
+          removePatch: (document) => document,
         }),
         yamlPatch({
           id: 'yaml',
           targetPath: join(tempDir, 'config.yml'),
           patch: () => ({ repos: [{ repo: 'local' }] }),
+          removePatch: (document) => document,
         }),
         tomlPatch({
           id: 'toml',
           targetPath: join(tempDir, 'config.toml'),
           patch: (document) => ({ ...document, enabled: true }),
+          removePatch: (document) => document,
         }),
         textSnippet({
           id: 'text',

--- a/tests/unit/cli/commands/integrate/_common/remove-helpers.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/remove-helpers.test.ts
@@ -1,0 +1,122 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  removeAgentHooks,
+  SONAR_SECRETS_MARKER,
+  upsertAgentHooks,
+} from '../../../../../../src/cli/commands/integrate/_common/hooks';
+import {
+  removeCodexMcpServer,
+  removeJsonMcpServer,
+} from '../../../../../../src/cli/commands/integrate/_common/mcp-config';
+import { removeCopilotHookConfig } from '../../../../../../src/cli/commands/integrate/copilot/hooks';
+import {
+  normalizePreCommitConfig,
+  removeSonarHooksFromPreCommitConfig,
+  upsertSonarHook,
+} from '../../../../../../src/cli/commands/integrate/git/tools/pre-commit';
+
+describe('integration remove helpers', () => {
+  it('removeAgentHooks strips entries managed by marker', () => {
+    const patched = upsertAgentHooks(
+      {
+        hooks: {
+          PostToolUse: [
+            { matcher: 'x', hooks: [{ type: 'command', command: 'other', timeout: 60 }] },
+          ],
+        },
+      },
+      [
+        {
+          eventType: 'PostToolUse',
+          marker: 'sonar-sqaa',
+          hookConfig: {
+            matcher: 'Edit',
+            hooks: [{ type: 'command', command: 'sonar-sqaa/script.sh', timeout: 60 }],
+          },
+        },
+      ],
+    );
+
+    const removed = removeAgentHooks(patched, ['sonar-sqaa']);
+
+    expect(removed.hooks?.PostToolUse).toHaveLength(1);
+    expect(removed.hooks?.PostToolUse?.[0]?.hooks[0]?.command).toBe('other');
+  });
+
+  it('removeJsonMcpServer drops sonarqube server only', () => {
+    const result = removeJsonMcpServer({
+      mcpServers: { sonarqube: { command: 'sonar' }, other: { command: 'x' } },
+    });
+
+    expect(result.mcpServers).toEqual({ other: { command: 'x' } });
+  });
+
+  it('removeCodexMcpServer drops sonarqube from mcp_servers', () => {
+    const result = removeCodexMcpServer({
+      mcp_servers: { sonarqube: { command: 'sonar' }, other: {} },
+    });
+
+    expect(result.mcp_servers).toEqual({ other: {} });
+  });
+
+  it('removeCopilotHookConfig strips sonar-secrets preToolUse entry', () => {
+    const result = removeCopilotHookConfig({
+      version: 1,
+      hooks: {
+        preToolUse: [
+          { type: 'command', bash: 'sonar-secrets/build-scripts/pretool-secrets.sh' },
+          { type: 'command', bash: '/usr/bin/other' },
+        ],
+      },
+    });
+
+    expect(result.hooks?.preToolUse).toEqual([{ type: 'command', bash: '/usr/bin/other' }]);
+  });
+
+  it('removeSonarHooksFromPreCommitConfig removes local sonar hook', () => {
+    const config = normalizePreCommitConfig({ repos: [] });
+    upsertSonarHook(config, 'pre-commit');
+
+    const removed = removeSonarHooksFromPreCommitConfig(config);
+
+    expect(removed.repos).toEqual([]);
+  });
+
+  it('removeAgentHooks is a no-op for unrelated markers', () => {
+    const doc = upsertAgentHooks({}, [
+      {
+        eventType: 'PostToolUse',
+        marker: SONAR_SECRETS_MARKER,
+        hookConfig: {
+          matcher: 'x',
+          hooks: [{ type: 'command', command: `${SONAR_SECRETS_MARKER}/hook.sh`, timeout: 60 }],
+        },
+      },
+    ]);
+
+    const removed = removeAgentHooks(doc, ['sonar-sqaa']);
+
+    expect(removed.hooks?.PostToolUse).toHaveLength(1);
+  });
+});

--- a/tests/unit/cli/commands/integrate/git/git-native-resource.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-native-resource.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
@@ -59,5 +59,45 @@ describe('nativeGitHookResource', () => {
     });
 
     expect(isApplied).toBe(true);
+  });
+
+  it('remove deletes a Sonar-managed hook file', async () => {
+    const hookPath = join(TEMP_DIR, 'pre-commit');
+    const resource = nativeGitHookResource({
+      id: 'hook-file',
+      displayName: 'pre-commit hook',
+      hook: 'pre-commit',
+    });
+    writeFileSync(hookPath, getPreCommitHookScript(), { mode: 0o755 });
+
+    await resource.remove!({
+      state: getDefaultState('test'),
+      targetRoot: TEMP_DIR,
+      scope: 'global',
+      executionMode: 'install',
+      resolvedDependencies: new Map(),
+    });
+
+    expect(existsSync(hookPath)).toBe(false);
+  });
+
+  it('remove leaves a third-party hook file without the Sonar marker', async () => {
+    const hookPath = join(TEMP_DIR, 'pre-commit');
+    const resource = nativeGitHookResource({
+      id: 'hook-file',
+      displayName: 'pre-commit hook',
+      hook: 'pre-commit',
+    });
+    writeFileSync(hookPath, '#!/bin/sh\necho custom\n', { mode: 0o755 });
+
+    await resource.remove!({
+      state: getDefaultState('test'),
+      targetRoot: TEMP_DIR,
+      scope: 'global',
+      executionMode: 'install',
+      resolvedDependencies: new Map(),
+    });
+
+    expect(existsSync(hookPath)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add shared remove helpers (agent hooks, MCP config, Copilot hooks, pre-commit config).
- Require `removePatch` on patch resources and wire uninstall for Claude, Copilot, Codex, git, and secrets hooks.
- Add native git hook `remove()` and lazy-load the integration registry to avoid circular imports.

## Stack

PR **1/4** → `master`

Follow-ups: #PR2 (safe-path), #PR3 (reset core), #PR4 (reset integrations) — links updated after PR numbers exist.

## Test plan

- [x] `bun test tests/unit/cli/commands/integrate/_common/remove-helpers.test.ts`
- [x] `bun test tests/unit/cli/commands/integrate/_common/registry-remove.test.ts`
- [x] `bun test tests/unit/cli/commands/integrate/git/git-native-resource.test.ts`
- [x] `bun run typecheck`