### PR TITLE
CLI-640 Align and reorder `sonar integrate` install output

### DIFF
--- a/src/cli/commands/integrate/_common/context-augmentation.ts
+++ b/src/cli/commands/integrate/_common/context-augmentation.ts
@@ -144,7 +144,7 @@ export async function resolveContextAugmentationSetup(
 export async function runToolIntegrateCommand(
   p: ApplyContextAugmentationToolIntegrationParams,
 ): Promise<void> {
-  text('Installing SonarQube Context Augmentation...');
+  text('     Installing SonarQube Context Augmentation...');
 
   const initEnv = buildContextAugmentationEnv({
     organization: p.auth.orgKey,

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -100,7 +100,6 @@ export async function installIntegration<TOptions>({
       force: context.force,
       attrs: context.attrs,
     });
-    text(`Installing ${feature.displayName}...`);
   }
 
   try {
@@ -110,11 +109,14 @@ export async function installIntegration<TOptions>({
       applications,
       {
         callbacks: {
+          onFeatureApplyStart: (feature) => {
+            text(`     Installing ${feature.displayName}...`);
+          },
           onDependencySkipped: (dependency) => {
-            text(`${dependency.displayName ?? dependency.id} already installed`);
+            text(`     ${dependency.displayName ?? dependency.id} already installed`);
           },
           onResourceSkipped: (resource) => {
-            text(`${resource.displayName ?? resource.id} already installed`);
+            text(`     ${resource.displayName ?? resource.id} already installed`);
           },
         },
         executionMode: 'install',

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -274,7 +274,7 @@ export class IntegrationInstaller {
     context: IntegrationContext,
     installedFeature: InstalledIntegrationFeature | undefined,
     feature: FeatureDeclaration<TOptions>,
-    callbacks: ApplyFeatureCallbacks<TOptions> = {},
+    callbacks: ApplyFeatureCallbacks<TOptions>,
   ): Promise<AppliedFeature> {
     const preparedDependencies = await this.prepareUniqueDependencies(
       [
@@ -326,7 +326,7 @@ export class IntegrationInstaller {
 
   private async prepareUniqueDependencies<TOptions>(
     executions: PreparedFeatureExecution<TOptions>[],
-    callbacks: ApplyFeatureCallbacks<TOptions> = {},
+    callbacks: ApplyFeatureCallbacks<TOptions>,
   ): Promise<PreparedDependencies> {
     const resolvedDependencies = new Map<string, InstalledDependency>();
     const installedDependencies = new Map<string, InstalledDependency>();
@@ -375,7 +375,7 @@ export class IntegrationInstaller {
     installedFeature: InstalledIntegrationFeature | undefined,
     feature: FeatureDeclaration<TOptions>,
     preparedDependencies: PreparedDependencies,
-    callbacks: ApplyFeatureCallbacks<TOptions> = {},
+    callbacks: ApplyFeatureCallbacks<TOptions>,
   ): Promise<AppliedFeature> {
     const dependencyIds = new Set<string>();
     const dependencies: InstalledDependency[] = [];

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -46,7 +46,8 @@ import type {
   IntegrationInvocation,
 } from './types';
 
-interface ApplyFeatureCallbacks {
+interface ApplyFeatureCallbacks<TOptions = Record<string, unknown>> {
+  onFeatureApplyStart?: (feature: FeatureDeclaration<TOptions>) => void;
   onDependencyInstalled?: (dependency: DependencyDeclaration) => void;
   onDependencySkipped?: (dependency: DependencyDeclaration) => void;
   onResourceInstalled?: (resource: ResourceDeclaration) => void;
@@ -64,7 +65,7 @@ export interface FeatureApplication<TOptions = Record<string, unknown>> {
 }
 
 interface ApplyAndRecordFeaturesOptions<TOptions = Record<string, unknown>> {
-  callbacks?: ApplyFeatureCallbacks;
+  callbacks?: ApplyFeatureCallbacks<TOptions>;
   continueOnFeatureError?: boolean;
   executionMode?: IntegrationExecutionMode;
   onFeatureError?: (application: FeatureApplication<TOptions>, error: Error) => void;
@@ -241,6 +242,7 @@ export class IntegrationInstaller {
 
     for (const execution of executions) {
       try {
+        options.callbacks?.onFeatureApplyStart?.(execution.application.feature);
         const applied = await this.applyFeatureWithUniqueDependencies(
           execution.context,
           execution.installedFeature,
@@ -272,7 +274,7 @@ export class IntegrationInstaller {
     context: IntegrationContext,
     installedFeature: InstalledIntegrationFeature | undefined,
     feature: FeatureDeclaration<TOptions>,
-    callbacks: ApplyFeatureCallbacks = {},
+    callbacks: ApplyFeatureCallbacks<TOptions> = {},
   ): Promise<AppliedFeature> {
     const preparedDependencies = await this.prepareUniqueDependencies(
       [
@@ -324,7 +326,7 @@ export class IntegrationInstaller {
 
   private async prepareUniqueDependencies<TOptions>(
     executions: PreparedFeatureExecution<TOptions>[],
-    callbacks: ApplyFeatureCallbacks = {},
+    callbacks: ApplyFeatureCallbacks<TOptions> = {},
   ): Promise<PreparedDependencies> {
     const resolvedDependencies = new Map<string, InstalledDependency>();
     const installedDependencies = new Map<string, InstalledDependency>();
@@ -373,7 +375,7 @@ export class IntegrationInstaller {
     installedFeature: InstalledIntegrationFeature | undefined,
     feature: FeatureDeclaration<TOptions>,
     preparedDependencies: PreparedDependencies,
-    callbacks: ApplyFeatureCallbacks = {},
+    callbacks: ApplyFeatureCallbacks<TOptions> = {},
   ): Promise<AppliedFeature> {
     const dependencyIds = new Set<string>();
     const dependencies: InstalledDependency[] = [];

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -140,7 +140,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
         }),
         jsonPatch({
           id: 'claude-settings-sqaa-hook',
-          displayName: 'Claude SQAA hook configuration',
+          displayName: 'Claude SonarQube Agentic Analysis hook configuration',
           targetPath: resolveClaudeSettingsPath,
           defaultValue: { hooks: {} },
           patch: (document, context) =>

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -127,7 +127,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
         }),
         jsonPatch({
           id: 'codex-hooks-sqaa-hook',
-          displayName: 'Codex SQAA hook configuration',
+          displayName: 'Codex SonarQube Agentic Analysis hook configuration',
           targetPath: resolveCodexHooksPath,
           defaultValue: { hooks: {} },
           patch: (document, context) =>

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -135,7 +135,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       resources: [
         textSnippet({
           id: 'sqaa-instructions-file',
-          displayName: 'Copilot SQAA instructions',
+          displayName: 'Copilot SonarQube Agentic Analysis instructions',
           targetPath: resolveInstructionsPath,
           startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
           endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -106,7 +106,7 @@ describe('generic integration installer', () => {
     expect(await readFile(join(tempDir, 'config.txt'), 'utf-8')).toBe('enabled=true\n');
     expect(operationCalls).toEqual(['called']);
     expect(saveStateSpy).toHaveBeenCalledWith(state);
-    expect(hasUiCall('text', 'Installing Feature...')).toBe(true);
+    expect(hasUiCall('text', '     Installing Feature...')).toBe(true);
   });
 
   it('supports feature-specific target routing from a single installer invocation', async () => {
@@ -304,7 +304,7 @@ describe('generic integration installer', () => {
     });
 
     expect(installed[0].resources.some((resource) => resource.id === 'file')).toBe(true);
-    expect(hasUiCall('text', 'Config file already installed')).toBe(true);
+    expect(hasUiCall('text', '     Config file already installed')).toBe(true);
   });
 
   it('falls back to the resource id in the skip message when no displayName is set', async () => {
@@ -340,7 +340,7 @@ describe('generic integration installer', () => {
       scope: 'project',
     });
 
-    expect(hasUiCall('text', 'unnamed-file already installed')).toBe(true);
+    expect(hasUiCall('text', '     unnamed-file already installed')).toBe(true);
   });
 
   it('falls back to the dependency id in the skip message when no displayName is set', async () => {
@@ -384,7 +384,7 @@ describe('generic integration installer', () => {
       scope: 'project',
     });
 
-    expect(hasUiCall('text', 'unnamed-binary already installed')).toBe(true);
+    expect(hasUiCall('text', '     unnamed-binary already installed')).toBe(true);
   });
 
   it('does not run operations when shouldApply returns false', async () => {


### PR DESCRIPTION
----
## Summary by Gitar

- **CLI output improvements:**
  - Standardized indentation for `sonar integrate` installation logs and status messages.
  - Added `onFeatureApplyStart` callback to track installation progress more granularly.
- **Refactoring:**
  - Updated `IntegrationInstaller` to support feature-specific lifecycle callbacks.
  - Removed unused default callbacks container.
- **Naming consistency:**
  - Renamed "SQAA" to "SonarQube Agentic Analysis" in Claude, Codex, and Copilot integration display names.

<sub>This will update automatically on new commits.</sub>