### PR TITLE
CLI-619 Add sonar integrate cursor (MCP server + foundation)

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -70,6 +70,7 @@ import type { IntegrateAgentOptions } from './commands/integrate/_common/types';
 import { integrateClaude } from './commands/integrate/claude';
 import { integrateCodex } from './commands/integrate/codex';
 import { integrateCopilot } from './commands/integrate/copilot';
+import { integrateCursor } from './commands/integrate/cursor';
 import { integrateGit, type IntegrateGitOptions } from './commands/integrate/git';
 import {
   listIssues,
@@ -299,6 +300,22 @@ integrateCommand
   .option('--skip-context', 'Skip the sonar-context-augmentation install/init/skill step')
   .addHelpText('after', projectKeyExtraHelp)
   .authenticatedAction((auth, options: IntegrateAgentOptions) => integrateCodex(options, auth));
+
+// hidden until stable — remove { hidden: true } when sonar integrate cursor goes GA (CLI-221)
+integrateCommand
+  .command('cursor', { hidden: true })
+  .description(
+    'Setup SonarQube integration for Cursor. This will configure the SonarQube MCP Server, install secrets scanning hooks, and configure SonarQube Agentic Analysis.',
+  )
+  .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
+  .option('--non-interactive', 'Non-interactive mode (no prompts)')
+  .option(
+    '-g, --global',
+    "Install config globally to ~/.cursor instead of project directory. Note: Cursor's cloud/background agents only pick up project-level hooks, not global ones.",
+  )
+  .option('--skip-context', 'Skip the sonar-context-augmentation install/init/skill step')
+  .addHelpText('after', projectKeyExtraHelp)
+  .authenticatedAction((auth, options: IntegrateAgentOptions) => integrateCursor(options, auth));
 
 // Analyze code for quality and security issues
 const analyze = COMMAND_TREE.command('analyze')

--- a/src/cli/commands/integrate/_common/agent-integrate-prelude.ts
+++ b/src/cli/commands/integrate/_common/agent-integrate-prelude.ts
@@ -31,7 +31,7 @@ import { isGlobalIntegrateScope, resolveIntegrateScope } from './integrate-scope
 import { printAgentPreflightSummary } from './preflight-summary';
 import type { IntegrateAgentOptions } from './types';
 
-export type AgentIntegrateSubcommand = 'claude' | 'codex' | 'copilot';
+export type AgentIntegrateSubcommand = 'claude' | 'codex' | 'copilot' | 'cursor';
 
 export interface AgentIntegrateContext {
   project: DiscoveredProject;

--- a/src/cli/commands/integrate/_common/mcp-config.ts
+++ b/src/cli/commands/integrate/_common/mcp-config.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-/** Shared MCP config remove helpers for declarative integration patch resources. */
+/** Shared MCP config helpers for declarative integration patch resources. */
 
 export const SONARQUBE_MCP_SERVER_ID = 'sonarqube';
 
@@ -50,7 +50,25 @@ function toMcpSettings(document: unknown): {
 }
 
 /**
- * Remove a server entry from JSON MCP config (`mcpServers` object), e.g. Claude/Copilot.
+ * Upsert a server entry into a JSON MCP config (`mcpServers` object), e.g. Claude/Copilot/Cursor.
+ */
+export function upsertJsonMcpServer(
+  document: unknown,
+  serverConfig: object,
+  serverId: string = SONARQUBE_MCP_SERVER_ID,
+): Record<string, unknown> {
+  const settings = toMcpSettings(document);
+  return {
+    ...settings,
+    mcpServers: {
+      ...settings.mcpServers,
+      [serverId]: serverConfig,
+    },
+  };
+}
+
+/**
+ * Remove a server entry from JSON MCP config (`mcpServers` object), e.g. Claude/Copilot/Cursor.
  */
 export function removeJsonMcpServer(
   document: unknown,

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -31,7 +31,7 @@ import {
   resolveAgentHookScriptPath,
   upsertAgentHooks,
 } from '../_common/hooks';
-import { removeJsonMcpServer } from '../_common/mcp-config';
+import { removeJsonMcpServer, upsertJsonMcpServer } from '../_common/mcp-config';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
 import { askUser, jsonPatch, skip, wholeFile } from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
@@ -168,7 +168,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
           targetPath: resolveClaudeMcpConfigPath,
           defaultValue: {},
           patch: (document, context) =>
-            upsertClaudeMcpServer(document, getDesiredClaudeMcpConfig(context)),
+            upsertJsonMcpServer(document, getDesiredClaudeMcpConfig(context)),
           removePatch: (document) => removeJsonMcpServer(document),
         }),
       ],
