### PR TITLE
CLI-596 Interactive integrate: Wire Git to interactive feature selection

### DIFF
--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -26,7 +26,7 @@ import { join } from 'node:path';
 import { GLOBAL_HOOKS_DIR } from '../../../../lib/config-constants';
 import { normalizePath } from '../../../../lib/fs-utils';
 import { findGitRoot } from '../../../../lib/project-workspace';
-import { blank, confirmPrompt, intro, selectPrompt, text, warn } from '../../../../ui';
+import { blank, confirmPrompt, intro, text, warn } from '../../../../ui';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
 import { printGitPreflightSummary } from '../_common/preflight-summary';
@@ -97,35 +97,6 @@ export function validateHookOption(hook: string | undefined): void {
   }
 }
 
-/**
- * Validates and returns explicit `--hook`, or `pre-commit` when non-interactive with no hook, or prompts to select.
- */
-export async function resolveHookType(options: IntegrateGitOptions): Promise<GitHookType> {
-  if (options.hook !== undefined) {
-    return options.hook;
-  }
-  if (options.nonInteractive) {
-    return 'pre-commit';
-  }
-  const choice = await selectPrompt<GitHookType>(
-    'Would you like to install the pre-commit or pre-push hook?',
-    [
-      {
-        value: 'pre-commit' as const,
-        label: 'pre-commit (scan staged files)',
-      },
-      {
-        value: 'pre-push' as const,
-        label: 'pre-push (scan files in unpushed commits)',
-      },
-    ],
-  );
-  if (choice === null) {
-    throw new CommandFailedError('Installation cancelled');
-  }
-  return choice;
-}
-
 async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   validateHookOption(options.hook);
 
@@ -149,11 +120,7 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   }
   blank();
 
-  const hook = await resolveHookType(options);
-  text(`Hook: ${hook}`);
-  blank();
-
-  await installGitFeatures({ ...options, hook }, GLOBAL_HOOKS_DIR, 'global');
+  await installGitFeatures(options, GLOBAL_HOOKS_DIR, 'global');
 }
 
 export async function integrateGit(options: IntegrateGitOptions): Promise<void> {
@@ -183,15 +150,11 @@ export async function integrateGit(options: IntegrateGitOptions): Promise<void> 
   }
   blank();
 
-  const hook = await resolveHookType(options);
-  text(`Hook: ${hook}`);
-  blank();
-
-  await installGitFeatures({ ...options, hook }, gitRoot, 'project');
+  await installGitFeatures(options, gitRoot, 'project');
 }
 
 async function installGitFeatures(
-  options: IntegrateGitOptions & { hook: GitHookType },
+  options: IntegrateGitOptions,
   targetRoot: string,
   scope: 'project' | 'global',
 ): Promise<void> {
@@ -203,9 +166,6 @@ async function installGitFeatures(
     scope,
     force: options.force,
     nonInteractive: options.nonInteractive,
-    attrs: {
-      hook: options.hook,
-    },
   });
 }
 

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -24,7 +24,7 @@ import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependen
 import { textSnippet } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample, HOOK_MARKER, hookShouldInstall } from '../shared';
+import { gitHookExample, HOOK_MARKER, shouldInstallHook } from '../shared';
 import { getHuskySnippetContent } from './shell-fragments';
 
 export const HUSKY_INTEGRATION_ID = 'husky';
@@ -39,7 +39,7 @@ function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitO
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    shouldInstall: ({ options }) => hookShouldInstall(hook, options),
+    shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -24,7 +24,7 @@ import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependen
 import { textSnippet } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample, HOOK_MARKER } from '../shared';
+import { gitHookExample, HOOK_MARKER, hookShouldInstall } from '../shared';
 import { getHuskySnippetContent } from './shell-fragments';
 
 export const HUSKY_INTEGRATION_ID = 'husky';
@@ -39,7 +39,7 @@ function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitO
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    shouldInstall: ({ options }) => options.hook === hook,
+    shouldInstall: ({ options }) => hookShouldInstall(hook, options),
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -24,7 +24,7 @@ import { CommandFailedError } from '../../../../_common/error';
 import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample } from '../shared';
