### PR TITLE
CLI-565 sonar system reset — integration teardown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,12 +54,12 @@ The CAG installer (`src/cli/commands/_common/install/context-augmentation.ts`) h
 
 ### System reset
 
-`sonar system reset` returns the CLI to a factory-like state in one shot. Registered as `anonymousAction` so it works when auth is broken. Core implementation: `reset.ts`, `reset-auth.ts`, `reset-binaries.ts`, `reset-filesystem.ts`, and `safe-path.ts`. Integration teardown ships in a follow-up PR (`reset-integrations.ts`).
+`sonar system reset` returns the CLI to a factory-like state in one shot. Registered as `anonymousAction` so it works when auth is broken. Implementation is split across `src/cli/commands/system/reset.ts` (orchestration), `reset-auth.ts`, `reset-binaries.ts`, `reset-integrations.ts`, `reset-filesystem.ts`, and `safe-path.ts`.
 
 - **Confirmation:** interactive runs require typing `RESET`; non-interactive runs require `--force`.
 - **Authentication:** best-effort server token revoke via shared `revoke-server-token.ts` (same hints as `auth logout`) then keychain deletion; only successfully removed connections are dropped from `state.auth`.
 - **Binaries:** deletes paths from `state.dependencies.installed` and legacy `state.tools.installed` under `BIN_DIR` (`resolveSafePath`); stops CAG daemons before removing the context-augmentation binary.
-- **Integrations:** not wired in this PR (phase reports a follow-up message).
+- **Integrations:** calls `IntegrationInstaller.removeFeature()` for each declarative install, then cleans legacy `agentExtensions` (hooks/settings) when registry entries remain.
 - **Filesystem:** removes `LOG_DIR`, `SCA_SCANNER_CACHE_DIR`, and `GLOBAL_HOOKS_DIR` under `CLI_DIR`; reports approximate bytes cleared.
 - **Telemetry:** never disabled; `installationId`, `firstUseDate`, and pending `events` are preserved.
 - **Legacy fields:** `state.agents` is reset; `state.tools` is reset only when no installed tools remain after binary cleanup.

