### PR TITLE
CLI-618 Merge Git pre-commit+pre-push examples into one post-install example

### DIFF
--- a/src/cli/commands/integrate/_common/registry/completion-summary.ts
+++ b/src/cli/commands/integrate/_common/registry/completion-summary.ts
@@ -29,6 +29,7 @@ import { sep } from 'node:path';
 
 import type { InstalledIntegrationFeature } from '../../../../../lib/state';
 import { info, note, outro, phase, phaseItem, text } from '../../../../../ui';
+import { gitBothHooksExample } from '../../git/tools/shared';
 import type { FeatureDeclaration, IntegrationDeclaration, PostInstallExample } from './types';
 
 export function renderCompletionSummary<TOptions>(
@@ -69,6 +70,14 @@ function renderPostInstallExamples<TOptions>(
   integration: IntegrationDeclaration<TOptions>,
   installedFeatures: InstalledIntegrationFeature[],
 ): void {
+  // Temporary hard-coded special case when both git hooks are installed
+  // TODO: replace with a proper post-install example merging system.
+  // https://sonarsource.atlassian.net/browse/CLI-617
+  const ids = new Set(installedFeatures.map((f) => f.featureId));
+  if (ids.has('pre-commit-hook') && ids.has('pre-push-hook')) {
+    renderPostInstallExample(gitBothHooksExample());
+    return;
+  }
   for (const installed of installedFeatures) {
     const { postInstallExample } = featureDeclaration(integration, installed.featureId);
     if (postInstallExample) {

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -71,3 +71,29 @@ export function gitHookExample(hook: GitHookType): PostInstallExample {
     ],
   };
 }
+
+// Temporary hard-coded merged example shown when both git hooks are installed
+export function gitBothHooksExample(): PostInstallExample {
+  const deleteCommand = platform() === 'win32' ? 'del' : 'rm';
+  return {
+    title: 'Verify the hooks work',
+    lines: [
+      `1. Create a file named ${VERIFY_FILE_NAME} containing:`,
+      `     ${VERIFY_SECRET_CONTENT}`,
+      '',
+      '2. Pre-commit — stage and commit:',
+      `     git add ${VERIFY_FILE_NAME}`,
+      '     git commit -m "verify"',
+      '   → the pre-commit hook should block and report the secret.',
+      '',
+      '3. Pre-push — bypass pre-commit, then push:',
+      '     git commit -m "verify" --no-verify',
+      '     git push',
+      '   → the pre-push hook should block and report the secret.',
+      '',
+      `4. Clean up: ${deleteCommand} ${VERIFY_FILE_NAME}`,
+      '',
+      'To skip a hook: git commit --no-verify  /  git push --no-verify',
+    ],
+  };
+}

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -422,10 +422,16 @@ describe('integrate git (native hooks)', () => {
       const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
-      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
+      const bothHooksOutput = result.stdout + result.stderr;
+      expect(bothHooksOutput).toContain('✓  pre-commit hook');
+      expect(bothHooksOutput).toContain('✓  pre-push hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
+
+      // Both hooks installed -> a single merged verification example box.
+      expect(bothHooksOutput).toContain('Verify the hooks work');
+      expect(bothHooksOutput).toContain('Pre-commit — stage and commit:');
+      expect(bothHooksOutput).toContain('Pre-push — bypass pre-commit, then push:');
 
       const state = harness.stateJsonFile.asJson() as InstalledStateJson;
       const gitIntegration = getInstalledIntegration(state, 'native-git');


### PR DESCRIPTION
----
## Summary by Gitar

- **New features:**
  - Added `gitBothHooksExample` to provide a consolidated verification guide when both hooks are present.
- **Logic updates:**
  - Updated `renderCompletionSummary` to detect dual hook installation and display the merged example.
- **Test suite:**
  - Updated `git.test.ts` to verify that the combined example box is rendered correctly.

<sub>This will update automatically on new commits.</sub>