### PR TITLE
CLI-565 sonar system reset — core steps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,19 @@ After the CAG entitlement check passes, the integrate flow also queries SCA avai
 
 The CAG installer (`src/cli/commands/_common/install/context-augmentation.ts`) handles `.tar.gz` archives: download → verify detached `.asc` PGP signature → gunzip + USTAR-extract the inner binary into `~/.sonar/sonarqube-cli/bin/`. Tar reading is in `src/cli/commands/_common/install/tar.ts` (no external dep). The pinned CAG version is in `package.json#externalBinaries["sonar-context-augmentation"]` and `src/lib/signatures.ts`. In the declarative framework, the CAG binary is managed as a shared dependency (`sonar-context-augmentation`), while a single declarative feature owns both the skill file resource and the install-only `tool integrate` operation with the invocation prefix forced to `sonar context`.
 
+### System reset
+
+`sonar system reset` returns the CLI to a factory-like state in one shot. Registered as `anonymousAction` so it works when auth is broken. Core implementation: `reset.ts`, `reset-auth.ts`, `reset-binaries.ts`, `reset-filesystem.ts`, and `safe-path.ts`. Integration teardown ships in a follow-up PR (`reset-integrations.ts`).
+
+- **Confirmation:** interactive runs require typing `RESET`; non-interactive runs require `--force`.
+- **Authentication:** best-effort server token revoke via shared `revoke-server-token.ts` (same hints as `auth logout`) then keychain deletion; only successfully removed connections are dropped from `state.auth`.
+- **Binaries:** deletes paths from `state.dependencies.installed` and legacy `state.tools.installed` under `BIN_DIR` (`resolveSafePath`); stops CAG daemons before removing the context-augmentation binary.
+- **Integrations:** not wired in this PR (phase reports a follow-up message).
+- **Filesystem:** removes `LOG_DIR`, `SCA_SCANNER_CACHE_DIR`, and `GLOBAL_HOOKS_DIR` under `CLI_DIR`; reports approximate bytes cleared.
+- **Telemetry:** never disabled; `installationId`, `firstUseDate`, and pending `events` are preserved.
+- **Legacy fields:** `state.agents` is reset; `state.tools` is reset only when no installed tools remain after binary cleanup.
+- **Exit code:** `1` when any step reports warnings (partial reset).
+
 ## Error handling
 
 Please use the exception types defined in `src/cli/commands/_common/error.ts` for production code. If you need to throw an error from a mock in test code, it's fine to use the generic `Error` type.

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -78,6 +78,7 @@ import { listProjects, type ListProjectsOptions } from './commands/list/projects
 import { remediate, type RemediateOptions } from './commands/remediate';
 import { runMcp } from './commands/run/mcp.js';
 import { selfUpdate, type SelfUpdateOptions } from './commands/self-update/self-update';
+import { systemReset, type SystemResetOptions } from './commands/system/reset';
 import { getBanner, getCustomRootHelp } from './root-help.js';
 
 const DEFAULT_PAGE_SIZE = MAX_PAGE_SIZE;
@@ -409,6 +410,19 @@ COMMAND_TREE.command('self-update')
   .option('--status', 'Check for a newer version without installing')
   .option('--force', 'Install the latest version even if already up to date')
   .anonymousAction((options: SelfUpdateOptions) => selfUpdate(options));
