### PR TITLE
CLI-635 system reset must not tear down pre-commit framework hooks

### DIFF
--- a/src/cli/commands/integrate/git/tools/pre-commit/config.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/config.ts
@@ -190,3 +190,12 @@ export async function activatePreCommitFramework(root: string, hook: GitHookType
     );
   }
 }
+
+/** Best-effort pre-commit gc on Sonar hook removal; never throws. */
+export async function garbageCollectPreCommitFramework(root: string): Promise<void> {
+  try {
+    await runPreCommitCommand(['gc'], root);
+  } catch {
+    // Missing framework or gc failure — non-fatal for reset.
+  }
+}

--- a/src/cli/commands/integrate/git/tools/pre-commit/config.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/config.ts
@@ -190,13 +190,3 @@ export async function activatePreCommitFramework(root: string, hook: GitHookType
     );
   }
 }
-
-/** Best-effort pre-commit uninstall during factory reset; never throws. */
-export async function deactivatePreCommitFramework(root: string): Promise<void> {
-  try {
-    await runPreCommitCommand(['uninstall'], root);
-    await runPreCommitCommand(['clean'], root);
-  } catch {
-    // Missing framework or hook scripts — non-fatal for reset.
-  }
-}

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -26,6 +26,7 @@ import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { gitHookExample, shouldInstallHook } from '../shared';
 import {
   activatePreCommitFramework,
+  garbageCollectPreCommitFramework,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,
   removeLegacyHook,
@@ -68,6 +69,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
         id: 'activate-hook',
         displayName: `${hook} hook activation`,
         apply: ({ targetRoot }) => activatePreCommitFramework(targetRoot, hook),
+        undo: ({ targetRoot }) => garbageCollectPreCommitFramework(targetRoot),
       },
     ],
   };
@@ -75,6 +77,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
 
 export {
   activatePreCommitFramework,
+  garbageCollectPreCommitFramework,
   hasSonarHookInPreCommitConfig,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -67,7 +67,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
       {
         id: 'activate-hook',
         displayName: `${hook} hook activation`,
-        apply: ({ targetRoot }) => activatePreCommitFramework(targetRoot, hook)
+        apply: ({ targetRoot }) => activatePreCommitFramework(targetRoot, hook),
       },
     ],
   };

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -26,7 +26,6 @@ import type { GitHookType, IntegrateGitOptions } from '../../options';
 import { gitHookExample, shouldInstallHook } from '../shared';
 import {
   activatePreCommitFramework,
-  deactivatePreCommitFramework,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,
   removeLegacyHook,
@@ -68,8 +67,7 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
       {
         id: 'activate-hook',
         displayName: `${hook} hook activation`,
-        apply: ({ targetRoot }) => activatePreCommitFramework(targetRoot, hook),
-        undo: ({ targetRoot }) => deactivatePreCommitFramework(targetRoot),
+        apply: ({ targetRoot }) => activatePreCommitFramework(targetRoot, hook)
       },
     ],
   };
@@ -77,7 +75,6 @@ function createPreCommitFeature(hook: GitHookType): FeatureDeclaration<Integrate
 
 export {
   activatePreCommitFramework,
-  deactivatePreCommitFramework,
   hasSonarHookInPreCommitConfig,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,

--- a/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
@@ -29,6 +29,7 @@ import type { IntegrationContext } from '../../../../../../src/cli/commands/inte
 import { IntegrationInstaller } from '../../../../../../src/cli/commands/integrate/_common/registry';
 import {
   activatePreCommitFramework,
+  garbageCollectPreCommitFramework,
   hasSonarHookInPreCommitConfig,
   normalizePreCommitConfig,
   PRE_COMMIT_CONFIG_FILE,
@@ -373,6 +374,31 @@ describe('activatePreCommitFramework', () => {
   });
 });
 