--- a/src/cli/commands/system/reset-integrations.ts
+++ b/src/cli/commands/system/reset-integrations.ts
@@ -1,0 +1,300 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync, rmSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type {
+  AgentExtension,
+  CliState,
+  HookExtension,
+  InstalledIntegration,
+  InstalledIntegrationFeature,
+} from '../../../lib/state';
+import type { PhaseItem } from '../../../ui';
+import { phaseItem } from '../../../ui';
+import { readOrInitJson, removeAgentHooks, SONAR_SECRETS_MARKER } from '../integrate/_common/hooks';
+import {
+  type IntegrationDeclaration,
+  integrationInstaller,
+  type IntegrationRegistry,
+  makeContext,
+} from '../integrate/_common/registry';
+import { removeCopilotHookConfig } from '../integrate/copilot/hooks';
+
+export interface IntegrationResetResult {
+  item: PhaseItem;
+  integrationFeatures: Array<{ integrationStateId: string; featureId: string }>;
+  agentExtensionIds: string[];
+}
+
+/** Maps declarative integration ids to legacy `agentExtensions.agentId` values. */
+const INTEGRATION_TO_AGENT_ID: Record<string, string> = {
+  'claude-code': 'claude-code',
+  'copilot-cli': 'copilot-cli',
+  codex: 'codex',
+};
+
+type FeatureRemoveOutcome =
+  | {
+      status: 'removed';
+      integrationStateId: string;
+      featureId: string;
+      agentExtensionIds: string[];
+    }
+  | { status: 'failed'; message: string };
+
+interface DeclarativeIntegrationReset {
+  integrationFeatures: Array<{ integrationStateId: string; featureId: string }>;
+  agentExtensionIds: string[];
+  failed: string[];
+  removedFeatures: number;
+}
+
+export async function removeAllIntegrations(state: CliState): Promise<IntegrationResetResult> {
+  const supportedIntegrations = await loadSupportedIntegrations();
+  const declarative = await removeDeclarativeIntegrations(state, supportedIntegrations);
+  const legacy = await removeLegacyAgentExtensions(state);
+
+  const agentExtensionIds = [...new Set([...declarative.agentExtensionIds, ...legacy.cleanedIds])];
+  const failed = [...declarative.failed, ...legacy.failed];
+  const totalRemoved = declarative.removedFeatures + legacy.cleanedIds.length;
+
+  return {
+    item: buildIntegrationPhaseItem(totalRemoved, failed),
+    integrationFeatures: declarative.integrationFeatures,
+    agentExtensionIds,
+  };
+}
+
+async function loadSupportedIntegrations(): Promise<IntegrationRegistry> {
+  const { supportedIntegrations } = await import('../integrate/index.js');
+  return supportedIntegrations;
+}
+
+async function removeDeclarativeIntegrations(
+  state: CliState,
+  supportedIntegrations: IntegrationRegistry,
+): Promise<DeclarativeIntegrationReset> {
+  const integrationFeatures: Array<{ integrationStateId: string; featureId: string }> = [];
+  const agentExtensionIds: string[] = [];
+  const failed: string[] = [];
+  let removedFeatures = 0;
+
+  for (const installed of state.integrations.installed) {
+    const declaration = supportedIntegrations.get(installed.integrationId);
+    if (!declaration) {
+      failed.push(`${installed.integrationId}: unknown integration`);
+      continue;
+    }
+
+    for (const installedFeature of installed.features) {
+      const outcome = await tryRemoveInstalledFeature(
+        state,
+        installed,
+        installedFeature,
+        declaration,
+      );
+      if (outcome.status === 'removed') {
+        integrationFeatures.push({
+          integrationStateId: outcome.integrationStateId,
+          featureId: outcome.featureId,
+        });
+        agentExtensionIds.push(...outcome.agentExtensionIds);
+        removedFeatures += 1;
+      } else {
+        failed.push(outcome.message);
+      }
+    }
+  }
+
+  return { integrationFeatures, agentExtensionIds, failed, removedFeatures };
+}
+
+async function tryRemoveInstalledFeature(
+  state: CliState,
+  installed: InstalledIntegration,
+  installedFeature: InstalledIntegrationFeature,
+  declaration: IntegrationDeclaration,
+): Promise<FeatureRemoveOutcome> {
+  const featureDeclaration = declaration.features.find(
+    (feature) => feature.id === installedFeature.featureId,
+  );
+  if (!featureDeclaration) {
+    return {
+      status: 'failed',
+      message: `${installed.integrationId}.${installedFeature.featureId}: unknown feature`,
+    };
+  }
+
+  const context = makeContext(
+    state,
+    installedFeature.targetRoot,
+    installedFeature.scope,
+    'install',
+    undefined,
+    true,
+    installedFeature.attrs,
+  );
+
+  try {
+    await integrationInstaller.removeFeature(context, featureDeclaration);
+    return {
+      status: 'removed',
+      integrationStateId: installed.id,
+      featureId: installedFeature.featureId,
+      agentExtensionIds: collectAgentExtensionIds(
+        state,
+        installed.integrationId,
+        installedFeature.targetRoot,
+      ),
+    };
+  } catch (err) {
+    return {
+      status: 'failed',
+      message: `${installed.integrationId}.${installedFeature.featureId}: ${(err as Error).message}`,
+    };
+  }
+}
+
+function collectAgentExtensionIds(
+  state: CliState,
+  integrationId: string,
+  targetRoot: string,
+): string[] {
+  const agentId = INTEGRATION_TO_AGENT_ID[integrationId];
+  if (!agentId) {
+    return [];
+  }
+
+  return state.agentExtensions
+    .filter((ext) => ext.agentId === agentId && ext.projectRoot === targetRoot)
+    .map((ext) => ext.id);
+}
+
+function buildIntegrationPhaseItem(totalRemoved: number, failed: string[]): PhaseItem {
+  if (failed.length > 0) {
+    const counts =
+      totalRemoved > 0
+        ? `${totalRemoved} removed, ${failed.length} failed`
+        : `${failed.length} failed`;
+    return phaseItem('Integrations', 'warn', `${counts}: ${failed.join('; ')}`);
+  }
+
+  if (totalRemoved > 0) {
+    const label = totalRemoved === 1 ? 'target' : 'targets';
+    return phaseItem('Integrations', 'done', `Removed ${totalRemoved} integration ${label}.`);
+  }
+
+  return phaseItem('Integrations', 'info', 'Nothing to remove.');
+}
+
+async function removeLegacyAgentExtensions(
+  state: CliState,
+): Promise<{ cleanedIds: string[]; failed: string[] }> {
+  const cleanedIds: string[] = [];
+  const failed: string[] = [];
+
+  for (const extension of state.agentExtensions) {
+    try {
+      await cleanupLegacyExtension(extension);
+      cleanedIds.push(extension.id);
+    } catch (err) {
+      failed.push(`${extension.agentId}/${extension.name}: ${(err as Error).message}`);
+    }
+  }
+
+  return { cleanedIds, failed };
+}
+
+async function cleanupLegacyExtension(extension: AgentExtension): Promise<void> {
+  if (extension.kind === 'hook') {
+    await cleanupLegacyHookExtension(extension);
+    return;
+  }
+
+  if (extension.kind === 'instructions') {
+    // Instructions are marker-based snippets; declarative remove handles new installs.
+    // Legacy-only instructions have no stable on-disk path beyond agent-specific files.
+    return;
+  }
+
+  const skillPath = join(extension.projectRoot, '.agents', 'skills', extension.name, 'SKILL.md');
+  if (existsSync(skillPath)) {
+    rmSync(skillPath, { force: true });
+  }
+}
+
+async function cleanupLegacyHookExtension(extension: HookExtension): Promise<void> {
+  if (extension.agentId === 'claude-code') {
+    await cleanupClaudeLegacyHook(extension);
+    return;
+  }
+
+  if (extension.agentId === 'copilot-cli') {
+    await cleanupCopilotLegacyHook(extension);
+  }
+}
+
+function claudeHookMarkers(extension: HookExtension): string[] {
+  if (extension.name === 'sonar-sqaa') {
+    return ['sonar-sqaa'];
+  }
+  if (extension.name === SONAR_SECRETS_MARKER) {
+    return [SONAR_SECRETS_MARKER];
+  }
+  return [extension.name];
+}
+
+async function cleanupClaudeLegacyHook(extension: HookExtension): Promise<void> {
+  const settingsPath = join(extension.projectRoot, '.claude', 'settings.json');
+  if (existsSync(settingsPath)) {
+    const document = await readOrInitJson(settingsPath, { hooks: {} });
+    const updated = removeAgentHooks(document, claudeHookMarkers(extension));
+    await writeFile(settingsPath, `${JSON.stringify(updated, null, 2)}\n`);
+  }
+
+  const hookDir = join(extension.projectRoot, '.claude', 'hooks', extension.name);
+  if (existsSync(hookDir)) {
+    rmSync(hookDir, { recursive: true, force: true });
+  }
+}
+
+async function cleanupCopilotLegacyHook(extension: HookExtension): Promise<void> {
+  const hooksJsonPath = extension.global
+    ? join(homedir(), '.copilot', 'hooks', 'hooks.json')
+    : join(extension.projectRoot, '.github', 'hooks', 'hooks.json');
+
+  if (existsSync(hooksJsonPath)) {
+    const raw = await readFile(hooksJsonPath, 'utf-8');
+    const document = JSON.parse(raw) as unknown;
+    const updated = removeCopilotHookConfig(document);
+    await writeFile(hooksJsonPath, `${JSON.stringify(updated, null, 2)}\n`);
+  }
+
+  const scriptDir = extension.global
+    ? join(homedir(), '.copilot', 'hooks', SONAR_SECRETS_MARKER)
+    : join(extension.projectRoot, '.github', 'hooks', SONAR_SECRETS_MARKER);
+  if (existsSync(scriptDir)) {
+    rmSync(scriptDir, { recursive: true, force: true });
+  }
+}

