### PR TITLE
CLI-650 Fix sonar system status command clarity

### DIFF
--- a/src/cli/commands/system/status.ts
+++ b/src/cli/commands/system/status.ts
@@ -58,6 +58,12 @@ const PINNED_VERSIONS: Partial<Record<string, string>> = {
   [SCA_SCANNER_BINARY_NAME]: SCA_SCANNER_CLI_VERSION,
 };
 
+const BINARY_DISPLAY_NAMES: Record<string, string> = {
+  'sonar-secrets': 'Secrets Detection',
+  'sonar-context-augmentation': 'Sonar Context Augmentation',
+  'sca-scanner-cli': 'Dependency Risks Scanner',
+};
+
 export interface SystemStatusOptions {
   json?: boolean;
 }
@@ -68,18 +74,21 @@ type McpRunningStatus = 'running' | 'not_running' | 'unknown';
 interface McpStatus {
   config: McpConfigStatus;
   running: McpRunningStatus;
-  /** Set when config is 'invalid' — identifies which integration to reinstall. */
-  invalidIntegrationId?: string;
 }
 
 interface IntegrationInfo {
   id: string;
   name: string;
   path?: string;
+  mcp?: McpStatus;
 }
 
 function abbreviatePath(p: string): string {
   return p.replace(homedir(), '~');
+}
+
+function getBinaryDisplayName(binaryId: string): string {
+  return BINARY_DISPLAY_NAMES[binaryId] ?? binaryId;
 }
 
 // integrationId → agent string for getMcpConfigFilePath
@@ -166,17 +175,22 @@ async function checkMcpRunning(): Promise<McpRunningStatus> {
   }
 }
 
