### PR TITLE
CLI-670 Bug fixes

### DIFF
--- a/src/cli/commands/_common/install/tar.ts
+++ b/src/cli/commands/_common/install/tar.ts
@@ -21,12 +21,11 @@
 // Minimal in-process tar reader. Sufficient for SonarSource binary archives
 // where we only need to extract a single regular-file entry by basename.
 // Implements the USTAR header layout (POSIX 1003.1-1988): 512-byte aligned
-// blocks, octal-ASCII size at offset 124, typeflag at 156.
+// blocks, octal-ASCII size at offset 124, typeflag at 156, prefix at 345.
 //
 // Limitations: GNU tar long-name extensions (typeflag 'L' / 'K') are NOT
 // supported — the long-name payload would be misparsed as a header block and
-// the following real entry would be skipped. Any SonarSource archive with
-// paths exceeding 100 bytes must be repacked in USTAR-compatible form.
+// the following real entry would be skipped.
 
 import { gunzipSync } from 'node:zlib';
 
@@ -35,6 +34,8 @@ const TAR_NAME_LEN = 100;
 const TAR_SIZE_OFFSET = 124;
 const TAR_SIZE_LEN = 12;
 const TAR_TYPEFLAG_OFFSET = 156;
+const TAR_PREFIX_OFFSET = 345;
+const TAR_PREFIX_LEN = 155;
 const OCTAL_RADIX = 8;
 
 /**
@@ -58,6 +59,8 @@ export function extractFileFromTar(tar: Buffer, entryBasename: string): Buffer |
       break;
     }
     const name = readNullTerminated(header, 0, TAR_NAME_LEN);
+    const prefix = readNullTerminated(header, TAR_PREFIX_OFFSET, TAR_PREFIX_LEN);
+    const fullName = prefix ? `${prefix}/${name}` : name;
     const sizeStr = readNullTerminated(header, TAR_SIZE_OFFSET, TAR_SIZE_LEN).trim();
     const size = sizeStr ? Number.parseInt(sizeStr, OCTAL_RADIX) : 0;
     const typeflag = String.fromCodePoint(header[TAR_TYPEFLAG_OFFSET]);
@@ -66,7 +69,9 @@ export function extractFileFromTar(tar: Buffer, entryBasename: string): Buffer |
     const dataStart = offset + TAR_BLOCK_SIZE;
     const dataEnd = dataStart + size;
 
-    if (isRegularFile && name && basename(name) === entryBasename) {
+    const hasTraversal =
+      !fullName || fullName.startsWith('/') || fullName.split('/').includes('..');
+    if (isRegularFile && !hasTraversal && basename(fullName) === entryBasename) {
       return Buffer.from(tar.subarray(dataStart, dataEnd));
     }
 

--- a/src/cli/commands/hook/agent-post-tool-use.ts
+++ b/src/cli/commands/hook/agent-post-tool-use.ts
@@ -24,7 +24,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 
 import { resolveAuth } from '../../../lib/auth-resolver';
-import { toRelativePosixPath } from '../../../lib/fs-utils';
+import { canonicalizePath, toRelativePosixPath } from '../../../lib/fs-utils';
 import logger from '../../../lib/logger';
 import { SonarQubeClient } from '../../../sonarqube/client';
 import { formatSqaaIssuesForHook, writePostToolUseHookOutput } from './format-sqaa-hook-context';
@@ -59,14 +59,15 @@ export async function agentPostToolUse(options: AgentPostToolUseOptions): Promis
   const projectKey = options.project;
   if (!projectKey) return;
 
-  const normalizedPath = toRelativePosixPath(filePath);
+  const canonicalPath = canonicalizePath(filePath);
+  const normalizedPath = toRelativePosixPath(canonicalPath);
   if (normalizedPath == null) {
     logger.debug(`PostToolUse SQAA skipped: file outside cwd: ${filePath}`);
     return;
   }
 
   try {
-    const fileContent = readFileSync(filePath, 'utf-8');
+    const fileContent = readFileSync(canonicalPath, 'utf-8');
     const client = new SonarQubeClient(auth.serverUrl, auth.token);
 
     const response = await client.createAnalysis({

--- a/src/lib/fetch-guarded.ts
+++ b/src/lib/fetch-guarded.ts
@@ -1,0 +1,128 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Shared fetch utilities: request init builder and redirect guard.
+
+export function buildFetchInit(
+  method: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+  body?: string,
+): RequestInit {
+  return { method, headers, body, signal: AbortSignal.timeout(timeoutMs) };
+}
+
+// Fetch wrapper that prevents bearer token leakage via cross-origin redirects.
+
+const HTTP_301_MOVED_PERMANENTLY = 301;
+const HTTP_302_FOUND = 302;
+const HTTP_303_SEE_OTHER = 303;
+const HTTP_307_TEMPORARY_REDIRECT = 307;
+const HTTP_308_PERMANENT_REDIRECT = 308;
+
+const REDIRECT_STATUSES = new Set([
+  HTTP_301_MOVED_PERMANENTLY,
+  HTTP_302_FOUND,
+  HTTP_303_SEE_OTHER,
+  HTTP_307_TEMPORARY_REDIRECT,
+  HTTP_308_PERMANENT_REDIRECT,
+]);
+const MAX_REDIRECTS = 5;
+
+/**
+ * Fetch wrapper that prevents bearer token leakage via cross-origin redirects.
+ *
+ * Uses redirect: 'manual' to intercept every 3xx before the runtime follows it.
+ * Actual redirect statuses (301, 302, 303, 307, 308) are handled explicitly:
+ * - HTTP→HTTPS upgrades on the same hostname and port are allowed
+ * - Same-origin redirects are followed transparently
+ * - Cross-origin redirects throw so the Authorization header is never forwarded
+ * Non-redirect 3xx (e.g. 304 Not Modified) are returned as-is.
+ */
+export async function fetchGuarded(url: string, init: RequestInit): Promise<Response> {
+  let currentUrl = url;
+  let currentInit = init;
+
+  for (let redirectCount = 0; ; redirectCount++) {
+    const response = await fetch(currentUrl, { ...currentInit, redirect: 'manual' });
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return response;
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      return response;
+    }
+
+    if (redirectCount >= MAX_REDIRECTS) {
+      throw new Error('too many redirects');
+    }
+
+    const redirectUrl = new URL(location, currentUrl);
+    assertAllowedRedirect(currentUrl, redirectUrl);
+
+    // 301/302/303 downgrade POST → GET, drop the body, and strip Content-Type.
+    // 307/308 preserve method, body, and headers unchanged.
+    const preservesMethod =
+      response.status === HTTP_307_TEMPORARY_REDIRECT ||
+      response.status === HTTP_308_PERMANENT_REDIRECT;
+
+    currentUrl = redirectUrl.toString();
+    if (!preservesMethod) {
+      currentInit = {
+        ...currentInit,
+        method: 'GET',
+        body: undefined,
+        headers: withoutContentType(currentInit.headers),
+      };
+    }
+  }
+}
+
+function assertAllowedRedirect(fromUrl: string, redirectUrl: URL): void {
+  const from = new URL(fromUrl);
+  const isSameOrigin = redirectUrl.origin === from.origin;
+  const isHttpsUpgrade =
+    redirectUrl.hostname === from.hostname &&
+    redirectUrl.port === from.port &&
+    from.protocol === 'http:' &&
+    redirectUrl.protocol === 'https:';
+
+  if (!isSameOrigin && !isHttpsUpgrade) {
+    throw new Error(
+      `cross-origin redirect to ${redirectUrl.origin} rejected — bearer token not forwarded`,
+    );
+  }
+}
+
+function toPairs(src: NonNullable<RequestInit['headers']>): [string, string][] {
+  if (src instanceof Headers) return [...src.entries()];
+  if (Array.isArray(src)) return src.map(([k, v]): [string, string] => [k, v]);
+  return Object.entries(src).map(([k, v]): [string, string] => [
+    k,
+    typeof v === 'string' ? v : v.join(', '),
+  ]);
+}
+
+function withoutContentType(src: RequestInit['headers']): Record<string, string> {
+  const pairs = src ? toPairs(src) : [];
+  return Object.fromEntries(pairs.filter(([key]) => key.toLowerCase() !== 'content-type'));
+}