@@ -198,17 +198,6 @@ function resolveClaudeSkillPath(context: IntegrationContext): string {
   );
 }
 
-function upsertClaudeMcpServer(document: unknown, serverConfig: object): Record<string, unknown> {
-  const settings = toMcpSettings(document);
-  return {
-    ...settings,
-    mcpServers: {
-      ...settings.mcpServers,
-      sonarqube: serverConfig,
-    },
-  };
-}
-
 function getDesiredClaudeMcpConfig(context: IntegrationContext) {
   return getMcpConfig(
     CLI_COMMAND,
@@ -220,24 +209,4 @@ function getDesiredClaudeMcpConfig(context: IntegrationContext) {
           projectKey: getOptionalStringAttr(context, 'projectKey'),
         },
   );
-}
-
-function toMcpSettings(document: unknown): {
-  mcpServers: Record<string, unknown>;
-  [key: string]: unknown;
-} {
-  if (!document || typeof document !== 'object' || Array.isArray(document)) {
-    return { mcpServers: {} };
-  }
-
-  const settings = document as { mcpServers?: unknown; [key: string]: unknown };
-  return {
-    ...settings,
-    mcpServers:
-      settings.mcpServers &&
-      typeof settings.mcpServers === 'object' &&
-      !Array.isArray(settings.mcpServers)
-        ? { ...(settings.mcpServers as Record<string, unknown>) }
-        : {},
-  };
 }

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -30,7 +30,7 @@ import {
   sonarBeginMarker,
   sonarEndMarker,
 } from '../_common/instructions-templates';
-import { removeJsonMcpServer } from '../_common/mcp-config';
+import { removeJsonMcpServer, upsertJsonMcpServer } from '../_common/mcp-config';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
 import {
   askUser,
@@ -156,7 +156,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
           targetPath: resolveCopilotMcpConfigPath,
           defaultValue: {},
           patch: (document, context) =>
-            upsertCopilotMcpServer(document, getDesiredCopilotMcpConfig(context)),
+            upsertJsonMcpServer(document, getDesiredCopilotMcpConfig(context)),
           removePatch: (document) => removeJsonMcpServer(document),
         }),
       ],
@@ -239,18 +239,6 @@ function createHookCommandEntry(context: IntegrationContext): HookCommandEntry {
       };
 }
 
-function upsertCopilotMcpServer(document: unknown, serverConfig: object): Record<string, unknown> {
-  const existing = toJsonObject(document);
-  const mcpServers = toJsonObject(existing.mcpServers);
-  return {
-    ...existing,
-    mcpServers: {
-      ...mcpServers,
-      sonarqube: serverConfig,
-    },
-  };
-}
-
 function getDesiredCopilotMcpConfig(context: IntegrationContext) {
   return getMcpConfig(
     CLI_COMMAND,
@@ -262,11 +250,4 @@ function getDesiredCopilotMcpConfig(context: IntegrationContext) {
           projectKey: getOptionalStringAttr(context, 'projectKey'),
         },
   );
-}
-
-function toJsonObject(document: unknown): Record<string, unknown> {
-  if (!document || typeof document !== 'object' || Array.isArray(document)) {
-    return {};
-  }
-  return { ...(document as Record<string, unknown>) };
 }

--- a/src/cli/commands/integrate/cursor/declaration.ts
+++ b/src/cli/commands/integrate/cursor/declaration.ts
@@ -21,7 +21,7 @@
 import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { getOptionalStringAttr } from '../_common/attrs';
-import { removeJsonMcpServer } from '../_common/mcp-config';
+import { removeJsonMcpServer, upsertJsonMcpServer } from '../_common/mcp-config';
 import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
 import { jsonPatch } from '../_common/registry';
 import type { IntegrateAgentOptions } from '../_common/types';
