### PR TITLE
CLI-639 Mark analyze dependency-risks as beta

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -375,7 +375,9 @@ const dependencyRisksStatusFilterOption = new Option(
 
 analyze
   .command('dependency-risks')
-  .description('Analyze project dependencies for security and license risks')
+  .description(
+    'Analyze project dependencies for security and license risks (beta: subject to change)',
+  )
   .requiredOption('-p, --project <project>', 'Project key')
   .addOption(dependencyRisksFormatOption)
   .addOption(dependencyRisksStatusFilterOption)

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -49,7 +49,7 @@ export async function analyzeDependencyRisks(
   options: AnalyzeDependencyRisksOptions,
   auth: ResolvedAuth,
 ): Promise<void> {
-  warn('analyze dependency-risks is in Beta');
+  warn(`'analyze dependency-risks' is in Beta`);
   warn(
     'Dependency manifest files (e.g. package-lock.json, pom.xml) will be uploaded to SonarQube for analysis.\n' +
       '  → Learn more: https://docs.sonarsource.com/sonarqube-server/advanced-security/analyzing-projects-for-dependencies#supported-languages-and-package-managers',

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -49,6 +49,12 @@ export async function analyzeDependencyRisks(
   options: AnalyzeDependencyRisksOptions,
   auth: ResolvedAuth,
 ): Promise<void> {
+  warn('analyze dependency-risks is in Beta');
+  warn(
+    'Dependency manifest files (e.g. package-lock.json, pom.xml) will be uploaded to SonarQube for analysis.\n' +
+      '  → Learn more: https://docs.sonarsource.com/sonarqube-server/advanced-security/analyzing-projects-for-dependencies#supported-languages-and-package-managers',
+  );
+
   const filter = buildRiskFilter(options.statuses);
   if (!filter) {
     throw new InvalidOptionError(`Invalid --statuses value: '${options.statuses}'`);

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -48,7 +48,7 @@ function getExpectedRootHelp(): string {
     '  COMMANDS',
     '    analyze                               Analyze code for quality and security issues',
     '    analyze secrets                       Scan files or stdin for hardcoded secrets',
-    '    analyze dependency-risks              Analyze project dependencies for security and license risks',
+    '    analyze dependency-risks              Analyze project dependencies for security and license risks (beta: subject to change)',
     '    analyze agentic                       Run server-side Agentic Analysis (SonarQube Cloud only). Limitations apply.',
     '    remediate                             Trigger AI agent remediation for eligible issues (SonarQube Cloud only)',
     '',


### PR DESCRIPTION
Part of CLI-202

----
## Summary by Gitar

- **Beta Status:**
  - Marked `analyze dependency-risks` as beta in the CLI description and help output.
  - Added a runtime warning to notify users that dependency manifest files are uploaded to SonarQube.

<sub>This will update automatically on new commits.</sub>