### PR TITLE
CLI-637 system reset must clear auth state when keychain read/delete fails

### DIFF
--- a/src/cli/commands/system/reset-auth.ts
+++ b/src/cli/commands/system/reset-auth.ts
@@ -74,14 +74,16 @@ async function purgeConnectionAuth(conn: AuthConnection): Promise<ConnectionOutc
 
 function buildKeychainWarningDetail(
   authConnectionIds: string[],
-  keychainWarningCount: number,
+  keychainOperationFailureCount: number,
 ): string {
+  const operationLabel = keychainOperationFailureCount === 1 ? 'operation' : 'operations';
+
   if (authConnectionIds.length === 0) {
-    return `${keychainWarningCount} keychain failures`;
+    return `${keychainOperationFailureCount} keychain ${operationLabel} failed`;
   }
 
   const connectionLabel = authConnectionIds.length === 1 ? 'connection' : 'connections';
-  return `${authConnectionIds.length} ${connectionLabel} cleared from state; keychain cleanup failed for ${keychainWarningCount}`;
+  return `${authConnectionIds.length} ${connectionLabel} cleared from state; ${keychainOperationFailureCount} keychain ${operationLabel} failed`;
 }
 
 function buildAuthResetPhaseItem(

--- a/src/cli/commands/system/reset-auth.ts
+++ b/src/cli/commands/system/reset-auth.ts
@@ -19,7 +19,7 @@
  */
 
 import { deleteToken, getToken } from '../../../lib/keychain';
-import type { CliState } from '../../../lib/state';
+import type { AuthConnection, CliState } from '../../../lib/state';
 import type { PhaseItem } from '../../../ui';
 import { phaseItem } from '../../../ui';
 import {
@@ -32,9 +32,74 @@ export interface AuthResetResult {
   authConnectionIds: string[];
 }
 
-type ConnectionOutcome =
-  | { status: 'cleaned'; connectionId: string }
-  | { status: 'failed'; message: string };
+interface ConnectionOutcome {
+  connectionId: string;
+  keychainWarnings: string[];
+}
+
+function formatConnectionTarget(conn: AuthConnection): string {
+  return conn.orgKey ? `${conn.serverUrl} (${conn.orgKey})` : conn.serverUrl;
+}
+
+function formatKeychainWarning(target: string, operation: 'read' | 'delete', err: unknown): string {
+  const detail = err instanceof Error ? err.message.split('\n')[0] : String(err);
+  return `${target}: could not ${operation} keychain entry (${detail})`;
+}
+
+async function purgeConnectionAuth(conn: AuthConnection): Promise<ConnectionOutcome> {
+  const target = formatConnectionTarget(conn);
+  const keychainWarnings: string[] = [];
+
+  let token: string | undefined;
+  try {
+    token = (await getToken(conn.serverUrl, conn.orgKey)) ?? undefined;
+  } catch (err) {
+    keychainWarnings.push(formatKeychainWarning(target, 'read', err));
+  }
+
+  const revokeOutcome = await revokeServerTokenIfPossible(conn, token);
+  reportRevokeServerTokenOutcome(revokeOutcome, {
+    serverUrl: conn.serverUrl,
+    continuingMessage: 'Continuing with local reset.',
+  });
+
+  try {
+    await deleteToken(conn.serverUrl, conn.orgKey);
+  } catch (err) {
+    keychainWarnings.push(formatKeychainWarning(target, 'delete', err));
+  }
+
+  return { connectionId: conn.id, keychainWarnings };
+}
+
+function buildKeychainWarningDetail(
+  authConnectionIds: string[],
+  keychainWarningCount: number,
+): string {
+  if (authConnectionIds.length === 0) {
+    return `${keychainWarningCount} keychain failures`;
+  }
+
+  const connectionLabel = authConnectionIds.length === 1 ? 'connection' : 'connections';
+  return `${authConnectionIds.length} ${connectionLabel} cleared from state; keychain cleanup failed for ${keychainWarningCount}`;
+}
+
+function buildAuthResetPhaseItem(
+  authConnectionIds: string[],
+  keychainWarnings: string[],
+): PhaseItem {
+  if (keychainWarnings.length > 0) {
+    const counts = buildKeychainWarningDetail(authConnectionIds, keychainWarnings.length);
+    return phaseItem('Authentication', 'warn', `${counts}: ${keychainWarnings.join('; ')}`);
+  }
+
+  const tokenLabel = authConnectionIds.length === 1 ? 'token' : 'tokens';
+  return phaseItem(
+    'Authentication',
+    'done',
+    `${authConnectionIds.length} ${tokenLabel} removed from keychain.`,
+  );
+}
 
 export async function purgeAuth(state: CliState): Promise<AuthResetResult> {
   // Delete tokens sequentially: the file-backed keychain (CI/tests) does an
@@ -43,38 +108,14 @@ export async function purgeAuth(state: CliState): Promise<AuthResetResult> {
   // fails fast via its own 10s timeout.
   const outcomes: ConnectionOutcome[] = [];
   for (const conn of state.auth.connections) {
-    const target = conn.orgKey ? `${conn.serverUrl} (${conn.orgKey})` : conn.serverUrl;
-    try {
-      const token = (await getToken(conn.serverUrl, conn.orgKey)) ?? undefined;
-      const revokeOutcome = await revokeServerTokenIfPossible(conn, token);
-      reportRevokeServerTokenOutcome(revokeOutcome, {
-        serverUrl: conn.serverUrl,
-        continuingMessage: 'Continuing with local reset.',
-      });
-      await deleteToken(conn.serverUrl, conn.orgKey);
-      outcomes.push({ status: 'cleaned', connectionId: conn.id });
-    } catch (err) {
-      outcomes.push({ status: 'failed', message: `${target}: ${(err as Error).message}` });
-    }
+    outcomes.push(await purgeConnectionAuth(conn));
   }
 
-  const cleanedIds = outcomes.flatMap((o) => (o.status === 'cleaned' ? [o.connectionId] : []));
-  const failed = outcomes.flatMap((o) => (o.status === 'failed' ? [o.message] : []));
+  const authConnectionIds = outcomes.map((outcome) => outcome.connectionId);
+  const keychainWarnings = outcomes.flatMap((outcome) => outcome.keychainWarnings);
 
-  let item: PhaseItem;
-  if (failed.length > 0) {
-    const counts =
-      cleanedIds.length > 0
-        ? `${cleanedIds.length} removed, ${failed.length} failed`
-        : `${failed.length} failed`;
-    item = phaseItem('Authentication', 'warn', `${counts}: ${failed.join('; ')}`);
-  } else {
-    item = phaseItem(
-      'Authentication',
-      'done',
-      `${cleanedIds.length} token${cleanedIds.length === 1 ? '' : 's'} removed from keychain.`,
-    );
-  }
-
-  return { item, authConnectionIds: cleanedIds };
+  return {
+    item: buildAuthResetPhaseItem(authConnectionIds, keychainWarnings),
+    authConnectionIds,
+  };
 }

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -38,6 +38,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { nativeGitIntegration } from '../../../../src/cli/commands/integrate/git/tools/native';
 import { SCA_SCANNER_CACHE_DIR } from '../../../../src/lib/config-constants';
 import { generateKeychainAccount } from '../../../../src/lib/keychain';
+import { runCli } from '../../harness/cli-runner.js';
 import { hookScriptName, TestHarness } from '../../harness';
 import { buildHomeEnv, IS_WINDOWS } from '../../harness/platform';
 
@@ -232,6 +233,39 @@ describe('system reset --force', () => {
       const state = readState(harness.stateJsonFile.path);
       expect(state.auth.connections).toHaveLength(0);
       expect(state.auth.isAuthenticated).toBe(false);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'warns and still clears auth state when keychain delete fails',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('reset-token').start();
+      harness
+        .state()
+        .withAuth(server.baseUrl(), 'reset-token')
+        .withKeychainToken(server.baseUrl(), 'reset-token');
+
+      const account = generateKeychainAccount(server.baseUrl());
+      const env = harness.env();
+      try {
+        chmodSync(harness.keychainJsonFile, 0o444);
+        const result = await runCli('system reset --force', env, { cwd: harness.cwd.path });
+
+        expect(result.exitCode).toBe(1);
+        expect(result.stdout).toMatch(/Authentication:.*could not delete keychain entry/);
+        expect(result.stdout).toContain('keychain operation failed');
+        expect(result.stderr).toContain('System reset completed with warnings');
+
+        const state = readState(harness.stateJsonFile.path);
+        expect(state.auth.connections).toHaveLength(0);
+        expect(state.auth.isAuthenticated).toBe(false);
+        expect(readKeychainTokens(harness.keychainJsonFile)[account]).toBe('reset-token');
+      } finally {
+        if (existsSync(harness.keychainJsonFile)) {
+          chmodSync(harness.keychainJsonFile, 0o644);
+        }
+      }
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -38,8 +38,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { nativeGitIntegration } from '../../../../src/cli/commands/integrate/git/tools/native';
 import { SCA_SCANNER_CACHE_DIR } from '../../../../src/lib/config-constants';
 import { generateKeychainAccount } from '../../../../src/lib/keychain';
-import { runCli } from '../../harness/cli-runner.js';
 import { hookScriptName, TestHarness } from '../../harness';
+import { runCli } from '../../harness/cli-runner.js';
 import { buildHomeEnv, IS_WINDOWS } from '../../harness/platform';
 
 const CODEX_SQAA_SCRIPT_DIRS = ['.codex', 'hooks', 'sonar-sqaa', 'build-scripts'];

--- a/tests/unit/cli/commands/system/reset-auth.test.ts
+++ b/tests/unit/cli/commands/system/reset-auth.test.ts
@@ -27,9 +27,7 @@ import * as keychain from '../../../../../src/lib/keychain';
 import type { CliState } from '../../../../../src/lib/state';
 import { getDefaultState } from '../../../../../src/lib/state';
 
-function stateWithConnection(
-  overrides: Partial<CliState['auth']['connections'][number]> = {},
-): CliState {
+function stateWithConnection(): CliState {
   const state = getDefaultState('test');
   state.auth.isAuthenticated = true;
   state.auth.connections = [
@@ -41,14 +39,13 @@ function stateWithConnection(
       region: 'eu',
       tokenName: 'SonarQube CLI 9',
       authenticatedAt: new Date().toISOString(),
-      ...overrides,
     },
   ];
   state.auth.activeConnectionId = 'conn-1';
   return state;
 }
 
-describe('purgeAuth', () => {
+describe('purgeAuth keychain read failures', () => {
   afterEach(() => {
     spyOn(keychain, 'getToken').mockRestore();
     spyOn(keychain, 'deleteToken').mockRestore();
@@ -63,19 +60,7 @@ describe('purgeAuth', () => {
     spyOn(revokeServerToken, 'reportRevokeServerTokenOutcome').mockImplementation(() => {});
   });
 
-  it('clears state and deletes keychain entries when all steps succeed', async () => {
-    const getTokenSpy = spyOn(keychain, 'getToken').mockResolvedValue('squ_token');
-    const deleteTokenSpy = spyOn(keychain, 'deleteToken').mockResolvedValue(undefined);
-
-    const result = await purgeAuth(stateWithConnection());
-
-    expect(result.authConnectionIds).toEqual(['conn-1']);
-    expect(result.item.status).toBe('done');
-    expect(getTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'sonarsource');
-    expect(deleteTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'sonarsource');
-  });
-
-  it('still clears state when keychain read fails but delete succeeds', async () => {
+  it('still clears state and attempts delete when keychain read fails', async () => {
     spyOn(keychain, 'getToken').mockRejectedValue(
       new CommandFailedError('Failed to access the system keychain.'),
     );
@@ -86,11 +71,14 @@ describe('purgeAuth', () => {
     expect(result.authConnectionIds).toEqual(['conn-1']);
     expect(result.item.status).toBe('warn');
     expect(result.item.detail).toContain('could not read keychain entry');
+    expect(result.item.detail).toContain('1 keychain operation failed');
     expect(deleteTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'sonarsource');
   });
 
-  it('still clears state when keychain delete fails after a successful read', async () => {
-    spyOn(keychain, 'getToken').mockResolvedValue('squ_token');
+  it('reports multiple keychain operation failures for one connection', async () => {
+    spyOn(keychain, 'getToken').mockRejectedValue(
+      new CommandFailedError('Failed to access the system keychain.'),
+    );
     spyOn(keychain, 'deleteToken').mockRejectedValue(
       new CommandFailedError('Failed to access the system keychain.'),
     );
@@ -98,18 +86,8 @@ describe('purgeAuth', () => {
     const result = await purgeAuth(stateWithConnection());
 
     expect(result.authConnectionIds).toEqual(['conn-1']);
-    expect(result.item.status).toBe('warn');
+    expect(result.item.detail).toContain('2 keychain operations failed');
+    expect(result.item.detail).toContain('could not read keychain entry');
     expect(result.item.detail).toContain('could not delete keychain entry');
-  });
-
-  it('still attempts delete when read fails', async () => {
-    spyOn(keychain, 'getToken').mockRejectedValue(
-      new CommandFailedError('Failed to access the system keychain.'),
-    );
-    const deleteTokenSpy = spyOn(keychain, 'deleteToken').mockResolvedValue(undefined);
-
-    await purgeAuth(stateWithConnection());
-
-    expect(deleteTokenSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/cli/commands/system/reset-auth.test.ts
+++ b/tests/unit/cli/commands/system/reset-auth.test.ts
@@ -1,0 +1,115 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { CommandFailedError } from '../../../../../src/cli/commands/_common/error';
+import * as revokeServerToken from '../../../../../src/cli/commands/auth/revoke-server-token';
+import { purgeAuth } from '../../../../../src/cli/commands/system/reset-auth';
+import * as keychain from '../../../../../src/lib/keychain';
+import type { CliState } from '../../../../../src/lib/state';
+import { getDefaultState } from '../../../../../src/lib/state';
+
+function stateWithConnection(
+  overrides: Partial<CliState['auth']['connections'][number]> = {},
+): CliState {
+  const state = getDefaultState('test');
+  state.auth.isAuthenticated = true;
+  state.auth.connections = [
+    {
+      id: 'conn-1',
+      serverUrl: 'https://sonarcloud.io',
+      orgKey: 'sonarsource',
+      type: 'cloud',
+      region: 'eu',
+      tokenName: 'SonarQube CLI 9',
+      authenticatedAt: new Date().toISOString(),
+      ...overrides,
+    },
+  ];
+  state.auth.activeConnectionId = 'conn-1';
+  return state;
+}
+
+describe('purgeAuth', () => {
+  afterEach(() => {
+    spyOn(keychain, 'getToken').mockRestore();
+    spyOn(keychain, 'deleteToken').mockRestore();
+    spyOn(revokeServerToken, 'revokeServerTokenIfPossible').mockRestore();
+    spyOn(revokeServerToken, 'reportRevokeServerTokenOutcome').mockRestore();
+  });
+
+  beforeEach(() => {
+    spyOn(revokeServerToken, 'revokeServerTokenIfPossible').mockResolvedValue({
+      status: 'success',
+    });
+    spyOn(revokeServerToken, 'reportRevokeServerTokenOutcome').mockImplementation(() => {});
+  });
+
+  it('clears state and deletes keychain entries when all steps succeed', async () => {
+    const getTokenSpy = spyOn(keychain, 'getToken').mockResolvedValue('squ_token');
+    const deleteTokenSpy = spyOn(keychain, 'deleteToken').mockResolvedValue(undefined);
+
+    const result = await purgeAuth(stateWithConnection());
+
+    expect(result.authConnectionIds).toEqual(['conn-1']);
+    expect(result.item.status).toBe('done');
+    expect(getTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'sonarsource');
+    expect(deleteTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'sonarsource');
+  });
+
+  it('still clears state when keychain read fails but delete succeeds', async () => {
+    spyOn(keychain, 'getToken').mockRejectedValue(
+      new CommandFailedError('Failed to access the system keychain.'),
+    );
+    const deleteTokenSpy = spyOn(keychain, 'deleteToken').mockResolvedValue(undefined);
+
+    const result = await purgeAuth(stateWithConnection());
+
+    expect(result.authConnectionIds).toEqual(['conn-1']);
+    expect(result.item.status).toBe('warn');
+    expect(result.item.detail).toContain('could not read keychain entry');
+    expect(deleteTokenSpy).toHaveBeenCalledWith('https://sonarcloud.io', 'sonarsource');
+  });
+
+  it('still clears state when keychain delete fails after a successful read', async () => {
+    spyOn(keychain, 'getToken').mockResolvedValue('squ_token');
+    spyOn(keychain, 'deleteToken').mockRejectedValue(
+      new CommandFailedError('Failed to access the system keychain.'),
+    );
+
+    const result = await purgeAuth(stateWithConnection());
+
+    expect(result.authConnectionIds).toEqual(['conn-1']);
+    expect(result.item.status).toBe('warn');
+    expect(result.item.detail).toContain('could not delete keychain entry');
+  });
+
+  it('still attempts delete when read fails', async () => {
+    spyOn(keychain, 'getToken').mockRejectedValue(
+      new CommandFailedError('Failed to access the system keychain.'),
+    );
+    const deleteTokenSpy = spyOn(keychain, 'deleteToken').mockResolvedValue(undefined);
+
+    await purgeAuth(stateWithConnection());
+
+    expect(deleteTokenSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored authentication purge logic:**
  - Modularized token removal in `purgeConnectionAuth` to ensure keychain read/delete failures are captured as warnings rather than fatal errors.
  - Updated `purgeAuth` to continue the reset process even if specific keychain operations fail for individual connections.
- **Improved error reporting:**
  - Added `buildAuthResetPhaseItem` and `buildKeychainWarningDetail` to provide granular feedback in the CLI when keychain operations encounter issues.
- **Added test coverage:**
  - Added `reset-auth.test.ts` to verify that state clearing proceeds correctly despite keychain read or delete failures.


<sub>This will update automatically on new commits.</sub>