@@ -34,37 +34,6 @@ export type CursorIntegrationOptions = IntegrateAgentOptions;
 
 function resolveCursorMcpConfigPath(context: IntegrationContext): string {
   return getMcpConfigFilePath('cursor', context.scope === 'global', context.targetRoot);
-}
-
-function toMcpSettings(document: unknown): {
-  mcpServers: Record<string, unknown>;
-  [key: string]: unknown;
-} {
-  if (!document || typeof document !== 'object' || Array.isArray(document)) {
-    return { mcpServers: {} };
-  }
-
-  const settings = document as { mcpServers?: unknown; [key: string]: unknown };
-  return {
-    ...settings,
-    mcpServers:
-      settings.mcpServers &&
-      typeof settings.mcpServers === 'object' &&
-      !Array.isArray(settings.mcpServers)
-        ? { ...(settings.mcpServers as Record<string, unknown>) }
-        : {},
-  };
-}
-
-function upsertCursorMcpServer(document: unknown, serverConfig: object): Record<string, unknown> {
-  const settings = toMcpSettings(document);
-  return {
-    ...settings,
-    mcpServers: {
-      ...settings.mcpServers,
-      sonarqube: serverConfig,
-    },
-  };
 }
 
 function getDesiredCursorMcpConfig(context: IntegrationContext) {
@@ -94,7 +63,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
           targetPath: resolveCursorMcpConfigPath,
           defaultValue: {},
           patch: (document, context) =>
-            upsertCursorMcpServer(document, getDesiredCursorMcpConfig(context)),
+            upsertJsonMcpServer(document, getDesiredCursorMcpConfig(context)),
           removePatch: (document) => removeJsonMcpServer(document),
         }),
       ],

--- a/src/cli/commands/integrate/cursor/declaration.ts
+++ b/src/cli/commands/integrate/cursor/declaration.ts
@@ -1,0 +1,103 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { CLI_COMMAND } from '../../../../lib/config-constants';
+import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
+import { getOptionalStringAttr } from '../_common/attrs';
+import { removeJsonMcpServer } from '../_common/mcp-config';
+import type { IntegrationContext, IntegrationDeclaration } from '../_common/registry';
+import { jsonPatch } from '../_common/registry';
+import type { IntegrateAgentOptions } from '../_common/types';
+
+export const CURSOR_CONFIG_DIR = '.cursor';
+
+export const CURSOR_INTEGRATION_ID = 'cursor';
+
+export type CursorIntegrationOptions = IntegrateAgentOptions;
+
+function resolveCursorMcpConfigPath(context: IntegrationContext): string {
+  return getMcpConfigFilePath('cursor', context.scope === 'global', context.targetRoot);
+}
+
+function toMcpSettings(document: unknown): {
+  mcpServers: Record<string, unknown>;
+  [key: string]: unknown;
+} {
+  if (!document || typeof document !== 'object' || Array.isArray(document)) {
+    return { mcpServers: {} };
+  }
+
+  const settings = document as { mcpServers?: unknown; [key: string]: unknown };
+  return {
+    ...settings,
+    mcpServers:
+      settings.mcpServers &&
+      typeof settings.mcpServers === 'object' &&
+      !Array.isArray(settings.mcpServers)
+        ? { ...(settings.mcpServers as Record<string, unknown>) }
+        : {},
+  };
+}
+
+function upsertCursorMcpServer(document: unknown, serverConfig: object): Record<string, unknown> {
+  const settings = toMcpSettings(document);
+  return {
+    ...settings,
+    mcpServers: {
+      ...settings.mcpServers,
+      sonarqube: serverConfig,
+    },
+  };
+}
+
+function getDesiredCursorMcpConfig(context: IntegrationContext) {
+  return getMcpConfig(
+    CLI_COMMAND,
+    context.scope === 'global'
+      ? { withFsMount: false }
+      : {
+          withFsMount: true,
+          projectRoot: context.targetRoot,
+          projectKey: getOptionalStringAttr(context, 'projectKey'),
+        },
+  );
+}
+
+export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions> = {
+  id: CURSOR_INTEGRATION_ID,
+  displayName: 'Cursor',
+  features: [
+    {
+      id: 'mcp-server',
+      displayName: 'MCP server',
+      resources: [
+        jsonPatch({
+          id: 'cursor-mcp-config',
+          displayName: 'Cursor MCP configuration',
+          targetPath: resolveCursorMcpConfigPath,
+          defaultValue: {},
+          patch: (document, context) =>
+            upsertCursorMcpServer(document, getDesiredCursorMcpConfig(context)),
+          removePatch: (document) => removeJsonMcpServer(document),
+        }),
+      ],
+    },
+  ],
+};