+
+const system = COMMAND_TREE.command('system').description(
+  'System maintenance commands for the SonarQube CLI installation.',
+);
+
+system
+  .command('reset')
+  .description(
+    'Reset the CLI to factory defaults: remove tokens, binaries, integrations, and cached files. ' +
+      'Telemetry settings are preserved.',
+  )
+  .option('--force', 'Skip the interactive confirmation prompt (required for non-interactive use)')
+  .anonymousAction((options: SystemResetOptions) => systemReset(options));
 
 const runCommand = COMMAND_TREE.command('run', { hidden: true }).description(
   'Run SonarQube services',

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -22,7 +22,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
-import { CLI_DIR } from '../../../../lib/config-constants';
+import { SCA_SCANNER_CACHE_DIR } from '../../../../lib/config-constants';
 import logger, { getLogLevelConfig } from '../../../../lib/logger';
 import { type SonarQubeClient } from '../../../../sonarqube/client';
 import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
@@ -55,7 +55,7 @@ export class ScaScanOrchestrator {
       downloadBaseUrl,
       sonarToken: auth.token,
       projectKey,
-      cacheDir: join(CLI_DIR, 'sca-scanner-cache'),
+      cacheDir: SCA_SCANNER_CACHE_DIR,
       workDir: join(tmpdir(), `sonar-sca-${Date.now()}`),
       scannerProperties: properties.scaProperties,
       excludedPaths: properties.exclusions,

--- a/src/cli/commands/auth/logout.ts
+++ b/src/cli/commands/auth/logout.ts
@@ -20,41 +20,9 @@
 
 import { deleteToken, getToken } from '../../../lib/keychain';
 import { loadState, saveState } from '../../../lib/repository/state-repository';
-import type { AuthConnection } from '../../../lib/state';
 import { getActiveConnection, removeConnection } from '../../../lib/state-manager';
-import { SonarQubeClient } from '../../../sonarqube/client';
-import { print, success, warn } from '../../../ui';
-
-/**
- * Attempt to revoke the server-side token before local cleanup.
- * Best-effort: warns and returns on failure so that local logout always proceeds.
- */
-async function revokeServerTokenIfPossible(
-  active: AuthConnection,
-  token: string | undefined,
-): Promise<void> {
-  if (!active.tokenName) {
-    warn(
-      'The server-side token name is unknown for this connection, so the token could not be revoked automatically. Revoke it manually on the server if needed.',
-    );
-    return;
-  }
-
-  if (!token) {
-    warn(
-      `Could not retrieve the local token from the keychain, so the server-side token "${active.tokenName}" could not be revoked automatically. Revoke it manually on the server if needed.`,
-    );
-    return;
-  }
-
-  try {
-    await new SonarQubeClient(active.serverUrl, token).revokeUserToken(active.tokenName);
-  } catch (error) {
-    warn(
-      `Failed to revoke the server-side token "${active.tokenName}": ${(error as Error).message}. Continuing with local logout.`,
-    );
-  }
-}
+import { print, success } from '../../../ui';
+import { revokeServerTokenIfPossible } from './revoke-server-token';
 
 /**
  * Logout command - remove token from keychain

--- a/src/cli/commands/auth/revoke-server-token.ts
+++ b/src/cli/commands/auth/revoke-server-token.ts
@@ -1,0 +1,64 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { AuthConnection } from '../../../lib/state';
+import { SonarQubeClient } from '../../../sonarqube/client';
+import { warn } from '../../../ui';
+
+export type RevokeServerTokenContext = 'logout' | 'reset';
+
+/**
+ * Attempt to revoke the server-side token before local cleanup.
+ * Best-effort: warns and returns on failure so that local cleanup always proceeds.
+ */
+export async function revokeServerTokenIfPossible(
+  connection: AuthConnection,
+  token: string | undefined,
+  context: RevokeServerTokenContext = 'logout',
+): Promise<void> {
+  if (!connection.tokenName) {
+    warn(
+      'The server-side token name is unknown for this connection, so the token could not be revoked automatically. Revoke it manually on the server if needed.',
+    );
+    return;
+  }
+
+  if (!token) {
+    warn(
+      `Could not retrieve the local token from the keychain, so the server-side token "${connection.tokenName}" could not be revoked automatically. Revoke it manually on the server if needed.`,
+    );
+    return;
+  }
+
+  try {
+    await new SonarQubeClient(connection.serverUrl, token).revokeUserToken(connection.tokenName);
+  } catch (error) {
+    const detail = (error as Error).message;
+    if (context === 'logout') {
+      warn(
+        `Failed to revoke the server-side token "${connection.tokenName}": ${detail}. Continuing with local logout.`,
+      );
+      return;
+    }
+    warn(
+      `Failed to revoke the server-side token "${connection.tokenName}" for ${connection.serverUrl}: ${detail}`,
+    );
+  }
+}

--- a/src/cli/commands/system/dir-size.ts
+++ b/src/cli/commands/system/dir-size.ts
@@ -1,0 +1,49 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+export function directorySizeBytes(dir: string): number {
+  if (!existsSync(dir)) {
+    return 0;
+  }
+
+  let total = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += directorySizeBytes(path);
+    } else if (entry.isFile()) {
+      total += statSync(path).size;
+    }
+  }
+  return total;
+}
+
+export function formatByteSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${Math.round(bytes / 1024)}KB`;
+  }
+  return `${Math.round(bytes / (1024 * 1024))}MB`;
+}

--- a/src/cli/commands/system/reset-auth.ts
+++ b/src/cli/commands/system/reset-auth.ts
@@ -1,0 +1,64 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { deleteToken, getToken } from '../../../lib/keychain';
+import type { CliState } from '../../../lib/state';
+import type { PhaseItem } from '../../../ui';
+import { phaseItem } from '../../../ui';
+import { revokeServerTokenIfPossible } from '../auth/revoke-server-token';
+
+export interface AuthResetResult {
+  item: PhaseItem;
+  authConnectionIds: string[];
+}
+
+export async function purgeAuth(state: CliState): Promise<AuthResetResult> {
+  const cleanedIds: string[] = [];
+  const failed: string[] = [];
+
+  for (const conn of state.auth.connections) {
+    const target = conn.orgKey ? `${conn.serverUrl} (${conn.orgKey})` : conn.serverUrl;
+    try {
+      const token = (await getToken(conn.serverUrl, conn.orgKey)) ?? undefined;
+      await revokeServerTokenIfPossible(conn, token, 'reset');
+      await deleteToken(conn.serverUrl, conn.orgKey);
+      cleanedIds.push(conn.id);
+    } catch (err) {
+      failed.push(`${target}: ${(err as Error).message}`);
+    }
+  }
+
+  let item: PhaseItem;
+  if (failed.length > 0) {
+    const counts =
+      cleanedIds.length > 0
+        ? `${cleanedIds.length} removed, ${failed.length} failed`
+        : `${failed.length} failed`;
+    item = phaseItem('Authentication', 'warn', `${counts}: ${failed.join('; ')}`);
+  } else {
+    item = phaseItem(
+      'Authentication',
+      'done',
+      `${cleanedIds.length} tokens removed from keychain.`,
+    );
+  }
+
+  return { item, authConnectionIds: cleanedIds };
+}

--- a/src/cli/commands/system/reset-binaries.ts
+++ b/src/cli/commands/system/reset-binaries.ts
@@ -1,0 +1,164 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+
+import { BIN_DIR } from '../../../lib/config-constants';
+import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../lib/install-types';
+import type { CliState } from '../../../lib/state';
+import type { PhaseItem } from '../../../ui';
+import { phaseItem } from '../../../ui';
+import { stopAllContextAugmentationTools } from '../integrate/_common/context-augmentation';
+import { resolveSafePath } from './safe-path';
+
+export interface BinaryResetResult {
+  item: PhaseItem;
+  dependencyIds: string[];
+  toolNames: string[];
+}
+
+interface PathRemovalPlan {
+  path: string;
+  dependencyIds: Set<string>;
+  toolNames: Set<string>;
+}
+
+type BinaryRemoveOutcome =
+  | { status: 'cleaned'; dependencyIds: string[]; toolNames: string[] }
+  | { status: 'failed'; message: string };
+
+export async function removeBinaries(state: CliState): Promise<BinaryResetResult> {
+  const { plans, failed: planFailures } = buildRemovalPlans(state);
+  const cleanedDependencyIds = new Set<string>();
+  const cleanedToolNames = new Set<string>();
+  const failed = [...planFailures];
+  let removedPathCount = 0;
+
+  for (const plan of plans) {
+    const outcome = await tryRemoveBinaryAtPath(plan);
+    if (outcome.status === 'cleaned') {
+      removedPathCount += 1;
+      for (const id of outcome.dependencyIds) {
+        cleanedDependencyIds.add(id);
+      }
+      for (const name of outcome.toolNames) {
+        cleanedToolNames.add(name);
+      }
+    } else {
+      failed.push(outcome.message);
+    }
+  }
+
+  return {
+    item: buildBinaryPhaseItem(removedPathCount, failed),
+    dependencyIds: [...cleanedDependencyIds],
+    toolNames: [...cleanedToolNames],
+  };
+}
+
+function buildRemovalPlans(state: CliState): {
+  plans: PathRemovalPlan[];
+  failed: string[];
+} {
+  const byPath = new Map<string, PathRemovalPlan>();
+  const failed: string[] = [];
+
+  for (const dep of state.dependencies.installed) {
+    if (!dep.path) {
+      failed.push(`${dep.id}: missing install path`);
+      continue;
+    }
+    addPathTarget(byPath, dep.path, dep.id, undefined);
+  }
+
+  for (const tool of state.tools?.installed ?? []) {
+    if (!tool.path) {
+      failed.push(`${tool.name}: missing install path`);
+      continue;
+    }
+    addPathTarget(byPath, tool.path, undefined, tool.name);
+  }
+
+  return { plans: [...byPath.values()], failed };
+}
+
+function addPathTarget(
+  byPath: Map<string, PathRemovalPlan>,
+  path: string,
+  dependencyId: string | undefined,
+  toolName: string | undefined,
+): void {
+  let plan = byPath.get(path);
+  if (!plan) {
+    plan = { path, dependencyIds: new Set(), toolNames: new Set() };
+    byPath.set(path, plan);
+  }
+  if (dependencyId) {
+    plan.dependencyIds.add(dependencyId);
+  }
+  if (toolName) {
+    plan.toolNames.add(toolName);
+  }
+}
+
+async function tryRemoveBinaryAtPath(plan: PathRemovalPlan): Promise<BinaryRemoveOutcome> {
+  const label = [...plan.dependencyIds, ...plan.toolNames].join(', ') || plan.path;
+  const safePath = resolveSafePath(plan.path, [BIN_DIR]);
+  if (!safePath) {
+    return { status: 'failed', message: `${label}: path rejected` };
+  }
+
+  const needsCagStop =
+    plan.dependencyIds.has(CONTEXT_AUGMENTATION_BINARY_NAME) ||
+    plan.toolNames.has(CONTEXT_AUGMENTATION_BINARY_NAME);
+  if (needsCagStop && existsSync(safePath)) {
+    await stopAllContextAugmentationTools(safePath);
+  }
+
+  try {
+    if (existsSync(safePath)) {
+      rmSync(safePath, { force: true });
+    }
+    return {
+      status: 'cleaned',
+      dependencyIds: [...plan.dependencyIds],
+      toolNames: [...plan.toolNames],
+    };
+  } catch (err) {
+    return { status: 'failed', message: `${label}: ${(err as Error).message}` };
+  }
+}
+
+function buildBinaryPhaseItem(removedCount: number, failed: string[]): PhaseItem {
+  if (failed.length > 0) {
+    const counts =
+      removedCount > 0
+        ? `${removedCount} removed, ${failed.length} failed`
+        : `${failed.length} failed`;
+    return phaseItem('Binaries', 'warn', `${counts}: ${failed.join('; ')}`);
+  }
+
+  if (removedCount > 0) {
+    const label = removedCount === 1 ? 'binary' : 'binaries';
+    return phaseItem('Binaries', 'done', `Removed ${removedCount} ${label} from ${BIN_DIR}.`);
+  }
+
+  return phaseItem('Binaries', 'info', 'Nothing to remove.');
+}

--- a/src/cli/commands/system/reset-filesystem.ts
+++ b/src/cli/commands/system/reset-filesystem.ts
@@ -1,0 +1,78 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+
+import {
+  CLI_DIR,
+  GLOBAL_HOOKS_DIR,
+  LOG_DIR,
+  SCA_SCANNER_CACHE_DIR,
+} from '../../../lib/config-constants';
+import type { PhaseItem } from '../../../ui';
+import { phaseItem } from '../../../ui';
+import { directorySizeBytes, formatByteSize } from './dir-size';
+import { resolveSafePath } from './safe-path';
+
+export interface FilesystemResetResult {
+  item: PhaseItem;
+}
+
+const CACHE_DIRS = [LOG_DIR, SCA_SCANNER_CACHE_DIR, GLOBAL_HOOKS_DIR];
+
+export function clearFilesystem(): FilesystemResetResult {
+  const failed: string[] = [];
+  let bytesFreed = 0;
+  let removedCount = 0;
+
+  for (const dir of CACHE_DIRS) {
+    const safeDir = resolveSafePath(dir, [CLI_DIR]);
+    if (!safeDir) {
+      failed.push(`${dir}: path rejected`);
+      continue;
+    }
+
+    try {
+      bytesFreed += directorySizeBytes(safeDir);
+      if (existsSync(safeDir)) {
+        rmSync(safeDir, { recursive: true, force: true });
+        removedCount += 1;
+      }
+    } catch (err) {
+      failed.push(`${dir}: ${(err as Error).message}`);
+    }
+  }
+
+  let item: PhaseItem;
+  if (failed.length > 0) {
+    item = phaseItem(
+      'Filesystem',
+      'warn',
+      `Failed to clear some directories: ${failed.join('; ')}`,
+    );
+  } else if (removedCount > 0) {
+    const sizeLabel = bytesFreed > 0 ? ` (${formatByteSize(bytesFreed)} cleared)` : '';
+    item = phaseItem('Filesystem', 'done', `Cleared CLI cache and logs${sizeLabel}.`);
+  } else {
+    item = phaseItem('Filesystem', 'info', 'Nothing to clear.');
+  }
+
+  return { item };
+}

--- a/src/cli/commands/system/reset.ts
+++ b/src/cli/commands/system/reset.ts
@@ -1,0 +1,223 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { version as VERSION } from '../../../../package.json';
+import { loadState, saveState } from '../../../lib/repository/state-repository';
+import { type CliState, getDefaultState, type InstalledIntegration } from '../../../lib/state';
+import type { PhaseItem } from '../../../ui';
+import { info, phase, phaseItem, print, success, text, textPrompt, warn } from '../../../ui';
+import { CommandFailedError } from '../_common/error';
+import { purgeAuth } from './reset-auth';
+import { removeBinaries } from './reset-binaries';
+import { clearFilesystem } from './reset-filesystem';
+
+export interface SystemResetOptions {
+  force?: boolean;
+}
+
+interface CleanedFields {
+  authConnectionIds: string[];
+  dependencyIds: string[];
+  toolNames: string[];
+  integrationFeatures: Array<{ integrationStateId: string; featureId: string }>;
+  agentExtensionIds: string[];
+}
+
+interface StepResult {
+  item: PhaseItem;
+  cleaned: CleanedFields;
+}
+
+function emptyCleanedFields(overrides: Partial<CleanedFields> = {}): CleanedFields {
+  return {
+    authConnectionIds: [],
+    dependencyIds: [],
+    toolNames: [],
+    integrationFeatures: [],
+    agentExtensionIds: [],
+    ...overrides,
+  };
+}
+
+function mergeCleanedFields(fields: CleanedFields[]): CleanedFields {
+  return {
+    authConnectionIds: fields.flatMap((f) => f.authConnectionIds),
+    dependencyIds: fields.flatMap((f) => f.dependencyIds),
+    toolNames: fields.flatMap((f) => f.toolNames),
+    integrationFeatures: fields.flatMap((f) => f.integrationFeatures),
+    agentExtensionIds: fields.flatMap((f) => f.agentExtensionIds),
+  };
+}
+
+/**
+ * Reset the CLI to factory defaults: remove tokens, binaries, integrations,
+ * and cached files. Telemetry settings are preserved.
+ */
+export async function systemReset(options: SystemResetOptions): Promise<void> {
+  if (!(options.force || (await confirmDestructiveAction()))) {
+    return;
+  }
+
+  info('Cleaning up SonarQube CLI environment...');
+
+  const state = loadState();
+
+  const authResult = await purgeAuth(state);
+  const binaryResult = await removeBinaries(state);
+  const integrationResult = integrationsResetPending();
+  const filesystemResult = clearFilesystem();
+
+  const results: StepResult[] = [
+    {
+      item: authResult.item,
+      cleaned: emptyCleanedFields({ authConnectionIds: authResult.authConnectionIds }),
+    },
+    {
+      item: binaryResult.item,
+      cleaned: emptyCleanedFields({
+        dependencyIds: binaryResult.dependencyIds,
+        toolNames: binaryResult.toolNames,
+      }),
+    },
+    {
+      item: integrationResult.item,
+      cleaned: integrationResult.cleaned,
+    },
+    { item: filesystemResult.item, cleaned: emptyCleanedFields() },
+  ];
+
+  phase(
+    'Reset',
+    results.map((r) => r.item),
+  );
+
+  applyCleanedState(state, mergeCleanedFields(results.map((r) => r.cleaned)));
+  clearLegacyState(state);
+  saveState(state);
+
+  const hasIssues = results.some((r) => r.item.status === 'warn');
+  if (hasIssues) {
+    text(
+      'CLI has been partially reset. Review the details above and clean up remaining items manually.',
+    );
+    throw new CommandFailedError('System reset completed with warnings.');
+  }
+
+  success('CLI has been successfully reset to factory settings.');
+}
+
+function integrationsResetPending(): StepResult {
+  return {
+    item: phaseItem('Integrations', 'info', 'Integration cleanup is not wired yet (follow-up PR).'),
+    cleaned: emptyCleanedFields(),
+  };
+}
+
+async function confirmDestructiveAction(): Promise<boolean> {
+  if (!process.stdin.isTTY) {
+    print('Reset cancelled. Use --force to skip the prompt in non-interactive mode.');
+    return false;
+  }
+  warn(
+    'This will remove all local credentials, uninstall Sonar binaries, and break active AI integrations.',
+  );
+  const answer = await textPrompt('Please type RESET to continue');
+  if (answer?.trim() !== 'RESET') {
+    print('Reset cancelled.');
+    return false;
+  }
+  return true;
+}
+
+function indexCleanedFeatures(
+  features: Array<{ integrationStateId: string; featureId: string }>,
+): Map<string, Set<string>> {
+  const index = new Map<string, Set<string>>();
+  for (const { integrationStateId, featureId } of features) {
+    let ids = index.get(integrationStateId);
+    if (!ids) {
+      ids = new Set();
+      index.set(integrationStateId, ids);
+    }
+    ids.add(featureId);
+  }
+  return index;
+}
+
+function removeCleanedFeatures(
+  integration: InstalledIntegration,
+  cleanedFeatures: Map<string, Set<string>>,
+): InstalledIntegration {
+  const cleanedIds = cleanedFeatures.get(integration.id);
+  return {
+    ...integration,
+    features: cleanedIds
+      ? integration.features.filter((f) => !cleanedIds.has(f.featureId))
+      : integration.features,
+  };
+}
+
+function applyCleanedState(state: CliState, cleaned: CleanedFields): void {
+  if (cleaned.authConnectionIds.length > 0) {
+    const removedIds = new Set(cleaned.authConnectionIds);
+    state.auth.connections = state.auth.connections.filter((c) => !removedIds.has(c.id));
+    state.auth.isAuthenticated = state.auth.connections.length > 0;
+    if (
+      state.auth.activeConnectionId !== undefined &&
+      !state.auth.connections.some((c) => c.id === state.auth.activeConnectionId)
+    ) {
+      state.auth.activeConnectionId = undefined;
+    }
+  }
+
+  if (cleaned.dependencyIds.length > 0) {
+    const removedIds = new Set(cleaned.dependencyIds);
+    state.dependencies.installed = state.dependencies.installed.filter(
+      (d) => !removedIds.has(d.id),
+    );
+  }
+
+  if (cleaned.toolNames.length > 0) {
+    const removedNames = new Set(cleaned.toolNames);
+    state.tools ??= { installed: [] };
+    state.tools.installed = state.tools.installed.filter((t) => !removedNames.has(t.name));
+  }
+
+  if (cleaned.integrationFeatures.length > 0) {
+    const cleanedFeatures = indexCleanedFeatures(cleaned.integrationFeatures);
+    state.integrations.installed = state.integrations.installed
+      .map((i) => removeCleanedFeatures(i, cleanedFeatures))
+      .filter((i) => i.features.length > 0);
+  }
+
+  if (cleaned.agentExtensionIds.length > 0) {
+    const removedIds = new Set(cleaned.agentExtensionIds);
+    state.agentExtensions = state.agentExtensions.filter((e) => !removedIds.has(e.id));
+  }
+}
+
+function clearLegacyState(state: CliState): void {
+  const defaults = getDefaultState(VERSION);
+  state.agents = defaults.agents;
+  if (state.tools?.installed.length === 0) {
+    state.tools = defaults.tools;
+  }
+  state.lastUpdated = new Date().toISOString();
+}

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -57,6 +57,9 @@ export const STATE_FILE = join(CLI_DIR, 'state.json');
 export const LOG_DIR = join(CLI_DIR, 'logs');
 export const LOG_FILE = join(LOG_DIR, `${APP_NAME}.log`);
 
+/** SCA scanner download cache used by dependency-risk analysis. */
+export const SCA_SCANNER_CACHE_DIR = join(CLI_DIR, 'sca-scanner-cache');
+
 // ---------------------------------------------------------------------------
 // sonar-secrets binary
 // ---------------------------------------------------------------------------

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -1,0 +1,309 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integration tests for `sonar system reset`
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { SCA_SCANNER_CACHE_DIR } from '../../../../src/lib/config-constants';
+import { generateKeychainAccount } from '../../../../src/lib/keychain';
+import { TestHarness } from '../../harness';
+
+interface AuthSnapshot {
+  isAuthenticated: boolean;
+  connections: unknown[];
+  activeConnectionId: string | undefined;
+}
+
+interface TelemetrySnapshot {
+  enabled: boolean;
+  installationId?: string;
+  firstUseDate: string;
+  events: unknown[];
+}
+
+interface ResetStateSnapshot {
+  auth: AuthSnapshot;
+  telemetry: TelemetrySnapshot;
+  tools?: { installed: Array<{ name: string }> };
+  dependencies: { installed: Array<{ id: string }> };
+  agentExtensions: unknown[];
+  integrations: { installed: unknown[] };
+}
+
+function readState(stateJsonPath: string): ResetStateSnapshot {
+  return JSON.parse(readFileSync(stateJsonPath, 'utf-8')) as ResetStateSnapshot;
+}
+
+function readKeychainTokens(keychainFile: string): Record<string, string> {
+  if (!existsSync(keychainFile)) return {};
+  try {
+    return (JSON.parse(readFileSync(keychainFile, 'utf-8')) as { tokens: Record<string, string> })
+      .tokens;
+  } catch {
+    return {};
+  }
+}
+
+describe('system reset --force', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'succeeds on an empty environment and prints all four status lines',
+    async () => {
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Cleaning up SonarQube CLI environment');
+      expect(result.stdout).toContain('Authentication: 0 tokens removed from keychain.');
+      expect(result.stdout).toContain('Integrations:');
+      expect(result.stdout).toContain('CLI has been successfully reset to factory settings.');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'purges seeded auth tokens from keychain and state',
+    async () => {
+      const server = await harness.newFakeServer().start();
+      harness.state().withAuth(server.baseUrl(), 'seeded-token');
+
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Authentication: 1 tokens removed from keychain.');
+
+      const account = generateKeychainAccount(server.baseUrl());
+      expect(readKeychainTokens(harness.keychainJsonFile)[account]).toBeUndefined();
+
+      const state = readState(harness.stateJsonFile.path);
+      expect(state.auth.connections).toHaveLength(0);
+      expect(state.auth.activeConnectionId).toBeUndefined();
+      expect(state.auth.isAuthenticated).toBe(false);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'removes binaries recorded in state',
+    async () => {
+      harness.state().withSecretsBinaryInstalled();
+
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/Binaries:.*Removed 1 binary/);
+
+      const binDir = join(harness.cliHome.path, 'bin');
+      const state = readState(harness.stateJsonFile.path);
+      expect(state.dependencies.installed).toHaveLength(0);
+      if (existsSync(binDir)) {
+        const remaining = readdirSync(binDir).filter((name) => name.includes('sonar'));
+        expect(remaining.length).toBe(0);
+      }
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'preserves telemetry installationId, firstUseDate, and events',
+    async () => {
+      const expectedInstallationId = '11111111-2222-3333-4444-555555555555';
+      const expectedFirstUseDate = '2020-01-01T00:00:00.000Z';
+      harness.state().withRawState(
+        JSON.stringify({
+          version: '1.0',
+          lastUpdated: expectedFirstUseDate,
+          auth: { isAuthenticated: false, connections: [] },
+          agents: {
+            'claude-code': {
+              configured: false,
+              hooks: { installed: [] },
+              skills: { installed: [] },
+            },
+          },
+          config: { cliVersion: '0.0.0' },
+          tools: { installed: [] },
+          dependencies: { installed: [] },
+          telemetry: {
+            enabled: true,
+            installationId: expectedInstallationId,
+            firstUseDate: expectedFirstUseDate,
+            events: [],
+          },
+          agentExtensions: [],
+          integrations: { installed: [] },
+        }),
+      );
+
+      const result = await harness.run('system reset --force');
+      expect(result.exitCode).toBe(0);
+
+      const after = readState(harness.stateJsonFile.path).telemetry;
+      expect(after.installationId).toBe(expectedInstallationId);
+      expect(after.firstUseDate).toBe(expectedFirstUseDate);
+      expect(after.enabled).toBe(true);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'clears logs and sca cache directories',
+    async () => {
+      const logDir = join(harness.cliHome.path, 'logs');
+      const cacheDir = join(harness.cliHome.path, 'sca-scanner-cache');
+      harness.state().withSecretsBinaryInstalled();
+
+      mkdirSync(logDir, { recursive: true });
+      mkdirSync(cacheDir, { recursive: true });
+      writeFileSync(join(logDir, 'sonarqube-cli.log'), 'fake log content', 'utf-8');
+      writeFileSync(join(cacheDir, 'entry.cache'), 'cache', 'utf-8');
+
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/Filesystem:.*Cleared CLI cache and logs/);
+      expect(existsSync(logDir)).toBe(false);
+      expect(existsSync(cacheDir)).toBe(false);
+      expect(SCA_SCANNER_CACHE_DIR).toContain('sca-scanner-cache');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'rejects dependency paths outside BIN_DIR',
+    async () => {
+      const outside = join(harness.cwd.path, 'outside-binary');
+      mkdirSync(harness.cwd.path, { recursive: true });
+      writeFileSync(outside, 'fake', 'utf-8');
+      harness.state().withRawState(
+        JSON.stringify({
+          version: '1.0',
+          lastUpdated: new Date().toISOString(),
+          auth: { isAuthenticated: false, connections: [] },
+          agents: {
+            'claude-code': {
+              configured: false,
+              hooks: { installed: [] },
+              skills: { installed: [] },
+            },
+          },
+          config: { cliVersion: '0.0.0' },
+          tools: { installed: [] },
+          dependencies: {
+            installed: [
+              {
+                id: 'sonar-secrets',
+                dependencyType: 'binary',
+                path: outside,
+                updatedByCliVersion: '0.0.0',
+                updatedAt: new Date().toISOString(),
+              },
+            ],
+          },
+          telemetry: {
+            enabled: false,
+            installationId: '00000000-0000-0000-0000-000000000000',
+            firstUseDate: new Date().toISOString(),
+            events: [],
+          },
+          agentExtensions: [],
+          integrations: { installed: [] },
+        }),
+      );
+
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('Binaries:');
+      expect(result.stdout).toContain('failed');
+      expect(result.stderr).toContain('System reset completed with warnings');
+
+      const state = readState(harness.stateJsonFile.path);
+      expect(state.dependencies.installed).toHaveLength(1);
+      expect(existsSync(outside)).toBe(true);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'removes sca-scanner-cli recorded only in tools.installed',
+    async () => {
+      harness.state().withScaScannerBinaryInstalled();
+
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/Binaries:.*Removed 1 binary/);
+
+      const state = readState(harness.stateJsonFile.path);
+      expect(state.tools?.installed ?? []).toHaveLength(0);
+      const binDir = join(harness.cliHome.path, 'bin');
+      if (existsSync(binDir)) {
+        const remaining = readdirSync(binDir).filter((name) => name.includes('sca-scanner'));
+        expect(remaining.length).toBe(0);
+      }
+    },
+    { timeout: 15000 },
+  );
+});
+
+describe('system reset (no --force)', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'cancels with a --force hint when stdin is not a TTY',
+    async () => {
+      const server = await harness.newFakeServer().start();
+      harness.state().withAuth(server.baseUrl(), 'seeded-token');
+
+      const result = await harness.run('system reset');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        'Reset cancelled. Use --force to skip the prompt in non-interactive mode.',
+      );
+
+      const state = readState(harness.stateJsonFile.path);
+      expect(state.auth.connections).toHaveLength(1);
+      expect(state.auth.isAuthenticated).toBe(true);
+    },
+    { timeout: 15000 },
+  );
+});


### PR DESCRIPTION
## Summary

- Add `sonar system reset` for auth, binaries, and filesystem cleanup.
- Extract shared server token revocation (`revoke-server-token.ts`) used by logout and reset.
- Clean `tools.installed` and `dependencies.installed` binaries under `BIN_DIR`; exit code `1` on partial failure.
- Integration teardown is **stubbed** (info phase) until PR4 lands.

## Stack

PR **3/4** → #393 (after #392 merges or review in stack order)

## Test plan

- [x] `bun test tests/integration/specs/system/reset.test.ts` (excludes legacy integration teardown)
- [x] `bun run typecheck`
- [x] `bun run build:binary`