### PR TITLE
CLI-627 Analyze change sets as multi-file requests with chunking

### DIFF
--- a/src/cli/commands/analyze/sqaa-analysis.ts
+++ b/src/cli/commands/analyze/sqaa-analysis.ts
@@ -18,16 +18,21 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Concurrent execution engine for SQAA change-set analysis
+// Sequential chunked execution engine for SQAA change-set analysis
 
 import { getSqaaRetry503BaseDelayMs } from '../../../lib/config-constants';
 import type { SqaaIssue } from '../../../sonarqube/client';
 import type { SqaaProgress } from '../../../ui/components/sqaa-progress.js';
-import { fetchWithRetry, MAX_503_RETRIES, readSqaaFileContent } from './sqaa-api';
+import { CommandFailedError } from '../_common/error.js';
+import {
+  fetchChunkWith413Split,
+  MAX_503_RETRIES,
+  readSqaaFileContent,
+  type SqaaChunkGroupError,
+  type SqaaChunkResponse,
+} from './sqaa-api';
 import type { CloudAuth } from './sqaa-auth';
-
-/** Maximum number of files analyzed concurrently. */
-export const SQAA_CONCURRENCY = 20;
+import { type SqaaChunk, type SqaaChunkFile } from './sqaa-chunking';
 
 export type FileSuccess = {
   file: string;
@@ -38,6 +43,11 @@ export type FileSuccess = {
 export type FileFailure = { file: string; filePath: string; failure: Error };
 export type FileResult = FileSuccess | FileFailure;
 
+type ChunkPath = { file: string; filePath: string };
+
+const PAYLOAD_TOO_LARGE_FAILURE_MESSAGE =
+  'SonarQube Agentic Analysis failed.\n  Request payload too large.';
+
 export interface RunContext {
   files: string[];
   allPaths: string[];
@@ -45,8 +55,6 @@ export interface RunContext {
   projectKey: string;
   branch: string | undefined;
   progress: SqaaProgress;
-  /** Directory used as the base for SQAA-side file paths (typically the git repo root). */
-  pathBase: string;
 }
 
 export interface RunTally {
@@ -57,88 +65,307 @@ export interface RunTally {
 }
 
 /**
- * Run analyses through a worker pool of `SQAA_CONCURRENCY`. Returns the merged
- * tally once every spawned worker has joined.
- *
- * Fail-fast contract: if any file fails, no worker will pick up a *new* file
- * after that point. Workers already mid-flight finish their current file.
+ * Run analyses as sequential multi-file chunks. Returns the merged tally once
+ * every chunk has been processed (or fail-fast stops remaining chunks).
  */
 export async function runAnalyses(ctx: RunContext): Promise<RunTally> {
-  const tally: RunTally = { allResults: [], totalIssues: 0, totalErrors: 0, totalFailures: 0 };
+  const tally = emptyTally();
   if (ctx.files.length === 0) return tally;
 
-  // Shared cursor and fail-fast flag.
-  // `next` is the count of indices claimed so far (each worker does `idx = next++`).
-  // `hadFailure` is the fail-fast signal: set when any file fails.
-  let next = 0;
-  let hadFailure = false;
+  const fileIndexByAbsolutePath = new Map(ctx.files.map((f, i) => [f, i]));
+  const { chunks, chunkFileIndices } = prepareChunks(
+    ctx,
+    fileIndexByAbsolutePath,
+    tally,
+    ctx.progress,
+  );
+  ctx.progress.start();
 
-  const worker = async (): Promise<void> => {
-    while (!hadFailure) {
-      const idx = next++;
-      if (idx >= ctx.files.length) return;
-      const result = await processFile(ctx, idx);
-      tally.allResults.push(result);
-      tallyResults([result], tally);
-      if ('failure' in result) {
-        hadFailure = true;
-      }
+  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+    const succeeded = await processChunk(
+      ctx,
+      tally,
+      chunkIndex,
+      chunks[chunkIndex],
+      chunkFileIndices[chunkIndex],
+      fileIndexByAbsolutePath,
+    );
+    if (!succeeded) {
+      skipUnprocessedAfterFailure(ctx, tally);
+      break;
     }
-  };
-
-  const workerCount = Math.min(SQAA_CONCURRENCY, ctx.files.length);
-  await Promise.all(Array.from({ length: workerCount }, () => worker()));
-
-  // `next` equals the total number of indices claimed across all workers (including
-  // any that went past the end of the array). Cap it to get the first unclaimed index.
-  const firstUnpicked = Math.min(next, ctx.files.length);
-  if (firstUnpicked < ctx.files.length) {
-    ctx.progress.skipRemaining(firstUnpicked);
   }
 
-  // Workers complete in arbitrary order. Restore original file ordering so that
-  // downstream consumers (JSON report, text display) see a stable, predictable sequence.
-  const fileIndexMap = new Map(ctx.files.map((f, i) => [f, i]));
-  tally.allResults.sort(
-    (a, b) => (fileIndexMap.get(a.file) ?? 0) - (fileIndexMap.get(b.file) ?? 0),
-  );
-
+  sortResultsByFileOrder(tally, ctx.files);
   return tally;
 }
 
-/**
- * Process a single file end-to-end: read content, call the API with 503 retry,
- * and emit progress transitions. Errors (including retry exhaustion) are caught and converted into a `FileFailure`.
- */
-async function processFile(ctx: RunContext, idx: number): Promise<FileResult> {
-  const file = ctx.files[idx];
-  const filePath = ctx.allPaths[idx];
-  ctx.progress.update(idx, 'analyzing');
+function emptyTally(): RunTally {
+  return { allResults: [], totalIssues: 0, totalErrors: 0, totalFailures: 0 };
+}
+
+function prepareChunks(
+  ctx: RunContext,
+  fileIndexByAbsolutePath: Map<string, number>,
+  tally: RunTally,
+  progress: SqaaProgress,
+): { chunks: SqaaChunk[]; chunkFileIndices: number[][] } {
+  const readableChunkFiles: SqaaChunkFile[] = [];
+  for (let idx = 0; idx < ctx.files.length; idx++) {
+    const file = ctx.files[idx];
+    try {
+      readableChunkFiles.push({
+        absolutePath: file,
+        relativePath: ctx.allPaths[idx],
+        content: readSqaaFileContent(file),
+      });
+    } catch (err) {
+      recordFileFailure(progress, tally, idx, { file, filePath: ctx.allPaths[idx] }, err as Error);
+    }
+  }
+
+  if (readableChunkFiles.length === 0) {
+    return { chunks: [], chunkFileIndices: [] };
+  }
+
+  const chunks: SqaaChunk[] = [{ files: readableChunkFiles }];
+  const chunkFileIndices = [
+    readableChunkFiles.map((f) => fileIndexByAbsolutePath.get(f.absolutePath)!),
+  ];
+  return { chunks, chunkFileIndices };
+}
+
+function chunkPathsForFiles(
+  ctx: RunContext,
+  chunkFiles: SqaaChunkFile[],
+  fileIndexByAbsolutePath: Map<string, number>,
+): { partPaths: ChunkPath[]; partIndices: number[] } {
+  const partPaths: ChunkPath[] = [];
+  const partIndices: number[] = [];
+  for (const chunkFile of chunkFiles) {
+    const idx = fileIndexByAbsolutePath.get(chunkFile.absolutePath)!;
+    partPaths.push({ file: chunkFile.absolutePath, filePath: ctx.allPaths[idx] });
+    partIndices.push(idx);
+  }
+  return { partPaths, partIndices };
+}
+
+function chunkPathsForIndices(ctx: RunContext, fileIndices: number[]): ChunkPath[] {
+  return fileIndices.map((idx) => ({
+    file: ctx.files[idx],
+    filePath: ctx.allPaths[idx],
+  }));
+}
+
+function recordSuccessfulParts(
+  ctx: RunContext,
+  tally: RunTally,
+  progress: SqaaProgress,
+  parts: Array<{ response: SqaaChunkResponse; files: SqaaChunkFile[] }>,
+  fileIndexByAbsolutePath: Map<string, number>,
+): void {
+  for (const part of parts) {
+    if (part.files.length === 0) {
+      continue;
+    }
+    const { partPaths, partIndices } = chunkPathsForFiles(ctx, part.files, fileIndexByAbsolutePath);
+    recordChunkSuccess(progress, tally, partIndices, partPaths, part.response);
+  }
+}
+
+function recordPayloadTooLargeFailures(
+  ctx: RunContext,
+  tally: RunTally,
+  progress: SqaaProgress,
+  failedFiles: SqaaChunkFile[],
+  fileIndexByAbsolutePath: Map<string, number>,
+): void {
+  for (const failed of failedFiles) {
+    const idx = fileIndexByAbsolutePath.get(failed.absolutePath);
+    if (idx === undefined) {
+      continue;
+    }
+    recordFileFailure(
+      progress,
+      tally,
+      idx,
+      { file: failed.absolutePath, filePath: ctx.allPaths[idx] },
+      new CommandFailedError(PAYLOAD_TOO_LARGE_FAILURE_MESSAGE),
+    );
+  }
+}
+
+function recordGroupFetchErrors(
+  ctx: RunContext,
+  tally: RunTally,
+  progress: SqaaProgress,
+  groupErrors: SqaaChunkGroupError[],
+  fileIndexByAbsolutePath: Map<string, number>,
+): void {
+  for (const { files, error } of groupErrors) {
+    for (const failed of files) {
+      const idx = fileIndexByAbsolutePath.get(failed.absolutePath);
+      if (idx === undefined) {
+        continue;
+      }
+      recordFileFailure(
+        progress,
+        tally,
+        idx,
+        { file: failed.absolutePath, filePath: ctx.allPaths[idx] },
+        error,
+      );
+    }
+  }
+}
+
+/** Whether to continue remaining chunks after a mixed or successful chunk fetch. */
+export function shouldContinueAfterChunk(
+  parts: Array<{ response: SqaaChunkResponse; files: SqaaChunkFile[] }>,
+  failedFiles: SqaaChunkFile[],
+  groupErrors: SqaaChunkGroupError[],
+): boolean {
+  const totalChunkFailure =
+    parts.length === 0 && failedFiles.length === 0 && groupErrors.length > 0;
+  return !totalChunkFailure;
+}
+
+async function processChunk(
+  ctx: RunContext,
+  tally: RunTally,
+  chunkIndex: number,
+  chunk: SqaaChunk,
+  fileIndices: number[],
+  fileIndexByAbsolutePath: Map<string, number>,
+): Promise<boolean> {
+  const chunkPaths = chunkPathsForIndices(ctx, fileIndices);
+  markChunkAnalyzing(ctx.progress, chunkIndex, fileIndices);
+
   try {
-    const fileContent = readSqaaFileContent(file);
-    const response = await fetchWithRetry(
+    const { parts, failedFiles, groupErrors } = await fetchChunkWith413Split(
       ctx.cloudAuth,
       ctx.projectKey,
-      file,
-      fileContent,
+      chunk.files,
       ctx.branch,
-      async (attempt) => {
-        await ctx.progress.retrying(
-          idx,
+      (attempt) =>
+        ctx.progress.retryingChunk(
+          chunkIndex,
           attempt,
           MAX_503_RETRIES,
           getSqaaRetry503BaseDelayMs() * 2 ** (attempt - 1),
-        );
-        // retrying() already resets status to 'analyzing' when the countdown ends.
+        ),
+      () => {
+        ctx.progress.warnPayloadSplit();
       },
-      ctx.pathBase,
     );
-    ctx.progress.update(idx, 'done');
-    return { file, filePath, issues: response.issues, errors: response.errors };
+
+    recordSuccessfulParts(ctx, tally, ctx.progress, parts, fileIndexByAbsolutePath);
+    recordPayloadTooLargeFailures(ctx, tally, ctx.progress, failedFiles, fileIndexByAbsolutePath);
+    recordGroupFetchErrors(ctx, tally, ctx.progress, groupErrors, fileIndexByAbsolutePath);
+
+    ctx.progress.updateChunk(chunkIndex, 'done');
+    return shouldContinueAfterChunk(parts, failedFiles, groupErrors);
   } catch (err) {
-    ctx.progress.update(idx, 'failed');
-    return { file, filePath, failure: err as Error };
+    recordChunkFailure(ctx.progress, tally, chunkIndex, fileIndices, chunkPaths, err as Error);
+    return false;
   }
+}
+
+function markChunkAnalyzing(
+  progress: SqaaProgress,
+  chunkIndex: number,
+  fileIndices: number[],
+): void {
+  progress.updateChunk(chunkIndex, 'analyzing');
+  for (const idx of fileIndices) {
+    progress.update(idx, 'analyzing');
+  }
+}
+
+function recordChunkSuccess(
+  progress: SqaaProgress,
+  tally: RunTally,
+  fileIndices: number[],
+  chunkPaths: ChunkPath[],
+  response: SqaaChunkResponse,
+): void {
+  const results = distributeChunkResponse(response.issues, response.errors, chunkPaths);
+  tally.allResults.push(...results);
+  tallyResults(results, tally);
+  for (const idx of fileIndices) {
+    progress.update(idx, 'done');
+  }
+}
+
+function recordFileFailure(
+  progress: SqaaProgress,
+  tally: RunTally,
+  fileIndex: number,
+  chunkPath: ChunkPath,
+  error: Error,
+): void {
+  progress.update(fileIndex, 'failed');
+  const failure: FileFailure = {
+    file: chunkPath.file,
+    filePath: chunkPath.filePath,
+    failure: error,
+  };
+  tally.allResults.push(failure);
+  tallyResults([failure], tally);
+}
+
+function recordChunkFailure(
+  progress: SqaaProgress,
+  tally: RunTally,
+  chunkIndex: number,
+  fileIndices: number[],
+  chunkPaths: ChunkPath[],
+  error: Error,
+): void {
+  progress.updateChunk(chunkIndex, 'failed');
+  for (let i = 0; i < chunkPaths.length; i++) {
+    recordFileFailure(progress, tally, fileIndices[i], chunkPaths[i], error);
+  }
+}
+
+function skipUnprocessedAfterFailure(ctx: RunContext, tally: RunTally): void {
+  const processedFiles = new Set(tally.allResults.map((r) => r.file));
+  const firstUnprocessed = ctx.files.findIndex((f) => !processedFiles.has(f));
+  if (firstUnprocessed >= 0) {
+    ctx.progress.skipRemaining(firstUnprocessed);
+  }
+}
+
+function sortResultsByFileOrder(tally: RunTally, files: string[]): void {
+  const fileIndexMap = new Map(files.map((f, i) => [f, i]));
+  tally.allResults.sort(
+    (a, b) => (fileIndexMap.get(a.file) ?? 0) - (fileIndexMap.get(b.file) ?? 0),
+  );
+}
+
+export function distributeChunkResponse(
+  issues: SqaaIssue[],
+  errors: Array<{ code: string; message: string }> | null | undefined,
+  chunkPaths: ChunkPath[],
+): FileSuccess[] {
+  const issuesByPath = new Map<string, SqaaIssue[]>();
+  const knownPaths = new Set(chunkPaths.map((p) => p.filePath));
+  const fallbackPath = chunkPaths[0]?.filePath;
+
+  for (const issue of issues) {
+    const path = issue.filePath && knownPaths.has(issue.filePath) ? issue.filePath : fallbackPath;
+    if (!path) continue;
+    const list = issuesByPath.get(path) ?? [];
+    list.push(issue);
+    issuesByPath.set(path, list);
+  }
+
+  return chunkPaths.map(({ file, filePath }, index) => ({
+    file,
+    filePath,
+    issues: issuesByPath.get(filePath) ?? [],
+    errors: index === 0 ? errors : null,
+  }));
 }
 
 export function tallyResults(results: FileResult[], tally: RunTally): void {

--- a/src/cli/commands/analyze/sqaa-api.ts
+++ b/src/cli/commands/analyze/sqaa-api.ts
@@ -24,12 +24,12 @@ import { readFileSync } from 'node:fs';
 
 import { getSqaaRetry503BaseDelayMs } from '../../../lib/config-constants';
 import { toRelativePosixPath as toRelativePosixPathOrNull } from '../../../lib/fs-utils';
-import type { SqaaIssue } from '../../../sonarqube/client';
+import type { SqaaAnalysisFile, SqaaIssue } from '../../../sonarqube/client';
 import { SonarQubeClient } from '../../../sonarqube/client';
-import { ServiceUnavailableError } from '../../../sonarqube/errors.js';
-import { blank, text } from '../../../ui';
+import { RequestPayloadTooLargeError, ServiceUnavailableError } from '../../../sonarqube/errors.js';
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
 import type { CloudAuth } from './sqaa-auth';
+import { type PackChunksLimits, packFilesIntoChunks, type SqaaChunkFile } from './sqaa-chunking';
 import { displaySqaaResults } from './sqaa-display';
 
 /** Maximum number of retries on 503 responses. */
@@ -37,6 +37,9 @@ export const MAX_503_RETRIES = 3;
 
 /** Interval for the live countdown tick in milliseconds. */
 const COUNTDOWN_TICK_MS = 1000;
+
+const SQAA_FAILURE_HINT =
+  'Check your SonarQube Cloud authentication, project key, and network connectivity, then retry.';
 
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -68,6 +71,43 @@ export function toRelativePosixPath(file: string, base: string = process.cwd()):
   return rel;
 }
 
+function isRetryableSqaaError(err: unknown, includePayloadTooLarge: boolean): boolean {
+  if (err instanceof ServiceUnavailableError) {
+    return true;
+  }
+  return includePayloadTooLarge && err instanceof RequestPayloadTooLargeError;
+}
+
+async function postSqaaAnalysis(
+  auth: CloudAuth,
+  projectKey: string,
+  branch: string | undefined,
+  files: SqaaAnalysisFile[],
+  options: { analysisDepth?: 'DEEP'; includePayloadTooLarge?: boolean } = {},
+): Promise<SqaaChunkResponse> {
+  const client = new SonarQubeClient(auth.serverUrl, auth.token);
+  try {
+    return await client.createAnalysis({
+      organizationKey: auth.orgKey,
+      projectKey,
+      ...(branch ? { branchName: branch } : {}),
+      ...(options.analysisDepth ? { analysisDepth: options.analysisDepth } : {}),
+      files,
+    });
+  } catch (err) {
+    if (isRetryableSqaaError(err, options.includePayloadTooLarge ?? false)) {
+      throw err;
+    }
+    throw new CommandFailedError(
+      `SonarQube Agentic Analysis failed.\n  ${(err as Error).message}`,
+      {
+        cause: err,
+        remediationHint: SQAA_FAILURE_HINT,
+      },
+    );
+  }
+}
+
 /**
  * Fetch the SQAA API response for a single file. Does not print anything.
  * Throws ServiceUnavailableError on 503 (caller handles retry), CommandFailedError on other failures.
@@ -85,45 +125,17 @@ export async function fetchSqaaResponse(
   pathBase?: string,
 ): Promise<{ issues: SqaaIssue[]; errors?: Array<{ code: string; message: string }> | null }> {
   const filePath = toRelativePosixPath(file, pathBase);
-  const client = new SonarQubeClient(auth.serverUrl, auth.token);
-  try {
-    return await client.createAnalysis({
-      organizationKey: auth.orgKey,
-      projectKey,
-      ...(branch ? { branchName: branch } : {}),
-      files: [{ path: filePath, content: fileContent }],
-    });
-  } catch (err) {
-    if (err instanceof ServiceUnavailableError) {
-      throw err;
-    }
-    throw new CommandFailedError(
-      `SonarQube Agentic Analysis failed.\n  ${(err as Error).message}`,
-      {
-        cause: err,
-        remediationHint:
-          'Check your SonarQube Cloud authentication, project key, and network connectivity, then retry.',
-      },
-    );
-  }
+  return postSqaaAnalysis(auth, projectKey, branch, [{ path: filePath, content: fileContent }]);
 }
 
-/**
- * Calls fetchSqaaResponse with a 503-retry loop.
- */
-export async function fetchWithRetry(
-  auth: CloudAuth,
-  projectKey: string,
-  file: string,
-  fileContent: string,
-  branch: string | undefined,
+async function with503Retry<T>(
+  fetch: () => Promise<T>,
   onRetry?: (attempt: number) => Promise<void>,
-  pathBase?: string,
-): Promise<{ issues: SqaaIssue[]; errors?: Array<{ code: string; message: string }> | null }> {
+): Promise<T> {
   let lastServiceError: ServiceUnavailableError | undefined;
   for (let attempt = 1; attempt <= MAX_503_RETRIES + 1; attempt++) {
     try {
-      return await fetchSqaaResponse(auth, projectKey, file, fileContent, branch, pathBase);
+      return await fetch();
     } catch (err) {
       if (!(err instanceof ServiceUnavailableError)) {
         throw err;
@@ -138,6 +150,201 @@ export async function fetchWithRetry(
     `SonarQube Agentic Analysis failed after ${MAX_503_RETRIES} retries. The service is still unavailable.`,
     { cause: lastServiceError },
   );
+}
+
+/**
+ * Calls fetchSqaaResponse with a 503-retry loop.
+ */
+export async function fetchWithRetry(
+  auth: CloudAuth,
+  projectKey: string,
+  file: string,
+  fileContent: string,
+  branch: string | undefined,
+  onRetry?: (attempt: number) => Promise<void>,
+  pathBase?: string,
+): Promise<{ issues: SqaaIssue[]; errors?: Array<{ code: string; message: string }> | null }> {
+  return with503Retry(
+    () => fetchSqaaResponse(auth, projectKey, file, fileContent, branch, pathBase),
+    onRetry,
+  );
+}
+
+export type SqaaChunkResponse = {
+  issues: SqaaIssue[];
+  errors?: Array<{ code: string; message: string }> | null;
+};
+
+export type SqaaChunkPart = {
+  response: SqaaChunkResponse;
+  files: SqaaChunkFile[];
+};
+
+export type SqaaChunkFetchResult = {
+  parts: SqaaChunkPart[];
+  failedFiles: SqaaChunkFile[];
+  groupErrors: SqaaChunkGroupError[];
+};
+
+export type SqaaChunkGroupError = {
+  files: SqaaChunkFile[];
+  error: Error;
+};
+
+function packLimitsForRequest(
+  auth: CloudAuth,
+  projectKey: string,
+  branch: string | undefined,
+  overrides: { maxRequestBytes?: number; maxFilesPerRequest?: number } = {},
+) {
+  return {
+    ...overrides,
+    organizationKey: auth.orgKey,
+    projectKey,
+    ...(branch ? { branchName: branch } : {}),
+  };
+}
+
+function packLimitsFrom413Error(
+  auth: CloudAuth,
+  projectKey: string,
+  branch: string | undefined,
+  err: RequestPayloadTooLargeError,
+) {
+  return packLimitsForRequest(auth, projectKey, branch, {
+    ...(err.meta?.maxRequestSize == null ? {} : { maxRequestBytes: err.meta.maxRequestSize }),
+    ...(err.meta?.maxFiles == null ? {} : { maxFilesPerRequest: err.meta.maxFiles }),
+  });
+}
+
+/**
+ * Fetch the SQAA API response for a multi-file chunk with `analysisDepth: DEEP`.
+ * Throws ServiceUnavailableError on 503, RequestPayloadTooLargeError on 413.
+ */
+export async function fetchChunkResponse(
+  auth: CloudAuth,
+  projectKey: string,
+  files: SqaaAnalysisFile[],
+  branch: string | undefined,
+): Promise<SqaaChunkResponse> {
+  return postSqaaAnalysis(auth, projectKey, branch, files, {
+    analysisDepth: 'DEEP',
+    includePayloadTooLarge: true,
+  });
+}
+
+/**
+ * Calls fetchChunkResponse with a 503-retry loop.
+ */
+export async function fetchChunkWithRetry(
+  auth: CloudAuth,
+  projectKey: string,
+  files: SqaaAnalysisFile[],
+  branch: string | undefined,
+  onRetry?: (attempt: number) => Promise<void>,
+): Promise<SqaaChunkResponse> {
+  return with503Retry(() => fetchChunkResponse(auth, projectKey, files, branch), onRetry);
+}
+
+function toAnalysisFiles(chunkFiles: SqaaChunkFile[]): SqaaAnalysisFile[] {
+  return chunkFiles.map((f) => ({ path: f.relativePath, content: f.content }));
+}
+
+function splitChunkFiles(files: SqaaChunkFile[], limits: PackChunksLimits): SqaaChunkFile[][] {
+  const packed = packFilesIntoChunks(files, limits);
+  if (packed.length > 1) {
+    return packed.map((chunk) => chunk.files);
+  }
+  const mid = Math.ceil(files.length / 2);
+  return [files.slice(0, mid), files.slice(mid)];
+}
+
+/** 503 after retry exhaustion is wrapped in CommandFailedError; both must fail-fast. */
+function isTransientChunkFetchError(err: unknown): boolean {
+  if (err instanceof ServiceUnavailableError) {
+    return true;
+  }
+  return err instanceof CommandFailedError && err.cause instanceof ServiceUnavailableError;
+}
+
+async function fetchSplitParts(
+  auth: CloudAuth,
+  projectKey: string,
+  partGroups: SqaaChunkFile[][],
+  branch: string | undefined,
+  onRetry?: (attempt: number) => Promise<void>,
+  onPayloadSplit?: () => void,
+): Promise<SqaaChunkFetchResult> {
+  const parts: SqaaChunkPart[] = [];
+  const failedFiles: SqaaChunkFile[] = [];
+  const groupErrors: SqaaChunkGroupError[] = [];
+  for (const group of partGroups) {
+    try {
+      const result = await fetchChunkWith413Split(
+        auth,
+        projectKey,
+        group,
+        branch,
+        onRetry,
+        onPayloadSplit,
+      );
+      parts.push(...result.parts);
+      failedFiles.push(...result.failedFiles);
+      groupErrors.push(...result.groupErrors);
+    } catch (err) {
+      if (isTransientChunkFetchError(err)) {
+        throw err;
+      }
+      groupErrors.push({ files: group, error: err as Error });
+    }
+  }
+  return { parts, failedFiles, groupErrors };
+}
+
+/**
+ * Send a chunk with 503 retry; on 413 split the chunk and retry sub-chunks sequentially.
+ * Returns partial successes when only some sub-chunks fail after splitting.
+ */
+export async function fetchChunkWith413Split(
+  auth: CloudAuth,
+  projectKey: string,
+  chunkFiles: SqaaChunkFile[],
+  branch: string | undefined,
+  onRetry?: (attempt: number) => Promise<void>,
+  onPayloadSplit?: () => void,
+): Promise<SqaaChunkFetchResult> {
+  try {
+    const response = await fetchChunkWithRetry(
+      auth,
+      projectKey,
+      toAnalysisFiles(chunkFiles),
+      branch,
+      onRetry,
+    );
+    return {
+      parts: [{ response, files: chunkFiles }],
+      failedFiles: [],
+      groupErrors: [],
+    };
+  } catch (err) {
+    if (!(err instanceof RequestPayloadTooLargeError)) {
+      throw err;
+    }
+    if (chunkFiles.length === 1) {
+      return { parts: [], failedFiles: chunkFiles, groupErrors: [] };
+    }
+
+    onPayloadSplit?.();
+
+    return fetchSplitParts(
+      auth,
+      projectKey,
+      splitChunkFiles(chunkFiles, packLimitsFrom413Error(auth, projectKey, branch, err)),
+      branch,
+      onRetry,
+      onPayloadSplit,
+    );
+  }
 }
 
 export async function waitBeforeRetry(
@@ -188,8 +395,6 @@ export async function callSqaaApiAndDisplay(
   fileContent: string,
   branch: string | undefined,
 ): Promise<number> {
-  blank();
-  text('Running SonarQube Agentic Analysis...');
   const response = await fetchWithRetry(auth, projectKey, file, fileContent, branch);
-  return displaySqaaResults(response.issues, response.errors);
+  return displaySqaaResults(response.issues, response.errors, toRelativePosixPath(file));
 }

--- a/src/cli/commands/analyze/sqaa-chunking.ts
+++ b/src/cli/commands/analyze/sqaa-chunking.ts
@@ -1,0 +1,145 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Pack SQAA request files into sub-chunks when splitting after a 413 response.
+
+import type { SqaaAnalysisFile, SqaaAnalysisRequest } from '../../../sonarqube/client';
+
+export interface SqaaChunkFile {
+  /** Absolute path on disk (for reading / error reporting). */
+  absolutePath: string;
+  /** Project-relative POSIX path sent to SQAA. */
+  relativePath: string;
+  content: string;
+}
+
+export interface SqaaChunk {
+  files: SqaaChunkFile[];
+}
+
+export interface PackChunksLimits {
+  maxRequestBytes?: number;
+  maxFilesPerRequest?: number;
+  organizationKey?: string;
+  projectKey?: string;
+  branchName?: string;
+}
+
+export interface EstimateRequestParams {
+  organizationKey: string;
+  projectKey: string;
+  branchName?: string;
+  files: SqaaAnalysisFile[];
+}
+
+/** Build the JSON body used for a DEEP multi-file SQAA request. */
+export function buildDeepAnalysisRequest(params: EstimateRequestParams): SqaaAnalysisRequest {
+  return {
+    organizationKey: params.organizationKey,
+    projectKey: params.projectKey,
+    ...(params.branchName ? { branchName: params.branchName } : {}),
+    analysisDepth: 'DEEP',
+    files: params.files,
+  };
+}
+
+/** Estimated UTF-8 byte size of a DEEP analysis request body. */
+export function estimateRequestBytes(params: EstimateRequestParams): number {
+  return Buffer.byteLength(JSON.stringify(buildDeepAnalysisRequest(params)), 'utf8');
+}
+
+const EMPTY_ENVELOPE_PARAMS = { organizationKey: '', projectKey: '' } as const;
+
+function envelopeParams(limits: PackChunksLimits): EstimateRequestParams {
+  return {
+    organizationKey: limits.organizationKey ?? EMPTY_ENVELOPE_PARAMS.organizationKey,
+    projectKey: limits.projectKey ?? EMPTY_ENVELOPE_PARAMS.projectKey,
+    ...(limits.branchName ? { branchName: limits.branchName } : {}),
+    files: [],
+  };
+}
+
+/** Byte size of the DEEP request JSON wrapper with an empty `files` array. */
+function deepRequestEnvelopeBytes(limits: PackChunksLimits): number {
+  return estimateRequestBytes(envelopeParams(limits));
+}
+
+function analysisFileJsonBytes(file: SqaaAnalysisFile): number {
+  return Buffer.byteLength(JSON.stringify(file), 'utf8');
+}
+
+/**
+ * Greedy pack using explicit byte and file-count limits (from a 413 response meta).
+ * Omit a limit to impose no constraint on that dimension.
+ */
+export function packFilesIntoChunks(
+  items: SqaaChunkFile[],
+  limits: PackChunksLimits = {},
+): SqaaChunk[] {
+  const maxRequestBytes = limits.maxRequestBytes ?? Number.POSITIVE_INFINITY;
+  const maxFilesPerRequest = limits.maxFilesPerRequest ?? Number.POSITIVE_INFINITY;
+
+  if (items.length === 0) {
+    return [];
+  }
+
+  const envelopeBytes = deepRequestEnvelopeBytes(limits);
+  const itemByteCosts = items.map((item) => analysisFileJsonBytes(toAnalysisFile(item)));
+
+  const chunks: SqaaChunk[] = [];
+  let current: SqaaChunkFile[] = [];
+  let currentBytes = envelopeBytes;
+
+  const flush = (): void => {
+    if (current.length > 0) {
+      chunks.push({ files: current });
+      current = [];
+      currentBytes = envelopeBytes;
+    }
+  };
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const itemBytes = itemByteCosts[i];
+    const candidateLength = current.length + 1;
+    const candidateBytes =
+      current.length === 0 ? envelopeBytes + itemBytes : currentBytes + 1 + itemBytes;
+
+    if (
+      current.length > 0 &&
+      (candidateBytes > maxRequestBytes || candidateLength > maxFilesPerRequest)
+    ) {
+      flush();
+      current = [item];
+      currentBytes = envelopeBytes + itemBytes;
+      continue;
+    }
+
+    current.push(item);
+    currentBytes = candidateBytes;
+  }
+
+  flush();
+  return chunks;
+}
+
+function toAnalysisFile(file: SqaaChunkFile): SqaaAnalysisFile {
+  return { path: file.relativePath, content: file.content };
+}

--- a/src/cli/commands/analyze/sqaa-display.ts
+++ b/src/cli/commands/analyze/sqaa-display.ts
@@ -20,14 +20,22 @@
 
 // Display layer for SQAA results: text and JSON output.
 
+import { basename, dirname } from 'node:path';
+
 import type { SqaaIssue } from '../../../sonarqube/client';
-import { blank, error, print, success, text } from '../../../ui';
+import { print, text } from '../../../ui';
+import { bold, dim, green, red, softBlue, yellow } from '../../../ui/colors.js';
 import type { FileFailure, FileResult, FileSuccess, RunTally } from './sqaa-analysis';
 import { toRelativePosixPath } from './sqaa-api';
 import type { IgnoredFile } from './sqaa-changeset';
 
+/** When analyzed file count exceeds this, clean files collapse to one summary row. */
+export const SQAA_COLLAPSE_CLEAN_THRESHOLD = 20;
+
 /** Exit code when analysis succeeds and issues are found. */
 export const EXIT_CODE_ISSUES_FOUND = 51;
+
+const ISSUE_LINE_INDENT = '     ';
 
 export interface SqaaJsonReport {
   files: Array<{
@@ -40,6 +48,369 @@ export interface SqaaJsonReport {
   /** Files in the change set that were never sent to the API (fail-fast skipped them). */
   skipped: string[];
   summary: { totalIssues: number; totalFailures: number; totalSkipped: number };
+}
+
+export interface SqaaRunSummaryStats {
+  filesAnalyzed: number;
+  filesWithIssues: number;
+  filesWithErrors: number;
+  totalIssues: number;
+  totalFailures: number;
+  totalErrors: number;
+}
+
+export interface PrintSqaaTextReportOptions {
+  tally: RunTally;
+  allPaths: string[];
+  ignoredPaths?: string[];
+}
+
+type PathParts = { dir: string; base: string };
+
+function splitSqaaPath(path: string): PathParts {
+  const base = basename(path);
+  const dir = dirname(path);
+  if (dir === '.' || dir === '') {
+    return { dir: '', base };
+  }
+  const normalized = dir.endsWith('/') ? dir : `${dir}/`;
+  return { dir: normalized, base };
+}
+
+/** Plain-text path: `dir/` + filename (no ANSI). */
+export function formatSqaaPathPlain(path: string): string {
+  const { dir, base } = splitSqaaPath(path);
+  return `${dir}${base}`;
+}
+
+/** Colored path: dim directory + bold filename. */
+export function formatSqaaPathColored(path: string): string {
+  const { dir, base } = splitSqaaPath(path);
+  if (!dir) {
+    return bold(base);
+  }
+  return `${dim(dir)}${bold(base)}`;
+}
+
+function formatIssueCountTag(issueCount: number, errorCount: number, colored: boolean): string {
+  const parts: string[] = [];
+  if (issueCount > 0) {
+    parts.push(`${issueCount} issue${issueCount === 1 ? '' : 's'}`);
+  }
+  if (errorCount > 0) {
+    parts.push(`${errorCount} error${errorCount === 1 ? '' : 's'}`);
+  }
+  if (parts.length === 0) {
+    return '';
+  }
+  const tag = ` · ${parts.join(', ')}`;
+  return colored ? yellow(tag) : tag;
+}
+
+/** Plain issue/error count suffix for hook and text output. */
+export function formatIssueCountTagPlain(issueCount: number, errorCount: number): string {
+  return formatIssueCountTag(issueCount, errorCount, false);
+}
+
+/** IDE-style issue line (plain text). */
+export function formatSqaaIssueLinePlain(issue: SqaaIssue, index: number): string {
+  const idx = `[${index}]`;
+  const { message, rule, textRange } = issue;
+  const linePart = textRange ? `line ${textRange.startLine}` : '';
+  if (linePart) {
+    return `${ISSUE_LINE_INDENT}${idx} ${linePart}  ${message}  ${rule}`;
+  }
+  return `${ISSUE_LINE_INDENT}${idx} ${message}  ${rule}`;
+}
+
+/** IDE-style issue line with ANSI colors. */
+export function formatSqaaIssueLineColored(issue: SqaaIssue, index: number): string {
+  const idx = dim(`[${index}]`);
+  const { message, rule, textRange } = issue;
+  if (textRange) {
+    const lineLabel = dim('line');
+    const lineNum = softBlue(String(textRange.startLine));
+    return `${ISSUE_LINE_INDENT}${idx} ${lineLabel} ${lineNum}  ${message}  ${dim(rule)}`;
+  }
+  return `${ISSUE_LINE_INDENT}${idx} ${message}  ${dim(rule)}`;
+}
+
+function formatSqaaErrorLine(err: { code: string; message: string }, colored: boolean): string {
+  const line = `${ISSUE_LINE_INDENT}[${err.code}] ${err.message}`;
+  return colored ? dim(line) : line;
+}
+
+/** Plain analysis error line for hook and text output. */
+export function formatSqaaErrorLinePlain(err: { code: string; message: string }): string {
+  return formatSqaaErrorLine(err, false);
+}
+
+function formatCleanCollapsedRow(count: number, colored: boolean): string {
+  const icon = colored ? green('✓') : '✓';
+  const countLabel = colored ? bold(String(count)) : String(count);
+  const suffix = colored ? dim(' — no issues') : ' — no issues';
+  return `  ${icon}  ${countLabel} files${suffix}`;
+}
+
+function formatCleanFileRow(path: string, colored: boolean): string {
+  const icon = colored ? green('✓') : '✓';
+  const pathLabel = colored ? formatSqaaPathColored(path) : formatSqaaPathPlain(path);
+  return `  ${icon}  ${pathLabel}`;
+}
+
+function formatFindingsFileRow(
+  path: string,
+  issueCount: number,
+  errorCount: number,
+  colored: boolean,
+): string {
+  const icon = colored ? yellow('!') : '!';
+  const pathLabel = colored ? formatSqaaPathColored(path) : formatSqaaPathPlain(path);
+  const tag = formatIssueCountTag(issueCount, errorCount, colored);
+  return `  ${icon}  ${pathLabel}${tag}`;
+}
+
+function formatFailedFileRow(path: string, colored: boolean): string {
+  const icon = colored ? red('✗') : '✗';
+  const pathLabel = colored ? formatSqaaPathColored(path) : formatSqaaPathPlain(path);
+  return `  ${icon}  ${pathLabel}`;
+}
+
+function formatSkippedOrIgnoredRow(
+  path: string,
+  label: '[SKIPPED]' | '[IGNORED]',
+  colored: boolean,
+): string {
+  const icon = colored ? dim('⊘') : '⊘';
+  const pathLabel = colored ? formatSqaaPathColored(path) : formatSqaaPathPlain(path);
+  const status = colored ? dim(label) : label;
+  return `  ${icon}  ${pathLabel}  ${status}`;
+}
+
+export function sqaaFileHasFindings(
+  issues: SqaaIssue[],
+  errors?: Array<{ code: string; message: string }> | null,
+): boolean {
+  return issues.length > 0 || (errors?.length ?? 0) > 0;
+}
+
+function fileHasFindings(result: FileSuccess): boolean {
+  return sqaaFileHasFindings(result.issues, result.errors);
+}
+
+function buildResultMap(results: FileResult[]): Map<string, FileResult> {
+  return new Map(results.map((r) => [r.filePath, r]));
+}
+
+export function computeRunSummaryStats(tally: RunTally, allPaths: string[]): SqaaRunSummaryStats {
+  let filesWithIssues = 0;
+  let filesWithErrors = 0;
+  for (const result of tally.allResults) {
+    if ('failure' in result) continue;
+    if (result.issues.length > 0) {
+      filesWithIssues += 1;
+    }
+    if ((result.errors?.length ?? 0) > 0) {
+      filesWithErrors += 1;
+    }
+  }
+  return {
+    filesAnalyzed: allPaths.length,
+    filesWithIssues,
+    filesWithErrors,
+    totalIssues: tally.totalIssues,
+    totalFailures: tally.totalFailures,
+    totalErrors: tally.totalErrors,
+  };
+}
+
+function formatSqaaRunSummary(stats: SqaaRunSummaryStats, colored: boolean): string {
+  const num = (n: number) => (colored ? yellow(String(n)) : String(n));
+  const lbl = (s: string) => (colored ? bold(s) : s);
+  const okIcon = colored ? green('✓') : '✓';
+
+  if (stats.totalFailures > 0) {
+    const failureWord = stats.totalFailures === 1 ? 'failure' : 'failures';
+    return `${num(stats.filesAnalyzed)} ${lbl('files analyzed')} · ${num(stats.totalFailures)} ${lbl(failureWord)}`;
+  }
+  if (stats.totalIssues > 0) {
+    const issueWord = stats.totalIssues === 1 ? 'issue' : 'issues';
+    return `${num(stats.filesAnalyzed)} ${lbl('files analyzed')} · ${num(stats.filesWithIssues)} ${lbl('with issues')} · ${num(stats.totalIssues)} ${lbl(issueWord)} found`;
+  }
+  if (stats.totalErrors > 0) {
+    const errorWord = stats.totalErrors === 1 ? 'error' : 'errors';
+    return `${num(stats.filesAnalyzed)} ${lbl('files analyzed')} · ${num(stats.filesWithErrors)} ${lbl('with errors')} · ${num(stats.totalErrors)} ${lbl(errorWord)}`;
+  }
+  return `${okIcon}  ${lbl('No issues found')} · ${num(stats.filesAnalyzed)} ${lbl('files analyzed')}`;
+}
+
+/** Plain-text run summary footer. */
+export function formatSqaaRunSummaryPlain(stats: SqaaRunSummaryStats): string {
+  return formatSqaaRunSummary(stats, false);
+}
+
+/** Colored run summary footer. */
+export function formatSqaaRunSummaryColored(stats: SqaaRunSummaryStats): string {
+  return formatSqaaRunSummary(stats, true);
+}
+
+function appendFileFindingsLines(lines: string[], result: FileSuccess, colored: boolean): void {
+  result.issues.forEach((issue, idx) => {
+    lines.push(
+      colored
+        ? formatSqaaIssueLineColored(issue, idx + 1)
+        : formatSqaaIssueLinePlain(issue, idx + 1),
+    );
+  });
+  if (result.errors) {
+    for (const err of result.errors) {
+      lines.push(formatSqaaErrorLine(err, colored));
+    }
+  }
+}
+
+/** Plain-text lines for one analyzed file (row + inline issues/errors). */
+export function renderPlainAnalyzedFileLines(
+  path: string,
+  issues: SqaaIssue[],
+  errors?: Array<{ code: string; message: string }> | null,
+): string[] {
+  return renderFileEntryLines(path, { file: path, filePath: path, issues, errors }, false);
+}
+
+/** Plain-text collapsed clean-files summary row. */
+export function formatPlainCleanCollapsedRow(count: number): string {
+  return formatCleanCollapsedRow(count, false);
+}
+
+/** Plain-text skipped or ignored file row. */
+export function formatPlainSkippedOrIgnoredRow(
+  path: string,
+  label: '[SKIPPED]' | '[IGNORED]',
+): string {
+  return formatSkippedOrIgnoredRow(path, label, false);
+}
+
+function renderFileEntryLines(
+  path: string,
+  result: FileResult | undefined,
+  colored: boolean,
+): string[] {
+  const lines: string[] = [];
+
+  if (!result) {
+    lines.push(formatSkippedOrIgnoredRow(path, '[SKIPPED]', colored));
+    return lines;
+  }
+
+  if ('failure' in result) {
+    const messageLine = colored
+      ? dim(`     ${result.failure.message}`)
+      : `     ${result.failure.message}`;
+    return [formatFailedFileRow(path, colored), messageLine];
+  }
+
+  if (fileHasFindings(result)) {
+    lines.push(
+      formatFindingsFileRow(path, result.issues.length, result.errors?.length ?? 0, colored),
+    );
+    appendFileFindingsLines(lines, result, colored);
+    return lines;
+  }
+
+  lines.push(formatCleanFileRow(path, colored));
+  return lines;
+}
+
+type ChangeSetPathBuckets = {
+  cleanCount: number;
+  findingPaths: string[];
+  failedPaths: string[];
+  skippedPaths: string[];
+};
+
+function classifyChangeSetPaths(
+  allPaths: string[],
+  resultMap: Map<string, FileResult>,
+): ChangeSetPathBuckets {
+  let cleanCount = 0;
+  const findingPaths: string[] = [];
+  const failedPaths: string[] = [];
+  const skippedPaths: string[] = [];
+
+  for (const path of allPaths) {
+    const result = resultMap.get(path);
+    if (!result) {
+      skippedPaths.push(path);
+      continue;
+    }
+    if ('failure' in result) {
+      failedPaths.push(path);
+      continue;
+    }
+    if (fileHasFindings(result)) {
+      findingPaths.push(path);
+      continue;
+    }
+    cleanCount += 1;
+  }
+
+  return { cleanCount, findingPaths, failedPaths, skippedPaths };
+}
+
+function renderCollapsedChangeSetLines(
+  buckets: ChangeSetPathBuckets,
+  resultMap: Map<string, FileResult>,
+  colored: boolean,
+): string[] {
+  const lines: string[] = [];
+  if (buckets.cleanCount > 0) {
+    lines.push(formatCleanCollapsedRow(buckets.cleanCount, colored));
+  }
+  for (const path of buckets.findingPaths) {
+    lines.push(...renderFileEntryLines(path, resultMap.get(path), colored));
+  }
+  for (const path of buckets.failedPaths) {
+    lines.push(...renderFileEntryLines(path, resultMap.get(path), colored));
+  }
+  for (const path of buckets.skippedPaths) {
+    lines.push(formatSkippedOrIgnoredRow(path, '[SKIPPED]', colored));
+  }
+  return lines;
+}
+
+function renderChangeSetReportLines(
+  tally: RunTally,
+  allPaths: string[],
+  ignoredPaths: string[],
+  colored: boolean,
+): string[] {
+  const resultMap = buildResultMap(tally.allResults);
+  const collapseClean = allPaths.length > SQAA_COLLAPSE_CLEAN_THRESHOLD;
+
+  const bodyLines = collapseClean
+    ? renderCollapsedChangeSetLines(classifyChangeSetPaths(allPaths, resultMap), resultMap, colored)
+    : allPaths.flatMap((path) => renderFileEntryLines(path, resultMap.get(path), colored));
+
+  const ignoredLines = ignoredPaths.map((path) =>
+    formatSkippedOrIgnoredRow(path, '[IGNORED]', colored),
+  );
+
+  return [...bodyLines, ...ignoredLines];
+}
+
+/** Unified change-set text report (file rows, inline issues, summary footer). */
+export function printSqaaTextReport(options: PrintSqaaTextReportOptions): void {
+  const { tally, allPaths, ignoredPaths = [] } = options;
+  const stats = computeRunSummaryStats(tally, allPaths);
+
+  for (const line of renderChangeSetReportLines(tally, allPaths, ignoredPaths, true)) {
+    text(line);
+  }
+
+  text('');
+  text(formatSqaaRunSummaryColored(stats));
+  applyExitCode(stats);
 }
 
 export function makeReport(
@@ -114,103 +485,58 @@ export function printJsonReport(
   print(JSON.stringify(buildJsonReport(tally, ignored, allPaths, pathBase), null, 2));
 }
 
-export function applyExitCode(totalIssues: number, totalFailures: number): void {
-  if (totalFailures > 0) {
+export function applyExitCode(stats: SqaaRunSummaryStats): void;
+export function applyExitCode(totalIssues: number, totalFailures: number): void;
+export function applyExitCode(
+  statsOrIssues: SqaaRunSummaryStats | number,
+  totalFailures = 0,
+): void {
+  const failures = typeof statsOrIssues === 'number' ? totalFailures : statsOrIssues.totalFailures;
+  const issues = typeof statsOrIssues === 'number' ? statsOrIssues : statsOrIssues.totalIssues;
+
+  if (failures > 0) {
     process.exitCode = 1;
-  } else if (totalIssues > 0) {
+  } else if (issues > 0) {
     process.exitCode = EXIT_CODE_ISSUES_FOUND;
   }
-}
-
-export function printFileDetails(allResults: FileResult[]): void {
-  blank();
-  for (const result of allResults) {
-    if ('failure' in result) {
-      text(`── ${result.filePath}`);
-      text(`   Failed to analyze: ${result.failure.message}`);
-      blank();
-    } else if (result.issues.length > 0 || (result.errors && result.errors.length > 0)) {
-      text(`── ${result.filePath}`);
-      printIssuesAndErrors(result.issues, result.errors);
-    }
-  }
-}
-
-export function printIssuesAndErrors(
-  issues: SqaaIssue[],
-  errors?: Array<{ code: string; message: string }> | null,
-): void {
-  if (issues.length > 0) {
-    text(`   Found ${issues.length} issue${issues.length === 1 ? '' : 's'}:`);
-    blank();
-    issues.forEach((issue, idx) => {
-      const location = issue.textRange ? ` (line ${issue.textRange.startLine})` : '';
-      text(`  [${idx + 1}] ${issue.message}${location}`);
-      text(`      Rule: ${issue.rule}`);
-    });
-    blank();
-  }
-  if (errors && errors.length > 0) {
-    text('   Analysis errors:');
-    errors.forEach((e) => {
-      text(`  [${e.code}] ${e.message}`);
-    });
-    blank();
-  }
-}
-
-export function printSummary(
-  totalIssues: number,
-  totalErrors: number,
-  totalFailures: number,
-): void {
-  if (totalFailures > 0) {
-    // Failures take precedence: the run was incomplete regardless of issues found so far.
-    error(
-      `SonarQube Agentic Analysis completed with ${totalFailures} failure${totalFailures === 1 ? '' : 's'}.`,
-    );
-    process.exitCode = 1;
-  } else if (totalIssues > 0) {
-    process.exitCode = EXIT_CODE_ISSUES_FOUND;
-  } else if (totalErrors === 0) {
-    success('SonarQube Agentic Analysis completed — change set is clean.');
-  }
-  // else: no issues, no failures, but API-level errors were printed per file — stay silent on the
-  // summary line (matches single-file behavior) and leave the exit code untouched.
 }
 
 export function displaySqaaResults(
   issues: SqaaIssue[],
-  errors?: Array<{ code: string; message: string }> | null,
-  inChangeSetMode = false,
+  errors: Array<{ code: string; message: string }> | null | undefined,
+  filePath: string,
 ): number {
-  blank();
+  const result: FileSuccess = {
+    file: filePath,
+    filePath,
+    issues,
+    errors,
+  };
 
-  if (issues.length === 0) {
-    if (!inChangeSetMode && !errors?.length) {
-      success('SonarQube Agentic Analysis completed — no issues found.');
-    }
+  const lines: string[] = [];
+  if (fileHasFindings(result)) {
+    lines.push(formatFindingsFileRow(filePath, issues.length, errors?.length ?? 0, true));
+    appendFileFindingsLines(lines, result, true);
   } else {
-    error(
-      `SonarQube Agentic Analysis found ${issues.length} issue${issues.length === 1 ? '' : 's'}:`,
-    );
-    blank();
-    issues.forEach((issue, idx) => {
-      const location = issue.textRange ? ` (line ${issue.textRange.startLine})` : '';
-      text(`  [${idx + 1}] ${issue.message}${location}`);
-      text(`      Rule: ${issue.rule}`);
-    });
+    lines.push(formatCleanFileRow(filePath, true));
   }
 
-  if (errors && errors.length > 0) {
-    blank();
-    error('SonarQube Agentic Analysis returned errors:');
-    errors.forEach((e) => {
-      text(`  [${e.code}] ${e.message}`);
-    });
+  for (const line of lines) {
+    text(line);
   }
 
-  blank();
+  const stats: SqaaRunSummaryStats = {
+    filesAnalyzed: 1,
+    filesWithIssues: issues.length > 0 ? 1 : 0,
+    filesWithErrors: (errors?.length ?? 0) > 0 ? 1 : 0,
+    totalIssues: issues.length,
+    totalFailures: 0,
+    totalErrors: errors?.length ?? 0,
+  };
+
+  text('');
+  text(formatSqaaRunSummaryColored(stats));
+  applyExitCode(stats);
 
   return issues.length;
 }

--- a/src/cli/commands/analyze/sqaa.ts
+++ b/src/cli/commands/analyze/sqaa.ts
@@ -38,11 +38,9 @@ import { resolveChangeSet } from './sqaa-changeset';
 import {
   applyExitCode,
   buildJsonReport,
-  EXIT_CODE_ISSUES_FOUND,
   makeReport,
-  printFileDetails,
   printJsonReport,
-  printSummary,
+  printSqaaTextReport,
   singleFileFailureReport,
   singleFileSuccessReport,
   type SqaaJsonReport,
@@ -177,10 +175,7 @@ async function runSqaaAnalysis(
     return;
   }
 
-  const issueCount = await callSqaaApiAndDisplay(cloudAuth, projectKey, file, fileContent, branch);
-  if (issueCount > 0) {
-    process.exitCode = EXIT_CODE_ISSUES_FOUND;
-  }
+  await callSqaaApiAndDisplay(cloudAuth, projectKey, file, fileContent, branch);
 }
 
 async function runSqaaAnalysisOnFiles(
@@ -203,7 +198,6 @@ async function runSqaaAnalysisOnFiles(
       projectKey,
       branch,
       progress: silentProgress,
-      pathBase: repoRoot,
     };
     const tally = await runAnalyses(ctx);
     printJsonReport(tally, ignored, allPaths, repoRoot);
@@ -220,14 +214,11 @@ async function runSqaaAnalysisOnFiles(
     projectKey,
     branch,
     progress,
-    pathBase: repoRoot,
   };
-  progress.start();
   const tally = await runAnalyses(ctx);
 
-  progress.finish(tally.allResults.length);
-  printFileDetails(tally.allResults);
-  printSummary(tally.totalIssues, tally.totalErrors, tally.totalFailures);
+  progress.finish();
+  printSqaaTextReport({ tally, allPaths, ignoredPaths });
 }
 
 async function fetchSingleFileReport(
@@ -302,7 +293,6 @@ export async function buildSqaaJsonReport(
     projectKey,
     branch,
     progress: silentProgress,
-    pathBase: repoRoot,
   };
 
   const tally = await runAnalyses(ctx);

--- a/src/cli/commands/analyze/sqaa.ts
+++ b/src/cli/commands/analyze/sqaa.ts
@@ -215,10 +215,12 @@ async function runSqaaAnalysisOnFiles(
     branch,
     progress,
   };
-  const tally = await runAnalyses(ctx);
-
-  progress.finish();
-  printSqaaTextReport({ tally, allPaths, ignoredPaths });
+  try {
+    const tally = await runAnalyses(ctx);
+    printSqaaTextReport({ tally, allPaths, ignoredPaths });
+  } finally {
+    progress.finish();
+  }
 }
 
 async function fetchSingleFileReport(

--- a/src/cli/commands/hook/agent-post-tool-use.ts
+++ b/src/cli/commands/hook/agent-post-tool-use.ts
@@ -76,7 +76,7 @@ export async function agentPostToolUse(options: AgentPostToolUseOptions): Promis
       files: [{ path: normalizedPath, content: fileContent }],
     });
 
-    const text = formatSqaaIssuesForHook(response.issues, response.errors);
+    const text = formatSqaaIssuesForHook(response.issues, response.errors, normalizedPath);
     writePostToolUseHookOutput(text);
   } catch (err) {
     logger.debug(`PostToolUse SQAA analysis failed: ${(err as Error).message}`);

--- a/src/cli/commands/hook/format-sqaa-hook-context.ts
+++ b/src/cli/commands/hook/format-sqaa-hook-context.ts
@@ -21,30 +21,60 @@
 // Text formatting for PostToolUse hook additionalContext (Claude + Codex).
 
 import type { SqaaIssue } from '../../../sonarqube/client';
-import type { SqaaJsonReport } from '../analyze/sqaa-display';
+import {
+  formatPlainCleanCollapsedRow,
+  formatPlainSkippedOrIgnoredRow,
+  formatSqaaRunSummaryPlain,
+  renderPlainAnalyzedFileLines,
+  SQAA_COLLAPSE_CLEAN_THRESHOLD,
+  sqaaFileHasFindings,
+  type SqaaJsonReport,
+  type SqaaRunSummaryStats,
+} from '../analyze/sqaa-display';
+
+function hookSummaryFromReport(report: SqaaJsonReport): SqaaRunSummaryStats {
+  let filesWithIssues = 0;
+  let filesWithErrors = 0;
+  let totalErrors = 0;
+  for (const file of report.files) {
+    totalErrors += file.errors?.length ?? 0;
+    if (file.issues.length > 0) {
+      filesWithIssues += 1;
+    }
+    if ((file.errors?.length ?? 0) > 0) {
+      filesWithErrors += 1;
+    }
+  }
+  return {
+    filesAnalyzed: report.files.length + report.failures.length + report.skipped.length,
+    filesWithIssues,
+    filesWithErrors,
+    totalIssues: report.summary.totalIssues,
+    totalFailures: report.summary.totalFailures,
+    totalErrors,
+  };
+}
 
 export function formatSqaaIssuesForHook(
   issues: SqaaIssue[],
-  errors?: Array<{ code: string; message: string }> | null,
+  errors: Array<{ code: string; message: string }> | null | undefined,
+  filePath: string,
 ): string {
-  const lines: string[] = [];
+  const issueCount = issues.length;
+  const errorCount = errors?.length ?? 0;
 
-  if (issues.length === 0) {
-    lines.push('Agentic Analysis completed — no issues found.');
-  } else {
-    lines.push(`Agentic Analysis found ${issues.length} issue${issues.length === 1 ? '' : 's'}:`);
-    issues.forEach((issue, idx) => {
-      const location = issue.textRange ? ` (line ${issue.textRange.startLine})` : '';
-      lines.push(`  [${idx + 1}] ${issue.message}${location} [${issue.rule}]`);
-    });
-  }
-
-  if (errors && errors.length > 0) {
-    lines.push('Agentic Analysis errors:');
-    errors.forEach((e) => lines.push(`  [${e.code}] ${e.message}`));
-  }
-
-  return lines.join('\n');
+  return [
+    ...renderPlainAnalyzedFileLines(filePath, issues, errors),
+    '',
+    formatSqaaRunSummaryPlain({
+      filesAnalyzed: 1,
+      filesWithIssues: issueCount > 0 ? 1 : 0,
+      filesWithErrors: errorCount > 0 ? 1 : 0,
+      totalIssues: issueCount,
+      totalFailures: 0,
+      totalErrors: errorCount,
+    }),
+  ].join('\n');
 }
 
 function appendIgnoredLines(lines: string[], ignored: SqaaJsonReport['ignored']): void {
@@ -84,43 +114,46 @@ export function formatSqaaJsonReportForHook(report: SqaaJsonReport): string | nu
         'Agentic Analysis: no files to analyze — all change set files were excluded (binary or oversized).',
       );
     } else {
-      lines.push('Agentic Analysis completed — no issues found.');
+      lines.push(formatSqaaRunSummaryPlain(hookSummaryFromReport(report)));
     }
     appendIgnoredLines(lines, report.ignored);
     return lines.join('\n');
   }
 
-  if (totalIssues > 0) {
-    lines.push(`Agentic Analysis found ${totalIssues} issue${totalIssues === 1 ? '' : 's'}:`);
-  }
+  const processableCount = report.files.length + report.failures.length + report.skipped.length;
+  const collapseClean = processableCount > SQAA_COLLAPSE_CLEAN_THRESHOLD;
 
-  let issueIndex = 0;
-  for (const file of report.files) {
-    if (file.issues.length === 0 && !(file.errors && file.errors.length > 0)) {
-      continue;
+  if (collapseClean) {
+    const cleanCount = report.files.filter((f) => !sqaaFileHasFindings(f.issues, f.errors)).length;
+    if (cleanCount > 0) {
+      lines.push(formatPlainCleanCollapsedRow(cleanCount));
     }
-    lines.push(`── ${file.path}`);
-    for (const issue of file.issues) {
-      issueIndex += 1;
-      const location = issue.textRange ? ` (line ${issue.textRange.startLine})` : '';
-      lines.push(`  [${issueIndex}] ${issue.message}${location} [${issue.rule}]`);
+    for (const file of report.files) {
+      if (!sqaaFileHasFindings(file.issues, file.errors)) continue;
+      lines.push(...renderPlainAnalyzedFileLines(file.path, file.issues, file.errors));
     }
-    if (file.errors && file.errors.length > 0) {
-      lines.push('  Analysis errors:');
-      file.errors.forEach((e) => lines.push(`  [${e.code}] ${e.message}`));
+  } else {
+    for (const file of report.files) {
+      lines.push(...renderPlainAnalyzedFileLines(file.path, file.issues, file.errors));
     }
   }
 
   if (report.failures.length > 0) {
     lines.push('Agentic Analysis failures:');
-    report.failures.forEach((f) => lines.push(`  ${f.path}: ${f.message}`));
+    report.failures.forEach((f) => lines.push(`  ✗  ${f.path}: ${f.message}`));
   }
 
   if (report.skipped.length > 0) {
-    lines.push(`Skipped ${report.skipped.length} file(s) (analysis not completed).`);
+    for (const path of report.skipped) {
+      lines.push(formatPlainSkippedOrIgnoredRow(path, '[SKIPPED]'));
+    }
   }
 
   appendIgnoredLines(lines, report.ignored);
+  if (lines.length > 0) {
+    lines.push('');
+  }
+  lines.push(formatSqaaRunSummaryPlain(hookSummaryFromReport(report)));
 
   return lines.join('\n');
 }

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -25,7 +25,12 @@ import { isSonarQubeCloud, resolveFromEndpoint } from '../lib/auth-resolver';
 import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import logger from '../lib/logger';
 import { print } from '../ui';
-import { RateLimitError, ServiceUnavailableError } from './errors';
+import {
+  RateLimitError,
+  RequestPayloadTooLargeError,
+  type RequestPayloadTooLargeMeta,
+  ServiceUnavailableError,
+} from './errors';
 import { stripGitRemoteUrlUserinfo } from './git-remote-url';
 import type { SettingsValue } from './settings-value';
 
@@ -35,6 +40,7 @@ const POST_REQUEST_TIMEOUT_MS = 60000; // 60 seconds for analysis
 const REVOKE_USER_TOKEN_TIMEOUT_MS = 10_000;
 const HTTP_STATUS_FORBIDDEN = 403;
 const HTTP_STATUS_NOT_FOUND = 404;
+const HTTP_STATUS_PAYLOAD_TOO_LARGE = 413;
 const HTTP_STATUS_TOO_MANY_REQUESTS = 429;
 const HTTP_STATUS_SERVICE_UNAVAILABLE = 503;
 
@@ -83,6 +89,9 @@ export class SonarQubeClient {
     }
     if (response.status === HTTP_STATUS_SERVICE_UNAVAILABLE) {
       throw new ServiceUnavailableError();
+    }
+    if (method === 'POST' && response.status === HTTP_STATUS_PAYLOAD_TOO_LARGE) {
+      throw await parseRequestPayloadTooLargeError(response);
     }
 
     if (method === 'GET') {
@@ -647,6 +656,28 @@ function redactSensitiveHeaders(headers: Record<string, string>): Record<string,
     return { ...headers, Authorization: 'REDACTED' };
   }
   return headers;
+}
+
+async function parseRequestPayloadTooLargeError(
+  response: Response,
+): Promise<RequestPayloadTooLargeError> {
+  const fallback = new RequestPayloadTooLargeError(
+    `SonarQube API error: ${response.status} ${response.statusText}`,
+  );
+  try {
+    const body = (await response.json()) as {
+      message?: string;
+      code?: string;
+      meta?: RequestPayloadTooLargeMeta;
+    };
+    const message =
+      body.message ?? `SonarQube API error: ${response.status} ${response.statusText}`;
+    const code =
+      body.code === 'REQUEST_TOO_LARGE' || body.code === 'TOO_MANY_FILES' ? body.code : undefined;
+    return new RequestPayloadTooLargeError(message, code, body.meta);
+  } catch {
+    return fallback;
+  }
 }
 
 export interface AgentJobRequest {

--- a/src/sonarqube/errors.ts
+++ b/src/sonarqube/errors.ts
@@ -33,3 +33,27 @@ export class ServiceUnavailableError extends Error {
     this.name = 'ServiceUnavailableError';
   }
 }
+
+export type RequestPayloadTooLargeCode = 'REQUEST_TOO_LARGE' | 'TOO_MANY_FILES';
+
+export interface RequestPayloadTooLargeMeta {
+  maxRequestSize?: number;
+  maxFiles?: number;
+}
+
+/** Thrown by the API client on HTTP 413 (Payload Too Large) for SQAA requests. */
+export class RequestPayloadTooLargeError extends Error {
+  readonly code?: RequestPayloadTooLargeCode;
+  readonly meta?: RequestPayloadTooLargeMeta;
+
+  constructor(
+    message: string,
+    code?: RequestPayloadTooLargeCode,
+    meta?: RequestPayloadTooLargeMeta,
+  ) {
+    super(message);
+    this.name = 'RequestPayloadTooLargeError';
+    this.code = code;
+    this.meta = meta;
+  }
+}

--- a/src/ui/components/sqaa-progress.ts
+++ b/src/ui/components/sqaa-progress.ts
@@ -98,6 +98,11 @@ export class SqaaProgress {
       recordCall('sqaaProgress.warnPayloadSplit');
       return;
     }
+    // Erase the live line first so the warning is not overwritten by the
+    // next animation tick; the live line is re-rendered fresh below it.
+    if (this.isTTY) {
+      this.eraseLiveLine();
+    }
     warn(PAYLOAD_SPLIT_WARNING);
   }
 

--- a/src/ui/components/sqaa-progress.ts
+++ b/src/ui/components/sqaa-progress.ts
@@ -26,14 +26,7 @@ import { cyan, yellow } from '../colors.js';
 import { warn } from '../messages.js';
 import { isMockActive, recordCall } from '../mock.js';
 
-export type FileStatus =
-  | 'waiting'
-  | 'analyzing'
-  | 'done'
-  | 'failed'
-  | 'retrying'
-  | 'skipped'
-  | 'ignored';
+export type FileStatus = 'waiting' | 'analyzing' | 'done' | 'failed' | 'skipped' | 'ignored';
 
 type RunPhase = 'idle' | 'analyzing' | 'retrying';
 

--- a/src/ui/components/sqaa-progress.ts
+++ b/src/ui/components/sqaa-progress.ts
@@ -18,11 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Live progress display for the SQAA worker-pool run.
+// Live progress display for SQAA change-set analysis.
 
 import * as readline from 'node:readline';
 
-import { bold, cyan, dim, green, red, yellow } from '../colors.js';
+import { cyan, yellow } from '../colors.js';
+import { warn } from '../messages.js';
 import { isMockActive, recordCall } from '../mock.js';
 
 export type FileStatus =
@@ -34,89 +35,38 @@ export type FileStatus =
   | 'skipped'
   | 'ignored';
 
-const BAR_WIDTH = 12;
-const FILLED = '⣿';
-const EMPTY = '⣀';
-/** Interval for the live countdown tick in milliseconds. */
+type RunPhase = 'idle' | 'analyzing' | 'retrying';
+
 const COUNTDOWN_TICK_MS = 1000;
+const DOT_ANIMATION_MS = 450;
+const DOT_FRAMES = ['.', '..', '...'] as const;
+
+const PAYLOAD_SPLIT_WARNING =
+  'Request size limit reached; analysis was split into smaller batches. Cross-file context may be reduced.';
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function renderBar(done: number, total: number): string {
-  const filled = total === 0 ? BAR_WIDTH : Math.round((done / total) * BAR_WIDTH);
-  return '[' + FILLED.repeat(filled) + EMPTY.repeat(BAR_WIDTH - filled) + ']';
-}
-
-function statusLabel(status: FileStatus, retryLabel?: string): string {
-  switch (status) {
-    case 'waiting':
-      return dim('[WAITING]');
-    case 'analyzing':
-      return cyan('[ANALYZING...]');
-    case 'done':
-      return green('[DONE]');
-    case 'failed':
-      return red('[FAILED]');
-    case 'retrying':
-      return yellow(retryLabel ?? '[RETRYING...]');
-    case 'skipped':
-      return dim('[SKIPPED]');
-    case 'ignored':
-      return dim('[IGNORED]');
-  }
-}
-
-function statusIcon(status: FileStatus): string {
-  if (status === 'waiting') return dim('○');
-  if (status === 'skipped' || status === 'ignored') return dim('⊘');
-  return '●';
-}
-
-/** Icon used in non-TTY per-file result lines (rolling output and finish()). */
-function fileStatusIcon(status: FileStatus): string {
-  if (status === 'done') return green('✓');
-  if (status === 'failed') return red('✗');
-  if (status === 'skipped' || status === 'ignored') return dim('⊘');
-  return dim('○');
-}
-
-/** Render a single file row with padding to align the status label column. */
-function formatFileLine(path: string, icon: string, label: string, colWidth: number): string {
-  const padding = ' '.repeat(Math.max(1, colWidth - path.length));
-  return `  ${icon} ${path}${padding}${label}`;
-}
-
 /**
- * Single progress renderer for an entire SQAA worker-pool run.
+ * Progress renderer for an SQAA change-set run.
  *
- * Initialized with all file paths upfront; all files are visible throughout the run.
- *
- * TTY: maintains one block on screen — erases and rewrites it in-place on every update.
- * Non-TTY: prints a one-time `Analyzing <N> files...` header on `start()`, then a
- *          per-file result line every time a file reaches a terminal status
- *          (`done`/`failed`) — i.e. rolling output in completion order.
+ * During the run: one live status line. On `finish()`: erases the live line only;
+ * final file list and issues are rendered by sqaa-display.
  */
 export class SqaaProgress {
   private readonly allFiles: string[];
   private readonly statuses: FileStatus[];
   private readonly isTTY: boolean;
-  /** When true, all rendering methods are no-ops (used by --format json). */
   private readonly silent: boolean;
-  /**
-   * Number of files the worker pool will actually analyze — i.e. `allFiles`
-   * minus pre-ignored entries. Used as the denominator of the progress bar and
-   * the `X/Y files analyzed` summary so 100% is reachable when ignored files
-   * are present.
-   */
   private readonly processableTotal: number;
-  /** Width of the path column — longest path length + 1 space minimum. */
-  private readonly colWidth: number;
-  /** Per-file dynamic label override (used for retry countdown). */
-  private readonly retryLabels = new Map<number, string>();
-  /** Number of lines currently written to stdout (TTY mode only). */
-  private linesRendered = 0;
+  private liveLineRendered = false;
+
+  private runPhase: RunPhase = 'idle';
+  private retryLabel?: string;
+  private payloadSplitWarned = false;
+  private dotFrameIndex = 0;
+  private dotAnimationTimer?: ReturnType<typeof setInterval>;
 
   constructor(opts: {
     files: string[];
@@ -132,15 +82,8 @@ export class SqaaProgress {
     this.isTTY = opts.isTTY ?? process.stdout.isTTY;
     this.silent = opts.silent ?? false;
     this.processableTotal = opts.files.length;
-    this.colWidth = Math.max(...this.allFiles.map((f) => f.length), 0) + 2;
   }
 
-  /**
-   * Render the initial state of the progress block. Call this once before the
-   * worker pool spawns; subsequent transitions arrive via `update()`.
-   * TTY: draws the full block.
-   * Non-TTY: prints a one-time `Analyzing <N> files...` header.
-   */
   start(): void {
     if (this.silent) return;
     if (isMockActive()) {
@@ -148,200 +91,164 @@ export class SqaaProgress {
       return;
     }
     if (this.isTTY) {
-      this.eraseTTY();
-      this.renderTTY();
-    } else {
-      // Files counted are the ones the pool will process — exclude files already
-      // marked as ignored (binary/oversized) at construction time.
-      process.stdout.write(`\nAnalyzing ${this.processableTotal} files...\n`);
+      this.startDotAnimation();
+      this.renderLiveLine();
     }
   }
 
-  /**
-   * Update a file's status by its global index across all files.
-   * TTY: redraws the full block.
-   * Non-TTY: prints a per-file result line on terminal transitions
-   *          (`done`/`failed`); other transitions are absorbed silently.
-   */
-  update(globalIndex: number, status: FileStatus): void {
-    if (this.silent) {
-      this.statuses[globalIndex] = status;
+  /** Warn once when a 413 response forces runtime request splitting. */
+  warnPayloadSplit(): void {
+    if (this.payloadSplitWarned) return;
+    this.payloadSplitWarned = true;
+    if (this.silent) return;
+    if (isMockActive()) {
+      recordCall('sqaaProgress.warnPayloadSplit');
       return;
     }
+    warn(PAYLOAD_SPLIT_WARNING);
+  }
+
+  updateChunk(_chunkIndex: number, status: Exclude<FileStatus, 'ignored'>): void {
+    if (status === 'analyzing') {
+      this.runPhase = 'analyzing';
+    } else if (status === 'done' || status === 'failed') {
+      this.runPhase = 'idle';
+      this.retryLabel = undefined;
+    }
+    if (this.silent) return;
+    if (isMockActive()) {
+      recordCall('sqaaProgress.updateChunk', _chunkIndex, status);
+      return;
+    }
+    if (this.isTTY) {
+      this.renderLiveLine();
+    }
+  }
+
+  update(globalIndex: number, status: FileStatus): void {
+    this.statuses[globalIndex] = status;
+    if (this.silent) return;
     if (isMockActive()) {
       recordCall('sqaaProgress.update', globalIndex, status);
       return;
     }
-    this.statuses[globalIndex] = status;
     if (this.isTTY) {
-      this.eraseTTY();
-      this.renderTTY();
-      return;
-    }
-    if (status === 'done' || status === 'failed') {
-      process.stdout.write(`  ${fileStatusIcon(status)}  ${this.allFiles[globalIndex]}\n`);
+      this.renderLiveLine();
     }
   }
 
-  /**
-   * Show a retry countdown for a file, waiting delayMs before resolving.
-   * Resets the file's status back to 'analyzing' when done so the caller
-   * can transition it without a stale [RETRYING...] flash.
-   * TTY: updates the file's label in the progress block each second.
-   * Non-TTY: prints a single static line then waits.
-   */
-  async retrying(
-    globalIndex: number,
+  async retryingChunk(
+    _chunkIndex: number,
     attempt: number,
     maxRetries: number,
     delayMs: number,
   ): Promise<void> {
+    this.runPhase = 'retrying';
     if (this.silent) {
-      // Still wait so retry semantics are preserved without rendering.
-      this.statuses[globalIndex] = 'retrying';
       await sleep(delayMs);
-      this.statuses[globalIndex] = 'analyzing';
+      this.runPhase = 'analyzing';
       return;
     }
     if (isMockActive()) {
-      recordCall('sqaaProgress.retrying', globalIndex, attempt, maxRetries, delayMs);
+      recordCall('sqaaProgress.retryingChunk', _chunkIndex, attempt, maxRetries, delayMs);
       return;
     }
-    const totalSeconds = Math.round(delayMs / COUNTDOWN_TICK_MS);
-    this.statuses[globalIndex] = 'retrying';
 
+    const totalSeconds = Math.round(delayMs / COUNTDOWN_TICK_MS);
     if (!this.isTTY) {
       process.stdout.write(
         `⚠️  Server busy (503). Retrying in ${totalSeconds}s... [Attempt ${attempt}/${maxRetries}]\n`,
       );
       await sleep(delayMs);
-      this.statuses[globalIndex] = 'analyzing';
+      this.runPhase = 'analyzing';
       return;
     }
 
     for (let remaining = totalSeconds; remaining > 0; remaining--) {
-      this.retryLabels.set(globalIndex, `[RETRYING in ${remaining}s... ${attempt}/${maxRetries}]`);
-      this.eraseTTY();
-      this.renderTTY();
+      this.retryLabel = `retrying in ${remaining}s (${attempt}/${maxRetries})`;
+      this.renderLiveLine();
       await sleep(COUNTDOWN_TICK_MS);
     }
-    this.retryLabels.delete(globalIndex);
-    // Reset status here so no intervening redraw shows the stale [RETRYING...] fallback.
-    this.statuses[globalIndex] = 'analyzing';
+    this.retryLabel = undefined;
+    this.runPhase = 'analyzing';
   }
 
-  /**
-   * Mark all files from fromIndex onwards as skipped.
-   * Call before finish() when fail-fast stops processing early.
-   */
   skipRemaining(fromIndex: number): void {
-    if (this.silent) {
-      // Still record skips in internal state so callers can read them.
-      for (let i = fromIndex; i < this.allFiles.length; i++) {
-        if (this.statuses[i] === 'waiting') {
-          this.statuses[i] = 'skipped';
-        }
-      }
-      return;
-    }
-    if (isMockActive()) {
-      recordCall('sqaaProgress.skipRemaining', fromIndex);
-      return;
-    }
     for (let i = fromIndex; i < this.allFiles.length; i++) {
       if (this.statuses[i] === 'waiting') {
         this.statuses[i] = 'skipped';
       }
     }
+    if (this.silent) return;
+    if (isMockActive()) {
+      recordCall('sqaaProgress.skipRemaining', fromIndex);
+      return;
+    }
+    if (this.isTTY) {
+      this.renderLiveLine();
+    }
   }
 
-  /**
-   * Read-only access to file statuses by global index.
-   * Exposed for testing and introspection (e.g. verifying silent-mode state transitions).
-   */
   getStatuses(): readonly FileStatus[] {
     return this.statuses;
   }
 
-  /**
-   * Called once after the worker pool has joined (success or fail-fast).
-   * TTY: erases the live block, reprints the summary bar first, then the file list with
-   *      final statuses — so the bar stays at the top and the list persists on screen.
-   * Non-TTY: prints any skipped files that were never reached (fail-fast path);
-   *          non-skipped files were already printed in rolling order by `update()`.
-   */
-  finish(processedTotal: number): void {
+  finish(): void {
+    this.stopDotAnimation();
     if (this.silent) return;
     if (isMockActive()) {
-      recordCall('sqaaProgress.finish', processedTotal);
+      recordCall('sqaaProgress.finish');
       return;
     }
     if (this.isTTY) {
-      this.eraseTTY();
-      const bar = renderBar(processedTotal, this.processableTotal);
-      process.stdout.write(`${bar} ${processedTotal}/${this.processableTotal} files analyzed\n\n`);
-      for (let i = 0; i < this.allFiles.length; i++) {
-        process.stdout.write(
-          formatFileLine(
-            this.allFiles[i],
-            statusIcon(this.statuses[i]),
-            statusLabel(this.statuses[i]),
-            this.colWidth,
-          ) + '\n',
-        );
-      }
-      process.stdout.write('\n');
-      this.linesRendered = 0;
-    } else {
-      // Print skipped files that the rolling per-file output never reached
-      // (fail-fast path — these files were never picked up by a worker).
-      for (let i = 0; i < this.allFiles.length; i++) {
-        if (this.statuses[i] === 'skipped') {
-          process.stdout.write(`  ${fileStatusIcon('skipped')}  ${this.allFiles[i]}\n`);
-        }
-      }
+      this.eraseLiveLine();
     }
   }
 
-  private buildLines(): string[] {
-    const done = this.statuses.filter((s) => s === 'done' || s === 'failed').length;
-    const bar = renderBar(done, this.processableTotal);
-    const lines: string[] = [
-      bold('SonarQube Agentic Analysis in progress...'),
-      `${bar} ${done}/${this.processableTotal} files analyzed`,
-      '',
-    ];
-    for (let i = 0; i < this.allFiles.length; i++) {
-      lines.push(
-        formatFileLine(
-          this.allFiles[i],
-          statusIcon(this.statuses[i]),
-          statusLabel(this.statuses[i], this.retryLabels.get(i)),
-          this.colWidth,
-        ),
-      );
-    }
-    return lines;
+  private filesAnalyzedCount(): number {
+    return this.statuses
+      .slice(0, this.processableTotal)
+      .filter((s) => s === 'done' || s === 'failed').length;
   }
 
-  private renderTTY(): void {
-    const lines = this.buildLines();
-    for (const line of lines) {
-      process.stdout.write(line + '\n');
+  private buildLiveLine(): string {
+    const total = this.processableTotal;
+    const dots = DOT_FRAMES[this.dotFrameIndex];
+    if (this.runPhase === 'retrying') {
+      return yellow(`Analyzing ${total} files${dots} ${this.retryLabel ?? 'retrying...'}`);
     }
-    this.linesRendered = lines.length;
+    const analyzed = this.filesAnalyzedCount();
+    const base = `Analyzing ${total} files${dots}`;
+    if (analyzed > 0) {
+      return cyan(`${base} (${analyzed}/${total})`);
+    }
+    return cyan(base);
   }
 
-  private eraseTTY(): void {
-    // Cap lines to erase at the current terminal height to avoid moving the cursor
-    // past the top of the viewport if the block scrolled out of view.
-    // Cap to terminal height when known, to avoid moving the cursor above the viewport.
-    const rows: number | undefined = process.stdout.rows;
-    const linesToErase = rows ? Math.min(this.linesRendered, rows - 1) : this.linesRendered;
-    for (let i = 0; i < linesToErase; i++) {
-      readline.moveCursor(process.stdout, 0, -1);
-      readline.clearLine(process.stdout, 0);
-    }
-    this.linesRendered = 0;
+  private startDotAnimation(): void {
+    if (this.dotAnimationTimer) return;
+    this.dotAnimationTimer = setInterval(() => {
+      this.dotFrameIndex = (this.dotFrameIndex + 1) % DOT_FRAMES.length;
+      this.renderLiveLine();
+    }, DOT_ANIMATION_MS);
+  }
+
+  private stopDotAnimation(): void {
+    if (!this.dotAnimationTimer) return;
+    clearInterval(this.dotAnimationTimer);
+    this.dotAnimationTimer = undefined;
+  }
+
+  private renderLiveLine(): void {
+    this.eraseLiveLine();
+    process.stdout.write(this.buildLiveLine() + '\n');
+    this.liveLineRendered = true;
+  }
+
+  private eraseLiveLine(): void {
+    if (!this.liveLineRendered) return;
+    readline.moveCursor(process.stdout, 0, -1);
+    readline.clearLine(process.stdout, 0);
+    this.liveLineRendered = false;
   }
 }

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -135,6 +135,7 @@ export class FakeSonarQubeServerBuilder {
   private sqaaResponse?: SqaaResponseConfig;
   private sqaaStatusCode?: number;
   private sqaaStatusBody?: string;
+  private sqaaPayloadLimit?: { maxRequestSize?: number; maxFiles?: number };
   private scaEnabled?: boolean;
   private readonly projectSettings: Map<string, SettingsValue[]> = new Map();
   private agentJobErrorCode?: number;
@@ -231,6 +232,15 @@ export class FakeSonarQubeServerBuilder {
     return this;
   }
 
+  /**
+   * Reject POST /a3s-analysis/analyses with 413 when the raw body or file count
+   * exceeds the configured limits. Returns server meta on the error body.
+   */
+  withSqaaPayloadLimit(limit: { maxRequestSize?: number; maxFiles?: number }): this {
+    this.sqaaPayloadLimit = limit;
+    return this;
+  }
+
   withSqaaEntitlement(
     orgKey: string,
     uuid: string,
@@ -291,6 +301,7 @@ export class FakeSonarQubeServerBuilder {
       sqaaResponse,
       sqaaStatusCode,
       sqaaStatusBody,
+      sqaaPayloadLimit,
       sqaaEntitlementOrgs,
       cagEntitlementOrgs,
       scaEnabled,
@@ -726,9 +737,35 @@ export class FakeSonarQubeServerBuilder {
             });
           }
 
+          const files = requestBody.files as Array<{ path: string; content: string }>;
+
+          if (sqaaPayloadLimit) {
+            const bodyBytes = Buffer.byteLength(body ?? '', 'utf8');
+            const tooMany =
+              sqaaPayloadLimit.maxFiles != null && files.length > sqaaPayloadLimit.maxFiles;
+            const tooLarge =
+              sqaaPayloadLimit.maxRequestSize != null &&
+              bodyBytes > sqaaPayloadLimit.maxRequestSize;
+            if (tooMany || tooLarge) {
+              return new Response(
+                JSON.stringify({
+                  message: tooMany ? 'Too many files in request' : 'Request payload too large',
+                  code: tooMany ? 'TOO_MANY_FILES' : 'REQUEST_TOO_LARGE',
+                  meta: {
+                    maxRequestSize: sqaaPayloadLimit.maxRequestSize,
+                    maxFiles: sqaaPayloadLimit.maxFiles,
+                  },
+                }),
+                { status: 413, headers: { 'Content-Type': 'application/json' } },
+              );
+            }
+          }
+
+          let issueFileIndex = 0;
           const issues = (sqaaResponse.issues ?? []).map((i) => ({
             rule: i.rule,
             message: i.message,
+            filePath: files[issueFileIndex++ % files.length]?.path,
             textRange: i.startLine
               ? { startLine: i.startLine, endLine: i.startLine, startOffset: 0, endOffset: 0 }
               : null,

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -27,7 +27,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestHarness } from '../../harness';
 import { commitFile, git, initGitRepo, stageFile } from '../hook/git-test-helpers';
-import { parseSqaaRequestBody, sqaaRequestFirstFilePath } from './sqaa-request-helpers';
+import {
+  allSqaaRequestsUseDeep,
+  parseSqaaRequestBody,
+  sqaaRequestFileCount,
+  sqaaRequestFirstFilePath,
+  totalSqaaFilesSent,
+} from './sqaa-request-helpers';
 
 const VALID_TOKEN = 'integration-test-token';
 const TEST_ORG = 'my-org';
@@ -86,7 +92,7 @@ describe('analyze (no subcommand)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('change set is clean');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -315,7 +321,7 @@ describe('analyze (no subcommand)', () => {
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
       expect(output).not.toContain('no project configured');
-      expect(output).toContain('change set is clean');
+      expect(output).toContain('No issues found');
 
       const sqaaCalls = server
         .getRecordedRequests()
@@ -325,7 +331,7 @@ describe('analyze (no subcommand)', () => {
       expect(sqaaRequestFirstFilePath(sqaaCalls[0].body)).toBe('new.ts');
       expect(request.projectKey).toBe('explicit-project');
       expect(request.files).toHaveLength(1);
-      expect(request.analysisDepth).toBeUndefined();
+      expect(request.analysisDepth).toBe('DEEP');
     },
     { timeout: 15000 },
   );
@@ -616,7 +622,7 @@ describe('analyze agentic', () => {
       );
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('no issues found');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -650,7 +656,7 @@ describe('analyze agentic', () => {
   );
 
   it(
-    'calls SQAA API and reports no issues found for clean file',
+    'calls SQAA API and reports No issues found for clean file',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -668,7 +674,7 @@ describe('analyze agentic', () => {
       const result = await harness.run('analyze agentic --file src/index.ts');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('no issues found');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -735,7 +741,7 @@ describe('analyze agentic', () => {
       const output = result.stdout + result.stderr;
       expect(output).toContain('NOT_ENTITLED');
       expect(output).toContain('not entitled');
-      expect(output).not.toContain('no issues found');
+      expect(output).not.toContain('No issues found');
     },
     { timeout: 15000 },
   );
@@ -806,7 +812,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       const result = await harness.run('analyze agentic');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('change set is clean');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -836,7 +842,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       const result = await harness.run('analyze agentic');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('change set is clean');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -915,7 +921,9 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
-      expect(sqaaCalls).toHaveLength(51);
+      expect(sqaaCalls).toHaveLength(1);
+      expect(sqaaRequestFileCount(sqaaCalls[0].body)).toBe(51);
+      expect(allSqaaRequestsUseDeep(sqaaCalls)).toBe(true);
     },
     { timeout: 30000 },
   );
@@ -945,9 +953,46 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
-      expect(sqaaCalls).toHaveLength(51);
+      expect(sqaaCalls).toHaveLength(1);
+      expect(totalSqaaFilesSent(sqaaCalls)).toBe(51);
     },
     { timeout: 30000 },
+  );
+
+  it(
+    'splits on 413 using server-reported payload limits',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .withSqaaPayloadLimit({ maxRequestSize: 5 * 1024 * 1024 })
+        .start();
+      harness
+        .state()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaExtension(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      commitFile(harness.cwd.path, 'README.md', 'hello');
+      const largeContent = 'x'.repeat(4 * 1024 * 1024);
+      harness.cwd.writeFile('large-a.ts', largeContent);
+      harness.cwd.writeFile('large-b.ts', largeContent);
+      harness.cwd.writeFile('large-c.ts', largeContent);
+
+      const result = await harness.run('analyze agentic --force');
+
+      expect(result.exitCode).toBe(0);
+      const sqaaCalls = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/a3s-analysis/analyses');
+      expect(sqaaCalls.length).toBe(4);
+      expect(sqaaRequestFileCount(sqaaCalls[0]?.body)).toBe(3);
+      for (const call of sqaaCalls.slice(1)) {
+        expect(sqaaRequestFileCount(call.body)).toBe(1);
+      }
+      expect(allSqaaRequestsUseDeep(sqaaCalls)).toBe(true);
+    },
+    { timeout: 60000 },
   );
 
   it(
@@ -972,7 +1017,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       const result = await harness.run('analyze agentic --staged');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('change set is clean');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -1032,7 +1077,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       const result = await harness.run('analyze agentic --base master');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('change set is clean');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -1210,7 +1255,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
   );
 
   it(
-    'does not report "change set is clean" when the API returned errors for every file',
+    'does not report "No issues found" when the API returned errors for every file',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -1236,7 +1281,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       // No issues were reported, so exit code must not be 51.
       expect(result.exitCode).not.toBe(51);
       // When the server returned errors for every file, don't mislead the user with "clean".
-      expect(output).not.toContain('change set is clean');
+      expect(output).not.toContain('No issues found');
     },
     { timeout: 15000 },
   );
@@ -1300,7 +1345,7 @@ describe('verify — change-set mode (no --file)', () => {
       const result = await harness.run('verify');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('change set is clean');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       expect(result.stderr).toContain('deprecated');
       expect(result.stderr).toContain('sonar analyze');
       const sqaaCalls = server
@@ -1332,7 +1377,7 @@ describe('verify — change-set mode (no --file)', () => {
       const result = await harness.run('verify --staged');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('change set is clean');
+      expect(result.stdout + result.stderr).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
@@ -1367,7 +1412,9 @@ describe('verify — change-set mode (no --file)', () => {
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
-      expect(sqaaCalls).toHaveLength(51);
+      expect(sqaaCalls).toHaveLength(1);
+      expect(sqaaRequestFileCount(sqaaCalls[0].body)).toBe(51);
+      expect(allSqaaRequestsUseDeep(sqaaCalls)).toBe(true);
     },
     { timeout: 30000 },
   );
@@ -1397,7 +1444,8 @@ describe('verify — change-set mode (no --file)', () => {
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
-      expect(sqaaCalls).toHaveLength(51);
+      expect(sqaaCalls).toHaveLength(1);
+      expect(totalSqaaFilesSent(sqaaCalls)).toBe(51);
     },
     { timeout: 30000 },
   );
@@ -1472,7 +1520,7 @@ describe('analyze agentic — API error codes', () => {
   );
 
   it(
-    'retries 503 for multiple files concurrently in change-set mode',
+    'retries 503 per chunk in change-set mode',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -1487,7 +1535,6 @@ describe('analyze agentic — API error codes', () => {
 
       initGitRepo(harness.cwd.path);
       commitFile(harness.cwd.path, '.gitignore', '.claude/\n');
-      // Two files in the same batch will both hit 503 concurrently.
       harness.cwd.writeFile('a.ts', 'const a = 1;');
       harness.cwd.writeFile('b.ts', 'const b = 2;');
 
@@ -1495,11 +1542,12 @@ describe('analyze agentic — API error codes', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('Server busy');
-      // Each file gets 1 initial + 3 retries = 4 attempts; 2 files = 8 total.
+      // One chunk with two files: 1 initial + 3 retries = 4 attempts.
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
-      expect(sqaaCalls).toHaveLength(8);
+      expect(sqaaCalls).toHaveLength(4);
+      expect(sqaaRequestFileCount(sqaaCalls[0].body)).toBe(2);
     },
     { timeout: 15000 },
   );
@@ -1652,10 +1700,8 @@ describe('analyze agentic — --format json', () => {
   );
 
   it(
-    'JSON report surfaces files skipped on fail-fast and skips the large-changeset prompt',
+    'JSON report lists all files as failures when a chunk fails (no per-file skip bucket)',
     async () => {
-      // 429 fails immediately (no retry), so the first worker to fail triggers
-      // fail-fast and later files are never picked up — without the long 503 backoff.
       const server = await harness
         .newFakeServer()
         .withAuthToken(VALID_TOKEN)
@@ -1668,8 +1714,6 @@ describe('analyze agentic — --format json', () => {
         .withSqaaExtension(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
 
       commitFile(harness.cwd.path, 'README.md', 'hello');
-      // 51 files: > concurrency (20) so fail-fast leaves later files skipped,
-      // and > large-changeset threshold (50) so we also exercise the no-prompt path.
       for (let i = 1; i <= 51; i++) {
         harness.cwd.writeFile(`file${i}.ts`, `const x${i} = ${i};`);
       }
@@ -1677,7 +1721,6 @@ describe('analyze agentic — --format json', () => {
       const result = await harness.run('analyze agentic --format json');
 
       expect(result.exitCode).toBe(1);
-      // JSON consumers should never see the interactive prompt warning.
       expect(result.stderr).not.toContain('large number of files');
 
       const report = JSON.parse(result.stdout) as {
@@ -1686,10 +1729,9 @@ describe('analyze agentic — --format json', () => {
         skipped: string[];
         summary: { totalIssues: number; totalFailures: number; totalSkipped: number };
       };
-      expect(report.failures.length).toBeGreaterThan(0);
-      expect(report.skipped.length).toBeGreaterThan(0);
-      expect(report.summary.totalSkipped).toBe(report.skipped.length);
-      // Every staged file ends up in exactly one bucket (succeeded/failed/skipped).
+      expect(report.failures).toHaveLength(51);
+      expect(report.skipped).toHaveLength(0);
+      expect(report.summary.totalSkipped).toBe(0);
       expect(report.files.length + report.failures.length + report.skipped.length).toBe(51);
     },
     { timeout: 30000 },
@@ -1770,15 +1812,17 @@ describe('analyze agentic — running from a subdirectory', () => {
       const output = result.stdout + result.stderr;
       // Project must still be found — no fallthrough to the "no project configured" warning.
       expect(output).not.toContain('no project configured');
-      expect(output).toContain('change set is clean');
+      expect(output).toContain('No issues found');
 
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
-      expect(sqaaCalls).toHaveLength(2);
+      expect(sqaaCalls).toHaveLength(1);
+      expect(sqaaRequestFileCount(sqaaCalls[0].body)).toBe(2);
+      expect(allSqaaRequestsUseDeep(sqaaCalls)).toBe(true);
 
-      // Paths sent to SQAA are relative to the repo root regardless of cwd.
-      const filePaths = sqaaCalls.map((c) => sqaaRequestFirstFilePath(c.body)).sort();
+      const request = parseSqaaRequestBody(sqaaCalls[0].body);
+      const filePaths = (request.files ?? []).map((f) => f.path).sort();
       expect(filePaths).toEqual(['src/ui/inside.ts', 'top-level.ts']);
     },
     { timeout: 15000 },

--- a/tests/integration/specs/analyze/sqaa-request-helpers.ts
+++ b/tests/integration/specs/analyze/sqaa-request-helpers.ts
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import type { RecordedRequest } from '../../harness';
+
 export interface ParsedSqaaRequestBody {
   organizationKey?: string;
   projectKey?: string;
@@ -33,4 +35,19 @@ export function parseSqaaRequestBody(body: string | undefined): ParsedSqaaReques
 /** Path of the first entry in `files[]`. */
 export function sqaaRequestFirstFilePath(body: string | undefined): string | undefined {
   return parseSqaaRequestBody(body).files?.[0]?.path;
+}
+
+/** Number of files in a SQAA request body. */
+export function sqaaRequestFileCount(body: string | undefined): number {
+  return parseSqaaRequestBody(body).files?.length ?? 0;
+}
+
+/** Sum of `files.length` across all recorded SQAA POST bodies. */
+export function totalSqaaFilesSent(calls: RecordedRequest[]): number {
+  return calls.reduce((sum, call) => sum + sqaaRequestFileCount(call.body), 0);
+}
+
+/** True when every change-set SQAA call uses `analysisDepth: DEEP`. */
+export function allSqaaRequestsUseDeep(calls: RecordedRequest[]): boolean {
+  return calls.every((call) => parseSqaaRequestBody(call.body).analysisDepth === 'DEEP');
 }

--- a/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
@@ -65,7 +65,7 @@ describe('sonar hook claude-post-tool-use', () => {
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
       expect(output.hookSpecificOutput.hookEventName).toBe('PostToolUse');
-      expect(output.hookSpecificOutput.additionalContext).toContain('no issues');
+      expect(output.hookSpecificOutput.additionalContext).toContain('No issues found');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
@@ -23,6 +23,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { TestHarness } from '../../harness';
+import {
+  allSqaaRequestsUseDeep,
+  parseSqaaRequestBody,
+  sqaaRequestFileCount,
+} from '../analyze/sqaa-request-helpers';
 import { commitFile, initGitRepo } from './git-test-helpers';
 
 const VALID_TOKEN = 'integration-test-token';
@@ -58,11 +63,38 @@ describe('sonar hook codex-post-tool-use', () => {
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
       expect(output.hookSpecificOutput.hookEventName).toBe('PostToolUse');
-      expect(output.hookSpecificOutput.additionalContext).toContain('no issues');
+      expect(output.hookSpecificOutput.additionalContext).toContain('No issues found');
       const sqaaCalls = server
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
-      expect(sqaaCalls.length).toBeGreaterThan(0);
+      expect(sqaaCalls).toHaveLength(1);
+      expect(allSqaaRequestsUseDeep(sqaaCalls)).toBe(true);
+      expect(parseSqaaRequestBody(sqaaCalls[0].body).analysisDepth).toBe('DEEP');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'sends one multi-file DEEP request when multiple files changed',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+      harness.cwd.writeFile('a.ts', 'const a = 1;');
+      harness.cwd.writeFile('b.ts', 'const b = 2;');
+
+      const result = await harness.run(`hook codex-post-tool-use --project ${TEST_PROJECT}`);
+
+      expect(result.exitCode).toBe(0);
+      const sqaaCalls = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/a3s-analysis/analyses');
+      expect(sqaaCalls).toHaveLength(1);
+      expect(sqaaRequestFileCount(sqaaCalls[0].body)).toBe(2);
+      expect(allSqaaRequestsUseDeep(sqaaCalls)).toBe(true);
     },
     { timeout: 15000 },
   );

--- a/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
@@ -215,6 +215,17 @@ describe('analyzeSqaa: API call and result display', () => {
       'SonarQube Agentic Analysis failed',
     );
   });
+
+  it('renders file row and summary footer for a clean single-file result', async () => {
+    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH);
+
+    const lines = getMockUiCalls()
+      .filter((c) => c.method === 'text')
+      .map((c) => String(c.args[0]));
+    expect(lines.some((line) => line.includes('src/index.ts'))).toBe(true);
+    expect(lines.some((line) => line.includes('No issues found'))).toBe(true);
+    expect(lines.at(-1)).toContain('1 files analyzed');
+  });
 });
 
 describe('analyzeSqaa: path normalization', () => {

--- a/tests/unit/cli/commands/analyze/sqaa-analysis.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-analysis.test.ts
@@ -1,0 +1,173 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import {
+  distributeChunkResponse,
+  runAnalyses,
+  shouldContinueAfterChunk,
+} from '../../../../../src/cli/commands/analyze/sqaa-analysis';
+import * as sqaaApi from '../../../../../src/cli/commands/analyze/sqaa-api';
+import type { CloudAuth } from '../../../../../src/cli/commands/analyze/sqaa-auth';
+import type { SqaaChunkFile } from '../../../../../src/cli/commands/analyze/sqaa-chunking';
+import { SqaaProgress } from '../../../../../src/ui/components/sqaa-progress.js';
+
+describe('distributeChunkResponse', () => {
+  it('attaches chunk-level errors only to the first file', () => {
+    const chunkErrors = [{ code: 'WARN', message: 'chunk warning' }];
+    const results = distributeChunkResponse([], chunkErrors, [
+      { file: '/repo/a.ts', filePath: 'a.ts' },
+      { file: '/repo/b.ts', filePath: 'b.ts' },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].errors).toEqual(chunkErrors);
+    expect(results[1].errors).toBeNull();
+  });
+
+  it('attributes issues with unrecognized filePath to the first chunk file', () => {
+    const results = distributeChunkResponse(
+      [{ rule: 'ts:S1', message: 'issue', filePath: './a.ts', id: '1' }],
+      null,
+      [
+        { file: '/repo/a.ts', filePath: 'a.ts' },
+        { file: '/repo/b.ts', filePath: 'b.ts' },
+      ],
+    );
+
+    expect(results[0].issues).toHaveLength(1);
+    expect(results[1].issues).toHaveLength(0);
+  });
+});
+
+describe('shouldContinueAfterChunk', () => {
+  it('continues when some parts succeeded despite group errors', () => {
+    expect(
+      shouldContinueAfterChunk(
+        [{ response: { issues: [], errors: null }, files: [] }],
+        [],
+        [{ files: [], error: new Error('fail') }],
+      ),
+    ).toBe(true);
+  });
+
+  it('stops when the entire chunk failed via group errors only', () => {
+    expect(shouldContinueAfterChunk([], [], [{ files: [], error: new Error('fail') }])).toBe(false);
+  });
+
+  it('continues when only 413 per-file failures were recorded', () => {
+    expect(
+      shouldContinueAfterChunk(
+        [],
+        [{ absolutePath: '/repo/a.ts', relativePath: 'a.ts', content: 'x' }],
+        [],
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('runAnalyses partial 413', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+  let readSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = spyOn(sqaaApi, 'fetchChunkWith413Split');
+    readSpy = spyOn(sqaaApi, 'readSqaaFileContent').mockReturnValue('x');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    readSpy.mockRestore();
+  });
+
+  function chunkFile(path: string): SqaaChunkFile {
+    return { absolutePath: `/repo/${path}`, relativePath: path, content: 'x' };
+  }
+
+  const AUTH: CloudAuth = { serverUrl: 'https://sonarcloud.io', token: 't', orgKey: 'org' };
+
+  it('sends all readable files in one request and records partial 413 failures', async () => {
+    const a = chunkFile('a.ts');
+    const b = chunkFile('b.ts');
+    const c = chunkFile('c.ts');
+
+    fetchSpy.mockResolvedValue({
+      parts: [
+        {
+          response: { issues: [{ rule: 'r', message: 'm', filePath: 'a.ts' }], errors: null },
+          files: [a],
+        },
+        {
+          response: { issues: [], errors: null },
+          files: [c],
+        },
+      ],
+      failedFiles: [b],
+      groupErrors: [],
+    });
+
+    const files = ['/repo/a.ts', '/repo/b.ts', '/repo/c.ts'];
+    const progress = new SqaaProgress({ files: ['a.ts', 'b.ts', 'c.ts'], silent: true });
+    const tally = await runAnalyses({
+      files,
+      allPaths: ['a.ts', 'b.ts', 'c.ts'],
+      cloudAuth: AUTH,
+      projectKey: 'proj',
+      branch: undefined,
+      progress,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[2]).toEqual([a, b, c]);
+    expect(tally.totalIssues).toBe(1);
+    expect(tally.totalFailures).toBe(1);
+    expect(tally.allResults).toHaveLength(3);
+  });
+
+  it('records read failures per file and continues analyzing readable files', async () => {
+    const ok = chunkFile('ok.ts');
+    readSpy.mockImplementation((file: string) => {
+      if (file === '/repo/bad.ts') {
+        throw new Error('Failed to read file');
+      }
+      return 'x';
+    });
+    fetchSpy.mockResolvedValue({
+      parts: [{ response: { issues: [], errors: null }, files: [ok] }],
+      failedFiles: [],
+      groupErrors: [],
+    });
+
+    const progress = new SqaaProgress({ files: ['ok.ts', 'bad.ts'], silent: true });
+    const tally = await runAnalyses({
+      files: ['/repo/ok.ts', '/repo/bad.ts'],
+      allPaths: ['ok.ts', 'bad.ts'],
+      cloudAuth: AUTH,
+      projectKey: 'proj',
+      branch: undefined,
+      progress,
+    });
+
+    expect(tally.totalFailures).toBe(1);
+    expect(tally.allResults).toHaveLength(2);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/cli/commands/analyze/sqaa-api-chunk-fetch.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-api-chunk-fetch.test.ts
@@ -1,0 +1,199 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.js';
+import { fetchChunkWith413Split } from '../../../../../src/cli/commands/analyze/sqaa-api';
+import type { CloudAuth } from '../../../../../src/cli/commands/analyze/sqaa-auth';
+import type { SqaaChunkFile } from '../../../../../src/cli/commands/analyze/sqaa-chunking';
+import * as sqaaChunking from '../../../../../src/cli/commands/analyze/sqaa-chunking';
+import { ENV_SQAA_RETRY_BASE_DELAY_MS } from '../../../../../src/lib/config-constants';
+import { SonarQubeClient, type SqaaAnalysisRequest } from '../../../../../src/sonarqube/client.js';
+import {
+  RequestPayloadTooLargeError,
+  ServiceUnavailableError,
+} from '../../../../../src/sonarqube/errors.js';
+
+const AUTH: CloudAuth = {
+  serverUrl: 'https://sonarcloud.io',
+  token: 'token',
+  orgKey: 'org',
+};
+
+function makeFile(relativePath: string): SqaaChunkFile {
+  return {
+    absolutePath: `/repo/${relativePath}`,
+    relativePath,
+    content: 'const x = 1;',
+  };
+}
+
+describe('fetchChunkWith413Split', () => {
+  let createAnalysisSpy: ReturnType<typeof spyOn>;
+  let previousRetryDelay: string | undefined;
+
+  beforeEach(() => {
+    previousRetryDelay = process.env[ENV_SQAA_RETRY_BASE_DELAY_MS];
+    process.env[ENV_SQAA_RETRY_BASE_DELAY_MS] = '0';
+    createAnalysisSpy = spyOn(SonarQubeClient.prototype, 'createAnalysis');
+  });
+
+  afterEach(() => {
+    createAnalysisSpy.mockRestore();
+    if (previousRetryDelay === undefined) {
+      delete process.env[ENV_SQAA_RETRY_BASE_DELAY_MS];
+    } else {
+      process.env[ENV_SQAA_RETRY_BASE_DELAY_MS] = previousRetryDelay;
+    }
+  });
+
+  it('returns partial successes when a later sub-chunk cannot be split further', async () => {
+    createAnalysisSpy.mockImplementation((request: SqaaAnalysisRequest) => {
+      if (request.files.length === 2) {
+        return Promise.reject(
+          new RequestPayloadTooLargeError('Payload too large', 'REQUEST_TOO_LARGE'),
+        );
+      }
+      if (request.files[0]?.path === 'a.ts') {
+        return Promise.resolve({
+          issues: [{ rule: 'ts:S1', message: 'issue', filePath: 'a.ts' }],
+          errors: null,
+        });
+      }
+      return Promise.reject(
+        new RequestPayloadTooLargeError('Payload too large', 'REQUEST_TOO_LARGE'),
+      );
+    });
+
+    const result = await fetchChunkWith413Split(
+      AUTH,
+      'project',
+      [makeFile('a.ts'), makeFile('b.ts')],
+      undefined,
+    );
+
+    expect(result.parts).toHaveLength(1);
+    expect(result.parts[0]?.response.issues).toHaveLength(1);
+    expect(result.parts[0]?.response.issues[0]?.filePath).toBe('a.ts');
+    expect(result.parts[0]?.files).toEqual([makeFile('a.ts')]);
+    expect(result.failedFiles).toEqual([makeFile('b.ts')]);
+    expect(result.groupErrors).toEqual([]);
+  });
+
+  it('keeps earlier sub-chunk successes when a later sub-chunk hits a non-413 error', async () => {
+    createAnalysisSpy.mockImplementation((request: SqaaAnalysisRequest) => {
+      if (request.files.length === 2) {
+        return Promise.reject(
+          new RequestPayloadTooLargeError('Payload too large', 'TOO_MANY_FILES'),
+        );
+      }
+      if (request.files[0]?.path === 'a.ts') {
+        return Promise.resolve({
+          issues: [{ rule: 'ts:S1', message: 'issue', filePath: 'a.ts' }],
+          errors: null,
+        });
+      }
+      return Promise.reject(new CommandFailedError('network down'));
+    });
+
+    const result = await fetchChunkWith413Split(
+      AUTH,
+      'project',
+      [makeFile('a.ts'), makeFile('b.ts')],
+      undefined,
+    );
+
+    expect(result.parts).toHaveLength(1);
+    expect(result.parts[0]?.response.issues).toHaveLength(1);
+    expect(result.groupErrors).toHaveLength(1);
+    expect(result.groupErrors[0]?.files).toEqual([makeFile('b.ts')]);
+    expect(result.groupErrors[0]?.error.message).toContain('network down');
+  });
+
+  it('re-throws transient 503 errors from a later split sub-group', async () => {
+    createAnalysisSpy.mockImplementation((request: SqaaAnalysisRequest) => {
+      if (request.files.length === 2) {
+        return Promise.reject(
+          new RequestPayloadTooLargeError('Payload too large', 'TOO_MANY_FILES'),
+        );
+      }
+      if (request.files[0]?.path === 'a.ts') {
+        return Promise.resolve({ issues: [], errors: null });
+      }
+      return Promise.reject(new ServiceUnavailableError());
+    });
+
+    const err = await fetchChunkWith413Split(
+      AUTH,
+      'project',
+      [makeFile('a.ts'), makeFile('b.ts')],
+      undefined,
+    ).catch((rejected: unknown) => rejected);
+
+    expect(
+      err instanceof ServiceUnavailableError ||
+        (err instanceof CommandFailedError && err.cause instanceof ServiceUnavailableError),
+    ).toBe(true);
+  });
+
+  it('uses server meta limits when re-packing after REQUEST_TOO_LARGE', async () => {
+    const packSpy = spyOn(sqaaChunking, 'packFilesIntoChunks');
+
+    createAnalysisSpy.mockImplementation((request: SqaaAnalysisRequest) => {
+      if (request.files.length === 3) {
+        return Promise.reject(
+          new RequestPayloadTooLargeError('Payload too large', 'REQUEST_TOO_LARGE', {
+            maxRequestSize: 512_000,
+            maxFiles: 2,
+          }),
+        );
+      }
+      return Promise.resolve({ issues: [], errors: null });
+    });
+
+    const files = [makeFile('a.ts'), makeFile('b.ts'), makeFile('c.ts')];
+
+    try {
+      await fetchChunkWith413Split(AUTH, 'project', files, undefined);
+      expect(packSpy.mock.calls[0]?.[1]).toMatchObject({
+        maxRequestBytes: 512_000,
+        maxFilesPerRequest: 2,
+        organizationKey: 'org',
+        projectKey: 'project',
+      });
+    } finally {
+      packSpy.mockRestore();
+    }
+  });
+
+  it('marks a single file as failed when it exceeds the payload limit', async () => {
+    createAnalysisSpy.mockRejectedValue(
+      new RequestPayloadTooLargeError('Payload too large', 'REQUEST_TOO_LARGE'),
+    );
+
+    const file = makeFile('large.ts');
+    const result = await fetchChunkWith413Split(AUTH, 'project', [file], undefined);
+
+    expect(result.parts).toEqual([]);
+    expect(result.failedFiles).toEqual([file]);
+    expect(result.groupErrors).toEqual([]);
+  });
+});

--- a/tests/unit/cli/commands/analyze/sqaa-chunking.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-chunking.test.ts
@@ -1,0 +1,109 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  estimateRequestBytes,
+  packFilesIntoChunks,
+  type SqaaChunkFile,
+} from '../../../../../src/cli/commands/analyze/sqaa-chunking';
+
+function makeFile(relativePath: string, content: string): SqaaChunkFile {
+  return { absolutePath: `/repo/${relativePath}`, relativePath, content };
+}
+
+describe('packFilesIntoChunks', () => {
+  it('returns no chunks for an empty list', () => {
+    expect(packFilesIntoChunks([])).toEqual([]);
+  });
+
+  it('returns one chunk for all files when no limits are provided', () => {
+    const files = Array.from({ length: 50 }, (_, i) =>
+      makeFile(`file${i}.ts`, `const x${i} = ${i};`),
+    );
+    const chunks = packFilesIntoChunks(files);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].files).toHaveLength(50);
+  });
+
+  it('packs a single small file into one chunk', () => {
+    const chunks = packFilesIntoChunks([makeFile('a.ts', 'const x = 1;')]);
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].files).toHaveLength(1);
+  });
+
+  it('splits when file count exceeds maxFilesPerRequest', () => {
+    const files = Array.from({ length: 5 }, (_, i) =>
+      makeFile(`file${i}.ts`, `const x${i} = ${i};`),
+    );
+    const chunks = packFilesIntoChunks(files, { maxFilesPerRequest: 2 });
+    expect(chunks).toHaveLength(3);
+    expect(chunks.map((c) => c.files.length)).toEqual([2, 2, 1]);
+  });
+
+  it('splits when payload exceeds the byte budget', () => {
+    const largeContent = 'x'.repeat(4 * 1024 * 1024);
+    const maxRequestBytes = 10 * 1024 * 1024;
+    const files = [
+      makeFile('a.ts', largeContent),
+      makeFile('b.ts', largeContent),
+      makeFile('c.ts', largeContent),
+    ];
+    const chunks = packFilesIntoChunks(files, { maxRequestBytes });
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      const bytes = estimateRequestBytes({
+        organizationKey: 'org',
+        projectKey: 'proj',
+        files: chunk.files.map((f) => ({ path: f.relativePath, content: f.content })),
+      });
+      expect(bytes).toBeLessThanOrEqual(maxRequestBytes);
+    }
+  });
+
+  it('accounts for JSON wrapper overhead in byte estimates', () => {
+    const content = 'a'.repeat(100);
+    const file = makeFile('src/big.ts', content);
+    const withWrapper = estimateRequestBytes({
+      organizationKey: 'my-org',
+      projectKey: 'my-project',
+      branchName: 'feature/x',
+      files: [{ path: file.relativePath, content: file.content }],
+    });
+    expect(withWrapper).toBeGreaterThan(Buffer.byteLength(content, 'utf8'));
+  });
+
+  it('matches full JSON.stringify byte estimates for each packed chunk', () => {
+    const maxRequestBytes = 10 * 1024 * 1024;
+    const files = Array.from({ length: 30 }, (_, i) =>
+      makeFile(`src/file-${i}.ts`, `export const v${i} = ${i};\n`.repeat(20)),
+    );
+    const chunks = packFilesIntoChunks(files, { maxRequestBytes });
+    for (const chunk of chunks) {
+      const incrementalBytes = estimateRequestBytes({
+        organizationKey: '',
+        projectKey: '',
+        files: chunk.files.map((f) => ({ path: f.relativePath, content: f.content })),
+      });
+      expect(incrementalBytes).toBeLessThanOrEqual(maxRequestBytes);
+    }
+  });
+});

--- a/tests/unit/cli/commands/analyze/sqaa-display.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-display.test.ts
@@ -1,0 +1,222 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import type { FileResult, RunTally } from '../../../../../src/cli/commands/analyze/sqaa-analysis';
+import {
+  computeRunSummaryStats,
+  formatSqaaIssueLinePlain,
+  formatSqaaPathPlain,
+  formatSqaaRunSummaryPlain,
+  printSqaaTextReport,
+  SQAA_COLLAPSE_CLEAN_THRESHOLD,
+} from '../../../../../src/cli/commands/analyze/sqaa-display';
+import type { SqaaIssue } from '../../../../../src/sonarqube/client';
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../src/ui';
+
+const ANSI_ESCAPE_CODES = /\x1b\[[0-9;]*m/g;
+
+function stripAnsi(text: string): string {
+  return text.replaceAll(ANSI_ESCAPE_CODES, '');
+}
+
+function getMockTextLines(): string[] {
+  return getMockUiCalls()
+    .filter((c) => c.method === 'text')
+    .map((c) => stripAnsi(String(c.args[0])));
+}
+
+const SAMPLE_ISSUE: SqaaIssue = {
+  id: '1',
+  message: 'Remove redundant jump',
+  rule: 'typescript:S3626',
+  textRange: { startLine: 190, endLine: 190, startOffset: 0, endOffset: 0 },
+};
+
+function success(path: string, issues: SqaaIssue[] = []): FileResult {
+  return { file: path, filePath: path, issues, errors: null };
+}
+
+function failure(path: string, message: string): FileResult {
+  return { file: path, filePath: path, failure: new Error(message) };
+}
+
+describe('formatSqaaPathPlain', () => {
+  it('keeps bare filenames unchanged', () => {
+    expect(formatSqaaPathPlain('foo.ts')).toBe('foo.ts');
+  });
+
+  it('preserves directory prefix', () => {
+    expect(formatSqaaPathPlain('src/cli/foo.ts')).toBe('src/cli/foo.ts');
+  });
+});
+
+describe('formatSqaaIssueLinePlain', () => {
+  it('puts line number before message and rule', () => {
+    expect(formatSqaaIssueLinePlain(SAMPLE_ISSUE, 1)).toBe(
+      '     [1] line 190  Remove redundant jump  typescript:S3626',
+    );
+  });
+});
+
+describe('formatSqaaRunSummaryPlain', () => {
+  it('formats clean success summary', () => {
+    expect(
+      formatSqaaRunSummaryPlain({
+        filesAnalyzed: 7,
+        filesWithIssues: 0,
+        filesWithErrors: 0,
+        totalIssues: 0,
+        totalFailures: 0,
+        totalErrors: 0,
+      }),
+    ).toBe('✓  No issues found · 7 files analyzed');
+  });
+
+  it('formats issues summary', () => {
+    expect(
+      formatSqaaRunSummaryPlain({
+        filesAnalyzed: 14,
+        filesWithIssues: 7,
+        filesWithErrors: 0,
+        totalIssues: 56,
+        totalFailures: 0,
+        totalErrors: 0,
+      }),
+    ).toBe('14 files analyzed · 7 with issues · 56 issues found');
+  });
+});
+
+describe('printSqaaTextReport', () => {
+  afterEach(() => {
+    setMockUi(false);
+    process.exitCode = 0;
+  });
+
+  it('renders clean and finding files inline with summary footer', () => {
+    setMockUi(true);
+    clearMockUiCalls();
+
+    const tally: RunTally = {
+      allResults: [success('src/a.ts'), success('src/b.ts', [SAMPLE_ISSUE])],
+      totalIssues: 1,
+      totalErrors: 0,
+      totalFailures: 0,
+    };
+
+    printSqaaTextReport({ tally, allPaths: ['src/a.ts', 'src/b.ts'] });
+
+    const texts = getMockTextLines();
+
+    expect(texts.some((l) => l.includes('src/a.ts'))).toBe(true);
+    expect(texts.some((l) => l.includes('src/b.ts') && l.includes('1 issue'))).toBe(true);
+    expect(texts.some((l) => l.includes('line 190'))).toBe(true);
+    expect(texts.some((l) => l.includes('typescript:S3626'))).toBe(true);
+    expect(texts.at(-1)).toContain('2 files analyzed · 1 with issues · 1 issue found');
+  });
+
+  it('collapses clean files when count exceeds threshold', () => {
+    setMockUi(true);
+    clearMockUiCalls();
+
+    const cleanPaths = Array.from(
+      { length: SQAA_COLLAPSE_CLEAN_THRESHOLD },
+      (_, i) => `src/clean-${i}.ts`,
+    );
+    const findingPath = 'src/hot.ts';
+    const allPaths = [...cleanPaths, findingPath];
+
+    const tally: RunTally = {
+      allResults: [...cleanPaths.map((p) => success(p)), success(findingPath, [SAMPLE_ISSUE])],
+      totalIssues: 1,
+      totalErrors: 0,
+      totalFailures: 0,
+    };
+
+    printSqaaTextReport({ tally, allPaths });
+
+    const texts = getMockTextLines();
+
+    expect(
+      texts.some(
+        (l) => l.includes(`${SQAA_COLLAPSE_CLEAN_THRESHOLD} files`) && l.includes('no issues'),
+      ),
+    ).toBe(true);
+    expect(texts.filter((l) => l.includes('clean-0.ts'))).toHaveLength(0);
+    expect(texts.some((l) => l.includes('src/hot.ts'))).toBe(true);
+  });
+
+  it('renders failed and skipped files', () => {
+    setMockUi(true);
+    clearMockUiCalls();
+
+    const tally: RunTally = {
+      allResults: [success('src/a.ts'), failure('src/b.ts', 'network error')],
+      totalIssues: 0,
+      totalErrors: 0,
+      totalFailures: 1,
+    };
+
+    printSqaaTextReport({ tally, allPaths: ['src/a.ts', 'src/b.ts', 'src/c.ts'] });
+
+    const texts = getMockTextLines();
+
+    expect(texts.some((l) => l.includes('src/b.ts'))).toBe(true);
+    expect(texts.some((l) => l.includes('network error'))).toBe(true);
+    expect(texts.some((l) => l.includes('[SKIPPED]') && l.includes('src/c.ts'))).toBe(true);
+    expect(texts.at(-1)).toContain('1 failure');
+  });
+});
+
+describe('computeRunSummaryStats', () => {
+  it('counts files with API errors separately from issues', () => {
+    const tally: RunTally = {
+      allResults: [
+        {
+          file: 'src/a.ts',
+          filePath: 'src/a.ts',
+          issues: [],
+          errors: [{ code: 'E', message: 'boom' }],
+        },
+      ],
+      totalIssues: 0,
+      totalErrors: 1,
+      totalFailures: 0,
+    };
+
+    const stats = computeRunSummaryStats(tally, ['src/a.ts']);
+    expect(stats.filesWithIssues).toBe(0);
+    expect(stats.filesWithErrors).toBe(1);
+  });
+
+  it('formats errors-only summary without implying issues', () => {
+    expect(
+      formatSqaaRunSummaryPlain({
+        filesAnalyzed: 3,
+        filesWithIssues: 0,
+        filesWithErrors: 1,
+        totalIssues: 0,
+        totalFailures: 0,
+        totalErrors: 2,
+      }),
+    ).toBe('3 files analyzed · 1 with errors · 2 errors');
+  });
+});

--- a/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/agent-post-tool-use.test.ts
@@ -74,7 +74,7 @@ describe('agentPostToolUse', () => {
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     const output = JSON.parse((stdoutSpy.mock.calls[0][0] as string).trim());
     expect(output.hookSpecificOutput.hookEventName).toBe('PostToolUse');
-    expect(output.hookSpecificOutput.additionalContext).toContain('no issues');
+    expect(output.hookSpecificOutput.additionalContext).toContain('No issues found');
   });
 
   it('triggers analysis when tool_name is Write', async () => {

--- a/tests/unit/cli/commands/hook/codex-post-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/codex-post-tool-use.test.ts
@@ -62,7 +62,7 @@ describe('codexPostToolUse', () => {
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
     const output = JSON.parse((stdoutSpy.mock.calls[0][0] as string).trim());
     expect(output.hookSpecificOutput.hookEventName).toBe('PostToolUse');
-    expect(output.hookSpecificOutput.additionalContext).toContain('no issues');
+    expect(output.hookSpecificOutput.additionalContext).toContain('No issues found');
   });
 
   it('surfaces per-file analysis errors when totalIssues is zero', async () => {

--- a/tests/unit/cli/commands/hook/format-sqaa-hook-context.test.ts
+++ b/tests/unit/cli/commands/hook/format-sqaa-hook-context.test.ts
@@ -92,7 +92,7 @@ describe('formatSqaaJsonReportForHook', () => {
       summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 0 },
     });
 
-    expect(text).toContain('no issues found');
+    expect(text).toContain('No issues found');
     expect(text).toContain('Excluded 1 file(s)');
     expect(text).toContain('large.bin');
     expect(text).toContain('oversized');

--- a/tests/unit/ui/sqaa-progress.test.ts
+++ b/tests/unit/ui/sqaa-progress.test.ts
@@ -163,10 +163,41 @@ describe('SqaaProgress — TTY', () => {
     const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
     try {
       const stdout = captureStdout(() => progress.warnPayloadSplit());
-      expect(stdout).toBe('');
+      expect(stdout).toContain('\x1B[1A');
       expect(String(stderrSpy.mock.calls[0]?.[0])).toContain('Request size limit reached');
     } finally {
       stderrSpy.mockRestore();
+      progress.finish();
+    }
+  });
+
+  it('warnPayloadSplit erases the live line before writing the warning', () => {
+    const progress = new SqaaProgress({ files: FILES, isTTY: true });
+    captureStdout(() => progress.start());
+
+    const events: Array<'stdout-erase' | 'stderr-warn'> = [];
+    const stdoutSpy = spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      const text = String(chunk);
+      if (text.includes('\x1B[1A') || text.includes('\x1b[1A')) {
+        events.push('stdout-erase');
+      }
+      return true;
+    });
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => {
+      events.push('stderr-warn');
+      return true;
+    });
+    try {
+      progress.warnPayloadSplit();
+      const warnIdx = events.indexOf('stderr-warn');
+      const eraseBeforeWarn = events.lastIndexOf('stdout-erase', warnIdx);
+      expect(warnIdx).toBeGreaterThanOrEqual(0);
+      expect(eraseBeforeWarn).toBeGreaterThanOrEqual(0);
+      expect(eraseBeforeWarn).toBeLessThan(warnIdx);
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+      progress.finish();
     }
   });
 });

--- a/tests/unit/ui/sqaa-progress.test.ts
+++ b/tests/unit/ui/sqaa-progress.test.ts
@@ -18,8 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Unit tests for SqaaProgress — TTY and non-TTY rendering paths.
-
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../src/ui';
@@ -55,108 +53,121 @@ async function captureStdoutAsync(fn: () => Promise<void>): Promise<string> {
   return chunks.join('');
 }
 
-describe('SqaaProgress — non-TTY mode', () => {
-  it('prints a one-time header, rolling per-file result lines, and skipped files on fail-fast', () => {
+function countNewlines(text: string): number {
+  return (text.match(/\n/g) ?? []).length;
+}
+
+describe('SqaaProgress — non-TTY', () => {
+  it('writes nothing on start or finish', () => {
     const progress = new SqaaProgress({ files: FILES, isTTY: false });
-
     const header = captureStdout(() => progress.start());
-    expect(header).toContain('Analyzing 3 files');
+    expect(header).toBe('');
 
-    // Result lines arrive in completion order (rolling), one per terminal transition.
-    const aLine = captureStdout(() => progress.update(0, 'done'));
-    expect(aLine).toContain('src/a.ts');
-    // Intermediate transitions don't print anything in non-TTY mode.
-    expect(captureStdout(() => progress.update(1, 'analyzing'))).toBe('');
-    const bLine = captureStdout(() => progress.update(1, 'failed'));
-    expect(bLine).toContain('src/b.ts');
-
-    // Fail-fast: c.ts is never picked up, finish() flushes it as skipped.
+    progress.updateChunk(0, 'analyzing');
+    progress.update(0, 'done');
+    progress.update(1, 'failed');
     captureStdout(() => progress.skipRemaining(2));
-    const finish = captureStdout(() => progress.finish(2));
-    expect(finish).toContain('src/c.ts');
+    const finish = captureStdout(() => progress.finish());
+    expect(finish).toBe('');
   });
 
-  it('header counts only files the pool will process (excludes pre-ignored files)', () => {
+  it('does not print per-file lines during the run', () => {
+    const progress = new SqaaProgress({ files: FILES, isTTY: false });
+    progress.start();
+    progress.update(0, 'done');
+    progress.update(1, 'done');
+    const during = captureStdout(() => progress.update(2, 'done'));
+    expect(during).toBe('');
+    const finish = captureStdout(() => progress.finish());
+    expect(finish).toBe('');
+  });
+
+  it('ignored files do not affect processable total', () => {
     const progress = new SqaaProgress({
       files: FILES,
       ignoredFiles: ['build/output.bin'],
       isTTY: false,
     });
-
     const header = captureStdout(() => progress.start());
-    // Only the 3 waiting files count; the binary one is already accounted for elsewhere.
-    expect(header).toContain('Analyzing 3 files');
+    expect(header).toBe('');
+    expect(progress.getStatuses()).toHaveLength(4);
   });
 
-  it('retrying prints a countdown line and resets status to analyzing', async () => {
+  it('retryingChunk prints a countdown line', async () => {
     const progress = new SqaaProgress({ files: FILES, isTTY: false });
-    const output = await captureStdoutAsync(() => progress.retrying(0, 1, 3, 1));
+    progress.start();
+    const output = await captureStdoutAsync(() => progress.retryingChunk(0, 1, 3, 1));
     expect(output).toContain('Server busy (503)');
     expect(output).toContain('Attempt 1/3');
   });
 });
 
-describe('SqaaProgress — TTY mode', () => {
-  it('renders full block with all statuses through a complete lifecycle', () => {
+describe('SqaaProgress — TTY', () => {
+  it('shows one live line while running and erases it on finish', () => {
     const progress = new SqaaProgress({ files: FILES, isTTY: true });
-
     const start = captureStdout(() => progress.start());
-    expect(start).toContain('SonarQube Agentic Analysis in progress');
-    expect(start).toContain('0/3 files analyzed');
-    expect(start).toContain('[WAITING]');
+    expect(start).toMatch(/Analyzing 3 files\.+/);
+    expect(start).not.toContain('chunk');
+    expect(start).not.toContain('in progress');
+    expect(countNewlines(start)).toBe(1);
 
-    const analyzing = captureStdout(() => progress.update(0, 'analyzing'));
-    expect(analyzing).toContain('[ANALYZING...]');
+    const analyzing = captureStdout(() => progress.updateChunk(0, 'analyzing'));
+    expect(analyzing).toMatch(/Analyzing 3 files\.+/);
+    expect(analyzing).not.toContain('[ANALYZING...]');
+    expect(countNewlines(analyzing)).toBe(1);
 
-    const done = captureStdout(() => progress.update(0, 'done'));
-    expect(done).toContain('[DONE]');
-    expect(done).toContain('1/3 files analyzed');
+    progress.update(0, 'done');
+    const progressUpdate = captureStdout(() => progress.update(1, 'failed'));
+    expect(progressUpdate).toContain('(2/3)');
 
-    const failed = captureStdout(() => progress.update(1, 'failed'));
-    expect(failed).toContain('[FAILED]');
-
+    captureStdout(() => progress.updateChunk(0, 'done'));
     captureStdout(() => progress.skipRemaining(2));
-    const finish = captureStdout(() => progress.finish(2));
-    expect(finish).toContain('2/3 files analyzed');
-    expect(finish).toContain('[DONE]');
-    expect(finish).toContain('[FAILED]');
-    expect(finish).toContain('[SKIPPED]');
+
+    const finish = captureStdout(() => progress.finish());
+    expect(finish).not.toContain('⣿');
+    expect(finish).not.toContain('src/a.ts');
+    expect(finish).not.toContain('[FAILED]');
   });
 
-  it('retrying shows live countdown label and resets to analyzing', async () => {
+  it('cycles animated dots while the live line is active', async () => {
+    const progress = new SqaaProgress({ files: FILES, isTTY: true });
+    const output: string[] = [];
+    const writeSpy = spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      output.push(String(chunk));
+      return true;
+    });
+    try {
+      progress.start();
+      await Bun.sleep(950);
+      progress.finish();
+      const joined = output.join('');
+      expect(joined).toMatch(/Analyzing 3 files\./);
+      expect(joined).toMatch(/Analyzing 3 files\.\./);
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('retryingChunk updates the single live line', async () => {
     const progress = new SqaaProgress({ files: FILES, isTTY: true });
     captureStdout(() => progress.start());
-    // 500ms rounds to 1s so the countdown loop body executes once.
-    const output = await captureStdoutAsync(() => progress.retrying(0, 1, 3, 500));
-    expect(output).toContain('RETRYING');
-
-    const after = captureStdout(() => progress.update(0, 'done'));
-    expect(after).not.toContain('[RETRYING...]');
+    const output = await captureStdoutAsync(() => progress.retryingChunk(0, 1, 3, 500));
+    captureStdout(() => progress.finish());
+    expect(output).toContain('retrying');
+    expect(output).not.toContain('in progress');
   });
 
-  it('progress bar denominator excludes pre-ignored files', () => {
-    // 3 analyzable + 1 ignored. Bar total must be 3 (so 100% is reachable),
-    // not 4. Ignored files still appear in the listing below the bar.
-    const progress = new SqaaProgress({
-      files: FILES,
-      ignoredFiles: ['build/output.bin'],
-      isTTY: true,
-    });
-
-    const start = captureStdout(() => progress.start());
-    expect(start).toContain('0/3 files analyzed');
-    expect(start).not.toContain('0/4 files analyzed');
-
-    const afterDone = captureStdout(() => progress.update(0, 'done'));
-    expect(afterDone).toContain('1/3 files analyzed');
-
-    progress.update(1, 'done');
-    progress.update(2, 'done');
-    const finish = captureStdout(() => progress.finish(3));
-    expect(finish).toContain('3/3 files analyzed');
-    // Ignored entry is still listed below the summary bar.
-    expect(finish).toContain('build/output.bin');
-    expect(finish).toContain('[IGNORED]');
+  it('warnPayloadSplit writes to stderr only', () => {
+    const progress = new SqaaProgress({ files: FILES, isTTY: true });
+    captureStdout(() => progress.start());
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const stdout = captureStdout(() => progress.warnPayloadSplit());
+      expect(stdout).toBe('');
+      expect(String(stderrSpy.mock.calls[0]?.[0])).toContain('Request size limit reached');
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });
 
@@ -167,65 +178,63 @@ describe('SqaaProgress — mock mode', () => {
   });
   afterEach(() => setMockUi(false));
 
-  it('records all method calls and writes nothing to stdout', async () => {
+  it('records method calls and writes nothing to stdout', async () => {
     const progress = new SqaaProgress({ files: FILES });
 
     const output = captureStdout(() => {
       progress.start();
+      progress.updateChunk(0, 'done');
       progress.update(0, 'done');
+      progress.warnPayloadSplit();
       progress.skipRemaining(1);
-      progress.finish(3);
+      progress.finish();
     });
-    await progress.retrying(0, 1, 3, 1);
+    await progress.retryingChunk(0, 1, 3, 1);
 
     expect(output).toBe('');
     const methods = getMockUiCalls().map((c) => c.method);
     expect(methods).toContain('sqaaProgress.start');
+    expect(methods).toContain('sqaaProgress.updateChunk');
+    expect(methods).toContain('sqaaProgress.warnPayloadSplit');
     expect(methods).toContain('sqaaProgress.update');
     expect(methods).toContain('sqaaProgress.skipRemaining');
     expect(methods).toContain('sqaaProgress.finish');
-    expect(methods).toContain('sqaaProgress.retrying');
+    expect(methods).toContain('sqaaProgress.retryingChunk');
   });
 });
 
 describe('SqaaProgress — silent flag (used by --format json)', () => {
-  // Silent mode is the production replacement for setMockUi(true) in JSON mode:
-  // it must not write to stdout, must not record calls into the global mock
-  // buffer, and must still update internal status so consumers can read it.
-
   beforeEach(() => {
     setMockUi(true);
     clearMockUiCalls();
   });
   afterEach(() => setMockUi(false));
 
-  it('writes nothing to stdout and records no mock calls even when mock is active', async () => {
+  it('writes nothing to stdout and records no mock calls', async () => {
     const progress = new SqaaProgress({ files: FILES, silent: true });
 
     const output = await captureStdoutAsync(async () => {
       progress.start();
+      progress.updateChunk(0, 'done');
       progress.update(0, 'done');
+      progress.warnPayloadSplit();
       progress.skipRemaining(1);
-      progress.finish(3);
-      await progress.retrying(2, 1, 3, 1);
+      progress.finish();
+      await progress.retryingChunk(0, 1, 3, 1);
     });
 
     expect(output).toBe('');
-    // Crucially: no entries pushed into the global mock buffer (the original
-    // setMockUi(true) approach grew this array unboundedly during JSON runs).
     expect(getMockUiCalls()).toHaveLength(0);
   });
 
-  it('still updates internal status for skipRemaining and retrying', async () => {
+  it('still updates internal status for skipRemaining', async () => {
     const progress = new SqaaProgress({ files: FILES, silent: true });
+    progress.start();
 
     progress.update(0, 'done');
     progress.skipRemaining(1);
     expect(progress.getStatuses()).toEqual(['done', 'skipped', 'skipped']);
 
-    // retrying() preserves the wait so retry semantics are unchanged, and
-    // resets the status back to 'analyzing' on completion.
-    await progress.retrying(0, 1, 3, 1);
-    expect(progress.getStatuses()[0]).toBe('analyzing');
+    await progress.retryingChunk(0, 1, 3, 1);
   });
 });


### PR DESCRIPTION

<img width="979" height="192" alt="image" src="https://github.com/user-attachments/assets/a54752aa-7ff6-4b1b-ab68-eb0037224351" />

<img width="990" height="184" alt="image" src="https://github.com/user-attachments/assets/53e18bfa-baa1-4d95-ad42-2caf68be8ebc" />

Chunking test:
<img width="235" height="31" alt="image" src="https://github.com/user-attachments/assets/0e29b2f2-5147-4dff-af79-eb75905ce43a" />

----
## Summary by Gitar

- **Core Analysis Engine:**
  - Replaced concurrent worker-pool with a sequential chunked execution engine for `SQAA` analysis.
  - Added `SQAA_MAX_FILES_PER_REQUEST` and dynamic chunking logic to group files based on size and count limits.
  - Implemented `fetchChunkWith413Split` to handle `413 Request Payload Too Large` errors via automatic sub-chunking.
- **Progress & Reporting:**
  - Replaced file-by-file progress with an animated live status line for better UX during chunked requests.
  - Updated `printSqaaTextReport` with path collapsing (`SQAA_COLLAPSE_CLEAN_THRESHOLD`) and consolidated summary footers.
- **API Integration:**
  - Updated `SonarQubeClient` to handle `413` errors and enforced `DEEP` analysis depth for all `SQAA` requests.
- **Hooks & Context:**
  - Refactored `format-sqaa-hook-context.ts` to use shared reporting logic for consistent IDE-style issue display.


<sub>This will update automatically on new commits.</sub>