--- a/src/cli/commands/system/reset.ts
+++ b/src/cli/commands/system/reset.ts
@@ -22,11 +22,12 @@ import { version as VERSION } from '../../../../package.json';
 import { loadState, saveState } from '../../../lib/repository/state-repository';
 import { type CliState, getDefaultState, type InstalledIntegration } from '../../../lib/state';
 import type { PhaseItem } from '../../../ui';
-import { info, phase, phaseItem, print, success, text, textPrompt, warn } from '../../../ui';
+import { info, phase, print, success, text, textPrompt, warn } from '../../../ui';
 import { CommandFailedError } from '../_common/error';
 import { purgeAuth } from './reset-auth';
 import { removeBinaries } from './reset-binaries';
 import { clearFilesystem } from './reset-filesystem';
+import { removeAllIntegrations } from './reset-integrations';
 
 export interface SystemResetOptions {
   force?: boolean;
@@ -81,7 +82,7 @@ export async function systemReset(options: SystemResetOptions): Promise<void> {
 
   const authResult = await purgeAuth(state);
   const binaryResult = await removeBinaries(state);
-  const integrationResult = integrationsResetPending();
+  const integrationResult = await removeAllIntegrations(state);
   const filesystemResult = clearFilesystem();
 
   const results: StepResult[] = [
@@ -98,7 +99,10 @@ export async function systemReset(options: SystemResetOptions): Promise<void> {
     },
     {
       item: integrationResult.item,
-      cleaned: integrationResult.cleaned,
+      cleaned: emptyCleanedFields({
+        integrationFeatures: integrationResult.integrationFeatures,
+        agentExtensionIds: integrationResult.agentExtensionIds,
+      }),
     },
     { item: filesystemResult.item, cleaned: emptyCleanedFields() },
   ];
@@ -121,13 +125,6 @@ export async function systemReset(options: SystemResetOptions): Promise<void> {
   }
 
   success('CLI has been successfully reset to factory settings.');
-}
-
-function integrationsResetPending(): StepResult {
-  return {
-    item: phaseItem('Integrations', 'info', 'Integration cleanup is not wired yet (follow-up PR).'),
-    cleaned: emptyCleanedFields(),
-  };
 }
 
 async function confirmDestructiveAction(): Promise<boolean> {

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -199,6 +199,52 @@ describe('system reset --force', () => {
   );
 
   it(
+    'clears legacy agentExtensions registry entries',
+    async () => {
+      const server = await harness.newFakeServer().start();
+      const settingsPath = join(harness.cwd.path, '.claude', 'settings.json');
+      mkdirSync(join(harness.cwd.path, '.claude'), { recursive: true });
+      writeFileSync(
+        settingsPath,
+        JSON.stringify(
+          {
+            hooks: {
+              PostToolUse: [
+                {
+                  matcher: 'Edit|Write',
+                  hooks: [{ type: 'command', command: 'sonar-sqaa/build-scripts/posttool-sqaa' }],
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        ),
+        'utf-8',
+      );
+
+      harness
+        .state()
+        .withAuth(server.baseUrl(), 'tok', 'org-key')
+        .withSqaaExtension(harness.cwd.path, 'my-project');
+
+      const result = await harness.run('system reset --force');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toMatch(/Integrations:.*Removed/);
+
+      const state = readState(harness.stateJsonFile.path);
+      expect(state.agentExtensions).toHaveLength(0);
+
+      const settings = JSON.parse(readFileSync(settingsPath, 'utf-8')) as {
+        hooks?: { PostToolUse?: unknown[] };
+      };
+      expect(settings.hooks?.PostToolUse ?? []).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'rejects dependency paths outside BIN_DIR',
     async () => {
       const outside = join(harness.cwd.path, 'outside-binary');


### PR DESCRIPTION
## Summary

- Wire `reset-integrations.ts` into `sonar system reset` (declarative `removeFeature` + legacy `agentExtensions` cleanup).
- Complete integration tests including legacy Claude SQAA hook removal.
- Finalize `CLAUDE.md` / `AGENTS.md` for the full reset behavior.

## Stack

PR **4/4** → #394 (replaces monolithic #370)

Integration branch `feature/vt/CLI-438-system-reset` now points at this stack tip.

## Test plan

- [x] `bun test tests/integration/specs/system/reset.test.ts` (full suite)
- [x] `bun run typecheck`
- [x] `bun run build:binary`

## Note on #370

Please review/merge this stack instead of the original single PR. Close #370 once the stack is approved (or keep it as draft pointing here).