### PR TITLE
CLI-681 Pass SCA scanner token via env instead of CLI argument

### DIFF
--- a/src/cli/commands/analyze/dependency-risk-helpers/default-sca-scanner-spawner.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/default-sca-scanner-spawner.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SonarQube CLI
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
@@ -23,11 +23,11 @@ import { type ScaScannerSpawner } from './sca-scanner-spawner.ts';
 const ThreeMinuteTimeoutMs = 3 * 60 * 1000;
 
 export class DefaultScaScannerSpawner implements ScaScannerSpawner {
-  spawn(binaryPath: string, args: string[]): Promise<SpawnResult> {
+  spawn(binaryPath: string, args: string[], env?: Record<string, string>): Promise<SpawnResult> {
     return spawnProcessWithTimeout(
       binaryPath,
       args,
-      { stdout: 'pipe', stderr: 'pipe' },
+      { stdout: 'pipe', stderr: 'pipe', env },
       ThreeMinuteTimeoutMs,
       'Dependency Risk scanner timed out',
     );

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-runner-base.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-runner-base.ts
@@ -28,7 +28,8 @@ import { CommandFailedError } from '../../_common/error.ts';
 import { type ScaScannerInstaller } from '../../_common/install/sca-scanner.ts';
 import { type ScaScannerSpawner } from './sca-scanner-spawner.ts';
 
-const REDACTED_TOKEN = '***';
+/** Env var the sca-scanner reads the bearer token from. */
+const SONAR_TOKEN_ENV = 'SONAR_TOKEN';
 
 export const SCA_SCANNER_START_FAILURE_HINT =
   'Verify that the SCA scanner is installed and can run on this machine, then retry.';
@@ -62,10 +63,11 @@ export abstract class ScaScannerRunnerBase<T> {
 
   async run(invocation: ScaScannerInvocation): Promise<T> {
     const args = this.buildArgs(invocation);
-    logger.debug(`sca-scanner args: ${JSON.stringify(this.redactedArgs(args))}`);
+    logger.debug(`sca-scanner args: ${JSON.stringify(args)}`);
+    const env = { [SONAR_TOKEN_ENV]: invocation.sonarToken };
     const binaryPath = await this.installer.install();
     try {
-      const result = await this.spawnScanner(binaryPath, args);
+      const result = await this.spawnScanner(binaryPath, args, env);
       logger.info(`SCA Scanner stdout\n${result.stdout}`);
       logger.warn(`SCA Scanner stderr\n${result.stderr}`);
       this.assertSuccessfulExit(result);
@@ -89,7 +91,6 @@ export abstract class ScaScannerRunnerBase<T> {
       `--base-dir=${invocation.baseDir}`,
       `--api-base-url=${invocation.apiBaseUrl}`,
       `--download-base-url=${invocation.downloadBaseUrl}`,
-      `--sonar-token=${invocation.sonarToken}`,
       `--cache-dir=${invocation.cacheDir}`,
       `--work-dir=${invocation.workDir}`,
       ...extraArgs,
@@ -115,12 +116,6 @@ export abstract class ScaScannerRunnerBase<T> {
   /** Interprets stdout of a successful (exit-code 0) run. */
   protected abstract parseResult(result: SpawnResult): T;
 
-  private redactedArgs(args: string[]): string[] {
-    return args.map((arg) =>
-      arg.startsWith('--sonar-token=') ? `--sonar-token=${REDACTED_TOKEN}` : arg,
-    );
-  }
-
   protected parseJson(result: SpawnResult): unknown {
     try {
       return JSON.parse(result.stdout);
@@ -132,9 +127,13 @@ export abstract class ScaScannerRunnerBase<T> {
     }
   }
 
-  private async spawnScanner(binaryPath: string, args: string[]): Promise<SpawnResult> {
+  private async spawnScanner(
+    binaryPath: string,
+    args: string[],
+    env: Record<string, string>,
+  ): Promise<SpawnResult> {
     try {
-      return await this.spawner.spawn(binaryPath, args);
+      return await this.spawner.spawn(binaryPath, args, env);
     } catch (err) {
       throw new CommandFailedError(`${this.errorPrefix}: ${(err as Error).message}`, {
         remediationHint: SCA_SCANNER_START_FAILURE_HINT,

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-spawner.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-spawner.ts
@@ -21,5 +21,5 @@
 import { type SpawnResult } from '../../../../lib/process.ts';
 
 export interface ScaScannerSpawner {
-  spawn(binaryPath: string, args: string[]): Promise<SpawnResult>;
+  spawn(binaryPath: string, args: string[], env?: Record<string, string>): Promise<SpawnResult>;
 }

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-discover-manifests.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-discover-manifests.test.ts
@@ -140,7 +140,7 @@ describe('ScaDiscoverManifestsRunner.run', () => {
     const installer: ScaScannerInstaller = {
       install: () => Promise.resolve('/bin/sca-from-installer'),
     };
-    const spawn = mock((_binaryPath: string, _args: string[]) =>
+    const spawn = mock((_binaryPath: string, _args: string[], _env?: Record<string, string>) =>
       Promise.resolve({ exitCode: 0, stdout: JSON.stringify({ files: [] }), stderr: '' }),
     );
     const invocation = makeInvocation({
@@ -154,6 +154,7 @@ describe('ScaDiscoverManifestsRunner.run', () => {
     expect(spawn).toHaveBeenCalledWith(
       '/bin/sca-from-installer',
       discoverManifestsArgs(invocation),
+      { SONAR_TOKEN: invocation.sonarToken },
     );
   });
 
@@ -222,7 +223,6 @@ describe('ScaDiscoverManifestsRunner.buildArgs', () => {
       '--base-dir=/repo',
       '--api-base-url=https://api.sonarcloud.io',
       '--download-base-url=https://download.sonarcloud.io/tidelift-cli',
-      '--sonar-token=tok',
       '--cache-dir=/cache',
       '--work-dir=/work',
     ]);

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
@@ -53,7 +53,7 @@ function makeClient(
 // Discovery reports no manifests so the secrets pre-scan is a no-op, then the
 // scan call returns the supplied analyze-project payload.
 function mockSpawner(payload: unknown) {
-  return mock((_binaryPath: string, args: string[]) => {
+  return mock((_binaryPath: string, args: string[], _env?: Record<string, string>) => {
     const stdout =
       args[0] === 'discover-manifests' ? JSON.stringify({ files: [] }) : JSON.stringify(payload);
     return Promise.resolve({ exitCode: 0, stdout, stderr: '' });
@@ -101,9 +101,10 @@ describe('ScaScanOrchestrator', () => {
 
     const analyzeCall = spawn.mock.calls.find(([, args]) => args[0] === 'analyze-project');
     expect(analyzeCall).toBeDefined();
-    const [, args] = analyzeCall!;
+    const [, args, env] = analyzeCall!;
     expect(args).toContain('--project-key=my-project');
-    expect(args).toContain('--sonar-token=test-token');
+    expect(args.some((arg) => arg.includes('--sonar-token'))).toBe(false);
+    expect(env).toEqual({ SONAR_TOKEN: 'test-token' });
   });
 
   it('skips the analyze-project scan when the manifest pre-scan throws', async () => {

--- a/tests/unit/cli/commands/analyze/sca-scanner.test.ts
+++ b/tests/unit/cli/commands/analyze/sca-scanner.test.ts
@@ -188,7 +188,9 @@ describe('ScaScannerRunner.run', () => {
     const installer: ScaScannerInstaller = {
       install: () => Promise.resolve('/bin/sca-from-installer'),
     };
-    const spawn = mock((_binaryPath: string, _args: string[]) => Promise.resolve(EMPTY_SUCCESS));
+    const spawn = mock((_binaryPath: string, _args: string[], _env?: Record<string, string>) =>
+      Promise.resolve(EMPTY_SUCCESS),
+    );
     const invocation = makeInvocation({
       excludedPaths: ['**/test/**'],
       includeGitIgnoredPaths: true,
@@ -200,7 +202,24 @@ describe('ScaScannerRunner.run', () => {
     await runner.run(invocation);
 
     expect(spawn).toHaveBeenCalledTimes(1);
-    expect(spawn).toHaveBeenCalledWith('/bin/sca-from-installer', analyzeProjectArgs(invocation));
+    expect(spawn).toHaveBeenCalledWith('/bin/sca-from-installer', analyzeProjectArgs(invocation), {
+      SONAR_TOKEN: invocation.sonarToken,
+    });
+  });
+
+  it('passes the sonar token via the SONAR_TOKEN env and never in argv', async () => {
+    const spawn = mock((_binaryPath: string, _args: string[], _env?: Record<string, string>) =>
+      Promise.resolve(EMPTY_SUCCESS),
+    );
+    const invocation = makeInvocation({ sonarToken: 'super-secret' });
+
+    await new ScaScannerRunner(okInstaller, { spawn }).run(invocation);
+
+    const [, args, env] = spawn.mock.calls[0];
+    expect(args.some((arg) => arg.includes('super-secret') || arg.includes('--sonar-token'))).toBe(
+      false,
+    );
+    expect(env).toEqual({ SONAR_TOKEN: 'super-secret' });
   });
 });
 
@@ -211,7 +230,6 @@ describe('ScaScannerRunner.buildArgs', () => {
       '--base-dir=/repo',
       '--api-base-url=https://api.sonarcloud.io',
       '--download-base-url=https://download.sonarcloud.io/tidelift-cli',
-      '--sonar-token=tok',
       '--cache-dir=/cache',
       '--work-dir=/work',
       '--project-key=my-project',


### PR DESCRIPTION
----
## Summary by Gitar

- **Security enhancement:**
  - Refactored `sca-scanner` invocation to pass the `sonarToken` via `SONAR_TOKEN` environment variable instead of a command-line argument.
- **Refactoring:**
  - Updated `ScaScannerSpawner` interface and implementations to support an optional `env` object during process execution.
  - Removed `redactedArgs` logic as the sensitive token is no longer exposed in CLI arguments.
- **Testing:**
  - Updated unit tests for `ScaScannerRunner`, `ScaScanOrchestrator`, and `ScaDiscoverManifestsRunner` to verify correct environment variable injection and the absence of tokens in command-line arguments.


<sub>This will update automatically on new commits.</sub>