+import { gitHookExample, hookShouldInstall } from '../shared';
 import { nativeGitHookResource } from './resource';
 
 export const NATIVE_GIT_INTEGRATION_ID = 'native-git';
@@ -41,7 +41,7 @@ function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    shouldInstall: ({ options }) => options.hook === hook,
+    shouldInstall: ({ options }) => hookShouldInstall(hook, options),
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -24,7 +24,7 @@ import { CommandFailedError } from '../../../../_common/error';
 import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependencies';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample, hookShouldInstall } from '../shared';
+import { gitHookExample, shouldInstallHook } from '../shared';
 import { nativeGitHookResource } from './resource';
 
 export const NATIVE_GIT_INTEGRATION_ID = 'native-git';
@@ -41,7 +41,7 @@ function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    shouldInstall: ({ options }) => hookShouldInstall(hook, options),
+    shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -24,7 +24,7 @@ import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependen
 import { yamlPatch } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample } from '../shared';
+import { gitHookExample, hookShouldInstall } from '../shared';
 import {
   activatePreCommitFramework,
   normalizePreCommitConfig,
@@ -45,7 +45,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    shouldInstall: ({ options }) => options.hook === hook,
+    shouldInstall: ({ options }) => hookShouldInstall(hook, options),
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -24,7 +24,7 @@ import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependen
 import { yamlPatch } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample, hookShouldInstall } from '../shared';
