### PR TITLE
CLI-651 Preserve existing line endings when writing managed resource blocks

### DIFF
--- a/src/cli/commands/integrate/_common/registry/resources/common.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/common.ts
@@ -20,6 +20,7 @@
 
 import { existsSync } from 'node:fs';
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { EOL } from 'node:os';
 import { dirname } from 'node:path';
 
 import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
@@ -75,6 +76,32 @@ export async function readTextFile(path: string): Promise<string | undefined> {
     return undefined;
   }
   return readFile(path, 'utf-8');
+}
+
+/** Returns true when `a` and `b` have the same content, ignoring differences in line endings. */
+export function equalsIgnoringEol(a: string, b: string): boolean {
+  return toEol(a, '\n') === toEol(b, '\n');
+}
+
+/** Rewrites every line ending in `value` to `eol`. */
+export function toEol(value: string, eol: string): string {
+  return value.replaceAll('\r\n', '\n').replaceAll('\n', eol);
+}
+
+/**
+ * Returns the newline sequence the content already uses (`\r\n` or `\n`), so generated text
+ * can match the file's existing convention. Falls back to the OS default when both are present.
+ */
+export function detectEol(content: string): string {
+  const containsCrlf = content.includes('\r\n');
+  const containsLf = /(?<!\r)\n/.test(content);
+  if (containsCrlf && containsLf) {
+    return EOL;
+  }
+  if (containsCrlf) {
+    return '\r\n';
+  }
+  return '\n';
 }
 
 export interface PatchResourceOptions<TDoc = unknown> extends BaseResourceOptions {

--- a/src/cli/commands/integrate/_common/registry/resources/common.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/common.ts
@@ -80,7 +80,11 @@ export async function readTextFile(path: string): Promise<string | undefined> {
 
 /** Returns true when `a` and `b` have the same content, ignoring differences in line endings. */
 export function equalsIgnoringEol(a: string, b: string): boolean {
-  return toEol(a, '\n') === toEol(b, '\n');
+  return toEol(a, EOL) === toEol(b, EOL);
+}
+
+export function includesIgnoringEol(content: string, substring: string): boolean {
+  return toEol(content, EOL).includes(toEol(substring, EOL));
 }
 
 /** Rewrites every line ending in `value` to `eol`. */

--- a/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
@@ -22,6 +22,7 @@ import type { AppliedResource, IntegrationContext, MaybePromise } from '../types
 import {
   type BaseResourceOptions,
   detectEol,
+  includesIgnoringEol,
   type PathResolver,
   readTextFile,
   resolvePath,
@@ -72,7 +73,8 @@ export class TextSnippet implements ResourceDeclaration {
       return false;
     }
     const content = await this.resolveContent(context);
-    return existing.includes(this.renderManagedBlock(content, detectEol(existing)));
+    const renderedContent = this.renderManagedBlock(content, detectEol(existing));
+    return includesIgnoringEol(existing, renderedContent);
   }
 
   async remove(context: IntegrationContext): Promise<void> {

--- a/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/text-snippet.ts
@@ -21,10 +21,12 @@
 import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
   type BaseResourceOptions,
+  detectEol,
   type PathResolver,
   readTextFile,
   resolvePath,
   type ResourceDeclaration,
+  toEol,
   writeFileIfChanged,
 } from './common';
 
@@ -69,7 +71,8 @@ export class TextSnippet implements ResourceDeclaration {
     if (existing === undefined) {
       return false;
     }
-    return existing.includes(this.renderManagedBlock(await this.resolveContent(context)));
+    const content = await this.resolveContent(context);
+    return existing.includes(this.renderManagedBlock(content, detectEol(existing)));
   }
 
   async remove(context: IntegrationContext): Promise<void> {
@@ -93,7 +96,8 @@ export class TextSnippet implements ResourceDeclaration {
 
   private async renderContent(path: string, content: string): Promise<string> {
     const existing = (await readTextFile(path)) ?? '';
-    const managedBlock = this.renderManagedBlock(content);
+    const eol = detectEol(existing);
+    const managedBlock = this.renderManagedBlock(content, eol);
     const pattern = new RegExp(
       String.raw`${escapeRegExp(this.startMarker)}[\s\S]*?${escapeRegExp(this.endMarker)}`,
     );
@@ -103,14 +107,15 @@ export class TextSnippet implements ResourceDeclaration {
 
     const startMarkerIndex = existing.indexOf(this.startMarker);
     if (startMarkerIndex >= 0) {
-      return `${existing.slice(0, startMarkerIndex)}${managedBlock}\n`;
+      return `${existing.slice(0, startMarkerIndex)}${managedBlock}${eol}`;
     }
 
-    return appendBlock(existing, managedBlock);
+    return appendBlock(existing, managedBlock, eol);
   }
 
-  private renderManagedBlock(content: string): string {
-    return `${this.startMarker}\n${content.trimEnd()}\n${this.endMarker}`;
+  private renderManagedBlock(content: string, eol: string): string {
+    const body = toEol(content.trimEnd(), eol);
+    return [this.startMarker, body, this.endMarker].join(eol);
   }
 
   private get startMarker(): string {
@@ -122,11 +127,11 @@ export class TextSnippet implements ResourceDeclaration {
   }
 }
 
-function appendBlock(existing: string, block: string): string {
+function appendBlock(existing: string, block: string, eol: string): string {
   if (existing.length === 0) {
-    return `${block}\n`;
+    return `${block}${eol}`;
   }
-  return `${existing.trimEnd()}\n\n${block}\n`;
+  return `${existing.trimEnd()}${eol}${eol}${block}${eol}`;
 }
 
 function escapeRegExp(value: string): string {

--- a/src/cli/commands/integrate/_common/registry/resources/whole-file.ts
+++ b/src/cli/commands/integrate/_common/registry/resources/whole-file.ts
@@ -25,6 +25,7 @@ import { CommandFailedError } from '../../../../_common/error';
 import type { AppliedResource, IntegrationContext, MaybePromise } from '../types';
 import {
   type BaseResourceOptions,
+  equalsIgnoringEol,
   type PathResolver,
   readTextFile,
   resolvePath,
@@ -77,7 +78,9 @@ export class WholeFileResource implements ResourceDeclaration {
   async isApplied(context: IntegrationContext): Promise<boolean> {
     const path = await resolvePath(context, this.options.targetPath);
     const existing = await readTextFile(path);
-    return existing === (await this.resolveContent(context));
+    return (
+      existing !== undefined && equalsIgnoringEol(existing, await this.resolveContent(context))
+    );
   }
 
   async remove(context: IntegrationContext): Promise<void> {
@@ -106,7 +109,7 @@ export class WholeFileResource implements ResourceDeclaration {
     const existing = await readTextFile(path);
     if (
       existing === undefined ||
-      existing === content ||
+      equalsIgnoringEol(existing, content) ||
       this.options.requiresForce !== true ||
       context.force === true ||
       this.isManaged(existing)

--- a/tests/unit/cli/commands/integrate/_common/resources-eol.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/resources-eol.test.ts
@@ -1,0 +1,170 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import {
+  textSnippet,
+  wholeFile,
+} from '../../../../../../src/cli/commands/integrate/_common/registry';
+import type { IntegrationContext } from '../../../../../../src/cli/commands/integrate/_common/registry/types';
+import { getDefaultState } from '../../../../../../src/lib/state';
+
+describe('EOL-preserving resource writes', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sonar-cli-eol-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function context(): IntegrationContext {
+    return {
+      targetRoot: tempDir,
+      state: getDefaultState('test'),
+      scope: 'project',
+      executionMode: 'install',
+      resolvedDependencies: new Map(),
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // wholeFile
+  // ---------------------------------------------------------------------------
+  describe('wholeFile', () => {
+    it('isApplied returns true when on-disk file differs only by CRLF vs LF', async () => {
+      const path = join(tempDir, 'hook');
+      const lf = '#!/bin/sh\nsonar hook pre-commit\n';
+      const crlf = lf.replace(/\n/g, '\r\n');
+
+      await writeFile(path, crlf, 'utf-8');
+
+      const resource = wholeFile({
+        id: 'pre-commit',
+        targetPath: path,
+        content: lf,
+      });
+
+      expect(await resource.isApplied(context())).toBe(true);
+    });
+
+    it('isApplied returns false when content differs beyond EOL', async () => {
+      const path = join(tempDir, 'hook');
+      await writeFile(path, '#!/bin/sh\necho hello\r\n', 'utf-8');
+
+      const resource = wholeFile({
+        id: 'pre-commit',
+        targetPath: path,
+        content: '#!/bin/sh\nsonar hook pre-commit\n',
+      });
+
+      expect(await resource.isApplied(context())).toBe(false);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // textSnippet
+  // ---------------------------------------------------------------------------
+  describe('textSnippet', () => {
+    const START = '# sonar:begin my-snippet';
+    const END = '# sonar:end my-snippet';
+
+    function makeResource(content = 'sonar analyze\n') {
+      return textSnippet({
+        id: 'my-snippet',
+        targetPath: join(tempDir, 'config'),
+        content,
+        startMarker: START,
+        endMarker: END,
+      });
+    }
+
+    it('apply writes the managed block using the existing file EOL (CRLF file → CRLF block)', async () => {
+      const path = join(tempDir, 'config');
+      // File already has CRLF line endings
+      await writeFile(path, 'existing content\r\n', 'utf-8');
+
+      const resource = makeResource('sonar analyze\n');
+      await resource.apply(context());
+
+      const written = await readFile(path, 'utf-8');
+      // The managed block itself must use CRLF
+      expect(written).toContain(`${START}\r\n`);
+      expect(written).toContain(`\r\n${END}`);
+      // No stray bare LF (outside of the CRLF sequences)
+      expect(written.replace(/\r\n/g, '')).not.toContain('\n');
+    });
+
+    it('apply writes the managed block using LF when the existing file uses LF', async () => {
+      const path = join(tempDir, 'config');
+      await writeFile(path, 'existing content\n', 'utf-8');
+
+      const resource = makeResource('sonar analyze\n');
+      await resource.apply(context());
+
+      const written = await readFile(path, 'utf-8');
+      expect(written).toContain(`${START}\n`);
+      expect(written).not.toContain('\r\n');
+    });
+
+    it('apply replaces an existing managed block in a CRLF file using CRLF', async () => {
+      const path = join(tempDir, 'config');
+      // File already has a managed block with CRLF endings
+      const existing = `before\r\n${START}\r\nold command\r\n${END}\r\nafter\r\n`;
+      await writeFile(path, existing, 'utf-8');
+
+      const resource = makeResource('sonar analyze\n');
+      await resource.apply(context());
+
+      const written = await readFile(path, 'utf-8');
+      expect(written).toContain(`${START}\r\nsonar analyze\r\n${END}`);
+      expect(written).toContain('before\r\n');
+      expect(written).toContain('\r\nafter\r\n');
+      expect(written.replace(/\r\n/g, '')).not.toContain('\n');
+    });
+
+    it('isApplied returns true for a CRLF file when the template content uses LF', async () => {
+      const path = join(tempDir, 'config');
+      const lf = `${START}\nsonar analyze\n${END}\n`;
+      const crlf = lf.replace(/\n/g, '\r\n');
+      await writeFile(path, crlf, 'utf-8');
+
+      const resource = makeResource('sonar analyze\n');
+      expect(await resource.isApplied(context())).toBe(true);
+    });
+
+    it('isApplied returns false when the managed block content differs', async () => {
+      const path = join(tempDir, 'config');
+      const crlf = `${START}\r\nsome other command\r\n${END}\r\n`;
+      await writeFile(path, crlf, 'utf-8');
+
+      const resource = makeResource('sonar analyze\n');
+      expect(await resource.isApplied(context())).toBe(false);
+    });
+  });
+});

--- a/tests/unit/cli/commands/integrate/_common/resources-eol.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/resources-eol.test.ts
@@ -20,7 +20,7 @@
 
 import { mkdtempSync, rmSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
+import { EOL, tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
@@ -29,6 +29,12 @@ import {
   textSnippet,
   wholeFile,
 } from '../../../../../../src/cli/commands/integrate/_common/registry';
+import {
+  detectEol,
+  equalsIgnoringEol,
+  includesIgnoringEol,
+  toEol,
+} from '../../../../../../src/cli/commands/integrate/_common/registry/resources/common';
 import type { IntegrationContext } from '../../../../../../src/cli/commands/integrate/_common/registry/types';
 import { getDefaultState } from '../../../../../../src/lib/state';
 
@@ -166,5 +172,108 @@ describe('EOL-preserving resource writes', () => {
       const resource = makeResource('sonar analyze\n');
       expect(await resource.isApplied(context())).toBe(false);
     });
+
+    it('isApplied returns true when surrounding content uses CRLF but the managed block uses LF', async () => {
+      const path = join(tempDir, 'config');
+      // Mixed: rest of file is CRLF, block itself is LF — e.g. written by a different tool.
+      // detectEol returns the platform EOL for mixed content, so renderManagedBlock may produce
+      // a block with different endings than the one already in the file.
+      await writeFile(path, `before\r\n${START}\nsonar analyze\n${END}\r\nafter\r\n`, 'utf-8');
+
+      const resource = makeResource('sonar analyze\n');
+      expect(await resource.isApplied(context())).toBe(true);
+    });
+
+    it('isApplied returns true when surrounding content uses LF but the managed block uses CRLF', async () => {
+      const path = join(tempDir, 'config');
+      await writeFile(path, `before\n${START}\r\nsonar analyze\r\n${END}\nafter\n`, 'utf-8');
+
+      const resource = makeResource('sonar analyze\n');
+      expect(await resource.isApplied(context())).toBe(true);
+    });
+  });
+});
+
+describe('includesIgnoringEol', () => {
+  it('returns true when content includes substring with the same line endings', () => {
+    expect(includesIgnoringEol('a\nb\nc', 'a\nb')).toBe(true);
+  });
+
+  it('returns true when content uses CRLF but substring uses LF', () => {
+    expect(includesIgnoringEol('a\r\nb\r\nc', 'a\nb')).toBe(true);
+  });
+
+  it('returns true when content uses LF but substring uses CRLF', () => {
+    expect(includesIgnoringEol('a\nb\nc', 'a\r\nb')).toBe(true);
+  });
+
+  it('returns false when content does not contain the substring', () => {
+    expect(includesIgnoringEol('a\nb\nc', 'x\ny')).toBe(false);
+  });
+
+  it('returns false when substring is absent regardless of line endings', () => {
+    expect(includesIgnoringEol('a\r\nb\r\nc', 'x\r\ny')).toBe(false);
+  });
+});
+
+describe('toEol', () => {
+  it('converts LF to CRLF', () => {
+    expect(toEol('a\nb\n', '\r\n')).toBe('a\r\nb\r\n');
+  });
+
+  it('converts CRLF to LF', () => {
+    expect(toEol('a\r\nb\r\n', '\n')).toBe('a\nb\n');
+  });
+
+  it('normalises mixed line endings to the target EOL', () => {
+    expect(toEol('a\r\nb\nc\r\n', '\n')).toBe('a\nb\nc\n');
+  });
+
+  it('is a no-op when the value already uses the target EOL', () => {
+    expect(toEol('a\nb', '\n')).toBe('a\nb');
+  });
+
+  it('does not alter a string that contains no line endings', () => {
+    expect(toEol('abc', '\r\n')).toBe('abc');
+  });
+});
+
+describe('detectEol', () => {
+  it('returns LF for a string that contains only LF line endings', () => {
+    expect(detectEol('a\nb\nc\n')).toBe('\n');
+  });
+
+  it('returns CRLF for a string that contains only CRLF line endings', () => {
+    expect(detectEol('a\r\nb\r\nc\r\n')).toBe('\r\n');
+  });
+
+  it('returns the platform EOL for a string with mixed line endings', () => {
+    expect(detectEol('a\r\nb\nc\r\n')).toBe(EOL);
+  });
+
+  it('returns LF for a string with no line endings', () => {
+    expect(detectEol('abc')).toBe('\n');
+  });
+});
+
+describe('equalsIgnoringEol', () => {
+  it('returns true for identical strings', () => {
+    expect(equalsIgnoringEol('a\nb\n', 'a\nb\n')).toBe(true);
+  });
+
+  it('returns true when one string uses CRLF and the other uses LF', () => {
+    expect(equalsIgnoringEol('a\r\nb\r\n', 'a\nb\n')).toBe(true);
+  });
+
+  it('returns true when one string uses LF and the other uses CRLF', () => {
+    expect(equalsIgnoringEol('a\nb\n', 'a\r\nb\r\n')).toBe(true);
+  });
+
+  it('returns false when the strings differ beyond line endings', () => {
+    expect(equalsIgnoringEol('a\nb\n', 'a\nc\n')).toBe(false);
+  });
+
+  it('returns true for two empty strings', () => {
+    expect(equalsIgnoringEol('', '')).toBe(true);
   });
 });


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **EOL handling utilities:**
  - Added `detectEol` to identify existing file line endings (`\r\n` vs `\n`).
  - Added `toEol`, `equalsIgnoringEol`, and `includesIgnoringEol` to standardize or compare content regardless of line endings.
- **Resource management updates:**
  - Updated `TextSnippet` and `WholeFileResource` to detect and apply the existing file's EOL convention when writing managed blocks.
  - Modified `isApplied` logic to treat files with matching content but different line endings as already applied.
- **Test coverage:**
  - Added `resources-eol.test.ts` to verify EOL preservation for both `wholeFile` and `textSnippet` resource types.

<sub>This will update automatically on new commits.</sub>