--- a/src/cli/commands/integrate/cursor/index.ts
+++ b/src/cli/commands/integrate/cursor/index.ts
@@ -1,0 +1,70 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integrate command — setup SonarQube integration for Cursor.
+
+import type { ResolvedAuth } from '../../../../lib/auth-resolver';
+import type { IntegrationStateAttribute } from '../../../../lib/state';
+import { warn } from '../../../../ui';
+import {
+  displayAgentIntegratePrelude,
+  resolveIntegrateInstallTarget,
+} from '../_common/agent-integrate-prelude';
+import { installIntegration } from '../_common/registry';
+import type { IntegrateAgentOptions } from '../_common/types';
+import { supportedIntegrations } from '../index.js';
+import { CURSOR_INTEGRATION_ID } from './declaration';
+
+export async function integrateCursor(
+  options: IntegrateAgentOptions,
+  auth: ResolvedAuth,
+): Promise<void> {
+  const ctx = await displayAgentIntegratePrelude('Cursor', 'cursor', options, auth);
+
+  if (ctx.isGlobal) {
+    warn(
+      "Cursor's cloud/background agents only pick up project-level hooks, not global ones. Re-run without --global from a project directory for full hook coverage.",
+    );
+  }
+
+  const { installRoot, installScope } = resolveIntegrateInstallTarget(
+    ctx.isGlobal,
+    ctx.project.rootDir,
+  );
+
+  await installIntegration({
+    registry: supportedIntegrations,
+    integrationId: CURSOR_INTEGRATION_ID,
+    options,
+    targetRoot: installRoot,
+    scope: installScope,
+    auth,
+    nonInteractive: options.nonInteractive,
+    attrs: buildAttrs({ projectKey: ctx.projectKey }),
+  });
+}
+
+function buildAttrs(args: {
+  projectKey: string | undefined;
+}): Record<string, IntegrationStateAttribute> {
+  return {
+    projectKey: args.projectKey ?? null,
+  };
+}

--- a/src/cli/commands/integrate/index.ts
+++ b/src/cli/commands/integrate/index.ts
@@ -22,12 +22,14 @@ import { createIntegrationRegistry } from './_common/registry';
 import { claudeIntegration } from './claude/declaration';
 import { codexIntegration } from './codex/declaration';
 import { copilotIntegration } from './copilot/declaration';
+import { cursorIntegration } from './cursor/declaration';
 import { GIT_INTEGRATIONS } from './git/tools';
 
 export const ALL_INTEGRATIONS = [
   claudeIntegration,
   copilotIntegration,
   codexIntegration,
+  cursorIntegration,
   ...GIT_INTEGRATIONS,
 ] as const;
 