+import { gitHookExample, shouldInstallHook } from '../shared';
 import {
   activatePreCommitFramework,
   normalizePreCommitConfig,
@@ -45,7 +45,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
   return {
     id: `${hook}-hook`,
     displayName: `${hook} hook`,
-    shouldInstall: ({ options }) => hookShouldInstall(hook, options),
+    shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     dependencies: [sonarSecretsBinaryDependency],
     resources: [

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -21,9 +21,25 @@
 import { platform } from 'node:os';
 
 import type { PostInstallExample } from '../../_common/registry';
+import type { InstallDecision } from '../../_common/registry/selection';
+import { askUser, install, skip } from '../../_common/registry/selection';
+import type { IntegrateGitOptions } from '../options';
 import type { GitHookType } from '../options';
 
 export const HOOK_MARKER = 'Sonar secrets scan - installed by sonar integrate git';
+
+export function hookShouldInstall(
+  hook: GitHookType,
+  options: IntegrateGitOptions,
+): InstallDecision {
+  if (options.hook !== undefined) {
+    return options.hook === hook ? install() : skip();
+  }
+  if (options.nonInteractive) {
+    return hook === 'pre-commit' ? install() : skip();
+  }
+  return askUser();
+}
 export const SONAR_HOOK_SKIP_SECRETS_MESSAGE = 'sonarqube-cli not found, skipping secrets scan';
 
 export function resolveSonarHookCommand(hook: GitHookType): string {

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -23,8 +23,7 @@ import { platform } from 'node:os';
 import type { PostInstallExample } from '../../_common/registry';
 import type { InstallDecision } from '../../_common/registry/selection';
 import { askUser, install, skip } from '../../_common/registry/selection';
-import type { IntegrateGitOptions } from '../options';
-import type { GitHookType } from '../options';
+import type { GitHookType, IntegrateGitOptions } from '../options';
 
 export const HOOK_MARKER = 'Sonar secrets scan - installed by sonar integrate git';
 

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -34,9 +34,6 @@ export function shouldInstallHook(
   if (options.hook !== undefined) {
     return options.hook === hook ? install() : skip();
   }
-  if (options.nonInteractive) {
-    return hook === 'pre-commit' ? install() : skip();
-  }
   return askUser();
 }
 export const SONAR_HOOK_SKIP_SECRETS_MESSAGE = 'sonarqube-cli not found, skipping secrets scan';

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -27,7 +27,7 @@ import type { GitHookType, IntegrateGitOptions } from '../options';
 
 export const HOOK_MARKER = 'Sonar secrets scan - installed by sonar integrate git';
 
-export function hookShouldInstall(
+export function shouldInstallHook(
   hook: GitHookType,
   options: IntegrateGitOptions,
 ): InstallDecision {

--- a/tests/integration/harness/cli-runner.ts
+++ b/tests/integration/harness/cli-runner.ts
@@ -58,6 +58,7 @@ export async function runCli(
   options: {
     stdin?: string;
     stdinChunks?: string[];
+    stdinChunkDelayMs?: number;
     timeoutMs?: number;
     cwd: string;
     browserToken?: string;
@@ -99,9 +100,10 @@ export async function runCli(
     const encoder = new TextEncoder();
     // Write each chunk with a delay so readline in the CLI process finishes
     // handling one prompt before the next chunk arrives for the next prompt.
+    const chunkDelayMs = options.stdinChunkDelayMs ?? STDIN_CHUNK_DELAY_MS;
     await (async () => {
       for (const chunk of options.stdinChunks ?? []) {
-        await new Promise((r) => setTimeout(r, STDIN_CHUNK_DELAY_MS));
+        await new Promise((r) => setTimeout(r, chunkDelayMs));
         sink.write(encoder.encode(chunk));
       }
       sink.end();

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -190,6 +190,7 @@ export class TestHarness {
     return runCli(command, this.env(options), {
       stdin: options?.stdin,
       stdinChunks: options?.stdinChunks,
+      stdinChunkDelayMs: options?.stdinChunkDelayMs,
       timeoutMs: options?.timeoutMs,
       cwd: options?.cwd ?? this.cwd.path,
       browserToken: options?.browserToken,

--- a/tests/integration/harness/types.ts
+++ b/tests/integration/harness/types.ts
@@ -34,12 +34,18 @@ export interface RunOptions {
   timeoutMs?: number;
   stdin?: string;
   /**
-   * Writes stdin in separate chunks with a 300 ms delay between each. Use
-   * this when the CLI shows multiple sequential interactive prompts: sending
-   * all bytes at once causes readline to buffer and discard later bytes before
-   * the next prompt has started listening.
+   * Writes stdin in separate chunks with a delay between each (see
+   * `stdinChunkDelayMs`). Use this when the CLI shows multiple sequential
+   * interactive prompts: sending all bytes at once causes readline to buffer
+   * and discard later bytes before the next prompt has started listening.
    */
   stdinChunks?: string[];
+  /**
+   * Delay in milliseconds between successive `stdinChunks` writes. Defaults to
+   * 300 ms. Raise this when slow work (e.g. spawning `git` subprocesses)
+   * happens between prompts, so each chunk lands after its prompt is listening.
+   */
+  stdinChunkDelayMs?: number;
   /**
    * When set, the harness streams CLI stdout looking for the loopback OAuth
    * port (pattern: `port=\d+`), then delivers this token via POST request to

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -381,26 +381,29 @@ describe('integrate git (native hooks)', () => {
   );
 
   it(
-    'defaults to the pre-commit hook when --non-interactive is used without --hook',
+    'installs all hooks when --non-interactive is used without --hook',
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // No --hook flag: shouldInstallHook() must default to pre-commit and skip pre-push.
+      // No --hook flag: shouldInstallHook() defaults to ask, which the installer
+      // resolves to install for every hook in --non-interactive mode.
       const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
+      expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
-      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(false);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
 
       const state = harness.stateJsonFile.asJson() as InstalledStateJson;
       const gitIntegration = getInstalledIntegration(state, 'native-git');
-      expect(gitIntegration.features).toHaveLength(1);
-      expect(gitIntegration.features[0]).toMatchObject({
-        featureId: 'pre-commit-hook',
-        scope: 'project',
-      });
+      expect(gitIntegration.features).toHaveLength(2);
+      expect(
+        gitIntegration.features
+          .map((feature) => feature.featureId)
+          .sort((a, b) => a.localeCompare(b)),
+      ).toEqual(['pre-commit-hook', 'pre-push-hook']);
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -242,23 +242,6 @@ describe('integrate git (native hooks)', () => {
   });
 
   it(
-    'exits with error when user cancels the hook-type selection',
-    async () => {
-      await setupAuthenticated(harness);
-
-      // Minimal git repo: findGitRoot() detects the .git directory
-      harness.cwd.writeFile('.git/.keep', '');
-
-      // Ctrl+C sent to stdin cancels the interactive confirmPrompt
-      const result = await harness.run('integrate git', { stdin: '\x03' });
-
-      expect(result.exitCode).toBe(1);
-      expect(result.stdout + result.stderr).toContain('Installation cancelled');
-    },
-    { timeout: 15000 },
-  );
-
-  it(
     'exits with error when user is not authenticated',
     async () => {
       // No keychain token, no env vars — resolveAuth() throws
@@ -376,13 +359,14 @@ describe('integrate git (native hooks)', () => {
       // and resolveGitHooksDir() resolves to .git/hooks as expected
       initGitRepo(harness);
 
-      // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: '\r' confirms 'Install here?', then '\r' selects pre-commit
-      const result = await harness.run('integrate git', { stdinChunks: ['\r', '\r'] });
+      // Per-feature confirm flow: '\r' confirms 'Install here?', '\r' accepts the
+      // 'Install pre-commit hook?' prompt, 'n' declines 'Install pre-push hook?'.
+      const result = await harness.run('integrate git', { stdinChunks: ['\r', '\r', 'n'] });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(false);
     },
     { timeout: 15000 },
   );
@@ -404,9 +388,6 @@ describe('integrate git (native hooks)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'git-hook-file');
@@ -422,14 +403,46 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' confirms 'Install here?'; '\x1b[B' moves the selection down to pre-push; '\r' submits
+      // Per-feature confirm flow: '\r' confirms 'Install here?', 'n' declines the
+      // 'Install pre-commit hook?' prompt, '\r' accepts 'Install pre-push hook?'.
       const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', '\x1b[B', '\r'],
+        stdinChunks: ['\r', 'n', '\r'],
       });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(false);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'installs both native hooks when the user accepts each per-feature prompt',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      // Per-feature confirm flow: '\r' confirms 'Install here?', then '\r' accepts
+      // both the 'Install pre-commit hook?' and 'Install pre-push hook?' prompts.
+      const result = await harness.run('integrate git', { stdinChunks: ['\r', '\r', '\r'] });
+
+      expect(result.exitCode).toBe(0);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('Install pre-commit hook?');
+      expect(output).toContain('Install pre-push hook?');
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
+
+      const state = harness.stateJsonFile.asJson() as InstalledStateJson;
+      const gitIntegration = getInstalledIntegration(state, 'native-git');
+      const featureIds = gitIntegration.features
+        .map((feature) => feature.featureId)
+        .sort((a, b) => a.localeCompare(b));
+      expect(featureIds).toEqual(['pre-commit-hook', 'pre-push-hook']);
+      for (const feature of gitIntegration.features) {
+        expect(feature.attrs).toBeUndefined();
+      }
     },
     { timeout: 15000 },
   );
@@ -439,14 +452,17 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: '\r' confirms global hook warning, then '\r' selects pre-commit
-      const result = await harness.run('integrate git --global', { stdinChunks: ['\r', '\r'] });
+      // Per-feature confirm flow: '\r' confirms the global hook warning, '\r' accepts
+      // 'Install pre-commit hook?', 'n' declines 'Install pre-push hook?'.
+      const result = await harness.run('integrate git --global', {
+        stdinChunks: ['\r', '\r', 'n'],
+      });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
       expect(result.stdout + result.stderr).toContain('Applied global hooks path');
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-commit')).toBe(true);
+      expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-push')).toBe(false);
     },
     { timeout: 15000 },
   );
@@ -466,9 +482,6 @@ describe('integrate git (native hooks)', () => {
         featureId: 'pre-push-hook',
         scope: 'global',
         targetRoot: harness.userHome.file('.sonar', 'sonarqube-cli', 'hooks').path,
-        attrs: {
-          hook: 'pre-push',
-        },
       });
       expectInstalledOperation(feature, 'configure-global-hooks-path');
     },
@@ -480,16 +493,17 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      // Two separate stdin chunks with a delay between them so readline doesn't buffer
-      // both at once: '\r' confirms global hook warning, then '\r' selects pre-push
+      // Per-feature confirm flow: '\r' confirms the global hook warning, 'n' declines
+      // 'Install pre-commit hook?', '\r' accepts 'Install pre-push hook?'.
       const result = await harness.run('integrate git --global', {
-        stdinChunks: ['\r', '\x1b[B', '\r'],
+        stdinChunks: ['\r', 'n', '\r'],
       });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
       expect(result.stdout + result.stderr).toContain('Applied global hooks path');
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-push')).toBe(true);
+      expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-commit')).toBe(false);
     },
     { timeout: 15000 },
   );
@@ -531,9 +545,6 @@ describe('integrate git (husky)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
@@ -599,9 +610,6 @@ describe('integrate git (husky)', () => {
         featureId: 'pre-push-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-push',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
@@ -697,9 +705,6 @@ describe('integrate git (pre-commit framework)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
@@ -747,9 +752,6 @@ describe('integrate git (pre-commit framework)', () => {
         featureId: 'pre-push-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-push',
-        },
       });
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
@@ -815,9 +817,6 @@ describe('integrate git (pre-commit framework)', () => {
         featureId: 'pre-commit-hook',
         scope: 'project',
         targetRoot: harness.cwd.path,
-        attrs: {
-          hook: 'pre-commit',
-        },
       });
     },
     { timeout: 15000 },

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -111,6 +111,12 @@ function gitPush(
 const INTEGRATION_TEST_TOKEN = 'test-token';
 const LEGACY_PRE_COMMIT_REPO = 'https://github.com/SonarSource/sonar-secrets-pre-commit';
 
+// Project-scope interactive runs spawn `git` (e.g. resolveGitIntegrationId ->
+// usesHusky) between the per-feature confirm prompts. That latency races the
+// default 300 ms stdin chunk spacing and can drop a keystroke before the next
+// prompt starts listening, so give those chunks extra room.
+const PROJECT_PROMPT_CHUNK_DELAY_MS = 900;
+
 type InstalledStateJson = {
   dependencies: {
     installed: Array<{
@@ -361,7 +367,10 @@ describe('integrate git (native hooks)', () => {
 
       // Per-feature confirm flow: '\r' confirms 'Install here?', '\r' accepts the
       // 'Install pre-commit hook?' prompt, 'n' declines 'Install pre-push hook?'.
-      const result = await harness.run('integrate git', { stdinChunks: ['\r', '\r', 'n'] });
+      const result = await harness.run('integrate git', {
+        stdinChunks: ['\r', '\r', 'n'],
+        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
+      });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
@@ -407,6 +416,7 @@ describe('integrate git (native hooks)', () => {
       // 'Install pre-commit hook?' prompt, '\r' accepts 'Install pre-push hook?'.
       const result = await harness.run('integrate git', {
         stdinChunks: ['\r', 'n', '\r'],
+        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
       });
 
       expect(result.exitCode).toBe(0);
@@ -425,7 +435,10 @@ describe('integrate git (native hooks)', () => {
 
       // Per-feature confirm flow: '\r' confirms 'Install here?', then '\r' accepts
       // both the 'Install pre-commit hook?' and 'Install pre-push hook?' prompts.
-      const result = await harness.run('integrate git', { stdinChunks: ['\r', '\r', '\r'] });
+      const result = await harness.run('integrate git', {
+        stdinChunks: ['\r', '\r', '\r'],
+        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
+      });
 
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -386,7 +386,7 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // No --hook flag: hookShouldInstall() must default to pre-commit and skip pre-push.
+      // No --hook flag: shouldInstallHook() must default to pre-commit and skip pre-push.
       const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -461,6 +461,29 @@ describe('integrate git (native hooks)', () => {
   );
 
   it(
+    'fails with an explicit notice when the user declines every per-feature prompt',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      // Per-feature confirm flow: '\r' confirms 'Install here?', then 'n' declines
+      // both the 'Install pre-commit hook?' and 'Install pre-push hook?' prompts.
+      const result = await harness.run('integrate git', {
+        stdinChunks: ['\r', 'n', 'n'],
+        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
+      });
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stdout + result.stderr).toContain(
+        'No feature selected for Native Git integration',
+      );
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(false);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(false);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'installs native global pre-commit hook via interactive prompts when secrets is already installed',
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -381,6 +381,31 @@ describe('integrate git (native hooks)', () => {
   );
 
   it(
+    'defaults to the pre-commit hook when --non-interactive is used without --hook',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      // No --hook flag: hookShouldInstall() must default to pre-commit and skip pre-push.
+      const result = await harness.run('integrate git --non-interactive');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
+      expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(false);
+
+      const state = harness.stateJsonFile.asJson() as InstalledStateJson;
+      const gitIntegration = getInstalledIntegration(state, 'native-git');
+      expect(gitIntegration.features).toHaveLength(1);
+      expect(gitIntegration.features[0]).toMatchObject({
+        featureId: 'pre-commit-hook',
+        scope: 'project',
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'records project hook installation in state',
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -37,7 +37,6 @@ import {
   type IntegrateGitOptions,
   isGitHookType,
   resolveGitHooksDir,
-  resolveHookType,
 } from '../../../../../../src/cli/commands/integrate/git';
 import { PRE_COMMIT_CONFIG_FILE } from '../../../../../../src/cli/commands/integrate/git/tools/pre-commit';
 import { HOOK_MARKER } from '../../../../../../src/cli/commands/integrate/git/tools/shared';
@@ -323,55 +322,6 @@ describe('detectHookInstallation', () => {
     } finally {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });
-    }
-  });
-});
-
-describe('resolveHookType', () => {
-  it('returns pre-commit when --hook pre-commit is passed', async () => {
-    const result = await resolveHookType({ hook: 'pre-commit' });
-    expect(result).toBe('pre-commit');
-  });
-
-  it('returns pre-push when --hook pre-push is passed', async () => {
-    const result = await resolveHookType({ hook: 'pre-push' });
-    expect(result).toBe('pre-push');
-  });
-
-  it('defaults to pre-commit when non-interactive and hook is omitted', async () => {
-    const result = await resolveHookType({ nonInteractive: true });
-    expect(result).toBe('pre-commit');
-  });
-
-  it('returns pre-commit when the user selects it from the prompt', async () => {
-    setMockUi(true);
-    queueMockResponse('pre-commit');
-    try {
-      const result = await resolveHookType({});
-      expect(result).toBe('pre-commit');
-    } finally {
-      setMockUi(false);
-    }
-  });
-
-  it('returns pre-push when the user selects it from the prompt', async () => {
-    setMockUi(true);
-    queueMockResponse('pre-push');
-    try {
-      const result = await resolveHookType({});
-      expect(result).toBe('pre-push');
-    } finally {
-      setMockUi(false);
-    }
-  });
-
-  it('throws CommandFailedError when the user cancels the prompt', () => {
-    setMockUi(true);
-    queueMockResponse(null);
-    try {
-      expect(resolveHookType({})).rejects.toThrow('Installation cancelled');
-    } finally {
-      setMockUi(false);
     }
   });
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **Interactive integration:**
  - Introduced `shouldInstallHook` to centralize per-feature interactive selection logic for Git hooks.
  - Updated `husky`, `native`, and `pre-commit` tool integrations to support granular per-hook user confirmation.
- **Refactored internals:**
  - Consolidated hook installation logic into a shared `installGitFeatures` utility for both project and global scopes.
  - Simplified `feature` state by removing `attrs.hook`, streamlining feature identification.
- **Test framework improvements:**
  - Added `stdinChunkDelayMs` to `TestHarness` to accommodate latency when handling sequential interactive prompts.
- **Tests updated:**
  - Migrated integration tests to validate the new per-feature confirmation flows and explicit opt-out handling for all Git integrations.

<sub>This will update automatically on new commits.</sub>