--- a/src/lib/loopback-server.ts
+++ b/src/lib/loopback-server.ts
@@ -28,7 +28,15 @@ import logger from './logger.js';
 const HTTP_STATUS_OK = 200;
 const HTTP_STATUS_FORBIDDEN = 403;
 const FORCE_CLOSE_TIMEOUT_MS = 2000;
-const ALLOWED_LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+const ALLOWED_LOOPBACK_HOSTS = new Set([
+  'localhost',
+  '127.0.0.1',
+  '[::1]',
+  // IPv4-mapped IPv6 loopback: Bun normalizes all forms to [::ffff:7f00:1],
+  // but list the dotted form explicitly to guard against runtimes that don't.
+  '[::ffff:7f00:1]',
+  '[::ffff:127.0.0.1]',
+]);
 
 export interface LoopbackServerResult {
   port: number;
@@ -50,8 +58,9 @@ export function getSecurityHeaders(): Record<string, string> {
 }
 
 /**
- * Validate if origin is an allowed loopback address (localhost, 127.0.0.1, [::1])
- * Used for DNS rebinding attack prevention
+ * Validate if origin is an allowed loopback address.
+ * Accepts localhost, 127.0.0.1, ::1, and IPv4-mapped IPv6 loopback variants.
+ * Used for DNS rebinding attack prevention.
  */
 export function isValidLoopbackOrigin(origin: string): boolean {
   try {

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -22,6 +22,7 @@
 
 import { version as VERSION } from '../../package.json';
 import { isSonarQubeCloud, resolveFromEndpoint } from '../lib/auth-resolver';
+import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import logger from '../lib/logger';
 import { print } from '../ui';
 import { RateLimitError, ServiceUnavailableError } from './errors';
@@ -138,12 +139,7 @@ export class SonarQubeClient {
       print(`request body: ${requestBody}`, process.stderr);
     }
 
-    const response = await fetch(url, {
-      method,
-      headers,
-      body: requestBody,
-      signal: AbortSignal.timeout(timeout),
-    });
+    const response = await fetchGuarded(url, buildFetchInit(method, headers, timeout, requestBody));
 
     if (debug) {
       print(`response status: ${response.status}`, process.stderr);
@@ -185,11 +181,10 @@ export class SonarQubeClient {
       });
     }
 
-    const response = await fetch(url.toString(), {
-      method: 'GET',
-      headers: this.commonHeaders(),
-      signal: AbortSignal.timeout(GET_REQUEST_TIMEOUT_MS),
-    });
+    const response = await fetchGuarded(
+      url.toString(),
+      buildFetchInit('GET', this.commonHeaders(), GET_REQUEST_TIMEOUT_MS),
+    );
 
     const value = response.ok ? ((await response.json()) as TValue) : undefined;
 
@@ -202,12 +197,15 @@ export class SonarQubeClient {
   async post<T>(endpoint: string, body: unknown, baseUrl?: string): Promise<T> {
     const url = `${baseUrl ?? this.serverURL}${endpoint}`;
 
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: this.commonHeaders('json'),
-      body: JSON.stringify(body),
-      signal: AbortSignal.timeout(POST_REQUEST_TIMEOUT_MS),
-    });
+    const response = await fetchGuarded(
+      url,
+      buildFetchInit(
+        'POST',
+        this.commonHeaders('json'),
+        POST_REQUEST_TIMEOUT_MS,
+        JSON.stringify(body),
+      ),
+    );
 
     await this.raiseForStatus(response, 'POST');
 
@@ -224,12 +222,15 @@ export class SonarQubeClient {
     params: Record<string, string>,
     timeoutMs: number = POST_REQUEST_TIMEOUT_MS,
   ): Promise<void> {
-    const response = await fetch(`${this.serverURL}${endpoint}`, {
-      method: 'POST',
-      headers: this.commonHeaders('form'),
-      body: new URLSearchParams(params).toString(),
-      signal: AbortSignal.timeout(timeoutMs),
-    });
+    const response = await fetchGuarded(
+      `${this.serverURL}${endpoint}`,
+      buildFetchInit(
+        'POST',
+        this.commonHeaders('form'),
+        timeoutMs,
+        new URLSearchParams(params).toString(),
+      ),
+    );
 
     await this.raiseForStatus(response, 'POST');
   }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -24,6 +24,7 @@ import { type Command } from 'commander';
 
 import { version as VERSION } from '../../package.json';
 import { detectCallerAgent } from '../lib/agent-detector.js';
+import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import { INVOCATION_ID } from '../lib/invocation-id.js';
 import type { StoredTelemetryEvent, TelemetryEventPayload } from '../lib/state.js';
 import { getActiveConnection, loadState, saveState } from '../lib/state-manager.js';
@@ -153,17 +154,17 @@ export async function flushTelemetry(): Promise<void> {
     const remainingTime = deadline - Date.now();
     if (remainingTime <= 0) break;
     try {
-      await fetch(TELEMETRY_ENDPOINT, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-api-key': TELEMETRY_API_KEY,
-        },
-        body: JSON.stringify(telemetry.events[i], (_key, value) =>
-          value === null ? undefined : value,
+      await fetchGuarded(
+        TELEMETRY_ENDPOINT,
+        buildFetchInit(
+          'POST',
+          { 'Content-Type': 'application/json', 'x-api-key': TELEMETRY_API_KEY },
+          remainingTime,
+          JSON.stringify(telemetry.events[i], (_key, value) =>
+            value === null ? undefined : value,
+          ),
         ),
-        signal: AbortSignal.timeout(remainingTime),
-      });
+      );
 
       sentIndices.add(i);
     } catch {

--- a/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
@@ -263,4 +263,43 @@ describe('agentPostToolUse', () => {
     const output = JSON.parse((stdoutSpy.mock.calls[0][0] as string).trim());
     expect(output.hookSpecificOutput.additionalContext).not.toContain('Agentic Analysis errors');
   });
+
+  it('canonicalizes path once so symlink swap after validation cannot exfiltrate files', async () => {
+    // Vulnerability (double canonicalization): toRelativePosixPath(filePath) resolves the
+    // symlink at t0, then canonicalizePath(filePath) resolves it again at t1. An attacker
+    // can swap the symlink between t0 and t1 so validation passes but readFileSync reads
+    // the attacker-controlled file.
+    // Fix: canonicalize exactly once up front, pass the resolved real path to both
+    // toRelativePosixPath and readFileSync so no further symlink resolution occurs.
+    const symlinkPath = join(process.cwd(), 'src/link.ts');
+    const safeTarget = TEST_FILE;
+    const attackerTarget = join(process.cwd(), 'src/other.ts');
+
+    readStdinJsonSpy.mockResolvedValue({
+      tool_name: 'Edit',
+      tool_input: { file_path: symlinkPath },
+    });
+    existsSyncSpy.mockReturnValue(true);
+
+    // Simulate symlink swap: first realpathSync call sees the safe file,
+    // second call (if it happens) sees the attacker file.
+    let resolveCount = 0;
+    const realpathSyncSpy = spyOn(fs, 'realpathSync').mockImplementation(((p: fs.PathLike) => {
+      if (p === symlinkPath) {
+        return ++resolveCount === 1 ? safeTarget : attackerTarget;
+      }
+      return String(p);
+    }) as typeof fs.realpathSync);
+
+    await agentPostToolUse({ project: 'my-project' });
+
+    // Without fix (double canonicalization): resolveCount reaches 2 so readFileSync
+    // is called with attackerTarget — exfiltration succeeds.
+    // With fix (single canonicalization): resolveCount stays at 1 so readFileSync
+    // is called with safeTarget.
+    expect(readFileSyncSpy).toHaveBeenCalledWith(safeTarget, 'utf-8');
+    expect(readFileSyncSpy).not.toHaveBeenCalledWith(attackerTarget, expect.anything());
+
+    realpathSyncSpy.mockRestore();
+  });
 });

--- a/tests/unit/lib/fetch-guarded.test.ts
+++ b/tests/unit/lib/fetch-guarded.test.ts
@@ -1,0 +1,93 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Real Bun server tests: verify that redirect: 'manual' exposes a readable
+// 3xx status and Location header in this runtime, which is the assumption
+// fetchGuarded() relies on.
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+
+import { fetchGuarded } from '../../../src/lib/fetch-guarded.js';
+
+let server: ReturnType<typeof Bun.serve>;
+let base: string;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      switch (url.pathname) {
+        case '/redirect-same-origin':
+          return new Response(null, {
+            status: 302,
+            headers: { Location: `${base}/target` },
+          });
+        case '/redirect-cross-origin':
+          return new Response(null, {
+            status: 302,
+            headers: { Location: 'https://evil.example.com/steal' },
+          });
+        case '/redirect-chain':
+          return new Response(null, {
+            status: 301,
+            headers: { Location: `${base}/target` },
+          });
+        case '/target':
+          return new Response('ok', { status: 200 });
+        default:
+          return new Response('not found', { status: 404 });
+      }
+    },
+  });
+  base = `http://localhost:${server.port}`;
+});
+
+afterAll(async () => {
+  await server.stop();
+});
+
+describe('fetchGuarded — real Bun runtime redirect behavior', () => {
+  it('redirect: manual returns readable 3xx status and Location in Bun', async () => {
+    // Verifies the core runtime assumption: Bun exposes status and Location
+    // header for redirect: 'manual' responses (unlike spec-compliant opaque redirects).
+    const res = await fetch(`${base}/redirect-same-origin`, { redirect: 'manual' });
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('/target');
+  });
+
+  it('follows a same-origin redirect to the final response', async () => {
+    const res = await fetchGuarded(`${base}/redirect-same-origin`, {});
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+  });
+
+  it('follows a 301 redirect chain', async () => {
+    const res = await fetchGuarded(`${base}/redirect-chain`, {});
+    expect(res.status).toBe(200);
+  });
+
+  it('throws on a cross-origin redirect without making a second request', async () => {
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await expect(fetchGuarded(`${base}/redirect-cross-origin`, {})).rejects.toThrow(
+      'cross-origin redirect',
+    );
+  });
+});

