### PR TITLE
CLI-662 Group dependency chains by direct parent in view model

### DIFF
--- a/src/cli/commands/analyze/dependency-risk-helpers/pluralize.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/pluralize.ts
@@ -18,31 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { ChainGroupVM } from './chain-group.ts';
-import type { RiskGroupVM, RiskVM } from './risk.ts';
-
-export class PackageIdentity {
-  constructor(
-    readonly purl: string,
-    readonly name: string,
-    readonly version: string,
-    readonly packageManager: string,
-  ) {}
-
-  label(): string {
-    return this.version ? `${this.name}@${this.version}` : this.name;
-  }
-
-  compareTo(other: PackageIdentity): number {
-    return this.purl.localeCompare(other.purl);
-  }
-}
-
-export interface PackageVM {
-  package: PackageIdentity;
-  newlyIntroduced: boolean;
-  riskCount: number;
-  filePaths: string[];
-  chains: ChainGroupVM[];
-  groups: RiskGroupVM<RiskVM>[];
+export function pluralize(count: number, singular: string): string {
+  return `${singular}${count === 1 ? '' : 's'}`;
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
@@ -19,19 +19,21 @@
  */
 
 import { dim, green, red, STATUS_ICONS } from '../../../../../ui/colors.js';
+import { pluralize } from '../pluralize.ts';
 import type { RiskFilterDescription } from '../risk-filter.ts';
-import type {
-  DependencyRisksViewModel,
-  ErrorVM,
-  LicenseGroupVM,
-  MalwareGroupVM,
-  PackageIdentity,
-  PackageSummaryVM,
-  PackageVM,
-  RiskGroupVM,
-  RiskVM,
-  SummaryVM,
-  VulnerabilityGroupVM,
+import {
+  type ChainGroupVM,
+  type DependencyRisksViewModel,
+  type ErrorVM,
+  type LicenseGroupVM,
+  type MalwareGroupVM,
+  MINIMUM_TRANSITIVE_CHAIN_LENGTH,
+  type PackageSummaryVM,
+  type PackageVM,
+  type RiskGroupVM,
+  type RiskVM,
+  type SummaryVM,
+  type VulnerabilityGroupVM,
 } from '../view-model';
 import { appendLicenseGroup } from './format-table-license-group.ts';
 import { appendMalwareGroup } from './format-table-malware-group.ts';
@@ -169,38 +171,49 @@ function summarySeverityCell(label: string, count: number): string {
   return `${label} ${icon} ${String(count).padStart(SEVERITY_COUNT_WIDTH)}`;
 }
 
-function transitiveChainLines(chains: PackageIdentity[][]): string[] {
+function transitiveChainLines(chains: ChainGroupVM[]): string[] {
   if (chains.length === 0) {
     return [];
   }
   const displayed = chains.slice(0, MAX_CHAINS_DISPLAYED);
   const lines: string[] = [];
-  for (const chain of displayed) {
-    const labels = chain.map((id) => id.label());
-    for (const line of wrapChain(labels, MAX_LINE_WIDTH)) {
-      lines.push(line);
-    }
+  for (const group of displayed) {
+    for (const line of wrapChain(group, MAX_LINE_WIDTH)) lines.push(line);
   }
   const remaining = chains.length - displayed.length;
   if (remaining > 0) {
-    lines.push(`${LINE_INDENT}and via ${remaining} others`);
+    lines.push(`${LINE_INDENT}via ${remaining} other ${pluralize(remaining, 'package')}`);
   }
   return lines;
 }
 
-function wrapChain(labels: string[], maxWidth: number): string[] {
-  if (labels.length === 0) {
-    return [`${LINE_INDENT}via `];
+function wrapChain(group: ChainGroupVM, maxWidth: number): string[] {
+  const mainLabel = group.parentPackage
+    ? `${LINE_INDENT}via ${group.parentPackage.label()}`
+    : `${LINE_INDENT}direct`;
+
+  const otherRoutes = group.chains.length - 1;
+  const suffix =
+    otherRoutes > 0 ? ` and ${otherRoutes} other ${pluralize(otherRoutes, 'route')}` : '';
+
+  const ancestors = group.chains[0].slice(0, -MINIMUM_TRANSITIVE_CHAIN_LENGTH).reverse();
+
+  const segments = ancestors.map((a, i) => (i === 0 ? ` (← ${a.label()}` : ` ← ${a.label()}`));
+  if (suffix) {
+    segments.push(suffix);
   }
+  if (ancestors.length > 0) {
+    segments[segments.length - 1] += ')';
+  }
+
   const lines: string[] = [];
-  let current = `${LINE_INDENT}via ${labels[0]}`;
-  for (let i = 1; i < labels.length; i++) {
-    const candidate = `${current} → ${labels[i]}`;
-    if (candidate.length <= maxWidth) {
-      current = candidate;
+  let current = mainLabel;
+  for (const segment of segments) {
+    if ((current + segment).length <= maxWidth) {
+      current += segment;
     } else {
       lines.push(current);
-      current = `${CHAIN_CONTINUATION_INDENT}→ ${labels[i]}`;
+      current = `${CHAIN_CONTINUATION_INDENT}${segment.trimStart()}`;
     }
   }
   lines.push(current);

--- a/src/cli/commands/analyze/dependency-risk-helpers/view-model/build/group-chains-by-parent.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/view-model/build/group-chains-by-parent.ts
@@ -1,0 +1,44 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { type ChainGroupVM, MINIMUM_TRANSITIVE_CHAIN_LENGTH } from '../chain-group.ts';
+import type { PackageIdentity } from '../package.ts';
+
+export function groupChainsByParent(chains: PackageIdentity[][]): ChainGroupVM[] {
+  const groups = new Map<string, PackageIdentity[][]>();
+  for (const chain of chains) {
+    const parent =
+      chain.length >= MINIMUM_TRANSITIVE_CHAIN_LENGTH
+        ? chain.at(-MINIMUM_TRANSITIVE_CHAIN_LENGTH)!.purl
+        : '';
+    const group = groups.get(parent) ?? [];
+    group.push(chain);
+    groups.set(parent, group);
+  }
+  return [...groups.values()]
+    .map((group) => ({
+      parentPackage:
+        group[0].length >= MINIMUM_TRANSITIVE_CHAIN_LENGTH
+          ? (group[0].at(-MINIMUM_TRANSITIVE_CHAIN_LENGTH) ?? null)
+          : null,
+      chains: group.slice().sort((a, b) => a.length - b.length),
+    }))
+    .sort((a, b) => a.chains[0].length - b.chains[0].length);
+}

--- a/src/cli/commands/analyze/dependency-risk-helpers/view-model/build/package-builder.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/view-model/build/package-builder.ts
@@ -23,6 +23,7 @@ import type { RiskFilterPredicate } from '../../risk-filter.ts';
 import type { AnalyzeProjectRelease } from '../../sca-scanner.ts';
 import { PackageIdentity, type PackageVM } from '../package.ts';
 import { buildGroups } from './group-builder.ts';
+import { groupChainsByParent } from './group-chains-by-parent.ts';
 
 export function buildPackageIdentityMap(
   releases: AnalyzeProjectRelease[],
@@ -55,7 +56,7 @@ export function buildPackageVM(
     newlyIntroduced: release.newlyIntroduced,
     riskCount,
     filePaths: release.dependencyFilePaths,
-    chains: resolveChains(release, identityByPurl),
+    chains: groupChainsByParent(resolveChains(release, identityByPurl)),
     groups,
   };
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/view-model/chain-group.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/view-model/chain-group.ts
@@ -18,31 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { ChainGroupVM } from './chain-group.ts';
-import type { RiskGroupVM, RiskVM } from './risk.ts';
+import type { PackageIdentity } from './package.ts';
 
-export class PackageIdentity {
-  constructor(
-    readonly purl: string,
-    readonly name: string,
-    readonly version: string,
-    readonly packageManager: string,
-  ) {}
+export const MINIMUM_TRANSITIVE_CHAIN_LENGTH = 2;
 
-  label(): string {
-    return this.version ? `${this.name}@${this.version}` : this.name;
-  }
-
-  compareTo(other: PackageIdentity): number {
-    return this.purl.localeCompare(other.purl);
-  }
-}
-
-export interface PackageVM {
-  package: PackageIdentity;
-  newlyIntroduced: boolean;
-  riskCount: number;
-  filePaths: string[];
-  chains: ChainGroupVM[];
-  groups: RiskGroupVM<RiskVM>[];
+export interface ChainGroupVM {
+  parentPackage: PackageIdentity | null;
+  chains: PackageIdentity[][];
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/view-model/index.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/view-model/index.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+export { type ChainGroupVM, MINIMUM_TRANSITIVE_CHAIN_LENGTH } from './chain-group.ts';
 export type { DependencyRisksViewModel } from './dependency-risks-view-model.ts';
 export type { ErrorVM } from './error.ts';
 export type { FixVersionVM } from './fix-version.ts';

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -26,6 +26,7 @@ import { DefaultScaScannerInstaller } from '../_common/install/sca-scanner.ts';
 import { countSelectedRisks } from './dependency-risk-helpers/count-selected-risks.ts';
 import { DefaultScaScannerSpawner } from './dependency-risk-helpers/default-sca-scanner-spawner.ts';
 import { formatDependencyRisksJson } from './dependency-risk-helpers/format-dependency-risks-json.ts';
+import { pluralize } from './dependency-risk-helpers/pluralize.ts';
 import { buildRiskFilter } from './dependency-risk-helpers/risk-filter.ts';
 import { ScaScanOrchestrator } from './dependency-risk-helpers/sca-scan-orchestrator.ts';
 import { formatDependencyRisksTable } from './dependency-risk-helpers/table';
@@ -96,10 +97,6 @@ function handleResult(unresolvedRisksCount: number, errorCount: number) {
   } else {
     process.exitCode = EXIT_CODE_OK;
   }
-}
-
-function pluralize(count: number, singular: string): string {
-  return `${singular}${count === 1 ? '' : 's'}`;
 }
 
 export function countUnresolvedIssues(vm: DependencyRisksViewModel): number {

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/_helpers.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/_helpers.ts
@@ -37,6 +37,7 @@ import {
   type VulnerabilityRiskVM,
 } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/view-model';
 import { buildSummaryVM } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/view-model/build';
+import { groupChainsByParent } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/view-model/build/group-chains-by-parent.ts';
 
 export function pkgId(purl: string): PackageIdentity {
   const atIdx = purl.lastIndexOf('@');
@@ -123,18 +124,23 @@ export function mockVulnerabilityGroupVM(
   };
 }
 
-export function mockPackageVM(overrides: Partial<PackageVM> = {}): PackageVM {
+type MockPackageVMOverrides = Omit<Partial<PackageVM>, 'chains'> & {
+  chains?: PackageIdentity[][];
+};
+
+export function mockPackageVM(overrides: MockPackageVMOverrides = {}): PackageVM {
+  const { chains: rawChains, ...rest } = overrides;
   const identity =
-    overrides.package ?? new PackageIdentity('pkg:npm/lodash@4.17.21', 'lodash', '4.17.21', 'npm');
-  const groups = overrides.groups ?? [mockVulnerabilityGroupVM()];
+    rest.package ?? new PackageIdentity('pkg:npm/lodash@4.17.21', 'lodash', '4.17.21', 'npm');
+  const groups = rest.groups ?? [mockVulnerabilityGroupVM()];
   return {
     package: identity,
     newlyIntroduced: false,
     riskCount: groups.reduce((n, g) => n + g.selectedRisks.length, 0),
     filePaths: ['package-lock.json'],
-    chains: [[identity]],
+    chains: groupChainsByParent(rawChains ?? [[identity]]),
     groups,
-    ...overrides,
+    ...rest,
   };
 }
 

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/format-dependency-risks-json.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/format-dependency-risks-json.test.ts
@@ -81,14 +81,16 @@ describe('formatDependencyRisksJson', () => {
     ) as {
       packages: {
         package: string;
-        chains: string[][];
+        chains: { parentPackage: string | null; chains: string[][] }[];
         groups: { type: string; risks: unknown[] }[];
       }[];
     };
 
     expect(parsed.packages).toHaveLength(1);
     expect(parsed.packages[0].package).toBe('pkg:npm/lodash@1.0.0');
-    expect(parsed.packages[0].chains).toEqual([['pkg:npm/lodash@1.0.0']]);
+    expect(parsed.packages[0].chains).toEqual([
+      { parentPackage: null, chains: [['pkg:npm/lodash@1.0.0']] },
+    ]);
     expect(parsed.packages[0].groups).toHaveLength(1);
     expect(parsed.packages[0].groups[0]).toMatchObject({ type: 'VULNERABILITY' });
   });
@@ -126,6 +128,67 @@ describe('formatDependencyRisksJson', () => {
     expect(byType.VULNERABILITY.action).toBe('UPGRADE_PACKAGE');
     expect(byType.VULNERABILITY.fixVersions).toEqual([
       { version: '2.0.0', descriptionCode: 'LATEST_STABLE', vulnerabilityIds: [] },
+    ]);
+  });
+
+  it('serializes a transitive chain with the direct parent purl as parentPackage', () => {
+    const parent = pkgId('pkg:npm/parent@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const pkg = mockPackageVM({
+      package: target,
+      chains: [[parent, target]],
+    });
+    const parsed = JSON.parse(
+      formatDependencyRisksJson('demo', mockDependencyRisksViewModel({ packages: [pkg] })),
+    ) as { packages: { chains: { parentPackage: string | null; chains: string[][] }[] }[] };
+
+    expect(parsed.packages[0].chains).toEqual([
+      {
+        parentPackage: 'pkg:npm/parent@1.0.0',
+        chains: [['pkg:npm/parent@1.0.0', 'pkg:npm/foo@1.0.0']],
+      },
+    ]);
+  });
+
+  it('groups chains sharing the same direct parent into a single entry', () => {
+    const shared = pkgId('pkg:npm/shared@1.0.0');
+    const a = pkgId('pkg:npm/a@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const pkg = mockPackageVM({
+      package: target,
+      chains: [
+        [shared, target],
+        [a, shared, target],
+      ],
+    });
+    const parsed = JSON.parse(
+      formatDependencyRisksJson('demo', mockDependencyRisksViewModel({ packages: [pkg] })),
+    ) as { packages: { chains: { parentPackage: string | null; chains: string[][] }[] }[] };
+
+    expect(parsed.packages[0].chains).toHaveLength(1);
+    expect(parsed.packages[0].chains[0].parentPackage).toBe('pkg:npm/shared@1.0.0');
+    expect(parsed.packages[0].chains[0].chains).toHaveLength(2);
+  });
+
+  it('emits one group entry per unique direct parent', () => {
+    const p1 = pkgId('pkg:npm/p1@1.0.0');
+    const p2 = pkgId('pkg:npm/p2@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const pkg = mockPackageVM({
+      package: target,
+      chains: [
+        [p1, target],
+        [p2, target],
+      ],
+    });
+    const parsed = JSON.parse(
+      formatDependencyRisksJson('demo', mockDependencyRisksViewModel({ packages: [pkg] })),
+    ) as { packages: { chains: { parentPackage: string | null; chains: string[][] }[] }[] };
+
+    expect(parsed.packages[0].chains).toHaveLength(2);
+    expect(parsed.packages[0].chains.map((g) => g.parentPackage)).toEqual([
+      'pkg:npm/p1@1.0.0',
+      'pkg:npm/p2@1.0.0',
     ]);
   });
 

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/format-dependency-risks-table.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/format-dependency-risks-table.test.ts
@@ -172,40 +172,84 @@ describe('file path line', () => {
 });
 
 describe('dependency chain rendering', () => {
-  it('keeps only the three shortest chains and appends "and via N others" for the rest', () => {
+  it('caps at three unique-parent chains and shows "via N other packages" for the rest', () => {
+    const foo = pkgId('pkg:npm/foo@1.0.0');
+    const p1 = pkgId('pkg:npm/p1@1');
+    const p2 = pkgId('pkg:npm/p2@1');
+    const p3 = pkgId('pkg:npm/p3@1');
+    const p4 = pkgId('pkg:npm/p4@1');
+    const pkg = mockPackageVM({
+      package: foo,
+      chains: [
+        [pkgId('pkg:npm/a@1'), p1, foo],
+        [pkgId('pkg:npm/b@1'), p2, foo],
+        [pkgId('pkg:npm/c@1'), p3, foo],
+        [pkgId('pkg:npm/d@1'), p4, foo],
+      ],
+    });
+    const out = formatDependencyRisksTable(mockDependencyRisksViewModel({ packages: [pkg] }));
+    const chainLines = out
+      .split('\n')
+      .filter((l) => l.trimStart().startsWith('via ') && !l.includes('other package'));
+    expect(chainLines).toHaveLength(3);
+    expect(out).toContain('via 1 other package');
+  });
+
+  it('deduplicates chains sharing the same direct parent and shows "via N longer routes"', () => {
+    const sameParent = pkgId('pkg:npm/same-parent@1');
     const foo = pkgId('pkg:npm/foo@1.0.0');
     const pkg = mockPackageVM({
       package: foo,
-      // pre-sorted shortest first, as the builder would produce
+      // all three arrive via `sameParent` as the direct parent of `foo`
       chains: [
-        [pkgId('pkg:npm/b1@1'), foo],
-        [pkgId('pkg:npm/c1@1'), pkgId('pkg:npm/c2@1'), foo],
-        [pkgId('pkg:npm/a1@1'), pkgId('pkg:npm/a2@1'), pkgId('pkg:npm/a3@1'), foo],
-        [pkgId('pkg:npm/d1@1'), pkgId('pkg:npm/d2@1'), pkgId('pkg:npm/d3@1'), foo],
+        [pkgId('pkg:npm/root@1'), sameParent, foo],
+        [pkgId('pkg:npm/a@1'), pkgId('pkg:npm/a2@1'), sameParent, foo],
+        [pkgId('pkg:npm/b@1'), pkgId('pkg:npm/b2@1'), pkgId('pkg:npm/b3@1'), sameParent, foo],
       ],
     });
     const out = formatDependencyRisksTable(mockDependencyRisksViewModel({ packages: [pkg] }));
     const viaLines = out.split('\n').filter((l) => l.trimStart().startsWith('via '));
-    expect(viaLines).toHaveLength(3);
-    expect(out).toContain('and via 1 others');
-    expect(out).not.toContain('d1@1');
+    expect(viaLines).toHaveLength(1);
+    expect(out).toContain('root@1');
+    expect(out).toContain('and 2 other routes)');
+    expect(out).not.toContain('other package');
   });
 
-  it('omits the "and via N others" tail when there are at most three chains', () => {
-    const foo = pkgId('pkg:npm/foo@4.17.21');
+  it('omits the "and via N others" tail when unique-end chains fit within the display limit', () => {
     const pkg = mockPackageVM({
-      package: foo,
       chains: [
-        [pkgId('pkg:npm/a@1'), foo],
-        [pkgId('pkg:npm/b@1'), foo],
-        [pkgId('pkg:npm/c@1'), foo],
+        [pkgId('pkg:npm/a@1'), pkgId('pkg:npm/end1@1')],
+        [pkgId('pkg:npm/b@1'), pkgId('pkg:npm/end2@1')],
+        [pkgId('pkg:npm/c@1'), pkgId('pkg:npm/end3@1')],
       ],
     });
     const out = formatDependencyRisksTable(mockDependencyRisksViewModel({ packages: [pkg] }));
     expect(out).not.toContain('and via');
   });
 
-  it('wraps a chain that exceeds 80 chars onto a continuation line beginning with →', () => {
+  it('keeps every rendered line within 80 columns even when the "other routes" suffix is appended', () => {
+    // Each label is long enough that appending " and 2 other routes" would push
+    // the last wrapped line past 80 chars if the suffix were not pre-accounted.
+    const longLabel = 'some-very-long-package-name-here@10.20.30';
+    const sameParent = pkgId(`pkg:npm/${longLabel}`);
+    const foo = pkgId('pkg:npm/foo@1.0.0');
+    const pkg = mockPackageVM({
+      package: foo,
+      chains: [
+        [pkgId('pkg:npm/root@1'), sameParent, foo],
+        [pkgId('pkg:npm/a@1'), pkgId('pkg:npm/a2@1'), sameParent, foo],
+        [pkgId('pkg:npm/b@1'), pkgId('pkg:npm/b2@1'), sameParent, foo],
+      ],
+    });
+    const out = formatDependencyRisksTable(mockDependencyRisksViewModel({ packages: [pkg] }));
+    const overlongChainLines = out
+      .split('\n')
+      .filter((l) => l.trimStart().startsWith('via ') || l.trimStart().startsWith('(←'))
+      .filter((l) => l.length > 80);
+    expect(overlongChainLines).toEqual([]);
+  });
+
+  it('wraps a chain that exceeds 80 chars onto a continuation line beginning with ←', () => {
     const base = '@scope-with-a-really-long-name/sub-package';
     const a = `${base}-aaaa`;
     const b = `${base}-bbbb`;
@@ -217,10 +261,10 @@ describe('dependency chain rendering', () => {
     const lines = out.split('\n');
     const viaIdx = lines.findIndex((l) => l.trimStart().startsWith('via '));
     expect(viaIdx).toBeGreaterThan(-1);
-    expect(lines[viaIdx]).toContain(a);
-    expect(lines[viaIdx]).not.toContain(b);
-    expect(lines[viaIdx + 1].trimStart().startsWith('→')).toBe(true);
-    expect(lines[viaIdx + 1]).toContain(b);
+    expect(lines[viaIdx]).toContain(b);
+    expect(lines[viaIdx]).not.toContain(a);
+    expect(lines[viaIdx + 1].trimStart().startsWith('(←')).toBe(true);
+    expect(lines[viaIdx + 1]).toContain(a);
   });
 });
 

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/view-model/build/group-chains-by-parent.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/view-model/build/group-chains-by-parent.test.ts
@@ -1,0 +1,122 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { groupChainsByParent } from '../../../../../../../../src/cli/commands/analyze/dependency-risk-helpers/view-model/build/group-chains-by-parent.ts';
+import { pkgId } from '../../_helpers.ts';
+
+describe('groupChainsByParent', () => {
+  it('returns an empty array for no chains', () => {
+    expect(groupChainsByParent([])).toEqual([]);
+  });
+
+  it('produces a group with null parentPackage for a direct dependency', () => {
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const groups = groupChainsByParent([[target]]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].parentPackage).toBeNull();
+    expect(groups[0].chains).toEqual([[target]]);
+  });
+
+  it('sets parentPackage to the direct parent for a two-hop chain', () => {
+    const parent = pkgId('pkg:npm/parent@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const groups = groupChainsByParent([[parent, target]]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].parentPackage).toBe(parent);
+    expect(groups[0].chains).toEqual([[parent, target]]);
+  });
+
+  it('sets parentPackage to the second-to-last entry for a longer chain', () => {
+    const a = pkgId('pkg:npm/a@1.0.0');
+    const parent = pkgId('pkg:npm/parent@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const groups = groupChainsByParent([[a, parent, target]]);
+
+    expect(groups[0].parentPackage).toBe(parent);
+  });
+
+  it('merges chains that share the same direct parent into one group', () => {
+    const shared = pkgId('pkg:npm/shared@1.0.0');
+    const a = pkgId('pkg:npm/a@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const groups = groupChainsByParent([
+      [shared, target],
+      [a, shared, target],
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].parentPackage?.purl).toBe(shared.purl);
+    expect(groups[0].chains).toHaveLength(2);
+  });
+
+  it('sorts chains within a group shortest-first', () => {
+    const shared = pkgId('pkg:npm/shared@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const a = pkgId('pkg:npm/a@1.0.0');
+    const b = pkgId('pkg:npm/b@1.0.0');
+    const groups = groupChainsByParent([
+      [a, b, shared, target],
+      [shared, target],
+      [a, shared, target],
+    ]);
+
+    expect(groups[0].chains.map((c) => c.length)).toEqual([2, 3, 4]);
+  });
+
+  it('keeps chains with different direct parents in separate groups', () => {
+    const p1 = pkgId('pkg:npm/p1@1.0.0');
+    const p2 = pkgId('pkg:npm/p2@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const groups = groupChainsByParent([
+      [p1, target],
+      [p2, target],
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.parentPackage?.purl)).toEqual([p1.purl, p2.purl]);
+  });
+
+  it('sorts groups by their shortest chain length', () => {
+    const p1 = pkgId('pkg:npm/p1@1.0.0');
+    const p2 = pkgId('pkg:npm/p2@1.0.0');
+    const a = pkgId('pkg:npm/a@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const groups = groupChainsByParent([
+      [a, p2, target],
+      [p1, target],
+    ]);
+
+    expect(groups[0].parentPackage?.purl).toBe(p1.purl);
+    expect(groups[1].parentPackage?.purl).toBe(p2.purl);
+  });
+
+  it('places the direct-dependency group before transitive groups', () => {
+    const parent = pkgId('pkg:npm/parent@1.0.0');
+    const target = pkgId('pkg:npm/foo@1.0.0');
+    const groups = groupChainsByParent([[parent, target], [target]]);
+
+    expect(groups[0].parentPackage).toBeNull();
+    expect(groups[1].parentPackage?.purl).toBe(parent.purl);
+  });
+});

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/view-model/build/package-builder.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/view-model/build/package-builder.test.ts
@@ -132,7 +132,7 @@ describe('buildPackageVM — chain resolution', () => {
     const pkg = buildPackageVM(foo, ALLOW_ALL, identityByPurl)!;
 
     expect(pkg.chains).toHaveLength(1);
-    expect(pkg.chains[0].map((id) => id.label())).toEqual(['transit@1.0.0', 'foo@2.0.0']);
+    expect(pkg.chains[0].chains[0].map((id) => id.label())).toEqual(['transit@1.0.0', 'foo@2.0.0']);
   });
 
   it('drops a chain entirely when any purl in it is unknown', () => {
@@ -150,10 +150,10 @@ describe('buildPackageVM — chain resolution', () => {
     const pkg = buildPackageVM(foo, ALLOW_ALL, identityByPurl)!;
 
     expect(pkg.chains).toHaveLength(1);
-    expect(pkg.chains[0].map((id) => id.label())).toEqual(['known@1.0.0', 'foo@4.17.21']);
+    expect(pkg.chains[0].chains[0].map((id) => id.label())).toEqual(['known@1.0.0', 'foo@4.17.21']);
   });
 
-  it('orders resolved chains shortest-first', () => {
+  it('orders groups shortest-first by their shortest chain', () => {
     const foo = mockScaRelease({
       packageName: 'foo',
       dependencyChains: [
@@ -172,7 +172,7 @@ describe('buildPackageVM — chain resolution', () => {
 
     const pkg = buildPackageVM(foo, ALLOW_ALL, identityByPurl)!;
 
-    expect(pkg.chains.map((c) => c.length)).toEqual([1, 2, 3]);
+    expect(pkg.chains.map((g) => g.chains[0].length)).toEqual([1, 2, 3]);
   });
 
   it('preserves all chains — no cap at the builder layer', () => {


### PR DESCRIPTION
part of CLI-506

----
## Summary by Gitar

- **ViewModel restructuring:**
  - Introduced `ChainGroupVM` interface to support grouping chains by their direct parent.
  - Added `groupChainsByParent` builder to aggregate dependency chains and identify parent packages.
- **UI/UX enhancements:**
  - Updated `format-dependency-risks-table.ts` to display aggregated route counts for shared parents.
  - Refined chain rendering to use `(← )` arrow notation and improved multi-route summary formatting.
- **Utilities:**
  - Added `pluralize.ts` helper to manage grammatical correctness in UI string generation.
- **Test coverage:**
  - Added extensive unit tests for chain grouping logic and updated existing table/JSON rendering tests.

<sub>This will update automatically on new commits.</sub>