### PR TITLE
Remove references to 'sonar verify' from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The SonarQube CLI is designed for three distinct use cases:
 2. **🖥️ Interactive CLI** — Run commands directly in your terminal to scan code, check issues, and manage SonarQube projects manually
    ```bash
    sonar list issues --project my-app
-   sonar verify --staged
+   sonar analyze --file file.ext
    ```
 
 3. **⚙️ Scripting & Automation** — Integrate into scripts for reporting, dashboards, or automated quality gates
@@ -222,7 +222,7 @@ Supported formats: `json` (default), `table`, `toon`, `csv`.
 
 ```bash
 cd your-project-directory
-sonar verify --staged
+sonar analyze --file file.ext
 # Analyzes uncommitted changes for new issues
 # Only shows issues YOU introduced in your changes
 ```
@@ -230,9 +230,9 @@ sonar verify --staged
 **Common options:**
 
 ```bash
-sonar verify --file src/myfile.ts          # Analyze a specific file
-sonar verify --base main                   # Analyze changes vs main branch
-sonar verify --branch feature-xyz          # Set branch context
+sonar analyze --file src/myfile.ts          # Analyze a specific file
+sonar analyze --base main                   # Analyze changes vs main branch
+sonar analyze --branch feature-xyz          # Set branch context
 ```
 
 ---
@@ -350,7 +350,7 @@ CRITICAL | typescript:S3776 | Refactor this function to reduce its Cognitive Com
 ### Analyzing Local Changes
 
 ```bash
-$ sonar verify --staged
+$ sonar analyze
 SonarQube Agentic Analysis: no files in the change set to analyze.
 ```
 
@@ -448,20 +448,20 @@ For SonarQube Cloud, ensure you're using the correct region:
 
 ---
 
-### `sonar verify` says "Not a git repository"
+### `sonar analyze` says "Not a git repository"
 
-**Cause:** `sonar verify` requires git to detect changes.
+**Cause:** `sonar analyze` requires git to detect changes.
 
 **Solution:**
 
 - Run from inside a git repository:
   ```bash
   cd your-project
-  sonar verify
+  sonar analyze
   ```
 - Or analyze a specific file instead:
   ```bash
-  sonar verify --file src/myfile.ts
+  sonar analyze --file src/myfile.ts
   ```
 
 ---

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -94,17 +94,6 @@ a:hover { text-decoration: underline; }
 .logo:hover { text-decoration: none; opacity: 0.85; }
 
 /* ─── Version Badge ──────────────────────────────────────────── */
-.beta-badge {
-  display: inline-block;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 3px 8px;
-  border-radius: 999px;
-  background: var(--accent-dim);
-  color: var(--accent);
-  border: 1px solid var(--accent);
-  letter-spacing: 0.3px;
-}
 
 .version {
   font-size: 11px;
@@ -374,7 +363,6 @@ pre code {
   margin-bottom: 16px;
 }
 .hero h1 span { color: var(--accent); }
-.hero h1 .beta-badge { font-size: 14px; vertical-align: middle; }
 .hero .tagline {
   font-size: 20px;
   color: var(--text-muted);

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -31,7 +31,6 @@
     <img class="logo-dark"  src="assets/SQ-CLI_Dark Backgrounds.svg"  alt="SonarQube CLI">
     <img class="logo-light" src="assets/SQ-CLI_Light Backgrounds.svg" alt="SonarQube CLI">
   </a>
-  <span class="beta-badge">BETA</span>
   <span class="version" id="nav-version" style="display:none">v0.0.0</span>
   <div class="nav-links">
     <a href="index.html" class="nav-link">Home</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -351,8 +351,8 @@
         { t: 'Installing claude code hooks...',       c: C.muted, d: 600 },
         { t: '✅ Setup complete!',                   c: C.success },
       ],
-      [ // sonar verify --file
-        { t: '$ sonar verify --file src/auth.ts', cmd: true },
+      [ // sonar analyze --file
+        { t: '$ sonar analyze --file src/auth.ts', cmd: true },
         { t: '' },
         { t: 'Running SonarQube Agentic Analysis analysis...',              c: C.muted, d: 1200 },
         { t: '' },
@@ -536,7 +536,7 @@
     ],
     analyze: [
       { title: 'Authenticate',        cmd: 'sonar auth login',                                              desc: 'Connect to SonarQube.' },
-      { title: 'Analyze',             cmd: 'sonar verify --file &lt;file&gt; --project &lt;key&gt;',       desc: 'Runs server-side static analysis on a file (SonarQube Cloud only).' },
+      { title: 'Analyze',             cmd: 'sonar analyze --file &lt;file&gt; --project &lt;key&gt;',       desc: 'Runs server-side static analysis on a file (SonarQube Cloud only).' },
     ],
     hooks: [
       { title: 'Authenticate',        cmd: 'sonar auth login',                           desc: 'Connect to SonarQube.' },

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,7 @@
 
 <!-- ─── Hero ──────────────────────────────────────────────────── -->
 <section class="hero" style="position:relative;z-index:1;">
-  <h1>SonarQube <span>CLI</span> <span class="beta-badge">BETA</span></h1>
+  <h1>SonarQube <span>CLI</span></h1>
   <p class="tagline">Code verification in your terminal</p>
 
   <div class="hero-install">


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation updates:**
  - Replaced deprecated `sonar verify` command with `sonar analyze` throughout `README.md` and `docs/index.html`.
  - Removed "BETA" badge labels from `docs/index.html` header.
  - Cleaned up obsolete documentation references in `docs/assets/style.css` and `docs/commands.html`.

<sub>This will update automatically on new commits.</sub>