### PR TITLE
CLI-634 Unify SQAA warning and promotional messages throughout integrations

### DIFF
--- a/src/cli/commands/integrate/_common/instructions-templates.ts
+++ b/src/cli/commands/integrate/_common/instructions-templates.ts
@@ -28,8 +28,6 @@
 // instructions file (i.e. without clobbering anything the user appended
 // around it).
 
-import { AGENTIC_ANALYSIS_DOCS_URL } from '../../../../lib/config-constants';
-
 /**
  * Wrap a markdown body in stable HTML-comment markers. The `id` must remain
  * unique and stable across CLI versions — it is the only identifier we have
@@ -46,15 +44,6 @@ export function sonarBeginMarker(id: string): string {
 export function sonarEndMarker(id: string): string {
   return `<!-- sonar:end:${id} -->`;
 }
-
-/**
- * Shown when SQAA is not available for the current connection.
- */
-export const SQAA_PROMOTION_MESSAGE = `SonarQube Agentic Analysis is available on SonarQube Cloud. Learn more: ${AGENTIC_ANALYSIS_DOCS_URL}`;
-
-/** Shown when SQAA is available for the connection but cannot be set up because no project key could be resolved. */
-export const SQAA_MISSING_PROJECT_KEY_MESSAGE =
-  'Skipping SonarQube Agentic Analysis instructions because no project key could be resolved. Re-run with --project <key> or from a directory with a configured project.';
 
 export function buildSqaaSectionBody(projectKey: string): string {
   return `# SonarQube Agentic Analysis protocol

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -19,31 +19,8 @@
  */
 
 import { AGENTIC_ANALYSIS_DOCS_URL } from '../../../../lib/config-constants';
-import { SonarQubeClient } from '../../../../sonarqube/client';
+import { SonarQubeClient, type SqaaEntitlementStatus } from '../../../../sonarqube/client';
 import { info, warn } from '../../../../ui';
-
-/**
- * Check if the organization has SonarQube Agentic Analysis (SQAA) entitlement.
- *
- * Returns false for on-premise, missing org, or failed API call. The underlying
- * `hasSqaaEntitlement` already swallows network/API errors, so the try/catch
- * here is defence-in-depth for unexpected throws (e.g. malformed URLs from the
- * client constructor).
- */
-export async function resolveSqaaEntitlement(
-  serverURL: string,
-  token: string,
-  organization: string | undefined,
-): Promise<boolean> {
-  try {
-    const client = new SonarQubeClient(serverURL, token);
-    return await client.hasSqaaEntitlement(organization);
-  } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    warn(`Could not determine SonarQube Agentic Analysis entitlement — skipping: ${detail}`);
-    return false;
-  }
-}
 
 /**
  * Consistent notice shown across all agent integrations when SonarQube Agentic
@@ -66,19 +43,22 @@ export interface ResolveSqaaSetupParams {
 
 /**
  * Resolve whether SonarQube Agentic Analysis (SQAA) can be installed.
- *
- * Entitlement is checked first: an unentitled connection surfaces the
- * promotion message. SQAA is always project-scoped, so an entitled `--global`
- * integration can never install it and instead surfaces the global skip notice.
- * For entitled project installs this returns `true`.
  */
 export async function resolveSqaaSetup(params: ResolveSqaaSetupParams): Promise<boolean> {
-  const entitled = await resolveSqaaEntitlement(
-    params.serverURL,
-    params.token,
-    params.organization,
-  );
-  if (!entitled) {
+  let status: SqaaEntitlementStatus;
+  try {
+    status = await new SonarQubeClient(params.serverURL, params.token).hasSqaaEntitlement(
+      params.organization,
+    );
+  } catch {
+    status = 'check_failed';
+  }
+
+  if (status === 'check_failed') {
+    warn('Could not determine SonarQube Agentic Analysis entitlement — skipping.');
+    return false;
+  }
+  if (status === 'not_enabled') {
     info(SQAA_PROMOTION_MESSAGE);
     return false;
   }

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -66,5 +66,7 @@ export async function resolveSqaaSetup(params: ResolveSqaaSetupParams): Promise<
     warn(SQAA_GLOBAL_SKIP_MESSAGE);
     return false;
   }
+  // Explicit check so future statuses don't fall through to true.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return status === 'enabled';
 }

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -18,8 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { AGENTIC_ANALYSIS_DOCS_URL } from '../../../../lib/config-constants';
 import { SonarQubeClient } from '../../../../sonarqube/client';
-import { warn } from '../../../../ui';
+import { info, warn } from '../../../../ui';
 
 /**
  * Check if the organization has SonarQube Agentic Analysis (SQAA) entitlement.
@@ -51,6 +52,11 @@ export async function resolveSqaaEntitlement(
 export const SQAA_GLOBAL_SKIP_MESSAGE =
   'Skipping SonarQube Agentic Analysis: not supported with --global. Re-run without --global from a project directory to install it there.';
 
+/**
+ * Shown when SonarQube Agentic Analysis is not available for the current connection.
+ */
+export const SQAA_PROMOTION_MESSAGE = `SonarQube Agentic Analysis is available on SonarQube Cloud. Learn more: ${AGENTIC_ANALYSIS_DOCS_URL}`;
+
 export interface ResolveSqaaSetupParams {
   serverURL: string;
   token: string;
@@ -59,12 +65,12 @@ export interface ResolveSqaaSetupParams {
 }
 
 /**
- * Resolve whether SonarQube Agentic Analysis (SQAA) should be installed.
+ * Resolve whether SonarQube Agentic Analysis (SQAA) can be installed.
  *
- * SQAA is always project-scoped, so a `--global` integration can never install
- * it. We still resolve org entitlement first so that, on a global install, the
- * skip notice is only shown to orgs that could actually use SQAA (avoiding noise
- * for unentitled orgs). For project installs this returns the raw entitlement.
+ * Entitlement is checked first: an unentitled connection surfaces the
+ * promotion message. SQAA is always project-scoped, so an entitled `--global`
+ * integration can never install it and instead surfaces the global skip notice.
+ * For entitled project installs this returns `true`.
  */
 export async function resolveSqaaSetup(params: ResolveSqaaSetupParams): Promise<boolean> {
   const entitled = await resolveSqaaEntitlement(
@@ -72,11 +78,13 @@ export async function resolveSqaaSetup(params: ResolveSqaaSetupParams): Promise<
     params.token,
     params.organization,
   );
-  if (params.isGlobal) {
-    if (entitled) {
-      warn(SQAA_GLOBAL_SKIP_MESSAGE);
-    }
+  if (!entitled) {
+    info(SQAA_PROMOTION_MESSAGE);
     return false;
   }
-  return entitled;
+  if (params.isGlobal) {
+    warn(SQAA_GLOBAL_SKIP_MESSAGE);
+    return false;
+  }
+  return true;
 }

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -66,5 +66,5 @@ export async function resolveSqaaSetup(params: ResolveSqaaSetupParams): Promise<
     warn(SQAA_GLOBAL_SKIP_MESSAGE);
     return false;
   }
-  return true;
+  return status === 'enabled';
 }

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -29,8 +29,6 @@ import {
   buildSqaaSectionBody,
   sonarBeginMarker,
   sonarEndMarker,
-  SQAA_MISSING_PROJECT_KEY_MESSAGE,
-  SQAA_PROMOTION_MESSAGE,
 } from '../_common/instructions-templates';
 import { removeJsonMcpServer } from '../_common/mcp-config';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
@@ -68,7 +66,6 @@ export interface CopilotIntegrationOptions extends IntegrateAgentOptions {
   projectRoot?: string;
   globalSecretsHookExists?: boolean;
   installSqaaInstructions?: boolean;
-  sqaaEntitled?: boolean;
   installContextAugmentation?: boolean;
 }
 
@@ -131,14 +128,8 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      shouldInstall: ({ options }) => {
-        if (options.installSqaaInstructions === true) {
-          return askUser();
-        }
-        return skip(
-          options.sqaaEntitled === true ? SQAA_MISSING_PROJECT_KEY_MESSAGE : SQAA_PROMOTION_MESSAGE,
-        );
-      },
+      shouldInstall: ({ options }) =>
+        options.installSqaaInstructions === true ? askUser() : skip(),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
       scope: 'project',
       resources: [

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -38,11 +38,10 @@ import { detectGlobalSecretsHook } from './hooks';
 export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAgentOptions) {
   const ctx = await displayAgentIntegratePrelude('Copilot', 'copilot', options, auth);
 
-  // SQAA is always project-scoped. resolveSqaaSetup returns false (and surfaces
-  // the consistent "not supported with --global" notice when the org is
-  // entitled) on a global install; on a project install it returns the raw
-  // entitlement, which drives the declarative skip messaging (missing-key vs
-  // promotion).
+  // SQAA is always project-scoped. resolveSqaaSetup owns the user-facing
+  // messaging: it surfaces the promotion message when the org is not entitled
+  // and the "not supported with --global" notice on an entitled global install.
+  // We use the result to decide whether to bake in a project key.
   const entitled = await resolveSqaaSetup({
     serverURL: ctx.serverUrl,
     token: ctx.token,
@@ -70,7 +69,6 @@ export async function integrateCopilot(auth: ResolvedAuth, options: IntegrateAge
     projectRoot: ctx.project.rootDir,
     globalSecretsHookExists,
     installSqaaInstructions: sqaaProjectKey !== undefined,
-    sqaaEntitled: entitled,
     installContextAugmentation: contextAugmentation !== null,
   };
 

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -43,6 +43,8 @@ export type HttpMethod = (typeof GENERIC_HTTP_METHODS)[number];
 
 export type CagEntitlementStatus = 'enabled' | 'not_enabled' | 'check_failed';
 
+export type SqaaEntitlementStatus = 'enabled' | 'not_enabled' | 'check_failed';
+
 export class SonarQubeClient {
   private readonly serverURL: string;
   private readonly token: string;
@@ -300,9 +302,10 @@ export class SonarQubeClient {
 
   /**
    * Check if an organization has SQAA entitlement.
-   * Returns true only when both eligible and enabled are true.
+   * Returns `'enabled'` only when both eligible and enabled are true, `'not_enabled'`
+   * for a definitive negative answer, and `'check_failed'` when the API call errors out.
    */
-  async checkSqaaEntitlement(organizationUuid: string): Promise<boolean> {
+  async checkSqaaEntitlement(organizationUuid: string): Promise<SqaaEntitlementStatus> {
     try {
       const endpoint = `/a3s-analysis/org-config/${organizationUuid}`;
       const result = await this.get<{ id: string; enabled: boolean; eligible: boolean }>(
@@ -310,9 +313,9 @@ export class SonarQubeClient {
         undefined,
         resolveFromEndpoint(this.serverURL, endpoint),
       );
-      return result.eligible && result.enabled;
+      return result.eligible && result.enabled ? 'enabled' : 'not_enabled';
     } catch {
-      return false;
+      return 'check_failed';
     }
   }
 
@@ -354,14 +357,14 @@ export class SonarQubeClient {
   /**
    * Convenience: resolve org UUID then check SQAA entitlement in one call.
    */
-  async hasSqaaEntitlement(organizationKey?: string): Promise<boolean> {
+  async hasSqaaEntitlement(organizationKey?: string): Promise<SqaaEntitlementStatus> {
     if (!organizationKey || !isSonarQubeCloud(this.serverURL)) {
-      return false;
+      return 'not_enabled';
     }
 
     const uuid = await this.getOrganizationId(organizationKey);
     if (!uuid) {
-      return false;
+      return 'check_failed';
     }
 
     return this.checkSqaaEntitlement(uuid);

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -2101,4 +2101,39 @@ describe('integrate claude — interactive feature selection', () => {
     },
     { timeout: 30000 },
   );
+
+  it(
+    'warns and skips SQAA when the entitlement check fails',
+    async () => {
+      // Cloud connection whose org/entitlement lookup errors out: resolveSqaaSetup
+      // hits the 'check_failed' branch, which warns and skips silently rather than
+      // surfacing the promotion.
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('cloud-token')
+        .withOrganizations([{ key: 'my-org', name: 'My Org' }])
+        .withOrgsLookupError(503)
+        .withProject('my-project')
+        .start();
+      const serverUrl = server.baseUrl();
+      harness.withAuth(serverUrl, 'cloud-token', 'my-org');
+
+      // '\r' selects project scope, then the secret scanning hooks + MCP prompts.
+      // SQAA is skipped without a prompt because entitlement could not be resolved.
+      const result = await harness.run('integrate claude --project my-project', {
+        stdinChunks: ['\r', '\r', '\r'],
+        extraEnv: {
+          SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+          SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(output).toContain('Could not determine SonarQube Agentic Analysis entitlement');
+      expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
+      expect(findClaudeFeature(harness, 'sonar-sqaa-hook')).toBeUndefined();
+    },
+    { timeout: 30000 },
+  );
 });

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -1976,6 +1976,7 @@ describe('integrate claude — hook migration scenarios', () => {
 // ─── Interactive feature selection ────────────────────────────────────────────
 
 describe('integrate claude — interactive feature selection', () => {
+  const HTTP_SERVICE_UNAVAILABLE = 503;
   let harness: TestHarness;
 
   beforeEach(async () => {
@@ -2112,7 +2113,7 @@ describe('integrate claude — interactive feature selection', () => {
         .newFakeServer()
         .withAuthToken('cloud-token')
         .withOrganizations([{ key: 'my-org', name: 'My Org' }])
-        .withOrgsLookupError(503)
+        .withOrgsLookupError(HTTP_SERVICE_UNAVAILABLE)
         .withProject('my-project')
         .start();
       const serverUrl = server.baseUrl();

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -1988,11 +1988,12 @@ describe('integrate claude — interactive feature selection', () => {
   });
 
   it(
-    'prompts per feature, installs accepted features, and silently skips SQAA when not entitled',
+    'prompts per feature, installs accepted features, and shows the SQAA promotion when not entitled',
     async () => {
-      // On-premise auth with no org: SQAA and Context Augmentation are not
-      // available, so both are skipped silently. The secret scanning hooks and
-      // MCP server features each ask.
+      // On-premise auth with no org: SQAA is not available, so it is skipped
+      // without a prompt but surfaces the shared promotion message. Context
+      // Augmentation is skipped silently. The secret scanning hooks and MCP
+      // server features each ask.
       const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
       harness.withAuth(server.baseUrl(), 'tok');
       harness.cwd.writeFile(
@@ -2009,8 +2010,10 @@ describe('integrate claude — interactive feature selection', () => {
       const output = `${result.stdout}\n${result.stderr}`;
       expect(output).toContain('Install secret scanning hooks?');
       expect(output).toContain('Install MCP server?');
-      // SQAA is not eligible, so it is skipped silently without a prompt.
+      // SQAA is not eligible, so it is skipped without a prompt but the shared
+      // promotion message is surfaced.
       expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
+      expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
 
       // Accepted features are installed on disk.
       expect(

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -561,7 +561,7 @@ describe('integrate codex', () => {
     );
 
     it(
-      'writes ~/.codex/AGENTS.md (and nothing project-side) at global scope without SQAA entitlement, and does NOT warn about SQAA',
+      'writes ~/.codex/AGENTS.md (and nothing project-side) at global scope without SQAA entitlement, showing the promotion',
       async () => {
         const result = await harness.run('integrate codex -g --non-interactive');
 
@@ -571,7 +571,7 @@ describe('integrate codex', () => {
         expect(body).toContain(SECRETS_HEADING);
         expect(body).not.toContain(SQAA_HEADING);
         const output = `${result.stdout}\n${result.stderr}`;
-        expect(output).not.toContain('Skipping SonarQube Agentic Analysis');
+        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
       },
       { timeout: 30000 },
     );
@@ -630,8 +630,10 @@ describe('integrate codex', () => {
         expect(output).toContain('Install secret scanning hooks?');
         expect(output).toContain('Install secrets-on-read instructions?');
         expect(output).toContain('Install MCP server?');
-        // SQAA is not eligible, so it is skipped silently without a prompt.
+        // SQAA is not eligible, so it is skipped without a prompt but the shared
+        // promotion message is surfaced.
         expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
+        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
         // Accepted features are installed on disk.
         expect(
           harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),

--- a/tests/unit/cli/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/integrate.test.ts
@@ -99,7 +99,7 @@ describe('integrateCommand', () => {
     setMockUi(true);
 
     hasSqaaEntitlementSpy = spyOn(SonarQubeClient.prototype, 'hasSqaaEntitlement');
-    hasSqaaEntitlementSpy.mockResolvedValue(false);
+    hasSqaaEntitlementSpy.mockResolvedValue('not_enabled');
     hasCagEntitlementSpy = spyOn(SonarQubeClient.prototype, 'hasCagEntitlement');
     hasCagEntitlementSpy.mockResolvedValue('enabled');
     resolveContextAugmentationSetupSpy = spyOn(
@@ -280,7 +280,7 @@ describe('integrateCommand', () => {
   });
 
   it('checks SQAA entitlement', async () => {
-    hasSqaaEntitlementSpy.mockResolvedValue(true);
+    hasSqaaEntitlementSpy.mockResolvedValue('enabled');
 
     await integrateClaude({}, CLOUD_AUTH);
 
@@ -561,7 +561,7 @@ describe('integrateCommand', () => {
   }
 
   function mockSqaaEntitlement(hasEntitlement: boolean) {
-    hasSqaaEntitlementSpy.mockResolvedValue(hasEntitlement);
+    hasSqaaEntitlementSpy.mockResolvedValue(hasEntitlement ? 'enabled' : 'not_enabled');
   }
 
   function assertMigrationHookInstallationAndStateUpdateRan(

--- a/tests/unit/cli/commands/integrate/codex/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/codex/integrate.test.ts
@@ -74,7 +74,7 @@ describe('integrateCodex', () => {
     hasSqaaEntitlementSpy = spyOn(
       SonarQubeClient.prototype,
       'hasSqaaEntitlement',
-    ).mockResolvedValue(false);
+    ).mockResolvedValue('not_enabled');
     checkComponentSpy = spyOn(SonarQubeClient.prototype, 'checkComponent').mockResolvedValue(true);
     resolveContextAugmentationSetupSpy = spyOn(
       contextAugmentation,

--- a/tests/unit/cli/commands/integrate/copilot/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/copilot/integrate.test.ts
@@ -78,7 +78,7 @@ describe('integrateCopilot', () => {
     hasSqaaEntitlementSpy = spyOn(
       SonarQubeClient.prototype,
       'hasSqaaEntitlement',
-    ).mockResolvedValue(false);
+    ).mockResolvedValue('not_enabled');
     checkComponentSpy = spyOn(SonarQubeClient.prototype, 'checkComponent').mockResolvedValue(true);
     detectGlobalSecretsHookSpy = spyOn(hooks, 'detectGlobalSecretsHook').mockResolvedValue(
       undefined,

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -422,36 +422,36 @@ describe('SonarQubeClient', () => {
       cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
     });
 
-    it('returns false when organizationKey is not provided', async () => {
+    it("returns 'not_enabled' when organizationKey is not provided", async () => {
       fetchSpy = mockFetch({});
-      expect(await cloudClient.hasSqaaEntitlement(undefined)).toBe(false);
+      expect(await cloudClient.hasSqaaEntitlement(undefined)).toBe('not_enabled');
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('returns false when organizationKey is empty string', async () => {
+    it("returns 'not_enabled' when organizationKey is empty string", async () => {
       fetchSpy = mockFetch({});
-      expect(await cloudClient.hasSqaaEntitlement('')).toBe(false);
+      expect(await cloudClient.hasSqaaEntitlement('')).toBe('not_enabled');
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('returns false when server is not SonarQube Cloud', async () => {
+    it("returns 'not_enabled' when server is not SonarQube Cloud", async () => {
       const serverClient = new SonarQubeClient(SERVER_URL, TOKEN);
       fetchSpy = mockFetch({});
-      expect(await serverClient.hasSqaaEntitlement('my-org')).toBe(false);
+      expect(await serverClient.hasSqaaEntitlement('my-org')).toBe('not_enabled');
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('returns false when org UUID cannot be resolved (API error)', async () => {
+    it("returns 'check_failed' when org UUID cannot be resolved (API error)", async () => {
       fetchSpy = mockFetch({}, false, 404);
-      expect(await cloudClient.hasSqaaEntitlement('unknown-org')).toBe(false);
+      expect(await cloudClient.hasSqaaEntitlement('unknown-org')).toBe('check_failed');
     });
 
-    it('returns false when org UUID list is empty', async () => {
+    it("returns 'check_failed' when org UUID list is empty", async () => {
       fetchSpy = mockFetch([]);
-      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe(false);
+      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('check_failed');
     });
 
-    it('returns true when org UUID is resolved and entitlement is enabled and eligible', async () => {
+    it("returns 'enabled' when org UUID is resolved and entitlement is enabled and eligible", async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -464,10 +464,10 @@ describe('SonarQubeClient', () => {
           json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: true }),
         } as Response);
 
-      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe(true);
+      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('enabled');
     });
 
-    it('returns false when entitlement is enabled but not eligible', async () => {
+    it("returns 'not_enabled' when entitlement is enabled but not eligible", async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -480,10 +480,10 @@ describe('SonarQubeClient', () => {
           json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: false }),
         } as Response);
 
-      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe(false);
+      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('not_enabled');
     });
 
-    it('returns false when entitlement is eligible but not enabled', async () => {
+    it("returns 'not_enabled' when entitlement is eligible but not enabled", async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -496,10 +496,10 @@ describe('SonarQubeClient', () => {
           json: () => Promise.resolve({ id: 'org-uuid', enabled: false, eligible: true }),
         } as Response);
 
-      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe(false);
+      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('not_enabled');
     });
 
-    it('returns false when the entitlement check fails with an API error', async () => {
+    it("returns 'check_failed' when the entitlement check fails with an API error", async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -513,7 +513,7 @@ describe('SonarQubeClient', () => {
           json: () => Promise.resolve({}),
         } as Response);
 
-      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe(false);
+      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('check_failed');
     });
 
     it('passes the resolved UUID to the entitlement check', async () => {
@@ -536,7 +536,7 @@ describe('SonarQubeClient', () => {
       expect(entitlementUrl.pathname).toBe(`/a3s-analysis/org-config/${targetUuid}`);
     });
 
-    it('returns true for SonarQube Cloud US and hits US API', async () => {
+    it("returns 'enabled' for SonarQube Cloud US and hits US API", async () => {
       const usClient = new SonarQubeClient(SONARCLOUD_US_URL, TOKEN);
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
@@ -550,7 +550,7 @@ describe('SonarQubeClient', () => {
           json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: true }),
         } as Response);
 
-      expect(await usClient.hasSqaaEntitlement('my-org')).toBe(true);
+      expect(await usClient.hasSqaaEntitlement('my-org')).toBe('enabled');
 
       const orgUrl = (fetchSpy.mock.calls[0][0] as URL).toString();
       expect(orgUrl).toContain(SONARCLOUD_US_API_URL);


### PR DESCRIPTION
----
## Summary by Gitar

- **Message unification:**
  - Centralized SQAA warning and promotional message logic within `resolveSqaaSetup` to ensure consistent output.
  - Removed redundant message handling from individual integration declarations and templates.
- **Integration behavior:**
  - Updated `resolveSqaaSetup` to automatically surface the promotion message when an organization lacks SQAA entitlement.
  - Simplified declarative skip logic in `copilot` integration to rely on centralized setup messaging.
- **Test updates:**
  - Updated integration tests for `claude` and `codex` to verify that the standardized promotion message is now correctly surfaced.

<sub>This will update automatically on new commits.</sub>