### PR TITLE
CLI-640 Add missing indentation to binaries trace logs

### DIFF
--- a/src/cli/commands/_common/install/binary.ts
+++ b/src/cli/commands/_common/install/binary.ts
@@ -98,7 +98,7 @@ async function downloadAndInstall(
     return { skipped: true, binaryPath };
   }
 
-  text(`Installing ${spec.name} ${spec.version}`);
+  text(`     Installing ${spec.name} ${spec.version}`);
 
   const downloadUrl = buildDownloadUrl(spec.name, spec.version, spec.distPrefix, platform);
   await withSpinner(`Downloading ${spec.name} ${spec.version}`, () =>
@@ -121,7 +121,7 @@ async function downloadAndInstall(
   const installedVersion = await withSpinner('Verifying installation', () =>
     verifyInstallation(binaryPath),
   );
-  print(`  ${spec.name} ${installedVersion}`);
+  print(`     ${spec.name} ${installedVersion}`);
 
   recordInstallationInState(spec.name, installedVersion, binaryPath);
   cleanupOldVersionBinaries(resolvedBinDir, spec.name, binaryName);

--- a/src/cli/commands/_common/install/context-augmentation.ts
+++ b/src/cli/commands/_common/install/context-augmentation.ts
@@ -104,8 +104,8 @@ export async function resolveContextAugmentationBinary(
     return { binaryPath, freshlyInstalled: false };
   }
 
-  text(`Installing sonar-context-augmentation ${SONAR_CONTEXT_AUGMENTATION_VERSION}`);
-  text(`  Platform: ${platform.os}-${platform.arch}`);
+  text(`     Installing sonar-context-augmentation ${SONAR_CONTEXT_AUGMENTATION_VERSION}`);
+  text(`     Platform: ${platform.os}-${platform.arch}`);
 
   const archivePath = `${binaryPath}.tar.gz`;
   const ascPath = `${archivePath}.asc`;


### PR DESCRIPTION
----
## Summary by Gitar

- **Logging improvements:**
  - Applied consistent indentation to binary installation and platform trace logs in `binary.ts` and `context-augmentation.ts`.

<sub>This will update automatically on new commits.</sub>