-async function getMcpStatus(state: CliState): Promise<McpStatus> {
-  const mcpFeatures = findMcpFeatures(state);
-  if (mcpFeatures.length === 0) {
-    return { config: 'not_configured', running: 'unknown' };
-  }
+function getMcpStatusForIntegration(
+  integrationId: string,
+  targetRoot: string,
+  cachedRunning: McpRunningStatus,
+  allMcpFeatures: Array<{ integrationId: string; scope: 'project' | 'global'; targetRoot: string }>,
+): McpStatus | null {
+  const agentStr = INTEGRATION_TO_MCP_AGENT[integrationId];
+  if (!agentStr) return null;
 
-  // Scan all features: prefer 'configured' over 'invalid' regardless of iteration order
-  let firstInvalid: string | undefined;
+  const mcpFeatures = allMcpFeatures.filter(
+    (f) => f.integrationId === integrationId && f.targetRoot === targetRoot,
+  );
+  if (mcpFeatures.length === 0) return null;
+
+  let hasInvalid = false;
   for (const feature of mcpFeatures) {
-    const agentStr = INTEGRATION_TO_MCP_AGENT[feature.integrationId];
-    if (!agentStr) continue;
     const configPath = getMcpConfigFilePath(
       agentStr,
       feature.scope === 'global',
@@ -184,21 +198,52 @@ async function getMcpStatus(state: CliState): Promise<McpStatus> {
     );
     const configStatus = checkMcpConfigFile(configPath);
     if (configStatus === 'configured') {
-      const running = await checkMcpRunning();
-      return { config: 'configured', running };
+      return { config: 'configured', running: cachedRunning };
     }
-    if (configStatus === 'invalid' && firstInvalid === undefined) {
-      firstInvalid = feature.integrationId;
+    if (configStatus === 'invalid') {
+      hasInvalid = true;
     }
   }
-  if (firstInvalid !== undefined) {
-    return { config: 'invalid', running: 'unknown', invalidIntegrationId: firstInvalid };
+  if (hasInvalid) {
+    return { config: 'invalid', running: 'unknown' };
   }
   return { config: 'not_configured', running: 'unknown' };
 }
 
-function getInstalledIntegrations(state: CliState): IntegrationInfo[] {
+async function getMcpStatusMap(state: CliState): Promise<Map<string, McpStatus>> {
+  const allMcpFeatures = findMcpFeatures(state);
+
+  if (allMcpFeatures.length === 0) return new Map();
+
+  // Build a Map of unique (integrationId, targetRoot) pairs
+  const uniquePairs = new Map<string, { integrationId: string; targetRoot: string }>();
+  for (const f of allMcpFeatures) {
+    const key = `${f.integrationId}:${f.targetRoot}`;
+    if (!uniquePairs.has(key)) {
+      uniquePairs.set(key, { integrationId: f.integrationId, targetRoot: f.targetRoot });
+    }
+  }
+
+  const cachedRunning = await checkMcpRunning();
+  const statusMap = new Map<string, McpStatus>();
+
+  for (const [key, { integrationId, targetRoot }] of uniquePairs) {
+    const status = getMcpStatusForIntegration(
+      integrationId,
+      targetRoot,
+      cachedRunning,
+      allMcpFeatures,
+    );
+    if (status) {
+      statusMap.set(key, status);
+    }
+  }
+  return statusMap;
+}
+
+async function getInstalledIntegrations(state: CliState): Promise<IntegrationInfo[]> {
   const result: IntegrationInfo[] = [];
+  const mcpStatusMap = await getMcpStatusMap(state);
 
   // The framework stores one InstalledIntegration per integrationId; multiple
   // project installs accumulate as separate features with distinct targetRoots.
@@ -206,17 +251,17 @@ function getInstalledIntegrations(state: CliState): IntegrationInfo[] {
   for (const i of state.integrations.installed) {
     const name = supportedIntegrations.get(i.integrationId)?.displayName ?? i.integrationId;
 
-    const localRoots = [
-      ...new Set(i.features.filter((f) => f.scope !== 'global').map((f) => f.targetRoot)),
-    ];
+    // Collect all unique targetRoots across all features (project and global)
+    const allRoots = [...new Set(i.features.map((f) => f.targetRoot))];
 
-    if (localRoots.length > 0) {
-      for (const root of localRoots) {
-        const features = i.features.filter((f) => f.targetRoot === root);
-        result.push({ id: i.integrationId, name, path: pathFromFeatures(features) });
-      }
-    } else {
-      result.push({ id: i.integrationId, name, path: pathFromFeatures(i.features) });
+    for (const root of allRoots) {
+      const features = i.features.filter((f) => f.targetRoot === root);
+      result.push({
+        id: i.integrationId,
+        name,
+        path: pathFromFeatures(features),
+        mcp: mcpStatusMap.get(`${i.integrationId}:${root}`),
+      });
     }
   }
 
@@ -225,7 +270,13 @@ function getInstalledIntegrations(state: CliState): IntegrationInfo[] {
   for (const [agentId, config] of Object.entries(state.agents)) {
     if (config.configured && !declarativeIds.has(agentId)) {
       const name = supportedIntegrations.get(agentId)?.displayName ?? agentId;
-      result.push({ id: agentId, name, path: getLegacyAgentPath(agentId, state) });
+      // Legacy agents don't have MCP info, so leave mcp undefined
+      result.push({
+        id: agentId,
+        name,
+        path: getLegacyAgentPath(agentId, state),
+        mcp: undefined,
+      });
     }
   }
 
@@ -266,10 +317,10 @@ function mcpStatusLine(mcp: McpStatus): string {
 export async function systemStatus(options: SystemStatusOptions): Promise<void> {
   const state = loadState();
 
-  const [auth, updateResult, mcp] = await Promise.all([
+  const [auth, updateResult, integrations] = await Promise.all([
     resolveAuth().catch(() => null),
     checkForUpdate(process.env.SONARQUBE_CLI_UPDATE_SCRIPT_BASE_URL).catch(() => null),
-    getMcpStatus(state),
+    getInstalledIntegrations(state),
   ]);
 
   const tokenStatus: TokenStatus | null = auth
@@ -304,9 +355,9 @@ export async function systemStatus(options: SystemStatusOptions): Promise<void> 
   const binaries = [...legacyBinaries, ...depBinaries.filter((b) => !seen.has(b.name))];
 
   const cacheDirs = [
-    { name: 'logs', path: LOG_DIR },
-    { name: 'sca-scanner-cache', path: SCA_SCANNER_CACHE_DIR },
-    { name: 'global-hooks', path: GLOBAL_HOOKS_DIR },
+    { name: 'Logs', path: LOG_DIR },
+    { name: 'Dependency Risks Scanner Cache', path: SCA_SCANNER_CACHE_DIR },
+    { name: 'Global Git Hooks', path: GLOBAL_HOOKS_DIR },
   ];
   const cache: CacheInfo[] = cacheDirs.map(({ name, path }) => ({
     name,
@@ -314,10 +365,11 @@ export async function systemStatus(options: SystemStatusOptions): Promise<void> 
     present: existsSync(path) && statSync(path).isDirectory(),
   }));
 
-  const integrations = getInstalledIntegrations(state);
-
-  const hasIssues = tokenStatus === null || tokenStatus === 'invalid' || mcp.config === 'invalid';
-  const recommendations = buildRecommendations(tokenStatus, updateResult, mcp);
+  const hasMcpIssues = integrations.some(
+    (i) => i.mcp && (i.mcp.config === 'invalid' || i.mcp.config === 'not_configured'),
+  );
+  const hasIssues = tokenStatus === null || tokenStatus === 'invalid' || hasMcpIssues;
+  const recommendations = buildRecommendations(tokenStatus, updateResult, integrations);
 
   const data: StatusData = {
     auth,
@@ -325,7 +377,6 @@ export async function systemStatus(options: SystemStatusOptions): Promise<void> 
     binaries,
     cache,
     integrations,
-    mcp,
     hasIssues,
     recommendations,
   };
@@ -353,7 +404,6 @@ interface StatusData {
   binaries: BinaryInfo[];
   cache: CacheInfo[];
   integrations: IntegrationInfo[];
-  mcp: McpStatus;
   hasIssues: boolean;
   recommendations: string[];
 }
@@ -361,7 +411,7 @@ interface StatusData {
 function buildRecommendations(
   tokenStatus: TokenStatus | null,
   updateResult: { latestVersion: string; updateAvailable: boolean } | null,
-  mcp: McpStatus,
+  integrations: IntegrationInfo[],
 ): string[] {
   const recommendations: string[] = [];
   if (tokenStatus === null) recommendations.push("Run 'sonar auth login' to authenticate");
@@ -371,11 +421,17 @@ function buildRecommendations(
       `Run 'sonar self-update' to update to v${stripBuildNumber(updateResult.latestVersion)}`,
     );
   }
-  if (mcp.config === 'invalid') {
-    const integrateCmd =
-      INTEGRATION_TO_COMMAND[mcp.invalidIntegrationId ?? 'claude-code'] ?? 'sonar integrate claude';
+
+  const seenMcpIntegrations = new Set<string>();
+  for (const integration of integrations) {
+    if (seenMcpIntegrations.has(integration.id) || integration.mcp?.config !== 'invalid') {
+      continue;
+    }
+    seenMcpIntegrations.add(integration.id);
+    const integrateCmd = INTEGRATION_TO_COMMAND[integration.id] ?? 'sonar integrate claude';
     recommendations.push(`Run '${integrateCmd}' to reinstall MCP configuration`);
   }
+
   return recommendations;
 }
 
@@ -387,8 +443,7 @@ function tokenStatusLabel(tokenStatus: TokenStatus | null): string {
 }
 
 function printJsonStatus(version: string, data: StatusData): void {
-  const { auth, tokenStatus, binaries, cache, integrations, mcp, hasIssues, recommendations } =
-    data;
+  const { auth, tokenStatus, binaries, cache, integrations, hasIssues, recommendations } = data;
   print(
     JSON.stringify(
       {
@@ -402,24 +457,28 @@ function printJsonStatus(version: string, data: StatusData): void {
             }
           : { status: 'unauthenticated', token: 'not_set' },
         binaries: binaries.map(({ name, version, path, updateAvailable, latestVersion }) => ({
-          name,
+          name: getBinaryDisplayName(name),
           version,
           path,
           updateAvailable,
           ...(updateAvailable ? { latestVersion: stripBuildNumber(latestVersion) } : {}),
         })),
         cache,
-        integrations: integrations.map(({ id, name, path }) => ({
+        integrations: integrations.map(({ id, name, path, mcp }) => ({
           id,
           name,
           ...(path ? { path } : {}),
+          ...(mcp
+            ? {
+                mcp: {
+                  configured: mcp.config !== 'not_configured',
+                  valid: mcp.config === 'configured',
+                  session_active: mcp.running === 'running',
+                },
+              }
+            : {}),
         })),
         healthy: !hasIssues,
-        mcp: {
-          configured: mcp.config !== 'not_configured',
-          valid: mcp.config === 'configured',
-          session_active: mcp.running === 'running',
-        },
         recommendations,
       },
       null,
@@ -449,7 +508,8 @@ function renderBinariesSection(binaries: BinaryInfo[]): void {
   blank();
   text('BINARIES');
   for (const b of binaries) {
-    text(`  • ${b.name}: Installed (${b.path})`);
+    const displayName = getBinaryDisplayName(b.name);
+    text(`  • ${displayName}: Installed (${b.path})`);
     const versionSuffix = b.updateAvailable
       ? ` (Update available: v${stripBuildNumber(b.latestVersion)})`
       : '';
@@ -466,15 +526,17 @@ function renderCacheSection(cache: CacheInfo[]): void {
   }
 }
 
-function renderIntegrationsSection(integrations: IntegrationInfo[], mcp: McpStatus): void {
-  if (integrations.length === 0 && mcp.config === 'not_configured') return;
+function renderIntegrationsSection(integrations: IntegrationInfo[]): void {
+  if (integrations.length === 0) return;
   blank();
   text('INTEGRATIONS');
   for (const i of integrations) {
     const line = i.path ? `${i.name}: CONFIGURED (${i.path})` : `${i.name}: CONFIGURED`;
     text(`  • ${line}`);
+    if (i.mcp) {
+      text(`    • MCP Server: ${mcpStatusLine(i.mcp)}`);
+    }
   }
-  text(`  • MCP Server: ${mcpStatusLine(mcp)}`);
 }
 
 function renderRecommendationsSection(recommendations: string[]): void {
@@ -487,8 +549,7 @@ function renderRecommendationsSection(recommendations: string[]): void {
 }
 
 function renderTextStatus(version: string, data: StatusData): void {
-  const { auth, tokenStatus, binaries, cache, integrations, mcp, hasIssues, recommendations } =
-    data;
+  const { auth, tokenStatus, binaries, cache, integrations, hasIssues, recommendations } = data;
   print(getBanner(version));
   blank();
 
@@ -502,6 +563,6 @@ function renderTextStatus(version: string, data: StatusData): void {
   renderAuthSection(auth, tokenStatus);
   renderBinariesSection(binaries);
   renderCacheSection(cache);
-  renderIntegrationsSection(integrations, mcp);
+  renderIntegrationsSection(integrations);
   renderRecommendationsSection(recommendations);
 }

--- a/src/cli/commands/system/status.ts
+++ b/src/cli/commands/system/status.ts
@@ -33,14 +33,12 @@ import {
   SCA_SCANNER_BINARY_NAME,
 } from '../../../lib/install-types';
 import { getMcpConfigFilePath } from '../../../lib/mcp/mcp-helper';
-import { spawnProcess } from '../../../lib/process';
 import { loadState } from '../../../lib/repository/state-repository';
 import {
   SCA_SCANNER_CLI_VERSION,
   SONAR_CONTEXT_AUGMENTATION_VERSION,
 } from '../../../lib/signatures';
 import type { CliState } from '../../../lib/state';
-import { detectContainerRuntime } from '../../../lib/tool-detector';
 import { isNewerVersion, stripBuildNumber } from '../../../lib/version';
 import { blank, print, success, text, warn } from '../../../ui';
 import { getBanner } from '../../root-help';
@@ -69,11 +67,9 @@ export interface SystemStatusOptions {
 }
 
 type McpConfigStatus = 'configured' | 'invalid' | 'not_configured';
-type McpRunningStatus = 'running' | 'not_running' | 'unknown';
 
 interface McpStatus {
   config: McpConfigStatus;
-  running: McpRunningStatus;
 }
 
 interface IntegrationInfo {
@@ -158,27 +154,9 @@ function checkMcpConfigFile(configPath: string): McpConfigStatus {
   }
 }
 
-async function checkMcpRunning(): Promise<McpRunningStatus> {
-  const runtime = await detectContainerRuntime().catch(() => null);
-  if (!runtime) return 'unknown';
-  try {
-    const result = await spawnProcess(runtime, [
-      'ps',
-      '--filter',
-      'ancestor=mcp/sonarqube',
-      '--format',
-      '{{.ID}}',
-    ]);
-    return result.stdout.trim().length > 0 ? 'running' : 'not_running';
-  } catch {
-    return 'unknown';
-  }
-}
-
 function getMcpStatusForIntegration(
   integrationId: string,
   targetRoot: string,
-  cachedRunning: McpRunningStatus,
   allMcpFeatures: Array<{ integrationId: string; scope: 'project' | 'global'; targetRoot: string }>,
 ): McpStatus | null {
   const agentStr = INTEGRATION_TO_MCP_AGENT[integrationId];
@@ -198,19 +176,19 @@ function getMcpStatusForIntegration(
     );
     const configStatus = checkMcpConfigFile(configPath);
     if (configStatus === 'configured') {
-      return { config: 'configured', running: cachedRunning };
+      return { config: 'configured' };
     }
     if (configStatus === 'invalid') {
       hasInvalid = true;
     }
   }
   if (hasInvalid) {
-    return { config: 'invalid', running: 'unknown' };
+    return { config: 'invalid' };
   }
-  return { config: 'not_configured', running: 'unknown' };
+  return { config: 'not_configured' };
 }
 
-async function getMcpStatusMap(state: CliState): Promise<Map<string, McpStatus>> {
+function getMcpStatusMap(state: CliState): Map<string, McpStatus> {
   const allMcpFeatures = findMcpFeatures(state);
 
   if (allMcpFeatures.length === 0) return new Map();
@@ -224,16 +202,10 @@ async function getMcpStatusMap(state: CliState): Promise<Map<string, McpStatus>>
     }
   }
 
-  const cachedRunning = await checkMcpRunning();
   const statusMap = new Map<string, McpStatus>();
 
   for (const [key, { integrationId, targetRoot }] of uniquePairs) {
-    const status = getMcpStatusForIntegration(
-      integrationId,
-      targetRoot,
-      cachedRunning,
-      allMcpFeatures,
-    );
+    const status = getMcpStatusForIntegration(integrationId, targetRoot, allMcpFeatures);
     if (status) {
       statusMap.set(key, status);
     }
@@ -241,9 +213,9 @@ async function getMcpStatusMap(state: CliState): Promise<Map<string, McpStatus>>
   return statusMap;
 }
 
-async function getInstalledIntegrations(state: CliState): Promise<IntegrationInfo[]> {
+function getInstalledIntegrations(state: CliState): IntegrationInfo[] {
   const result: IntegrationInfo[] = [];
-  const mcpStatusMap = await getMcpStatusMap(state);
+  const mcpStatusMap = getMcpStatusMap(state);
 
   // The framework stores one InstalledIntegration per integrationId; multiple
   // project installs accumulate as separate features with distinct targetRoots.
@@ -310,17 +282,16 @@ function getLegacyAgentPath(agentId: string, state: CliState): string | undefine
 function mcpStatusLine(mcp: McpStatus): string {
   if (mcp.config === 'not_configured') return 'NOT CONFIGURED';
   if (mcp.config === 'invalid') return 'CONFIGURED / INVALID CONFIG';
-  if (mcp.running === 'running') return 'CONFIGURED / SESSION ACTIVE';
-  return 'CONFIGURED / NO ACTIVE SESSION';
+  return 'CONFIGURED';
 }
 
 export async function systemStatus(options: SystemStatusOptions): Promise<void> {
   const state = loadState();
+  const integrations = getInstalledIntegrations(state);
 
-  const [auth, updateResult, integrations] = await Promise.all([
+  const [auth, updateResult] = await Promise.all([
     resolveAuth().catch(() => null),
     checkForUpdate(process.env.SONARQUBE_CLI_UPDATE_SCRIPT_BASE_URL).catch(() => null),
-    getInstalledIntegrations(state),
   ]);
 
   const tokenStatus: TokenStatus | null = auth
@@ -355,19 +326,22 @@ export async function systemStatus(options: SystemStatusOptions): Promise<void> 
   const binaries = [...legacyBinaries, ...depBinaries.filter((b) => !seen.has(b.name))];
 
   const cacheDirs = [
-    { name: 'Logs', path: LOG_DIR },
-    { name: 'Dependency Risks Scanner Cache', path: SCA_SCANNER_CACHE_DIR },
-    { name: 'Global Git Hooks', path: GLOBAL_HOOKS_DIR },
+    { id: 'logs', name: 'Logs', path: LOG_DIR },
+    {
+      id: 'sca-scanner-cache',
+      name: 'Dependency Risks Scanner Cache',
+      path: SCA_SCANNER_CACHE_DIR,
+    },
+    { id: 'global-git-hooks', name: 'Global Git Hooks', path: GLOBAL_HOOKS_DIR },
   ];
-  const cache: CacheInfo[] = cacheDirs.map(({ name, path }) => ({
+  const cache: CacheInfo[] = cacheDirs.map(({ id, name, path }) => ({
+    id,
     name,
     path: abbreviatePath(path),
     present: existsSync(path) && statSync(path).isDirectory(),
   }));
 
-  const hasMcpIssues = integrations.some(
-    (i) => i.mcp && (i.mcp.config === 'invalid' || i.mcp.config === 'not_configured'),
-  );
+  const hasMcpIssues = integrations.some((i) => i.mcp?.config === 'invalid');
   const hasIssues = tokenStatus === null || tokenStatus === 'invalid' || hasMcpIssues;
   const recommendations = buildRecommendations(tokenStatus, updateResult, integrations);
 
@@ -396,7 +370,7 @@ type BinaryInfo = {
   updateAvailable: boolean;
   latestVersion: string;
 };
-type CacheInfo = { name: string; path: string; present: boolean };
+type CacheInfo = { id: string; name: string; path: string; present: boolean };
 
 interface StatusData {
   auth: ResolvedAuth | null;
@@ -457,6 +431,7 @@ function printJsonStatus(version: string, data: StatusData): void {
             }
           : { status: 'unauthenticated', token: 'not_set' },
         binaries: binaries.map(({ name, version, path, updateAvailable, latestVersion }) => ({
+          id: name,
           name: getBinaryDisplayName(name),
           version,
           path,
@@ -473,7 +448,6 @@ function printJsonStatus(version: string, data: StatusData): void {
                 mcp: {
                   configured: mcp.config !== 'not_configured',
                   valid: mcp.config === 'configured',
-                  session_active: mcp.running === 'running',
                 },
               }
             : {}),

--- a/tests/integration/specs/system/system-status.test.ts
+++ b/tests/integration/specs/system/system-status.test.ts
@@ -246,7 +246,7 @@ describe('system status', () => {
       const result = await harness.run('system status');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('sonar-secrets');
+      expect(result.stdout).toContain('Secrets Detection');
       expect(result.stdout).toContain('BINARIES');
     },
     { timeout: 15000 },
@@ -331,7 +331,7 @@ describe('system status', () => {
         binaries: Array<{ name: string; version: string; path: string; updateAvailable: boolean }>;
       };
       expect(json.binaries.length).toBe(1);
-      expect(json.binaries[0].name).toBe('sonar-secrets');
+      expect(json.binaries[0].name).toBe('Secrets Detection');
       expect(json.binaries[0].version).toBeTruthy();
       expect(json.binaries[0].path).toBeTruthy();
       expect(json.binaries[0].path).toContain('~');
@@ -751,8 +751,8 @@ describe('system status', () => {
       expect(result.exitCode).toBe(0);
       const json = JSON.parse(result.stdout) as { binaries: Array<{ name: string }> };
       const names = json.binaries.map((b) => b.name);
-      expect(names).toContain('sonar-context-augmentation');
-      expect(names).toContain('sca-scanner-cli');
+      expect(names).toContain('Sonar Context Augmentation');
+      expect(names).toContain('Dependency Risks Scanner');
     },
     { timeout: 15000 },
   );
@@ -907,5 +907,170 @@ describe('system status', () => {
       expect(json.integrations.filter((i) => i.id === 'claude-code')).toHaveLength(2);
     },
     { timeout: 60000 },
+  );
+
+  it(
+    'shows MCP status nested under Claude integration in text output',
+    async () => {
+      harness.userHome.writeFile('.claude.json', VALID_MCP_CONFIG);
+      harness
+        .state()
+        .withRawState(JSON.stringify(mcpClaudeIntegrationState(harness.userHome.path)));
+
+      const result = await harness.run('system status');
+
+      expect(result.exitCode).toBe(0);
+      const lines = result.stdout.split('\n');
+      // Find "Claude Code" line
+      const claudeLineIdx = lines.findIndex((l) => l.includes('Claude Code'));
+      expect(claudeLineIdx).toBeGreaterThanOrEqual(0);
+      // MCP Server should appear indented after Claude Code, not as a separate top-level entry
+      const nextLine = lines[claudeLineIdx + 1];
+      expect(nextLine).toContain('MCP Server');
+      expect(nextLine).toMatch(/^\s{4}•/); // indented with 4 spaces + bullet
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'includes MCP status per integration in JSON output',
+    async () => {
+      harness.userHome.writeFile('.claude.json', VALID_MCP_CONFIG);
+      harness
+        .state()
+        .withRawState(JSON.stringify(mcpClaudeIntegrationState(harness.userHome.path)));
+
+      const result = await harness.run('system status --json');
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout) as {
+        integrations: Array<{ id: string; mcp?: { configured: boolean } }>;
+      };
+      const claudeIntegration = json.integrations.find((i) => i.id === 'claude-code');
+      expect(claudeIntegration).toBeDefined();
+      expect(claudeIntegration?.mcp).toBeDefined();
+      expect(claudeIntegration?.mcp?.configured).toBe(true);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'shows invalid MCP config under specific agent, not globally',
+    async () => {
+      const invalidConfig = JSON.stringify({ mcpServers: { sonarqube: null } });
+      harness.userHome.writeFile('.claude.json', invalidConfig);
+      harness
+        .state()
+        .withRawState(JSON.stringify(mcpClaudeIntegrationState(harness.userHome.path)));
+
+      const result = await harness.run('system status');
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Claude Code');
+      expect(result.stdout).toContain('INVALID CONFIG');
+      expect(result.stdout).toContain('RECOMMENDATIONS');
+      expect(result.stdout).toContain('sonar integrate claude');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not show MCP status when no agents have MCP configured',
+    async () => {
+      const result = await harness.run('system status');
+
+      expect(result.exitCode).toBe(0);
+      // Should not contain any "MCP Server" line when no MCP is configured
+      const lines = result.stdout.split('\n');
+      const mcpLines = lines.filter((l) => l.includes('MCP Server'));
+      expect(mcpLines).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'shows separate MCP status for each integration when multiple have MCP configured',
+    async () => {
+      // Create state with multiple integrations, each with MCP
+      const claudeGlobalRoot = harness.userHome.path;
+      const copilotGlobalRoot = join(harness.userHome.path, '.copilot');
+      mkdirSync(copilotGlobalRoot, { recursive: true });
+
+      harness.userHome.writeFile('.claude.json', VALID_MCP_CONFIG);
+      harness.userHome.writeFile('.copilot/mcp-config.json', VALID_MCP_CONFIG);
+
+      const multiMcpState = baseState({
+        integrations: {
+          installed: [
+            makeInstallEntry('claude-id', 'claude-code', 'mcp-server', claudeGlobalRoot),
+            makeInstallEntry('copilot-id', 'copilot-cli', 'mcp-server', copilotGlobalRoot),
+          ],
+        },
+      });
+
+      harness.state().withRawState(JSON.stringify(multiMcpState));
+
+      const result = await harness.run('system status');
+
+      expect(result.exitCode).toBe(0);
+      const stdout = result.stdout;
+
+      // Both Claude Code and Copilot should appear
+      expect(stdout).toContain('Claude Code');
+      expect(stdout).toContain('Copilot');
+
+      // Count MCP Server lines — should be 2 (one for each integration)
+      const lines = stdout.split('\n');
+      const mcpLines = lines.filter((l) => l.includes('MCP Server'));
+      expect(mcpLines).toHaveLength(2);
+
+      // Both should show CONFIGURED status
+      mcpLines.forEach((line) => {
+        expect(line).toContain('CONFIGURED');
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'shows correct MCP status per integration in JSON when multiple agents have MCP',
+    async () => {
+      const claudeGlobalRoot = harness.userHome.path;
+      const copilotGlobalRoot = join(harness.userHome.path, '.copilot');
+      mkdirSync(copilotGlobalRoot, { recursive: true });
+
+      harness.userHome.writeFile('.claude.json', VALID_MCP_CONFIG);
+      harness.userHome.writeFile('.copilot/mcp-config.json', VALID_MCP_CONFIG);
+
+      const multiMcpState = baseState({
+        integrations: {
+          installed: [
+            makeInstallEntry('claude-id', 'claude-code', 'mcp-server', claudeGlobalRoot),
+            makeInstallEntry('copilot-id', 'copilot-cli', 'mcp-server', copilotGlobalRoot),
+          ],
+        },
+      });
+
+      harness.state().withRawState(JSON.stringify(multiMcpState));
+
+      const result = await harness.run('system status --json');
+
+      expect(result.exitCode).toBe(0);
+      const json = JSON.parse(result.stdout) as {
+        integrations: Array<{ id: string; mcp?: { configured: boolean } }>;
+      };
+
+      // Find both integrations
+      const claude = json.integrations.find((i) => i.id === 'claude-code');
+      const copilot = json.integrations.find((i) => i.id === 'copilot-cli');
+
+      expect(claude).toBeDefined();
+      expect(copilot).toBeDefined();
+
+      // Both should have MCP configured
+      expect(claude?.mcp?.configured).toBe(true);
+      expect(copilot?.mcp?.configured).toBe(true);
+    },
+    { timeout: 15000 },
   );
 });

--- a/tests/integration/specs/system/system-status.test.ts
+++ b/tests/integration/specs/system/system-status.test.ts
@@ -503,16 +503,15 @@ describe('system status', () => {
       const result = await harness.run('system status');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('CONFIGURED / NO ACTIVE SESSION');
+      expect(result.stdout).toContain('CONFIGURED');
     },
     { timeout: 15000 },
   );
 
   it.skipIf(IS_WINDOWS)(
-    'shows MCP running when docker reports active container',
+    'shows MCP configured status without checking docker',
     async () => {
       const mcpConfigPath = join(harness.userHome.path, '.claude.json');
-      harness.state().withDockerMock(true);
       harness
         .state()
         .withRawState(JSON.stringify(mcpStateWithFeature(harness.userHome.path, mcpConfigPath)));
@@ -521,7 +520,7 @@ describe('system status', () => {
       const result = await harness.run('system status');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain('CONFIGURED / SESSION ACTIVE');
+      expect(result.stdout).toContain('CONFIGURED');
     },
     { timeout: 15000 },
   );


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored MCP status tracking:**
  - Nested MCP status under specific integrations in the `system status` command output instead of a global entry.
  - Added support for multiple concurrent MCP configurations per integration based on `targetRoot`.
- **Performance and Reliability:**
  - Removed expensive docker process checks when determining MCP session status.
  - Optimized logic to resolve MCP feature status maps before rendering UI sections.
- **UI/UX improvements:**
  - Standardized binary display names in command output (e.g., 'Secrets Detection').
  - Improved label clarity for cache directory sections.
- **Testing:**
  - Added comprehensive integration tests verifying nested MCP output, multi-agent status, and JSON schema accuracy.

<sub>This will update automatically on new commits.</sub>