### PR TITLE
CLI-626 Align SQAA requests with multi-file API contract

### DIFF
--- a/src/cli/commands/analyze/sqaa-api.ts
+++ b/src/cli/commands/analyze/sqaa-api.ts
@@ -87,12 +87,11 @@ export async function fetchSqaaResponse(
   const filePath = toRelativePosixPath(file, pathBase);
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
   try {
-    return await client.analyzeFile({
+    return await client.createAnalysis({
       organizationKey: auth.orgKey,
       projectKey,
       ...(branch ? { branchName: branch } : {}),
-      filePath,
-      fileContent,
+      files: [{ path: filePath, content: fileContent }],
     });
   } catch (err) {
     if (err instanceof ServiceUnavailableError) {

--- a/src/cli/commands/hook/agent-post-tool-use.ts
+++ b/src/cli/commands/hook/agent-post-tool-use.ts
@@ -69,11 +69,10 @@ export async function agentPostToolUse(options: AgentPostToolUseOptions): Promis
     const fileContent = readFileSync(filePath, 'utf-8');
     const client = new SonarQubeClient(auth.serverUrl, auth.token);
 
-    const response = await client.analyzeFile({
+    const response = await client.createAnalysis({
       organizationKey: auth.orgKey,
       projectKey,
-      filePath: normalizedPath,
-      fileContent,
+      files: [{ path: normalizedPath, content: fileContent }],
     });
 
     const text = formatSqaaIssuesForHook(response.issues, response.errors);

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -604,10 +604,10 @@ export class SonarQubeClient {
   }
 
   /**
-   * Run server-side SonarQube Agentic Analysis on a single file.
-   * SonarQube Cloud only - endpoint lives on the region-specific API host.
+   * Create a SonarQube Agentic Analysis (single- or multi-file).
+   * SonarQube Cloud only — endpoint lives on the region-specific API host.
    */
-  async analyzeFile(request: SqaaAnalysisRequest): Promise<SqaaAnalysisResponse> {
+  async createAnalysis(request: SqaaAnalysisRequest): Promise<SqaaAnalysisResponse> {
     const endpoint = '/a3s-analysis/analyses';
     return await this.post<SqaaAnalysisResponse>(
       endpoint,
@@ -648,13 +648,22 @@ export interface AgentJobResponse {
   taskId: string;
 }
 
+export type SqaaAnalysisDepth = 'STANDARD' | 'DEEP';
+
+export type SqaaFileScope = 'MAIN' | 'TEST';
+
+export interface SqaaAnalysisFile {
+  path: string;
+  content: string;
+  scope?: SqaaFileScope;
+}
+
 export interface SqaaAnalysisRequest {
   organizationKey: string;
   projectKey: string;
   branchName?: string;
-  filePath: string;
-  fileContent: string;
-  fileScope?: 'MAIN' | 'TEST';
+  files: SqaaAnalysisFile[];
+  analysisDepth?: SqaaAnalysisDepth;
 }
 
 export interface SqaaAnalysisResponse {

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -696,6 +696,23 @@ export class FakeSonarQubeServerBuilder {
             );
           }
 
+          let requestBody: { files?: unknown } = {};
+          try {
+            requestBody = JSON.parse(body ?? '{}') as { files?: unknown };
+          } catch {
+            return new Response(JSON.stringify({ message: 'Invalid JSON body' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          if (!Array.isArray(requestBody.files) || requestBody.files.length === 0) {
+            return new Response(JSON.stringify({ message: 'files[] is required' }), {
+              status: 400,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
           const issues = (sqaaResponse.issues ?? []).map((i) => ({
             rule: i.rule,
             message: i.message,

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -27,6 +27,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestHarness } from '../../harness';
 import { commitFile, git, initGitRepo, stageFile } from '../hook/git-test-helpers';
+import { parseSqaaRequestBody, sqaaRequestSingleFilePath } from './sqaa-request-helpers';
 
 const VALID_TOKEN = 'integration-test-token';
 const TEST_ORG = 'my-org';
@@ -320,12 +321,11 @@ describe('analyze (no subcommand)', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
-      const request = JSON.parse(sqaaCalls[0].body ?? '{}') as {
-        filePath?: string;
-        projectKey?: string;
-      };
-      expect(request.filePath).toBe('new.ts');
+      const request = parseSqaaRequestBody(sqaaCalls[0].body);
+      expect(sqaaRequestSingleFilePath(sqaaCalls[0].body)).toBe('new.ts');
       expect(request.projectKey).toBe('explicit-project');
+      expect(request.files).toHaveLength(1);
+      expect(request.analysisDepth).toBeUndefined();
     },
     { timeout: 15000 },
   );
@@ -1778,9 +1778,7 @@ describe('analyze agentic — running from a subdirectory', () => {
       expect(sqaaCalls).toHaveLength(2);
 
       // Paths sent to SQAA are relative to the repo root regardless of cwd.
-      const filePaths = sqaaCalls
-        .map((c) => (JSON.parse(c.body ?? '{}') as { filePath?: string }).filePath)
-        .sort();
+      const filePaths = sqaaCalls.map((c) => sqaaRequestSingleFilePath(c.body)).sort();
       expect(filePaths).toEqual(['src/ui/inside.ts', 'top-level.ts']);
     },
     { timeout: 15000 },
@@ -1811,8 +1809,7 @@ describe('analyze agentic — running from a subdirectory', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
-      const sentPath = (JSON.parse(sqaaCalls[0].body ?? '{}') as { filePath?: string }).filePath;
-      expect(sentPath).toBe('with space.ts');
+      expect(sqaaRequestSingleFilePath(sqaaCalls[0].body)).toBe('with space.ts');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -27,7 +27,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestHarness } from '../../harness';
 import { commitFile, git, initGitRepo, stageFile } from '../hook/git-test-helpers';
-import { parseSqaaRequestBody, sqaaRequestSingleFilePath } from './sqaa-request-helpers';
+import { parseSqaaRequestBody, sqaaRequestFirstFilePath } from './sqaa-request-helpers';
 
 const VALID_TOKEN = 'integration-test-token';
 const TEST_ORG = 'my-org';
@@ -322,7 +322,7 @@ describe('analyze (no subcommand)', () => {
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
       const request = parseSqaaRequestBody(sqaaCalls[0].body);
-      expect(sqaaRequestSingleFilePath(sqaaCalls[0].body)).toBe('new.ts');
+      expect(sqaaRequestFirstFilePath(sqaaCalls[0].body)).toBe('new.ts');
       expect(request.projectKey).toBe('explicit-project');
       expect(request.files).toHaveLength(1);
       expect(request.analysisDepth).toBeUndefined();
@@ -1778,7 +1778,7 @@ describe('analyze agentic — running from a subdirectory', () => {
       expect(sqaaCalls).toHaveLength(2);
 
       // Paths sent to SQAA are relative to the repo root regardless of cwd.
-      const filePaths = sqaaCalls.map((c) => sqaaRequestSingleFilePath(c.body)).sort();
+      const filePaths = sqaaCalls.map((c) => sqaaRequestFirstFilePath(c.body)).sort();
       expect(filePaths).toEqual(['src/ui/inside.ts', 'top-level.ts']);
     },
     { timeout: 15000 },
@@ -1809,7 +1809,7 @@ describe('analyze agentic — running from a subdirectory', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
-      expect(sqaaRequestSingleFilePath(sqaaCalls[0].body)).toBe('with space.ts');
+      expect(sqaaRequestFirstFilePath(sqaaCalls[0].body)).toBe('with space.ts');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/analyze/sqaa-request-helpers.ts
+++ b/tests/integration/specs/analyze/sqaa-request-helpers.ts
@@ -30,7 +30,7 @@ export function parseSqaaRequestBody(body: string | undefined): ParsedSqaaReques
   return JSON.parse(body ?? '{}') as ParsedSqaaRequestBody;
 }
 
-/** First file path when the CLI sends a single-file request (`files: [1]`). */
-export function sqaaRequestSingleFilePath(body: string | undefined): string | undefined {
+/** Path of the first entry in `files[]`. */
+export function sqaaRequestFirstFilePath(body: string | undefined): string | undefined {
   return parseSqaaRequestBody(body).files?.[0]?.path;
 }

--- a/tests/integration/specs/analyze/sqaa-request-helpers.ts
+++ b/tests/integration/specs/analyze/sqaa-request-helpers.ts
@@ -1,0 +1,36 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+export interface ParsedSqaaRequestBody {
+  organizationKey?: string;
+  projectKey?: string;
+  branchName?: string;
+  analysisDepth?: string;
+  files?: Array<{ path: string; content: string; scope?: string }>;
+}
+
+export function parseSqaaRequestBody(body: string | undefined): ParsedSqaaRequestBody {
+  return JSON.parse(body ?? '{}') as ParsedSqaaRequestBody;
+}
+
+/** First file path when the CLI sends a single-file request (`files: [1]`). */
+export function sqaaRequestSingleFilePath(body: string | undefined): string | undefined {
+  return parseSqaaRequestBody(body).files?.[0]?.path;
+}

--- a/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
@@ -25,6 +25,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestHarness } from '../../harness';
+import { parseSqaaRequestBody, sqaaRequestSingleFilePath } from '../analyze/sqaa-request-helpers';
 
 const VALID_TOKEN = 'integration-test-token';
 const TEST_ORG = 'my-org';
@@ -143,8 +144,11 @@ describe('sonar hook claude-post-tool-use', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
-      const body = JSON.parse(sqaaCalls[0].body ?? '{}') as { filePath?: string };
-      expect(body.filePath).toBe('src/main.ts');
+      const body = parseSqaaRequestBody(sqaaCalls[0].body);
+      expect(sqaaRequestSingleFilePath(sqaaCalls[0].body)).toBe('src/main.ts');
+      expect(body.files).toHaveLength(1);
+      expect(body.files?.[0]?.content).toContain('const x');
+      expect(body.analysisDepth).toBeUndefined();
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
@@ -25,7 +25,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestHarness } from '../../harness';
-import { parseSqaaRequestBody, sqaaRequestSingleFilePath } from '../analyze/sqaa-request-helpers';
+import { parseSqaaRequestBody, sqaaRequestFirstFilePath } from '../analyze/sqaa-request-helpers';
 
 const VALID_TOKEN = 'integration-test-token';
 const TEST_ORG = 'my-org';
@@ -145,7 +145,7 @@ describe('sonar hook claude-post-tool-use', () => {
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
       const body = parseSqaaRequestBody(sqaaCalls[0].body);
-      expect(sqaaRequestSingleFilePath(sqaaCalls[0].body)).toBe('src/main.ts');
+      expect(sqaaRequestFirstFilePath(sqaaCalls[0].body)).toBe('src/main.ts');
       expect(body.files).toHaveLength(1);
       expect(body.files?.[0]?.content).toContain('const x');
       expect(body.analysisDepth).toBeUndefined();

--- a/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
@@ -54,7 +54,7 @@ let loadStateSpy: ReturnType<typeof spyOn>;
 let saveStateSpy: ReturnType<typeof spyOn>;
 let existsSpy: ReturnType<typeof spyOn>;
 let readFileSpy: ReturnType<typeof spyOn>;
-let analyzeFileSpy: ReturnType<typeof spyOn>;
+let createAnalysisSpy: ReturnType<typeof spyOn>;
 let spawnProcessSpy: ReturnType<typeof spyOn>;
 
 /** Cloud state WITH a sonar-sqaa extension entry for the current project root */
@@ -90,7 +90,7 @@ beforeEach(() => {
   existsSpy = spyOn(fs, 'existsSync').mockReturnValue(true);
   readFileSpy = spyOn(fs, 'readFileSync').mockReturnValue(FILE_CONTENT);
 
-  analyzeFileSpy = spyOn(SonarQubeClient.prototype, 'analyzeFile').mockResolvedValue({
+  createAnalysisSpy = spyOn(SonarQubeClient.prototype, 'createAnalysis').mockResolvedValue({
     id: 'analysis-1',
     issues: [],
     errors: null,
@@ -113,7 +113,7 @@ afterEach(() => {
   saveStateSpy.mockRestore();
   existsSpy.mockRestore();
   readFileSpy.mockRestore();
-  analyzeFileSpy.mockRestore();
+  createAnalysisSpy.mockRestore();
   spawnProcessSpy.mockRestore();
 });
 
@@ -163,7 +163,7 @@ describe('analyzeSqaa: auth resolution', () => {
     expect((thrown as Error).message).toContain(
       'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
     );
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
   });
 
   it('skips SQAA and warns when extension has no projectKey and requireProject is false (bare analyze)', async () => {
@@ -171,7 +171,7 @@ describe('analyzeSqaa: auth resolution', () => {
 
     await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH, { requireProject: false });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     const output = getMockUiCalls()
       .map((c) => String(c.args[0]))
       .join('\n');
@@ -182,21 +182,21 @@ describe('analyzeSqaa: auth resolution', () => {
 });
 
 describe('analyzeSqaa: API call and result display', () => {
-  it('calls client.analyzeFile with correct parameters', async () => {
+  it('calls client.createAnalysis with correct parameters', async () => {
     await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH);
 
-    expect(analyzeFileSpy).toHaveBeenCalledTimes(1);
-    const request = analyzeFileSpy.mock.calls[0][0];
+    expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
+    const request = createAnalysisSpy.mock.calls[0][0];
     expect(request.organizationKey).toBe(TEST_ORG);
     expect(request.projectKey).toBe(TEST_PROJECT);
-    expect(request.fileContent).toBe(FILE_CONTENT);
-    expect(typeof request.filePath).toBe('string');
+    expect(request.files).toEqual([{ path: expect.any(String) as string, content: FILE_CONTENT }]);
+    expect(request.analysisDepth).toBeUndefined();
   });
 
   it('does not send branchName in request when no branch is provided', async () => {
     await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH);
 
-    const request = analyzeFileSpy.mock.calls[0][0];
+    const request = createAnalysisSpy.mock.calls[0][0];
     // branchName: null causes a 400 from the real API — must be omitted entirely
     expect(request.branchName).toBeUndefined();
   });
@@ -204,12 +204,12 @@ describe('analyzeSqaa: API call and result display', () => {
   it('passes branch to client when --branch option is provided', async () => {
     await analyzeSqaa({ file: 'src/index.ts', branch: 'feature/my-branch' }, FAKE_AUTH);
 
-    const request = analyzeFileSpy.mock.calls[0][0];
+    const request = createAnalysisSpy.mock.calls[0][0];
     expect(request.branchName).toBe('feature/my-branch');
   });
 
   it('throws CommandFailedError when SQAA API call fails', () => {
-    analyzeFileSpy.mockRejectedValue(new Error('Network error'));
+    createAnalysisSpy.mockRejectedValue(new Error('Network error'));
 
     expect(analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH)).rejects.toThrow(
       'SonarQube Agentic Analysis failed',
@@ -221,8 +221,8 @@ describe('analyzeSqaa: path normalization', () => {
   it('normalizes Windows-style backslash paths to forward slashes in the API request', async () => {
     await analyzeSqaa({ file: String.raw`python\scripts\check_md_code_blocks.py` }, FAKE_AUTH);
 
-    const request = analyzeFileSpy.mock.calls[0][0];
-    expect(request.filePath).toBe('python/scripts/check_md_code_blocks.py');
+    const request = createAnalysisSpy.mock.calls[0][0];
+    expect(request.files[0].path).toBe('python/scripts/check_md_code_blocks.py');
   });
   it('throws InvalidOptionError when file is outside the current working directory', () => {
     const differentDrive =

--- a/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
@@ -37,7 +37,7 @@ describe('agentPostToolUse', () => {
   let readStdinJsonSpy: ReturnType<typeof spyOn>;
   let existsSyncSpy: ReturnType<typeof spyOn>;
   let readFileSyncSpy: ReturnType<typeof spyOn>;
-  let analyzeFileSpy: ReturnType<typeof spyOn>;
+  let createAnalysisSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     stdoutSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
@@ -53,9 +53,10 @@ describe('agentPostToolUse', () => {
     });
     existsSyncSpy = spyOn(fs, 'existsSync').mockReturnValue(true);
     readFileSyncSpy = spyOn(fs, 'readFileSync').mockReturnValue('const x = 1;');
-    analyzeFileSpy = spyOn(clientModule.SonarQubeClient.prototype, 'analyzeFile').mockResolvedValue(
-      { id: 'analysis-id', issues: [], errors: null },
-    );
+    createAnalysisSpy = spyOn(
+      clientModule.SonarQubeClient.prototype,
+      'createAnalysis',
+    ).mockResolvedValue({ id: 'analysis-id', issues: [], errors: null });
   });
 
   afterEach(() => {
@@ -64,7 +65,7 @@ describe('agentPostToolUse', () => {
     readStdinJsonSpy.mockRestore();
     existsSyncSpy.mockRestore();
     readFileSyncSpy.mockRestore();
-    analyzeFileSpy.mockRestore();
+    createAnalysisSpy.mockRestore();
   });
 
   it('writes additionalContext JSON when analysis returns no issues', async () => {
@@ -84,11 +85,21 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).toHaveBeenCalledTimes(1);
+    expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls createAnalysis with files[] and no analysisDepth', async () => {
+    await agentPostToolUse({ project: 'my-project' });
+
+    expect(createAnalysisSpy).toHaveBeenCalledWith({
+      organizationKey: 'myorg',
+      projectKey: 'my-project',
+      files: [{ path: 'src/index.ts', content: 'const x = 1;' }],
+    });
   });
 
   it('includes issue details in additionalContext when issues are found', async () => {
-    analyzeFileSpy.mockResolvedValue({
+    createAnalysisSpy.mockResolvedValue({
       id: 'analysis-id',
       issues: [
         {
@@ -112,7 +123,7 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
@@ -125,14 +136,14 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
   it('returns without output when project key is not provided', async () => {
     await agentPostToolUse({});
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
@@ -141,7 +152,7 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
   });
 
   it('returns without output when auth rejects', async () => {
@@ -149,7 +160,7 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
   });
 
   it('returns without output when file does not exist', async () => {
@@ -157,7 +168,7 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
@@ -166,12 +177,12 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
   it('returns without output when analysis throws', async () => {
-    analyzeFileSpy.mockRejectedValue(new Error('Network error'));
+    createAnalysisSpy.mockRejectedValue(new Error('Network error'));
 
     await agentPostToolUse({ project: 'my-project' });
 
@@ -179,7 +190,7 @@ describe('agentPostToolUse', () => {
   });
 
   it('includes errors in additionalContext when analysis returns errors', async () => {
-    analyzeFileSpy.mockResolvedValue({
+    createAnalysisSpy.mockResolvedValue({
       id: 'analysis-id',
       issues: [],
       errors: [{ code: 'FILE_NOT_FOUND', message: 'File not indexed' }],
@@ -197,7 +208,7 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
@@ -211,12 +222,12 @@ describe('agentPostToolUse', () => {
 
     await agentPostToolUse({ project: 'my-project' });
 
-    expect(analyzeFileSpy).not.toHaveBeenCalled();
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
     expect(stdoutSpy).not.toHaveBeenCalled();
   });
 
   it('uses plural "issues" when analysis returns more than one issue', async () => {
-    analyzeFileSpy.mockResolvedValue({
+    createAnalysisSpy.mockResolvedValue({
       id: 'analysis-id',
       issues: [
         { rule: 'java:S1', message: 'First', textRange: null },
@@ -232,7 +243,7 @@ describe('agentPostToolUse', () => {
   });
 
   it('omits line location when issue has no textRange', async () => {
-    analyzeFileSpy.mockResolvedValue({
+    createAnalysisSpy.mockResolvedValue({
       id: 'analysis-id',
       issues: [{ rule: 'java:S1', message: 'No location', textRange: null }],
       errors: null,
@@ -245,7 +256,7 @@ describe('agentPostToolUse', () => {
   });
 
   it('does not append errors section when errors array is empty', async () => {
-    analyzeFileSpy.mockResolvedValue({ id: 'analysis-id', issues: [], errors: [] });
+    createAnalysisSpy.mockResolvedValue({ id: 'analysis-id', issues: [], errors: [] });
 
     await agentPostToolUse({ project: 'my-project' });
 

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -882,20 +882,21 @@ describe('SonarQubeClient', () => {
   });
 
   // -------------------------------------------------------------------------
-  // analyzeFile
+  // createAnalysis
   // -------------------------------------------------------------------------
 
-  describe('analyzeFile', () => {
+  describe('createAnalysis', () => {
+    const singleFileRequest = {
+      organizationKey: 'my-org',
+      projectKey: 'my-project',
+      files: [{ path: 'src/index.ts', content: 'const x = 1;' }],
+    };
+
     it('sends POST to SONARCLOUD_API_URL for EU Cloud', async () => {
       const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
       fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
 
-      await cloudClient.analyzeFile({
-        organizationKey: 'my-org',
-        projectKey: 'my-project',
-        filePath: 'src/index.ts',
-        fileContent: 'const x = 1;',
-      });
+      await cloudClient.createAnalysis(singleFileRequest);
 
       const url = lastFetchUrl(fetchSpy);
       expect(url).toBe(`${SONARCLOUD_API_URL}/a3s-analysis/analyses`);
@@ -905,12 +906,7 @@ describe('SonarQubeClient', () => {
       const usClient = new SonarQubeClient(SONARCLOUD_US_URL, TOKEN);
       fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
 
-      await usClient.analyzeFile({
-        organizationKey: 'my-org',
-        projectKey: 'my-project',
-        filePath: 'src/index.ts',
-        fileContent: 'const x = 1;',
-      });
+      await usClient.createAnalysis(singleFileRequest);
 
       const url = lastFetchUrl(fetchSpy);
       expect(url).toBe(`${SONARCLOUD_US_API_URL}/a3s-analysis/analyses`);
@@ -919,44 +915,29 @@ describe('SonarQubeClient', () => {
     it('sends Bearer token in Authorization header', async () => {
       fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
 
-      await client.analyzeFile({
-        organizationKey: 'my-org',
-        projectKey: 'my-project',
-        filePath: 'src/index.ts',
-        fileContent: 'const x = 1;',
-      });
+      await client.createAnalysis(singleFileRequest);
 
       const init = lastFetchInit(fetchSpy);
       expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`);
     });
 
-    it('sends request body as JSON', async () => {
+    it('sends request body as JSON with files[]', async () => {
       fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
 
-      await client.analyzeFile({
-        organizationKey: 'my-org',
-        projectKey: 'my-project',
-        filePath: 'src/index.ts',
-        fileContent: 'const x = 1;',
-      });
+      await client.createAnalysis(singleFileRequest);
 
       const init = lastFetchInit(fetchSpy);
       const body = JSON.parse(init.body as string) as Record<string, unknown>;
       expect(body.organizationKey).toBe('my-org');
       expect(body.projectKey).toBe('my-project');
-      expect(body.filePath).toBe('src/index.ts');
-      expect(body.fileContent).toBe('const x = 1;');
+      expect(body.files).toEqual([{ path: 'src/index.ts', content: 'const x = 1;' }]);
+      expect(body.analysisDepth).toBeUndefined();
     });
 
     it('does not include branchName in body when not provided', async () => {
       fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
 
-      await client.analyzeFile({
-        organizationKey: 'my-org',
-        projectKey: 'my-project',
-        filePath: 'src/index.ts',
-        fileContent: 'const x = 1;',
-      });
+      await client.createAnalysis(singleFileRequest);
 
       const init = lastFetchInit(fetchSpy);
       const body = JSON.parse(init.body as string) as Record<string, unknown>;
@@ -966,17 +947,27 @@ describe('SonarQubeClient', () => {
     it('includes branchName in body when provided', async () => {
       fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
 
-      await client.analyzeFile({
-        organizationKey: 'my-org',
-        projectKey: 'my-project',
-        filePath: 'src/index.ts',
-        fileContent: 'const x = 1;',
+      await client.createAnalysis({
+        ...singleFileRequest,
         branchName: 'feature/my-branch',
       });
 
       const init = lastFetchInit(fetchSpy);
       const body = JSON.parse(init.body as string) as Record<string, unknown>;
       expect(body.branchName).toBe('feature/my-branch');
+    });
+
+    it('includes analysisDepth when provided', async () => {
+      fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
+
+      await client.createAnalysis({
+        ...singleFileRequest,
+        analysisDepth: 'DEEP',
+      });
+
+      const init = lastFetchInit(fetchSpy);
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.analysisDepth).toBe('DEEP');
     });
 
     it('returns parsed response', async () => {
@@ -987,12 +978,7 @@ describe('SonarQubeClient', () => {
       };
       fetchSpy = mockFetch(mockResponse);
 
-      const result = await client.analyzeFile({
-        organizationKey: 'my-org',
-        projectKey: 'my-project',
-        filePath: 'src/index.ts',
-        fileContent: 'const x = 1;',
-      });
+      const result = await client.createAnalysis(singleFileRequest);
 
       expect(result.id).toBe('analysis-123');
       expect(result.issues).toHaveLength(1);
@@ -1001,14 +987,7 @@ describe('SonarQubeClient', () => {
     it('throws on non-OK response', () => {
       fetchSpy = mockFetch({ message: 'Invalid request body' }, false, 400);
 
-      expect(
-        client.analyzeFile({
-          organizationKey: 'my-org',
-          projectKey: 'my-project',
-          filePath: 'src/index.ts',
-          fileContent: 'const x = 1;',
-        }),
-      ).rejects.toThrow('400');
+      expect(client.createAnalysis(singleFileRequest)).rejects.toThrow('400');
     });
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **API contract update:**
  - Renamed `analyzeFile` to `createAnalysis` in `SonarQubeClient` to support batch processing.
  - Replaced individual `filePath` and `fileContent` fields in `SqaaAnalysisRequest` with a `files` array of `SqaaAnalysisFile` objects.
- **New configuration types:**
  - Added `SqaaAnalysisDepth` (STANDARD/DEEP) and `SqaaFileScope` (MAIN/TEST) types to support flexible analysis parameters.
- **Test suite infrastructure:**
  - Updated all unit and integration tests to use `createAnalysis` and validate the new `files[]` request structure.
  - Added `sqaa-request-helpers.ts` to standardize request parsing in integration tests and updated the `fake-sonarqube-server` to enforce the new API schema.

<sub>This will update automatically on new commits.</sub>