### PR TITLE
CLI-606 Interactive integrate: Clean up output of `integrate` commands

### DIFF
--- a/src/cli/commands/integrate/_common/agent-integrate-prelude.ts
+++ b/src/cli/commands/integrate/_common/agent-integrate-prelude.ts
@@ -56,7 +56,7 @@ export function introAgentIntegration(agentDisplayName: string): void {
 }
 
 export async function discoverIntegrateProject(): Promise<DiscoveredProject> {
-  return withSpinner('Discovering project...', () => discoverProject(process.cwd()));
+  return withSpinner('Discovering project...', () => discoverProject(process.cwd(), true));
 }
 
 export function warnAuthProjectMismatches(auth: ResolvedAuth, project: DiscoveredProject): void {

--- a/src/cli/commands/integrate/_common/context-augmentation.ts
+++ b/src/cli/commands/integrate/_common/context-augmentation.ts
@@ -27,7 +27,7 @@ import logger from '../../../../lib/logger';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../../lib/signatures';
 import type { IntegrationStateAttribute } from '../../../../lib/state';
 import { SonarQubeClient } from '../../../../sonarqube/client';
-import { discreetSuccess, info, print, text, warn, withSpinner } from '../../../../ui';
+import { discreetSuccess, print, text, warn, withSpinner } from '../../../../ui';
 import { buildContextAugmentationEnv } from '../../_common/context-augmentation-env';
 import { CommandFailedError } from '../../_common/error';
 
@@ -144,7 +144,7 @@ export async function resolveContextAugmentationSetup(
 export async function runToolIntegrateCommand(
   p: ApplyContextAugmentationToolIntegrationParams,
 ): Promise<void> {
-  info('Setting up SonarQube Context Augmentation...');
+  text('Installing SonarQube Context Augmentation...');
 
   const initEnv = buildContextAugmentationEnv({
     organization: p.auth.orgKey,

--- a/src/cli/commands/integrate/_common/integrate-scope.ts
+++ b/src/cli/commands/integrate/_common/integrate-scope.ts
@@ -20,7 +20,7 @@
 
 import { normalizePath } from '../../../../lib/fs-utils';
 import type { IntegrationScope } from '../../../../lib/state';
-import { info, selectPrompt } from '../../../../ui';
+import { blank, info, selectPrompt } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 
 export interface IntegrateScopeOptions {
@@ -85,6 +85,7 @@ export async function resolveIntegrateScope(
   if (choice === null) {
     throw new CommandFailedError('Installation cancelled');
   }
+  blank();
   return choice;
 }
 

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -29,7 +29,7 @@ import type {
   IntegrationStateAttribute,
 } from '../../../../../lib/state';
 import { getDefaultState } from '../../../../../lib/state';
-import { discreetSuccess, info, text, warn } from '../../../../../ui';
+import { text, warn } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
 import { supportedIntegrations } from '../../index';
 import { renderCompletionSummary } from './completion-summary';
@@ -90,6 +90,7 @@ export async function installIntegration<TOptions>({
   }
 
   const applications: FeatureApplication<TOptions>[] = [];
+  text('');
   for (const feature of features) {
     const context = await resolveFeatureContext(state, invocation, feature, 'install');
     applications.push({
@@ -100,7 +101,7 @@ export async function installIntegration<TOptions>({
       force: context.force,
       attrs: context.attrs,
     });
-    text(`Installing ${integration.displayName}: ${feature.displayName}`);
+    text(`Installing ${feature.displayName}...`);
   }
 
   try {
@@ -110,20 +111,11 @@ export async function installIntegration<TOptions>({
       applications,
       {
         callbacks: {
-          onDependencyInstalled: (dependency) => {
-            discreetSuccess(`Installed ${dependency.displayName ?? dependency.id}`);
-          },
           onDependencySkipped: (dependency) => {
-            info(`${dependency.displayName ?? dependency.id} already installed`);
-          },
-          onResourceInstalled: (resource) => {
-            discreetSuccess(`Installed ${resource.displayName ?? resource.id}`);
+            text(`${dependency.displayName ?? dependency.id} already installed`);
           },
           onResourceSkipped: (resource) => {
-            info(`${resource.displayName ?? resource.id} already installed`);
-          },
-          onOperationApplied: (operation) => {
-            discreetSuccess(`Applied ${operation.displayName ?? operation.id}`);
+            text(`${resource.displayName ?? resource.id} already installed`);
           },
         },
         executionMode: 'install',

--- a/src/ui/components/phase.ts
+++ b/src/ui/components/phase.ts
@@ -41,7 +41,7 @@ function renderItem(item: PhaseItem, iconColors: Partial<Record<StepStatus, Colo
   const detail = item.detail ? dim(`: ${item.detail}`) : '';
   const lines = [`    ${icon}  ${item.text}${detail}`];
   for (const subItem of item.subItems ?? []) {
-    lines.push(dim(`       * ${subItem}`));
+    lines.push(dim(`       ${subItem}`));
   }
   return lines.join('\n');
 }
@@ -68,7 +68,7 @@ export function phase(title: string, items: PhaseItem[], opts: PhaseOptions = {}
       const detail = item.detail ? `: ${item.detail}` : '';
       process.stdout.write(`  ${icon}  ${item.text}${detail}\n`);
       for (const subItem of item.subItems ?? []) {
-        process.stdout.write(`       * ${subItem}\n`);
+        process.stdout.write(`       ${subItem}\n`);
       }
     }
     process.stdout.write('\n');

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -404,7 +404,7 @@ describe('integrate git (native hooks)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(false);
     },
@@ -479,7 +479,7 @@ describe('integrate git (native hooks)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(false);
     },
@@ -554,8 +554,7 @@ describe('integrate git (native hooks)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
-      expect(result.stdout + result.stderr).toContain('Applied global hooks path');
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-push')).toBe(false);
     },
@@ -595,8 +594,7 @@ describe('integrate git (native hooks)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
-      expect(result.stdout + result.stderr).toContain('Applied global hooks path');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-push')).toBe(true);
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-commit')).toBe(false);
     },
@@ -624,10 +622,8 @@ describe('integrate git (husky)', () => {
       const result = await harness.run('integrate git --hook pre-commit --non-interactive');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain(
-        'Installing Husky integration: pre-commit hook',
-      );
-      expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
+      expect(result.stdout + result.stderr).toContain('Installing pre-commit hook...');
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
       expect(harness.cwd.exists('.husky', 'pre-commit')).toBe(true);
       const hookContent = readFileSync(join(harness.cwd.path, '.husky', 'pre-commit'), 'utf-8');
       expect(hookContent).toContain('hook git-pre-commit');
@@ -689,10 +685,8 @@ describe('integrate git (husky)', () => {
       const result = await harness.run('integrate git --hook pre-push --non-interactive');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain(
-        'Installing Husky integration: pre-push hook',
-      );
-      expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
+      expect(result.stdout + result.stderr).toContain('Installing pre-push hook...');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
       expect(harness.cwd.exists('.husky', 'pre-push')).toBe(true);
       const hookContent = readFileSync(join(harness.cwd.path, '.husky', 'pre-push'), 'utf-8');
       expect(hookContent).toContain('hook git-pre-push');
@@ -777,10 +771,8 @@ describe('integrate git (pre-commit framework)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain(
-        'Installing pre-commit integration: pre-commit hook',
-      );
-      expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
+      expect(result.stdout + result.stderr).toContain('Installing pre-commit hook...');
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
 
       const config = readYamlFile<PreCommitYamlConfig>(
         join(harness.cwd.path, '.pre-commit-config.yaml'),
@@ -821,10 +813,8 @@ describe('integrate git (pre-commit framework)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain(
-        'Installing pre-commit integration: pre-push hook',
-      );
-      expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
+      expect(result.stdout + result.stderr).toContain('Installing pre-push hook...');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
 
       const config = readYamlFile<PreCommitYamlConfig>(
         join(harness.cwd.path, '.pre-commit-config.yaml'),

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -422,8 +422,8 @@ describe('integrate git (native hooks)', () => {
       const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installed pre-commit hook');
-      expect(result.stdout + result.stderr).toContain('Installed pre-push hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
 

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -307,6 +307,86 @@ describe('generic integration installer', () => {
     expect(hasUiCall('text', 'Config file already installed')).toBe(true);
   });
 
+  it('falls back to the resource id in the skip message when no displayName is set', async () => {
+    const state = getDefaultState('test');
+    loadStateSpy.mockReturnValue(state);
+    const feature: FeatureDeclaration = {
+      id: 'feature',
+      displayName: 'Feature',
+      resources: [
+        wholeFile({
+          id: 'unnamed-file',
+          targetPath: join(tempDir, 'unnamed.txt'),
+          content: 'enabled=true\n',
+        }),
+      ],
+    };
+    const integration = registerIntegration(registry, 'installer-skip-unnamed-resource', [feature]);
+
+    await installIntegration({
+      registry,
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+    clearMockUiCalls();
+
+    await installIntegration({
+      registry,
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(hasUiCall('text', 'unnamed-file already installed')).toBe(true);
+  });
+
+  it('falls back to the dependency id in the skip message when no displayName is set', async () => {
+    const state = getDefaultState('test');
+    loadStateSpy.mockReturnValue(state);
+    const dependency: DependencyDeclaration = {
+      id: 'unnamed-binary',
+      dependencyType: 'binary',
+      version: '1',
+      installOrUpdate: () => ({
+        id: 'unnamed-binary',
+        dependencyType: 'binary',
+        version: '1',
+        path: '/opt/sonar/unnamed-binary',
+      }),
+      isInstalled: () => true,
+    };
+    const integration = registerIntegration(registry, 'installer-skip-unnamed-dependency', [
+      {
+        id: 'feature',
+        displayName: 'Feature',
+        dependencies: [dependency],
+        operations: [{ id: 'noop', apply: () => undefined }],
+      },
+    ]);
+
+    await installIntegration({
+      registry,
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+    clearMockUiCalls();
+
+    await installIntegration({
+      registry,
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(hasUiCall('text', 'unnamed-binary already installed')).toBe(true);
+  });
+
   it('does not run operations when shouldApply returns false', async () => {
     let called = false;
     const integration = registerIntegration(registry, 'installer-should-apply', [

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -106,9 +106,7 @@ describe('generic integration installer', () => {
     expect(await readFile(join(tempDir, 'config.txt'), 'utf-8')).toBe('enabled=true\n');
     expect(operationCalls).toEqual(['called']);
     expect(saveStateSpy).toHaveBeenCalledWith(state);
-    expect(hasUiCall('text', 'Installing Test Integration: Feature')).toBe(true);
-    expect(hasUiCall('discreetSuccess', 'Installed Config file')).toBe(true);
-    expect(hasUiCall('discreetSuccess', 'Applied Setup operation')).toBe(true);
+    expect(hasUiCall('text', 'Installing Feature...')).toBe(true);
   });
 
   it('supports feature-specific target routing from a single installer invocation', async () => {
@@ -306,7 +304,7 @@ describe('generic integration installer', () => {
     });
 
     expect(installed[0].resources.some((resource) => resource.id === 'file')).toBe(true);
-    expect(hasUiCall('info', 'Config file already installed')).toBe(true);
+    expect(hasUiCall('text', 'Config file already installed')).toBe(true);
   });
 
   it('does not run operations when shouldApply returns false', async () => {

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -619,7 +619,7 @@ describe('integrateGitGlobal', () => {
     expect(caughtMessage).toBe('download failed');
   });
 
-  it('shows success messages when the full global installation succeeds', async () => {
+  it('shows the installed feature in the completion summary when the full global installation succeeds', async () => {
     const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
       exitCode: 0,
       stdout: '',
@@ -628,20 +628,10 @@ describe('integrateGitGlobal', () => {
     try {
       await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
       const calls = getMockUiCalls();
-      expect(
-        calls.some(
-          (c) =>
-            c.method === 'discreetSuccess' &&
-            String(c.args[0]).includes('Installed pre-commit hook'),
-        ),
-      ).toBe(true);
-      expect(
-        calls.some(
-          (c) =>
-            c.method === 'discreetSuccess' &&
-            String(c.args[0]).includes('Applied global hooks path'),
-        ),
-      ).toBe(true);
+      const summaryCall = calls.find((c) => c.method === 'phase' && c.args[0] === 'Installed');
+      expect(summaryCall).toBeDefined();
+      const items = (summaryCall?.args[1] ?? []) as Array<{ text: string }>;
+      expect(items.some((item) => item.text === 'pre-commit hook')).toBe(true);
       expect(state.integrations.installed[0]?.integrationId).toBe('native-git');
     } finally {
       spawnSpy.mockRestore();

--- a/tests/unit/ui/ui-components.test.ts
+++ b/tests/unit/ui/ui-components.test.ts
@@ -171,7 +171,7 @@ describe('phase: non-TTY output', () => {
     }
   });
 
-  it('renders sub-items as a bullet list under the item', () => {
+  it('renders sub-items as an indented list under the item', () => {
     const output: string[] = [];
     const writeSpy = spyOn(process.stdout, 'write').mockImplementation((s) => {
       output.push(String(s));
@@ -180,8 +180,8 @@ describe('phase: non-TTY output', () => {
     try {
       phase('Installed', [phaseItem('Feature', 'done', undefined, ['~/.config/a', '~/.config/b'])]);
       const combined = output.join('');
-      expect(combined).toContain('* ~/.config/a');
-      expect(combined).toContain('* ~/.config/b');
+      expect(combined).toContain('       ~/.config/a');
+      expect(combined).toContain('       ~/.config/b');
     } finally {
       writeSpy.mockRestore();
     }

--- a/tests/unit/ui/ui-tty.test.ts
+++ b/tests/unit/ui/ui-tty.test.ts
@@ -106,7 +106,7 @@ describe('phase: TTY rendering', () => {
     }
   });
 
-  it('renderItem: writes sub-items as a bullet list in TTY mode', () => {
+  it('renderItem: writes sub-items as an indented list in TTY mode', () => {
     const output: string[] = [];
     const writeSpy = spyOn(process.stdout, 'write').mockImplementation((s) => {
       output.push(String(s));
@@ -114,7 +114,7 @@ describe('phase: TTY rendering', () => {
     });
     try {
       phase('Installed', [phaseItem('Feature', 'done', undefined, ['~/.config/a'])]);
-      expect(output.join('')).toContain('* ~/.config/a');
+      expect(output.join('')).toContain('       ~/.config/a');
     } finally {
       writeSpy.mockRestore();
     }


### PR DESCRIPTION
----
## Summary by Gitar

- **CLI output improvements:**
  - Standardized `integrate` command logs to use `text` consistently instead of `info` or `discreetSuccess`.
  - Updated installation progress messages to `Installing <feature>...` and success confirmations to `✓ <feature>` format.
- **Refactored discovery logic:**
  - Updated `discoverIntegrateProject` to enable recursive project discovery by passing `true` to `discoverProject`.
- **Test updates:**
  - Updated unit and integration tests to reflect the new UI string patterns and verify the completion summary output.

<sub>This will update automatically on new commits.</sub>