### PR TITLE
CLI-636 System reset ends with ❌ red output for a warning

### DIFF
--- a/src/cli/commands/system/reset.ts
+++ b/src/cli/commands/system/reset.ts
@@ -23,7 +23,6 @@ import { loadState, saveState } from '../../../lib/repository/state-repository';
 import { type CliState, getDefaultState, type InstalledIntegration } from '../../../lib/state';
 import type { PhaseItem } from '../../../ui';
 import { info, phase, print, success, text, textPrompt, warn } from '../../../ui';
-import { CommandFailedError } from '../_common/error';
 import { supportedIntegrations } from '../integrate';
 import { purgeAuth } from './reset-auth';
 import { removeBinaries } from './reset-binaries';
@@ -123,7 +122,9 @@ export async function systemReset(options: SystemResetOptions): Promise<void> {
     text(
       'CLI has been partially reset. Review the details above and clean up remaining items manually.',
     );
-    throw new CommandFailedError('System reset completed with warnings.');
+    warn('System reset completed with warnings.');
+    process.exitCode = 1;
+    return;
   }
 
   success('CLI has been successfully reset to factory settings.');


### PR DESCRIPTION

<img width="874" height="251" alt="image" src="https://github.com/user-attachments/assets/63a96b2b-c88a-42bb-88bb-60cc92c9ba09" />

----
## Summary by Gitar

- **Bug fixes:**
  - Modified `systemReset` to use `warn()` instead of throwing `CommandFailedError` when reset completes with warnings.
  - Set `process.exitCode = 1` when warnings occur to ensure proper CLI termination state.

<sub>This will update automatically on new commits.</sub>