### PR TITLE
CLI-618 Merge Git integration post-install examples

### DIFF
--- a/src/cli/commands/integrate/_common/registry/completion-summary.ts
+++ b/src/cli/commands/integrate/_common/registry/completion-summary.ts
@@ -29,6 +29,7 @@ import { sep } from 'node:path';
 
 import type { InstalledIntegrationFeature } from '../../../../../lib/state';
 import { info, note, outro, phase, phaseItem, text } from '../../../../../ui';
+import { gitBothHooksExample } from '../../git/tools/shared';
 import type { FeatureDeclaration, IntegrationDeclaration, PostInstallExample } from './types';
 
 export function renderCompletionSummary<TOptions>(
@@ -69,6 +70,14 @@ function renderPostInstallExamples<TOptions>(
   integration: IntegrationDeclaration<TOptions>,
   installedFeatures: InstalledIntegrationFeature[],
 ): void {
+  // Temporary hard-coded special case when both git hooks are installed
+  // TODO: replace with a proper post-install example merging system.
+  // https://sonarsource.atlassian.net/browse/CLI-617
+  const ids = new Set(installedFeatures.map((f) => f.featureId));
+  if (ids.has('pre-commit-hook') && ids.has('pre-push-hook')) {
+    renderPostInstallExample(gitBothHooksExample());
+    return;
+  }
   for (const installed of installedFeatures) {
     const { postInstallExample } = featureDeclaration(integration, installed.featureId);
     if (postInstallExample) {

--- a/src/cli/commands/integrate/_common/registry/completion-summary.ts
+++ b/src/cli/commands/integrate/_common/registry/completion-summary.ts
@@ -29,7 +29,6 @@ import { sep } from 'node:path';
 
 import type { InstalledIntegrationFeature } from '../../../../../lib/state';
 import { info, note, outro, phase, phaseItem, text } from '../../../../../ui';
-import { gitBothHooksExample } from '../../git/tools/shared';
 import type { FeatureDeclaration, IntegrationDeclaration, PostInstallExample } from './types';
 
 export function renderCompletionSummary<TOptions>(
@@ -70,12 +69,14 @@ function renderPostInstallExamples<TOptions>(
   integration: IntegrationDeclaration<TOptions>,
   installedFeatures: InstalledIntegrationFeature[],
 ): void {
-  // Temporary hard-coded special case when both git hooks are installed
-  // TODO: replace with a proper post-install example merging system.
-  // https://sonarsource.atlassian.net/browse/CLI-617
-  const ids = new Set(installedFeatures.map((f) => f.featureId));
-  if (ids.has('pre-commit-hook') && ids.has('pre-push-hook')) {
-    renderPostInstallExample(gitBothHooksExample());
+  // An integration may collapse its per-feature examples into a single combined
+  // one when a specific set of features is installed together (e.g. both git
+  // hooks). When it declines (returns undefined), fall back to per-feature.
+  const combined = integration.combinedPostInstallExample?.(
+    installedFeatures.map((f) => f.featureId),
+  );
+  if (combined) {
+    renderPostInstallExample(combined);
     return;
   }
   for (const installed of installedFeatures) {

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -66,6 +66,7 @@ export interface IntegrationDeclaration<TOptions = Record<string, unknown>> {
   displayName: string;
   features: FeatureDeclaration<TOptions>[];
   legacyFeatures?: LegacyFeatureDeclaration[];
+  combinedPostInstallExample?: (installedFeatureIds: string[]) => PostInstallExample | undefined;
 }
 
 export interface PostInstallExample {

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -24,7 +24,7 @@ import { sonarSecretsBinaryDependency } from '../../../_common/registry/dependen
 import { textSnippet } from '../../../_common/registry/resources';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample, HOOK_MARKER, shouldInstallHook } from '../shared';
+import { gitCombinedHookExample, gitHookExample, HOOK_MARKER, shouldInstallHook } from '../shared';
 import { getHuskySnippetContent } from './shell-fragments';
 
 export const HUSKY_INTEGRATION_ID = 'husky';
@@ -33,6 +33,7 @@ export const huskyIntegration: IntegrationDeclaration<IntegrateGitOptions> = {
   id: HUSKY_INTEGRATION_ID,
   displayName: 'Husky integration',
   features: [createHuskyFeature('pre-commit'), createHuskyFeature('pre-push')],
+  combinedPostInstallExample: gitCombinedHookExample,
 };
 
 function createHuskyFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitOptions> {

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -24,7 +24,7 @@ import { CommandFailedError } from '../../../../_common/error';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry';
 import { sonarSecretsBinaryDependency } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample, shouldInstallHook } from '../shared';
+import { gitCombinedHookExample, gitHookExample, shouldInstallHook } from '../shared';
 import { nativeGitHookResource } from './resource';
 
 export const NATIVE_GIT_INTEGRATION_ID = 'native-git';
@@ -35,6 +35,7 @@ export const nativeGitIntegration: IntegrationDeclaration<IntegrateGitOptions> =
   id: NATIVE_GIT_INTEGRATION_ID,
   displayName: 'Native Git integration',
   features: [createNativeGitFeature('pre-commit'), createNativeGitFeature('pre-push')],
+  combinedPostInstallExample: gitCombinedHookExample,
 };
 
 function createNativeGitFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitOptions> {

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -23,7 +23,7 @@ import { join } from 'node:path';
 import type { FeatureDeclaration, IntegrationDeclaration } from '../../../_common/registry';
 import { sonarSecretsBinaryDependency, yamlPatch } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { gitHookExample, shouldInstallHook } from '../shared';
+import { gitCombinedHookExample, gitHookExample, shouldInstallHook } from '../shared';
 import {
   activatePreCommitFramework,
   deactivatePreCommitFramework,
@@ -40,6 +40,7 @@ export const preCommitIntegration: IntegrationDeclaration<IntegrateGitOptions> =
   id: PRE_COMMIT_INTEGRATION_ID,
   displayName: 'pre-commit integration',
   features: [createPreCommitFeature('pre-commit'), createPreCommitFeature('pre-push')],
+  combinedPostInstallExample: gitCombinedHookExample,
 };
 
 function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<IntegrateGitOptions> {

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -72,8 +72,18 @@ export function gitHookExample(hook: GitHookType): PostInstallExample {
   };
 }
 
-// Temporary hard-coded merged example shown when both git hooks are installed
-export function gitBothHooksExample(): PostInstallExample {
+/**
+ * Combined example shown when both git hooks are installed. Returns `undefined`
+ * so the framework falls back to per-feature examples when only one is present.
+ */
+export function gitCombinedHookExample(
+  installedFeatureIds: string[],
+): PostInstallExample | undefined {
+  const ids = new Set(installedFeatureIds);
+  return ids.has('pre-commit-hook') && ids.has('pre-push-hook') ? gitBothHooksExample() : undefined;
+}
+
+function gitBothHooksExample(): PostInstallExample {
   const deleteCommand = platform() === 'win32' ? 'del' : 'rm';
   return {
     title: 'Verify the hooks work',

--- a/src/cli/commands/integrate/git/tools/shared.ts
+++ b/src/cli/commands/integrate/git/tools/shared.ts
@@ -71,3 +71,29 @@ export function gitHookExample(hook: GitHookType): PostInstallExample {
     ],
   };
 }
+
+// Temporary hard-coded merged example shown when both git hooks are installed
+export function gitBothHooksExample(): PostInstallExample {
+  const deleteCommand = platform() === 'win32' ? 'del' : 'rm';
+  return {
+    title: 'Verify the hooks work',
+    lines: [
+      `1. Create a file named ${VERIFY_FILE_NAME} containing:`,
+      `     ${VERIFY_SECRET_CONTENT}`,
+      '',
+      '2. Pre-commit — stage and commit:',
+      `     git add ${VERIFY_FILE_NAME}`,
+      '     git commit -m "verify"',
+      '   → the pre-commit hook should block and report the secret.',
+      '',
+      '3. Pre-push — bypass pre-commit, then push:',
+      '     git commit -m "verify" --no-verify',
+      '     git push',
+      '   → the pre-push hook should block and report the secret.',
+      '',
+      `4. Clean up: ${deleteCommand} ${VERIFY_FILE_NAME}`,
+      '',
+      'To skip a hook: git commit --no-verify  /  git push --no-verify',
+    ],
+  };
+}

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -422,10 +422,16 @@ describe('integrate git (native hooks)', () => {
       const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
-      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
+      const bothHooksOutput = result.stdout + result.stderr;
+      expect(bothHooksOutput).toContain('✓  pre-commit hook');
+      expect(bothHooksOutput).toContain('✓  pre-push hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
+
+      // Both hooks installed -> a single merged verification example box.
+      expect(bothHooksOutput).toContain('Verify the hooks work');
+      expect(bothHooksOutput).toContain('Pre-commit — stage and commit:');
+      expect(bothHooksOutput).toContain('Pre-push — bypass pre-commit, then push:');
 
       const state = harness.stateJsonFile.asJson() as InstalledStateJson;
       const gitIntegration = getInstalledIntegration(state, 'native-git');

--- a/tests/unit/cli/commands/integrate/_common/completion-summary.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/completion-summary.test.ts
@@ -192,4 +192,45 @@ describe('renderCompletionSummary', () => {
     expect(String(exampleNote?.args[0])).toContain('do the thing');
     expect(calls.some((c) => c.method === 'text' && c.args[0] === 'it should work')).toBe(true);
   });
+
+  it('renders the combined example (and skips per-feature ones) when the integration provides one', () => {
+    const integration: IntegrationDeclaration = {
+      id: 'test',
+      displayName: 'Test',
+      features: [
+        { id: 'a', displayName: 'Feature A', postInstallExample: { lines: ['example a'] } },
+        { id: 'b', displayName: 'Feature B', postInstallExample: { lines: ['example b'] } },
+      ],
+      combinedPostInstallExample: (ids) =>
+        ids.includes('a') && ids.includes('b')
+          ? { title: 'Combined', lines: ['combined example'] }
+          : undefined,
+    };
+
+    renderCompletionSummary(integration, [installedFeature('a'), installedFeature('b')]);
+
+    const notes = getMockUiCalls().filter((c) => c.method === 'note');
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.args[1]).toBe('Combined');
+    expect(String(notes[0]?.args[0])).toContain('combined example');
+  });
+
+  it('falls back to per-feature examples when the combiner returns undefined', () => {
+    const integration: IntegrationDeclaration = {
+      id: 'test',
+      displayName: 'Test',
+      features: [
+        { id: 'a', displayName: 'Feature A', postInstallExample: { lines: ['example a'] } },
+        { id: 'b', displayName: 'Feature B', postInstallExample: { lines: ['example b'] } },
+      ],
+      combinedPostInstallExample: () => undefined,
+    };
+
+    renderCompletionSummary(integration, [installedFeature('a'), installedFeature('b')]);
+
+    const noteBodies = getMockUiCalls()
+      .filter((c) => c.method === 'note')
+      .map((c) => String(c.args[0]));
+    expect(noteBodies).toEqual(['example a', 'example b']);
+  });
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **New framework capability:**
  - Added `combinedPostInstallExample` to `IntegrationDeclaration` to support merging multiple feature instructions into a single block.
  - Updated `completion-summary.ts` to prioritize combined examples and fallback to individual ones if necessary.
- **Git integration updates:**
  - Implemented `gitCombinedHookExample` in `shared.ts` to provide a unified verification guide when both `pre-commit` and `pre-push` hooks are installed.
  - Registered the combined example for `husky`, `native-git`, and `pre-commit` integrations.
- **Testing:**
  - Added unit tests for the new collapsing logic and verified the combined hook output in integration tests.

<sub>This will update automatically on new commits.</sub>