### PR TITLE
CLI-638 Fix sonar analyze --file output when no project is configured

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -341,14 +341,12 @@ function applySqaaOptions(cmd: SonarCommand): SonarCommand {
       '-p, --project <project>',
       'SonarQube Cloud project key (overrides auto-detected project)',
     )
-    .authenticatedAction((auth, options: AnalyzeSqaaOptions, innerCmd: Command) =>
-      analyzeSqaa(options, auth, innerCmd),
-    );
+    .authenticatedAction((auth, options: AnalyzeSqaaOptions) => analyzeSqaa(options, auth));
 }
 
 // Default action for `sonar analyze` (no subcommand): run all analyses (secrets + agentic).
-applyBaseAgenticOptions(analyze).authenticatedAction(
-  (auth, options: AnalyzeAllOptions, innerCmd: Command) => analyzeAll(options, auth, innerCmd),
+applyBaseAgenticOptions(analyze).authenticatedAction((auth, options: AnalyzeAllOptions) =>
+  analyzeAll(options, auth),
 );
 
 const dependencyRisksFormatOption = new Option('--format <format>', 'Output format')

--- a/src/cli/commands/analyze/analyze-all.ts
+++ b/src/cli/commands/analyze/analyze-all.ts
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { Command } from 'commander';
-
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import {
   blank,
@@ -68,13 +66,9 @@ function printCombinedReport(secrets: SecretsReport | null, agentic: SqaaJsonRep
  * In json mode, outputs a single combined JSON report including any informational messages.
  * In text mode, each analysis prints its own output sequentially.
  */
-export async function analyzeAll(
-  options: AnalyzeAllOptions,
-  auth: ResolvedAuth,
-  command?: Command,
-): Promise<void> {
+export async function analyzeAll(options: AnalyzeAllOptions, auth: ResolvedAuth): Promise<void> {
   if (options.format === 'json') {
-    return analyzeAllJson(options, auth, command);
+    return analyzeAllJson(options, auth);
   }
 
   const { file, staged, base, force, format } = options;
@@ -83,7 +77,7 @@ export async function analyzeAll(
     await analyzeSecrets({ paths: [file] }, auth);
     // Bare `analyze` is a best-effort catch-all: skip agentic gracefully when no
     // project is configured rather than failing the whole command.
-    await analyzeSqaa({ file, format }, auth, command, { requireProject: false });
+    await analyzeSqaa({ file, format }, auth, { requireProject: false });
     return;
   }
 
@@ -103,20 +97,16 @@ export async function analyzeAll(
   // cover slightly different sets if the working tree changes between calls — this
   // is acceptable since the analyses are independent and best-effort.
   // requireProject: false → bare `analyze` skips agentic gracefully when unconfigured.
-  await analyzeSqaa({ staged, base, force, format }, auth, command, { requireProject: false });
+  await analyzeSqaa({ staged, base, force, format }, auth, { requireProject: false });
 }
 
-async function analyzeAllJson(
-  options: AnalyzeAllOptions,
-  auth: ResolvedAuth,
-  command?: Command,
-): Promise<void> {
+async function analyzeAllJson(options: AnalyzeAllOptions, auth: ResolvedAuth): Promise<void> {
   setFormattedOutputMode(true);
   try {
     const { file, staged, base } = options;
 
     if (file !== undefined) {
-      await runSecretsAndAgentic([file], options, auth, command);
+      await runSecretsAndAgentic([file], options, auth);
       return;
     }
 
@@ -127,7 +117,7 @@ async function analyzeAllJson(
       return;
     }
 
-    await runSecretsAndAgentic(changeSet.files, options, auth, command);
+    await runSecretsAndAgentic(changeSet.files, options, auth);
   } finally {
     setFormattedOutputMode(false);
   }
@@ -137,11 +127,10 @@ async function runSecretsAndAgentic(
   files: string[],
   options: AnalyzeAllOptions,
   auth: ResolvedAuth,
-  command?: Command,
 ): Promise<void> {
   const secrets = await runSecretsScan(files, auth);
   const secretsFailed = secrets !== null && secrets.exitCode !== 0;
-  const agentic = secretsFailed ? null : await buildSqaaJsonReport(options, auth, command);
+  const agentic = secretsFailed ? null : await buildSqaaJsonReport(options, auth);
 
   printCombinedReport(secrets?.report ?? null, agentic);
 

--- a/src/cli/commands/analyze/secrets.ts
+++ b/src/cli/commands/analyze/secrets.ts
@@ -159,7 +159,7 @@ function reportScanResult(result: SpawnResult, scanStartTime: number): void {
 
 function handleScanSuccess(result: { stdout: string }, scanDurationMs: number): void {
   blank();
-  success('Scan completed successfully');
+  success('Secrets scan completed successfully');
   try {
     const scanResult = JSON.parse(result.stdout);
     text(`  Duration: ${scanDurationMs}ms`);
@@ -169,7 +169,6 @@ function handleScanSuccess(result: { stdout: string }, scanDurationMs: number): 
     blank();
     print(result.stdout);
   }
-  blank();
 }
 
 function displayScanResults(scanResult: {

--- a/src/cli/commands/analyze/sqaa.ts
+++ b/src/cli/commands/analyze/sqaa.ts
@@ -19,8 +19,6 @@
  */
 import { existsSync } from 'node:fs';
 
-import type { Command } from 'commander';
-
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import { blank, print, text, warn } from '../../../ui';
 import { SqaaProgress } from '../../../ui/components/sqaa-progress.js';
@@ -79,7 +77,7 @@ export interface AnalyzeSqaaOptions {
  */
 function resolveSqaaContext(
   resolution: SqaaAuthResolution,
-  policy: { requireProject: boolean; command?: Command },
+  policy: { requireProject: boolean },
 ): { cloudAuth: CloudAuth; projectKey: string } | null {
   switch (resolution.kind) {
     case 'resolved':
@@ -106,7 +104,6 @@ function resolveSqaaContext(
 export async function analyzeSqaa(
   options: AnalyzeSqaaOptions,
   auth: ResolvedAuth,
-  command?: Command,
   runOptions: { requireProject?: boolean } = {},
 ): Promise<void> {
   // Explicit `analyze agentic` / `verify` require a project (exit 1 when missing);
@@ -122,7 +119,7 @@ export async function analyzeSqaa(
     if (!existsSync(file)) {
       throw new InvalidOptionError(`File not found: ${file}`);
     }
-    await runSqaaAnalysis(file, auth, branch, project, command, format, requireProject);
+    await runSqaaAnalysis(file, auth, branch, project, format, requireProject);
     return;
   }
 
@@ -146,7 +143,7 @@ export async function analyzeSqaa(
   // Resolve cloud auth + project key BEFORE prompting.
   // Pass repoRoot so we reuse the already-resolved root instead of spawning git again.
   const resolution = await resolveCloudAuthAndProject(auth, project, changeSet.repoRoot);
-  const resolved = resolveSqaaContext(resolution, { requireProject, command });
+  const resolved = resolveSqaaContext(resolution, { requireProject });
   if (!resolved) return;
 
   // JSON mode is consumed by scripts/CI: never block on an interactive prompt
@@ -163,12 +160,11 @@ async function runSqaaAnalysis(
   auth: ResolvedAuth,
   branch?: string,
   explicitProject?: string,
-  command?: Command,
   format: OutputFormat = 'text',
   requireProject = true,
 ): Promise<void> {
   const resolution = await resolveCloudAuthAndProject(auth, explicitProject);
-  const resolved = resolveSqaaContext(resolution, { requireProject, command });
+  const resolved = resolveSqaaContext(resolution, { requireProject });
   if (!resolved) return;
 
   const { cloudAuth, projectKey } = resolved;
@@ -258,13 +254,12 @@ async function fetchSingleFileReport(
 export async function buildSqaaJsonReport(
   options: AnalyzeSqaaOptions,
   auth: ResolvedAuth,
-  command?: Command,
 ): Promise<SqaaJsonReport | null> {
   const { file, staged, base, branch, project, force } = options;
 
   if (file !== undefined) {
     const resolution = await resolveCloudAuthAndProject(auth, project);
-    const resolved = resolveSqaaContext(resolution, { requireProject: false, command });
+    const resolved = resolveSqaaContext(resolution, { requireProject: false });
     if (!resolved) return null;
 
     const { cloudAuth, projectKey } = resolved;
@@ -283,7 +278,7 @@ export async function buildSqaaJsonReport(
   }
 
   const resolution = await resolveCloudAuthAndProject(auth, project, changeSet.repoRoot);
-  const resolved = resolveSqaaContext(resolution, { requireProject: false, command });
+  const resolved = resolveSqaaContext(resolution, { requireProject: false });
   if (!resolved) return null;
 
   // JSON mode is consumed by scripts/CI: never block on an interactive prompt

--- a/src/cli/commands/analyze/sqaa.ts
+++ b/src/cli/commands/analyze/sqaa.ts
@@ -99,7 +99,6 @@ function resolveSqaaContext(
       warn(
         'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
       );
-      if (process.stdin.isTTY) policy.command?.outputHelp();
       return null;
   }
 }

--- a/tests/integration/specs/analyze/analyze-secrets.test.ts
+++ b/tests/integration/specs/analyze/analyze-secrets.test.ts
@@ -77,7 +77,7 @@ describe('analyze secrets', () => {
       const result = await harness.run('analyze secrets clean.js');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Scan completed successfully');
+      expect(result.stdout + result.stderr).toContain('Secrets scan completed successfully');
     },
     { timeout: 30000 },
   );
@@ -108,7 +108,7 @@ describe('analyze secrets', () => {
       const result = await harness.run('analyze secrets --stdin', { stdin: CLEAN_CONTENT });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Scan completed successfully');
+      expect(result.stdout + result.stderr).toContain('Secrets scan completed successfully');
     },
     { timeout: 30000 },
   );
@@ -141,7 +141,7 @@ describe('analyze secrets', () => {
       const result = await harness.run('analyze secrets clean.js');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Scan completed successfully');
+      expect(result.stdout + result.stderr).toContain('Secrets scan completed successfully');
       expect(harness.cliHome.file('bin', buildLocalBinaryName(detectPlatform())).exists()).toBe(
         true,
       );

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -258,6 +258,39 @@ describe('analyze (no subcommand)', () => {
   );
 
   it(
+    'does not print help when --file is used without a configured project',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+
+      harness
+        .state()
+        .withSecretsBinaryInstalled()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      harness.cwd.writeFile('target.ts', 'const x = 1;');
+
+      const result = await harness.run('analyze --file target.ts', {
+        extraEnv: { SONAR_SECRETS_ALLOW_UNSECURE_HTTP: 'true' },
+      });
+
+      const output = result.stdout + result.stderr;
+      expect(result.exitCode).toBe(0);
+      expect(output).toContain('Secrets scan completed successfully');
+      expect(output).toContain('SonarQube Agentic Analysis skipped: no project configured');
+      expect(output).not.toContain('Usage: sonar analyze');
+      const sqaaCalls = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/a3s-analysis/analyses');
+      expect(sqaaCalls).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'exits with code 0 and reports no files when change set is empty (text mode)',
     async () => {
       const server = await harness.newFakeServer().withAuthToken(VALID_TOKEN).start();

--- a/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
@@ -169,9 +169,13 @@ describe('analyzeSqaa: auth resolution', () => {
   it('skips SQAA and warns when extension has no projectKey and requireProject is false (bare analyze)', async () => {
     loadStateSpy.mockReturnValue(stateWithExtensionMissingProjectKey());
 
-    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH, undefined, { requireProject: false });
+    const command = { outputHelp: () => {} } as import('commander').Command;
+    const outputHelpSpy = spyOn(command, 'outputHelp');
+
+    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH, command, { requireProject: false });
 
     expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(outputHelpSpy).not.toHaveBeenCalled();
     const output = getMockUiCalls()
       .map((c) => String(c.args[0]))
       .join('\n');

--- a/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
@@ -169,13 +169,9 @@ describe('analyzeSqaa: auth resolution', () => {
   it('skips SQAA and warns when extension has no projectKey and requireProject is false (bare analyze)', async () => {
     loadStateSpy.mockReturnValue(stateWithExtensionMissingProjectKey());
 
-    const command = { outputHelp: () => {} } as import('commander').Command;
-    const outputHelpSpy = spyOn(command, 'outputHelp');
-
-    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH, command, { requireProject: false });
+    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH, { requireProject: false });
 
     expect(analyzeFileSpy).not.toHaveBeenCalled();
-    expect(outputHelpSpy).not.toHaveBeenCalled();
     const output = getMockUiCalls()
       .map((c) => String(c.args[0]))
       .join('\n');


### PR DESCRIPTION
----
## Summary by Gitar

- **CLI output improvements:**
  - Rename success message from `Scan completed successfully` to `Secrets scan completed successfully`.
  - Suppress help menu output when `analyze --file` is executed without a configured project.
- **Refactoring:**
  - Remove redundant `Command` parameter from `analyzeSqaa`, `analyzeAll`, and helper functions across the CLI stack.
- **Testing:**
  - Add integration test to verify correct handling of `analyze --file` when no project is configured.
  - Update unit tests to ensure `outputHelp` is not triggered during SQAA execution.

<sub>This will update automatically on new commits.</sub>