--- a/tests/unit/lib/loopback-server.test.ts
+++ b/tests/unit/lib/loopback-server.test.ts
@@ -84,6 +84,12 @@ describe('loopback-server', () => {
       expect(isValidLoopbackOrigin('HTTP://LOCALHOST:8080')).toBe(true);
       expect(isValidLoopbackOrigin('HTTPS://127.0.0.1:8080')).toBe(true);
     });
+
+    it('should accept IPv4-mapped IPv6 loopback variants', () => {
+      // Bun's URL parser normalizes both to the same hostname: [::ffff:7f00:1]
+      expect(isValidLoopbackOrigin(`${HTTP_SCHEME}://[::ffff:127.0.0.1]:8080`)).toBe(true);
+      expect(isValidLoopbackOrigin(`${HTTP_SCHEME}://[::ffff:7f00:1]:8080`)).toBe(true);
+    });
   });
 
   describe('isValidLoopbackHost', () => {
@@ -102,6 +108,11 @@ describe('loopback-server', () => {
     it('should accept host without port', () => {
       expect(isValidLoopbackHost('localhost')).toBe(true);
       expect(isValidLoopbackHost('127.0.0.1')).toBe(true);
+    });
+
+    it('should accept IPv4-mapped IPv6 loopback variants in Host header', () => {
+      expect(isValidLoopbackHost('[::ffff:127.0.0.1]:8080')).toBe(true);
+      expect(isValidLoopbackHost('[::ffff:7f00:1]:8080')).toBe(true);
     });
 
     it('should reject external host headers', () => {

--- a/tests/unit/lib/tar.test.ts
+++ b/tests/unit/lib/tar.test.ts
@@ -34,6 +34,8 @@ const SIZE_OFFSET = 124;
 const TYPEFLAG_OFFSET = 156;
 const CHECKSUM_OFFSET = 148;
 const CHECKSUM_LEN = 8;
+const PREFIX_OFFSET = 345;
+const PREFIX_LEN = 155;
 const SIZE_OCTAL_LEN = 11; // 12 bytes total: 11 octal digits + NUL
 const CHECKSUM_OCTAL_LEN = 6; // 8 bytes total: 6 octal digits + NUL + space
 const ASCII_SPACE = 0x20;
@@ -44,13 +46,16 @@ const FILL_BYTE = 0xab;
  * Build a minimal valid USTAR file entry: 1 header block + N data blocks.
  * Returns the concatenated buffer (header + data, padded to 512-byte multiples).
  */
-function buildTarEntry(name: string, content: Buffer): Buffer {
+function buildTarEntry(name: string, content: Buffer, prefix?: string): Buffer {
   const header = Buffer.alloc(TAR_BLOCK_SIZE);
   header.write(name, 0, Math.min(name.length, NAME_LEN), 'utf-8');
   header.write('0000644\0', MODE_OFFSET, 'utf-8'); // file mode
   const sizeOctal = content.length.toString(8).padStart(SIZE_OCTAL_LEN, '0') + '\0';
   header.write(sizeOctal, SIZE_OFFSET, 'utf-8');
   header.write('0', TYPEFLAG_OFFSET, 'utf-8'); // regular file
+  if (prefix) {
+    header.write(prefix, PREFIX_OFFSET, Math.min(prefix.length, PREFIX_LEN), 'utf-8');
+  }
   // Fill checksum field with spaces, then compute and write the checksum.
   for (let i = 0; i < CHECKSUM_LEN; i++) header[CHECKSUM_OFFSET + i] = ASCII_SPACE;
   let checksum = 0;
@@ -64,8 +69,10 @@ function buildTarEntry(name: string, content: Buffer): Buffer {
   return Buffer.concat([header, data]);
 }
 
-function buildTarArchive(entries: Array<{ name: string; content: Buffer }>): Buffer {
-  const blocks = entries.map((e) => buildTarEntry(e.name, e.content));
+function buildTarArchive(
+  entries: Array<{ name: string; content: Buffer; prefix?: string }>,
+): Buffer {
+  const blocks = entries.map((e) => buildTarEntry(e.name, e.content, e.prefix));
   const eof = Buffer.alloc(TAR_BLOCK_SIZE * 2); // two empty blocks per spec
   return Buffer.concat([...blocks, eof]);
 }
@@ -96,6 +103,41 @@ describe('tar.extractFileFromTar', () => {
 
   it('returns null when no entry matches', () => {
     const tar = buildTarArchive([{ name: 'README.md', content: Buffer.from('hello', 'utf-8') }]);
+    expect(extractFileFromTar(tar, 'sonar-context-augmentation')).toBeNull();
+  });
+
+  it('extracts an entry stored with a USTAR prefix field (long filename)', () => {
+    const tar = buildTarArchive([
+      {
+        name: 'sonar-context-augmentation',
+        content: Buffer.from('binary-with-prefix', 'utf-8'),
+        prefix: 'some/long/directory/path',
+      },
+    ]);
+    const bytes = extractFileFromTar(tar, 'sonar-context-augmentation');
+    expect(bytes).not.toBeNull();
+    expect(bytes!.toString('utf-8')).toBe('binary-with-prefix');
+  });
+
+  it('rejects entries with path traversal in the prefix field', () => {
+    const tar = buildTarArchive([
+      {
+        name: 'sonar-context-augmentation',
+        content: Buffer.from('malicious', 'utf-8'),
+        prefix: '../../..',
+      },
+    ]);
+    expect(extractFileFromTar(tar, 'sonar-context-augmentation')).toBeNull();
+  });
+
+  it('rejects entries with an absolute path in the prefix field', () => {
+    const tar = buildTarArchive([
+      {
+        name: 'sonar-context-augmentation',
+        content: Buffer.from('malicious', 'utf-8'),
+        prefix: '/absolute/path',
+      },
+    ]);
     expect(extractFileFromTar(tar, 'sonar-context-augmentation')).toBeNull();
   });
 

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -27,6 +27,7 @@ import {
   SONARCLOUD_US_API_URL,
   SONARCLOUD_US_URL,
 } from '../../../src/lib/config-constants.js';
+import { fetchGuarded } from '../../../src/lib/fetch-guarded.js';
 import { SonarQubeClient } from '../../../src/sonarqube/client.js';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../src/ui';
 
@@ -136,6 +137,252 @@ describe('SonarQubeClient', () => {
       expect(client.get('/api/authentication/validate')).rejects.toThrow(
         'SonarQube API error: 401',
       );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Bearer token must not be forwarded to cross-origin redirect targets (F9)
+  //
+  // fetchGuarded() intercepts every 3xx before the runtime follows it:
+  // - same-origin redirects are followed transparently (e.g. HTTP→HTTPS)
+  // - cross-origin redirects throw so the Authorization header is never
+  //   forwarded to an attacker-controlled domain
+  //
+  // RED without the fix (redirect: 'follow' sends auth to all destinations)
+  // GREEN with it.
+  // -------------------------------------------------------------------------
+
+  describe('bearer token not forwarded on redirect', () => {
+    it('get uses redirect: manual so the runtime cannot auto-follow', async () => {
+      fetchSpy = mockFetch({});
+      await client.get('/api/endpoint');
+      expect(lastFetchInit(fetchSpy).redirect).toBe('manual');
+    });
+
+    it('post uses redirect: manual so the runtime cannot auto-follow', async () => {
+      fetchSpy = mockFetch({});
+      await client.post('/api/endpoint', {});
+      expect(lastFetchInit(fetchSpy).redirect).toBe('manual');
+    });
+
+    it('postForm uses redirect: manual so the runtime cannot auto-follow', async () => {
+      fetchSpy = mockFetch({}, true, 204);
+      await client.postForm('/api/endpoint', { k: 'v' });
+      expect(lastFetchInit(fetchSpy).redirect).toBe('manual');
+    });
+
+    it('follows a same-origin 302 redirect transparently', async () => {
+      // Scenario: server redirects /api/v1/endpoint → /api/v2/endpoint (same origin)
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          headers: new Headers({ location: `${SERVER_URL}/api/v2/endpoint` }),
+          text: () => Promise.resolve(''),
+          json: () => Promise.resolve({}),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.resolve({ valid: true }),
+          text: () => Promise.resolve('{"valid":true}'),
+        } as unknown as Response);
+
+      const result = await client.get<{ valid: boolean }>('/api/v1/endpoint');
+      expect(result.valid).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy.mock.calls[1][0] as string).toContain('/api/v2/endpoint');
+    });
+
+    it('rejects a cross-origin 302 redirect without forwarding the bearer token', async () => {
+      // Vulnerability: without fetchGuarded, Authorization would be sent to attacker.com
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location: 'https://attacker.com/steal' }),
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.get('/api/endpoint')).rejects.toThrow('cross-origin redirect');
+
+      // fetch was called exactly once — the token was never sent to attacker.com
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy.mock.calls[0][0] as string).toContain(SERVER_URL);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchGuarded — standalone redirect guard
+  // -------------------------------------------------------------------------
+
+  describe('fetchGuarded', () => {
+    it('follows a same-origin redirect and returns the final response', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 301,
+          headers: new Headers({ location: `${SERVER_URL}/new-path` }),
+          text: () => Promise.resolve(''),
+          json: () => Promise.resolve({}),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.resolve({ data: 'ok' }),
+          text: () => Promise.resolve('{"data":"ok"}'),
+        } as unknown as Response);
+
+      const res = await fetchGuarded(`${SERVER_URL}/old-path`, {});
+      expect(res.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws on cross-origin redirect before making a second request', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location: 'https://evil.com/capture' }),
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(fetchGuarded(`${SERVER_URL}/api`, {})).rejects.toThrow('cross-origin redirect');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('follows an HTTP→HTTPS upgrade redirect on the same hostname', async () => {
+      const httpUrl = 'http://sonarqube.example.com/api/endpoint';
+      const httpsUrl = 'https://sonarqube.example.com/api/endpoint';
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 301,
+          headers: new Headers({ location: httpsUrl }),
+          text: () => Promise.resolve(''),
+          json: () => Promise.resolve({}),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.resolve({ ok: true }),
+          text: () => Promise.resolve('{"ok":true}'),
+        } as unknown as Response);
+
+      const res = await fetchGuarded(httpUrl, {});
+      expect(res.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy.mock.calls[1][0] as string).toBe(httpsUrl);
+    });
+
+    it('returns 304 as-is without throwing (no Location header expected)', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 304,
+        headers: new Headers(),
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+
+      const res = await fetchGuarded(`${SERVER_URL}/api`, {});
+      expect(res.status).toBe(304);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('downgrades POST to GET on 301/302/303 redirect (drops body)', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          headers: new Headers({ location: `${SERVER_URL}/new-endpoint` }),
+          text: () => Promise.resolve(''),
+          json: () => Promise.resolve({}),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve('{}'),
+        } as unknown as Response);
+
+      await fetchGuarded(`${SERVER_URL}/api`, { method: 'POST', body: '{"key":"val"}' });
+
+      const secondInit = fetchSpy.mock.calls[1][1] as RequestInit;
+      expect(secondInit.method).toBe('GET');
+      expect(secondInit.body).toBeUndefined();
+    });
+
+    it('strips Content-Type header when downgrading POST to GET on 301/302/303', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 302,
+          headers: new Headers({ location: `${SERVER_URL}/new-endpoint` }),
+          text: () => Promise.resolve(''),
+          json: () => Promise.resolve({}),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve('{}'),
+        } as unknown as Response);
+
+      await fetchGuarded(`${SERVER_URL}/api`, {
+        method: 'POST',
+        body: '{"key":"val"}',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer tok' },
+      });
+
+      const secondInit = fetchSpy.mock.calls[1][1] as RequestInit;
+      const headers = secondInit.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBeUndefined();
+      // Authorization is preserved — token still goes to the (same-origin) redirect target
+      expect(headers['Authorization']).toBe('Bearer tok');
+    });
+
+    it('preserves POST body on 307/308 redirect', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 307,
+          headers: new Headers({ location: `${SERVER_URL}/new-endpoint` }),
+          text: () => Promise.resolve(''),
+          json: () => Promise.resolve({}),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve('{}'),
+        } as unknown as Response);
+
+      await fetchGuarded(`${SERVER_URL}/api`, { method: 'POST', body: '{"key":"val"}' });
+
+      const secondInit = fetchSpy.mock.calls[1][1] as RequestInit;
+      expect(secondInit.method).toBe('POST');
+      expect(secondInit.body).toBe('{"key":"val"}');
+    });
+
+    it('throws after too many same-origin redirects', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 302,
+        headers: new Headers({ location: `${SERVER_URL}/loop` }),
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(fetchGuarded(`${SERVER_URL}/loop`, {})).rejects.toThrow('too many redirects');
     });
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Security hardening:**
  - Prevent bearer token leakage by setting `redirect: 'manual'` in all `fetch` requests via new `fetchGuarded` utility.
  - Mitigate symlink TOCTOU vulnerabilities in `agentPostToolUse` by canonicalizing file paths exactly once before access.
  - Block DNS rebinding attacks by adding IPv4-mapped IPv6 loopback variants to allowed origins.
  - Prevent path traversal in tar extraction by validating the USTAR `prefix` field.
- **Feature updates:**
  - Enhance `tar.ts` to correctly parse USTAR archive entries using the `prefix` field for long path support.
- **New utility:**
  - Added `fetchGuarded.ts` to encapsulate request initiation and secure cross-origin redirect handling.

<sub>This will update automatically on new commits.</sub>