+describe('garbageCollectPreCommitFramework', () => {
+  it('calls pre-commit gc', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+
+    try {
+      await garbageCollectPreCommitFramework(TEMP_DIR);
+
+      const calls = spawnSpy.mock.calls.map((c) => (c as [string, string[]])[1]);
+      expect(calls).toEqual([['gc']]);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('does not throw when pre-commit gc fails', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_FAIL);
+
+    try {
+      await garbageCollectPreCommitFramework(TEMP_DIR);
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+});
+
 describe('pre-commit integration remove', () => {
   const installer = new IntegrationInstaller();
   const preCommitFeature = preCommitIntegration.features.find((f) => f.id === 'pre-commit-hook');
@@ -383,7 +409,7 @@ describe('pre-commit integration remove', () => {
   beforeEach(() => mkdirSync(TEMP_DIR, { recursive: true }));
   afterEach(() => rmSync(TEMP_DIR, { recursive: true, force: true }));
 
-  it('removes only Sonar hooks from the config without invoking the pre-commit framework CLI', async () => {
+  it('removes only Sonar hooks from the config and runs pre-commit gc', async () => {
     writeFileSync(
       join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
       yaml.dump({
@@ -426,7 +452,9 @@ describe('pre-commit integration remove', () => {
 
     try {
       await installer.removeFeature(context, preCommitFeature);
-      expect(spawnSpy).not.toHaveBeenCalled();
+
+      const calls = spawnSpy.mock.calls.map((c) => (c as [string, string[]])[1]);
+      expect(calls).toEqual([['gc']]);
 
       const config = yaml.load(
         readFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), 'utf-8'),

--- a/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
@@ -18,13 +18,15 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import yaml from 'js-yaml';
 
 import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error';
+import type { IntegrationContext } from '../../../../../../src/cli/commands/integrate/_common/registry';
+import { IntegrationInstaller } from '../../../../../../src/cli/commands/integrate/_common/registry';
 import {
   activatePreCommitFramework,
   hasSonarHookInPreCommitConfig,
@@ -32,11 +34,13 @@ import {
   PRE_COMMIT_CONFIG_FILE,
   PRE_COMMIT_LEGACY_REPO,
   type PreCommitConfig,
+  preCommitIntegration,
   removeLegacyHook,
   runPreCommitInstall,
   upsertSonarHook,
 } from '../../../../../../src/cli/commands/integrate/git/tools/pre-commit';
 import * as processLib from '../../../../../../src/lib/process.js';
+import { getDefaultState } from '../../../../../../src/lib/state';
 
 const TEMP_DIR = join(process.cwd(), 'tests', 'unit', '.git-precommit-framework-tmp');
 
@@ -363,6 +367,77 @@ describe('activatePreCommitFramework', () => {
       );
       expect(err).toBeInstanceOf(CommandFailedError);
       expect((err as CommandFailedError).remediationHint).toContain('--hook-type pre-push');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+});
+
+describe('pre-commit integration remove', () => {
+  const installer = new IntegrationInstaller();
+  const preCommitFeature = preCommitIntegration.features.find((f) => f.id === 'pre-commit-hook');
+  if (!preCommitFeature) {
+    throw new Error('pre-commit-hook feature not found');
+  }
+
+  beforeEach(() => mkdirSync(TEMP_DIR, { recursive: true }));
+  afterEach(() => rmSync(TEMP_DIR, { recursive: true, force: true }));
+
+  it('removes only Sonar hooks from the config', async () => {
+    writeFileSync(
+      join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
+      yaml.dump({
+        repos: [
+          {
+            repo: PRE_COMMIT_LEGACY_REPO,
+            rev: 'v2.41.0.10709',
+            hooks: [{ id: 'sonar-secrets', stages: ['pre-commit'] }],
+          },
+          {
+            repo: 'https://github.com/pre-commit/pre-commit-hooks',
+            rev: 'v4.6.0',
+            hooks: [{ id: 'trailing-whitespace' }],
+          },
+          {
+            repo: 'local',
+            hooks: [
+              { id: 'other-local-hook', name: 'x', entry: 'echo', language: 'system' },
+              {
+                id: 'sonar-secrets',
+                name: 'Sonar pre-commit scan',
+                entry: 'sonar hook git-pre-commit',
+                language: 'system',
+                stages: ['pre-commit'],
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(PRE_COMMIT_OK);
+    const context: IntegrationContext = {
+      state: getDefaultState('test'),
+      targetRoot: TEMP_DIR,
+      scope: 'project',
+      executionMode: 'install',
+      resolvedDependencies: new Map(),
+    };
+
+    try {
+      await installer.removeFeature(context, preCommitFeature);
+
+      const config = yaml.load(
+        readFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), 'utf-8'),
+      ) as PreCommitConfig;
+      expect(config.repos.some((r) => r.repo === PRE_COMMIT_LEGACY_REPO)).toBe(false);
+      const thirdPartyRepo = config.repos.find(
+        (r) => r.repo === 'https://github.com/pre-commit/pre-commit-hooks',
+      );
+      expect(thirdPartyRepo?.hooks.map((hook) => hook.id)).toEqual(['trailing-whitespace']);
+      const localRepo = config.repos.find((r) => r.repo === 'local');
+      expect(localRepo?.hooks.map((hook) => hook.id)).toEqual(['other-local-hook']);
+      expect(hasSonarHookInPreCommitConfig(TEMP_DIR)).toBe(false);
     } finally {
       spawnSpy.mockRestore();
     }

--- a/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-precommit-framework.test.ts
@@ -383,7 +383,7 @@ describe('pre-commit integration remove', () => {
   beforeEach(() => mkdirSync(TEMP_DIR, { recursive: true }));
   afterEach(() => rmSync(TEMP_DIR, { recursive: true, force: true }));
 
-  it('removes only Sonar hooks from the config', async () => {
+  it('removes only Sonar hooks from the config without invoking the pre-commit framework CLI', async () => {
     writeFileSync(
       join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE),
       yaml.dump({
@@ -426,6 +426,7 @@ describe('pre-commit integration remove', () => {
 
     try {
       await installer.removeFeature(context, preCommitFeature);
+      expect(spawnSpy).not.toHaveBeenCalled();
 
       const config = yaml.load(
         readFileSync(join(TEMP_DIR, PRE_COMMIT_CONFIG_FILE), 'utf-8'),


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored pre-commit integration:**
  - Removed `deactivatePreCommitFramework` to prevent accidental teardown of the entire framework during system resets.
- **Testing:**
  - Added unit tests to verify that removing Sonar hooks preserves other local and third-party pre-commit hooks.

<sub>This will update automatically on new commits.</sub>