### PR TITLE
CLI-661 sonar system reset should exit 0 on partial success

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The CAG installer (`src/cli/commands/_common/install/context-augmentation.ts`) h
 
 ### System reset
 
-`sonar system reset` returns the CLI to a factory-like state in one shot. Registered as `anonymousAction` so it works when auth is broken. Implementation is split across `src/cli/commands/system/reset.ts` (orchestration), `reset-auth.ts`, `reset-binaries.ts`, `reset-integrations.ts`, `reset-filesystem.ts`, and `safe-path.ts`. Integration teardown is declarative-only: `integrations.installed` features are removed via `removeFeature()`; legacy `agentExtensions` entries are cleared from state in `clearLegacyState()` but are not used for on-disk cleanup (1.0 does not guarantee removal of pre-declarative artifacts). Binary cleanup removes paths from both `dependencies.installed` and legacy `tools.installed` under `BIN_DIR`. Exits with code `1` when any reset step reports warnings (partial reset).
+`sonar system reset` returns the CLI to a factory-like state in one shot. Registered as `anonymousAction` so it works when auth is broken. Implementation is split across `src/cli/commands/system/reset.ts` (orchestration), `reset-auth.ts`, `reset-binaries.ts`, `reset-integrations.ts`, `reset-filesystem.ts`, and `safe-path.ts`. Integration teardown is declarative-only: `integrations.installed` features are removed via `removeFeature()`; legacy `agentExtensions` entries are cleared from state in `clearLegacyState()` but are not used for on-disk cleanup (1.0 does not guarantee removal of pre-declarative artifacts). Binary cleanup removes paths from both `dependencies.installed` and legacy `tools.installed` under `BIN_DIR`. Partial reset (step warnings) exits `0`.
 
 ## Error handling
 

--- a/src/cli/commands/system/reset.ts
+++ b/src/cli/commands/system/reset.ts
@@ -117,13 +117,20 @@ export async function systemReset(options: SystemResetOptions): Promise<void> {
     }
   }
 
-  const hasIssues = results.some((r) => r.item.status === 'warn');
-  if (hasIssues) {
+  const hasWarnings = results.some((r) => r.item.status === 'warn');
+  const hasFailures = results.some((r) => r.item.status === 'failed');
+  if (hasFailures) {
+    text('CLI reset could not be completed. Review the details above and try again.');
+    warn('System reset failed.');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (hasWarnings) {
     text(
       'CLI has been partially reset. Review the details above and clean up remaining items manually.',
     );
     warn('System reset completed with warnings.');
-    process.exitCode = 1;
     return;
   }
 

--- a/src/cli/commands/system/reset.ts
+++ b/src/cli/commands/system/reset.ts
@@ -118,13 +118,6 @@ export async function systemReset(options: SystemResetOptions): Promise<void> {
   }
 
   const hasWarnings = results.some((r) => r.item.status === 'warn');
-  const hasFailures = results.some((r) => r.item.status === 'failed');
-  if (hasFailures) {
-    text('CLI reset could not be completed. Review the details above and try again.');
-    warn('System reset failed.');
-    process.exitCode = 1;
-    return;
-  }
 
   if (hasWarnings) {
     text(

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -252,7 +252,7 @@ describe('system reset --force', () => {
         chmodSync(harness.keychainJsonFile, 0o444);
         const result = await runCli('system reset --force', env, { cwd: harness.cwd.path });
 
-        expect(result.exitCode).toBe(1);
+        expect(result.exitCode).toBe(0);
         expect(result.stdout).toMatch(/Authentication:.*could not delete keychain entry/);
         expect(result.stdout).toContain('keychain operation failed');
         expect(result.stderr).toContain('System reset completed with warnings');
@@ -416,7 +416,7 @@ describe('system reset --force', () => {
   );
 
   it.skipIf(SKIP_CHMOD_REMOVAL_TEST)(
-    'warns and exits 1 when a cache directory cannot be removed',
+    'warns and exits 0 when a cache directory cannot be removed',
     async () => {
       const logDir = join(harness.cliHome.path, 'logs');
       mkdirSync(logDir, { recursive: true });
@@ -426,7 +426,7 @@ describe('system reset --force', () => {
       try {
         const result = await harness.run('system reset --force');
 
-        expect(result.exitCode).toBe(1);
+        expect(result.exitCode).toBe(0);
         expect(result.stdout).toMatch(/Filesystem:.*Failed to clear some directories/);
         expect(result.stderr).toContain('System reset completed with warnings');
         expect(existsSync(logDir)).toBe(true);
@@ -529,7 +529,7 @@ describe('system reset --force', () => {
 
       const result = await harness.run('system reset --force');
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Binaries:');
       expect(result.stdout).toContain('failed');
       expect(result.stderr).toContain('System reset completed with warnings');
@@ -613,7 +613,7 @@ describe('system reset --force', () => {
   );
 
   it(
-    'warns and exits 1 when state references an unknown integration',
+    'warns and exits 0 when state references an unknown integration',
     async () => {
       harness.state().withRawState(
         buildRawState({
@@ -647,7 +647,7 @@ describe('system reset --force', () => {
 
       const result = await harness.run('system reset --force');
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(0);
       expect(result.stdout).toMatch(/Integrations:.*unknown integration/);
       expect(result.stderr).toContain('System reset completed with warnings');
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Logic changes:**
  - Modified `systemReset` in `src/cli/commands/system/reset.ts` to distinguish between warnings and failures.
  - Changed exit code from `1` to `0` when `system reset` encounters warnings (partial success).
- **Testing:**
  - Updated integration tests in `reset.test.ts` to assert a `0` exit code on partial reset scenarios.
- **Documentation:**
  - Updated `CLAUDE.md` to reflect the new exit code behavior for partial system resets.

<sub>This will update automatically on new commits.</sub>