--- a/src/lib/mcp/mcp-helper.ts
+++ b/src/lib/mcp/mcp-helper.ts
@@ -170,6 +170,10 @@ export function getMcpConfigFilePath(
     return isGlobal
       ? join(homedir(), '.codex', 'config.toml')
       : join(projectRoot, '.codex', 'config.toml');
+  } else if (agent === 'cursor') {
+    return isGlobal
+      ? join(homedir(), '.cursor', 'mcp.json')
+      : join(projectRoot, '.cursor', 'mcp.json');
   }
   throw new Error(`Unsupported agent: ${agent}`);
 }

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -1,0 +1,235 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integration tests for `sonar integrate cursor`.
+// PR 1 (CLI-619): covers MCP server setup, scope semantics, idempotency, and
+// state recording. Hook and CAG tests are added in subsequent PRs.
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { TestHarness } from '../../harness';
+import { findInstalledFeature, getInstalledIntegration } from './state-helpers';
+
+const MCP_JSON_DIRS = ['.cursor', 'mcp.json'];
+
+interface CursorMcpFile {
+  mcpServers?: Record<string, { command?: string; args?: string[] }>;
+}
+
+describe('integrate cursor', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+    const server = await harness.newFakeServer().withAuthToken('tok').start();
+    harness.withAuth(server.baseUrl(), 'tok');
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it('is not listed in sonar integrate --help (hidden until GA)', async () => {
+    const result = await harness.run('integrate --help');
+    expect(result.stdout).not.toContain('cursor');
+  });
+
+  describe('project-level install (default)', () => {
+    it(
+      'writes .cursor/mcp.json with a sonarqube MCP server entry',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withProject('my-project')
+          .start();
+        harness.withAuth(server.baseUrl(), 'test-token');
+        harness.cwd.writeFile(
+          'sonar-project.properties',
+          [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=my-project'].join('\n'),
+        );
+
+        const result = await harness.run('integrate cursor --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+        expect(harness.cwd.exists(...MCP_JSON_DIRS)).toBe(true);
+
+        const mcp: CursorMcpFile = harness.cwd.file(...MCP_JSON_DIRS).asJson();
+        expect(mcp.mcpServers?.sonarqube).toBeDefined();
+        expect(mcp.mcpServers?.sonarqube?.command).toBeDefined();
+        expect(mcp.mcpServers?.sonarqube?.args).toContain('mcp');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'records mcp-server feature in state with project scope',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withProject('my-project')
+          .start();
+        harness.withAuth(server.baseUrl(), 'test-token');
+        harness.cwd.writeFile(
+          'sonar-project.properties',
+          [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=my-project'].join('\n'),
+        );
+
+        const result = await harness.run('integrate cursor --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+
+        const integration = getInstalledIntegration(harness, 'cursor');
+        expect(integration).toBeDefined();
+        expect(integration!.features.map((f) => f.featureId).sort()).toEqual(['mcp-server']);
+
+        const mcpFeature = findInstalledFeature(harness, 'cursor', 'mcp-server');
+        expect(mcpFeature).toMatchObject({
+          scope: 'project',
+          resources: [
+            {
+              id: 'cursor-mcp-config',
+              resourceType: 'json-patch',
+              path: harness.cwd.file(...MCP_JSON_DIRS).path,
+            },
+          ],
+        });
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'uses a project-relative command path so the config is portable',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withProject('my-project')
+          .start();
+        harness.withAuth(server.baseUrl(), 'test-token');
+        harness.cwd.writeFile(
+          'sonar-project.properties',
+          [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=my-project'].join('\n'),
+        );
+
+        await harness.run('integrate cursor --non-interactive');
+
+        const mcp: CursorMcpFile = harness.cwd.file(...MCP_JSON_DIRS).asJson();
+        expect(mcp.mcpServers?.sonarqube?.args).toContain('my-project');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      're-running is idempotent — does not duplicate mcpServers entries',
+      async () => {
+        await harness.run('integrate cursor --non-interactive');
+        const firstBody = harness.cwd.file(...MCP_JSON_DIRS).asText();
+
+        const result = await harness.run('integrate cursor --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+        expect(harness.cwd.file(...MCP_JSON_DIRS).asText()).toBe(firstBody);
+
+        const mcp: CursorMcpFile = harness.cwd.file(...MCP_JSON_DIRS).asJson();
+        expect(Object.keys(mcp.mcpServers ?? {})).toHaveLength(1);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'fails when the existing .cursor/mcp.json contains invalid JSON',
+      async () => {
+        harness.cwd.writeFile('.cursor/mcp.json', '{ invalid json');
+
+        const result = await harness.run('integrate cursor --non-interactive');
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('invalid JSON');
+      },
+      { timeout: 30000 },
+    );
+  });
+
+  describe('global install (-g)', () => {
+    it(
+      'writes to ~/.cursor/mcp.json and not to the project directory',
+      async () => {
+        const result = await harness.run('integrate cursor -g --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+        expect(harness.cwd.exists(...MCP_JSON_DIRS)).toBe(false);
+        expect(harness.userHome.exists(...MCP_JSON_DIRS)).toBe(true);
+
+        const mcp: CursorMcpFile = harness.userHome.file(...MCP_JSON_DIRS).asJson();
+        expect(mcp.mcpServers?.sonarqube).toBeDefined();
+        expect(mcp.mcpServers?.sonarqube?.args).toContain('mcp');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'records mcp-server feature with global scope in state',
+      async () => {
+        const result = await harness.run('integrate cursor -g --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+
+        const mcpFeature = findInstalledFeature(harness, 'cursor', 'mcp-server', 'global');
+        expect(mcpFeature).toBeDefined();
+        expect(mcpFeature).toMatchObject({
+          scope: 'global',
+          resources: [
+            {
+              id: 'cursor-mcp-config',
+              resourceType: 'json-patch',
+              path: harness.userHome.file(...MCP_JSON_DIRS).path,
+            },
+          ],
+        });
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'emits a warning that cloud agents only pick up project-level hooks',
+      async () => {
+        const result = await harness.run('integrate cursor -g --non-interactive');
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stderr).toContain('cloud');
+      },
+      { timeout: 30000 },
+    );
+  });
+
+  it(
+    'rejects --global combined with --project',
+    async () => {
+      const result = await harness.run(
+        'integrate cursor --global --project my-project --non-interactive',
+      );
+      expect(result.exitCode).toBe(2);
+    },
+    { timeout: 30000 },
+  );
+});

--- a/tests/unit/cli/commands/integrate/_common/mcp-config.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/mcp-config.test.ts
@@ -28,6 +28,7 @@ import {
 import {
   removeCodexMcpServer,
   removeJsonMcpServer,
+  upsertJsonMcpServer,
 } from '../../../../../../src/cli/commands/integrate/_common/mcp-config';
 import { removeCopilotHookConfig } from '../../../../../../src/cli/commands/integrate/copilot/hooks';
 import {
@@ -62,6 +63,55 @@ describe('integration remove helpers', () => {
 
     expect(removed.hooks?.PostToolUse).toHaveLength(1);
     expect(removed.hooks?.PostToolUse?.[0]?.hooks[0]?.command).toBe('other');
+  });
+
+  it('upsertJsonMcpServer inserts sonarqube entry into an empty document', () => {
+    const result = upsertJsonMcpServer({}, { command: 'sonar', args: ['run', 'mcp'] });
+
+    expect(result.mcpServers).toEqual({ sonarqube: { command: 'sonar', args: ['run', 'mcp'] } });
+  });
+
+  it('upsertJsonMcpServer preserves existing mcpServers entries', () => {
+    const result = upsertJsonMcpServer(
+      { mcpServers: { other: { command: 'x' } } },
+      { command: 'sonar', args: ['run', 'mcp'] },
+    );
+
+    expect(result.mcpServers).toEqual({
+      other: { command: 'x' },
+      sonarqube: { command: 'sonar', args: ['run', 'mcp'] },
+    });
+  });
+
+  it('upsertJsonMcpServer overwrites an existing sonarqube entry', () => {
+    const result = upsertJsonMcpServer(
+      { mcpServers: { sonarqube: { command: 'old' } } },
+      { command: 'sonar', args: ['run', 'mcp'] },
+    );
+
+    expect(result.mcpServers).toEqual({ sonarqube: { command: 'sonar', args: ['run', 'mcp'] } });
+  });
+
+  it('upsertJsonMcpServer preserves other top-level keys', () => {
+    const result = upsertJsonMcpServer({ inputs: [{ type: 'promptString', id: 'token' }] }, {});
+
+    expect(result.inputs).toEqual([{ type: 'promptString', id: 'token' }]);
+  });
+
+  it('upsertJsonMcpServer handles a non-object document gracefully', () => {
+    expect(upsertJsonMcpServer(null, { command: 'sonar' }).mcpServers).toEqual({
+      sonarqube: { command: 'sonar' },
+    });
+    expect(upsertJsonMcpServer(['unexpected'], { command: 'sonar' }).mcpServers).toEqual({
+      sonarqube: { command: 'sonar' },
+    });
+  });
+
+  it('upsertJsonMcpServer uses a custom serverId when provided', () => {
+    const result = upsertJsonMcpServer({}, { command: 'sonar' }, 'my-server');
+
+    expect(result.mcpServers).toEqual({ 'my-server': { command: 'sonar' } });
+    expect(result.mcpServers).not.toHaveProperty('sonarqube');
   });
 
   it('removeJsonMcpServer drops sonarqube server only', () => {

--- a/tests/unit/cli/commands/integrate/claude/mcp.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/mcp.test.ts
@@ -299,8 +299,8 @@ describe('getMcpConfigFilePath', () => {
   });
 
   it('throws for an unsupported agent', () => {
-    expect(() => getMcpConfigFilePath('cursor', false, '/fake/project')).toThrow(
-      'Unsupported agent: cursor',
+    expect(() => getMcpConfigFilePath('unknown-agent', false, '/fake/project')).toThrow(
+      'Unsupported agent: unknown-agent',
     );
   });
 });


### PR DESCRIPTION
Register the cursor integration declaration with a single MCP server feature, wire up getMcpConfigFilePath for cursor (.cursor/mcp.json), and add the hidden cursor (until all of the `integrate cursor` are implemented) subcommand with integration tests.