### PR TITLE
CLI-674 Support impact severity values in --severities filter

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -76,7 +76,8 @@ import {
   listIssues,
   type ListIssuesOptions,
   VALID_FORMATS,
-  VALID_SEVERITIES,
+  VALID_MQR_SEVERITIES,
+  VALID_STANDARD_SEVERITIES,
   VALID_STATUSES,
 } from './commands/list/issues';
 import { listProjects, type ListProjectsOptions } from './commands/list/projects';
@@ -168,7 +169,7 @@ list
   )
   .option(
     '--severities <severities>',
-    `Filter by severity (comma-separated list of: ${VALID_SEVERITIES.join(', ')})`,
+    `Filter by severity. Valid values depend on server mode — Multi-Quality Rule (MQR) mode: ${VALID_MQR_SEVERITIES.join(', ')}; Standard Experience mode: ${VALID_STANDARD_SEVERITIES.join(', ')}.`,
   )
   .addOption(listIssuesFormatOption)
   .option('--branch <branch>', 'Branch name')

--- a/src/cli/commands/list/issues.ts
+++ b/src/cli/commands/list/issues.ts
@@ -33,7 +33,8 @@ import { print } from '../../../ui';
 import { InvalidOptionError } from '../_common/error';
 
 export const VALID_FORMATS = ['json', 'toon', 'table', 'csv'];
-export const VALID_SEVERITIES = ['INFO', 'MINOR', 'MAJOR', 'CRITICAL', 'BLOCKER'];
+export const VALID_STANDARD_SEVERITIES = ['INFO', 'MINOR', 'MAJOR', 'CRITICAL', 'BLOCKER'];
+export const VALID_MQR_SEVERITIES = ['INFO', 'LOW', 'MEDIUM', 'HIGH', 'BLOCKER'];
 export const VALID_STATUSES = ['OPEN', 'CONFIRMED', 'FALSE_POSITIVE', 'ACCEPTED', 'FIXED'];
 
 export interface ListIssuesOptions {
@@ -49,6 +50,24 @@ export interface ListIssuesOptions {
   format?: string;
   pageSize: number;
   page: number;
+}
+
+function normalizeSeverityValues(raw: string): string[] {
+  return raw.split(',').map((s) => s.trim().toUpperCase());
+}
+
+function parseSeverities(
+  raw: string,
+  mode: 'mqr' | 'standard',
+): { severities?: string; impactSeverities?: string } {
+  const values = normalizeSeverityValues(raw);
+  const validSet = mode === 'mqr' ? VALID_MQR_SEVERITIES : VALID_STANDARD_SEVERITIES;
+  if (values.some((s) => !validSet.includes(s))) {
+    throw new InvalidOptionError(
+      `Invalid severity(es): '${raw}'. Valid values for ${mode === 'mqr' ? 'Multi-Quality Rule (MQR)' : 'Standard Experience'} mode: ${validSet.join(', ')}.`,
+    );
+  }
+  return mode === 'mqr' ? { impactSeverities: values.join(',') } : { severities: values.join(',') };
 }
 
 /**
@@ -89,24 +108,32 @@ export async function listIssues(options: ListIssuesOptions, auth: ResolvedAuth)
     normalizedStatuses = statuses.join(',');
   }
 
-  let normalizedSeverities = options.severities;
-  if (normalizedSeverities) {
-    const severities = normalizedSeverities.split(',').map((s) => s.toUpperCase());
-    if (!severities.every((s) => VALID_SEVERITIES.includes(s))) {
+  if (options.severities) {
+    const preflightValues = normalizeSeverityValues(options.severities);
+    if (
+      preflightValues.some(
+        (s) => !VALID_STANDARD_SEVERITIES.includes(s) && !VALID_MQR_SEVERITIES.includes(s),
+      )
+    ) {
       throw new InvalidOptionError(
-        `Invalid severity(es): '${options.severities}'. Valid severities are: ${VALID_SEVERITIES.join(', ')}`,
+        `Invalid severity(es): '${options.severities}'. ` +
+          `Multi-Quality Rule (MQR) mode values: ${VALID_MQR_SEVERITIES.join(', ')}. ` +
+          `Standard Experience mode values: ${VALID_STANDARD_SEVERITIES.join(', ')}.`,
       );
     }
-    normalizedSeverities = severities.join(',');
   }
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
   const issuesClient = new IssuesClient(client);
 
+  const { severities: normalizedSeverities, impactSeverities: normalizedImpactSeverities } =
+    options.severities ? parseSeverities(options.severities, await client.getServerMode()) : {};
+
   const params: IssuesSearchParams = {
     projects: options.project,
     organization: auth.orgKey,
     severities: normalizedSeverities,
+    impactSeverities: normalizedImpactSeverities,
     types: options.type,
     issueStatuses: normalizedStatuses,
     rules: options.rule,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,7 @@ export interface IssuesSearchParams {
   projects?: string;
   organization?: string;
   severities?: string;
+  impactSeverities?: string;
   types?: string;
   issueStatuses?: string;
   rules?: string;

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -256,6 +256,16 @@ export class SonarQubeClient {
     return result.valid ? 'valid' : 'invalid';
   }
 
+  async getServerMode(): Promise<'mqr' | 'standard'> {
+    if (this.isCloud) return 'mqr';
+    const { response, value } = await this.getSafe<{ mode: string }>(
+      '/api/v2/clean-code-policy/mode',
+    );
+    if (response.status === HTTP_STATUS_NOT_FOUND) return 'standard';
+    await this.raiseForStatus(response, 'GET');
+    return value?.mode === 'MQR' ? 'mqr' : 'standard';
+  }
+
   /**
    * Get server system status
    */

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -142,6 +142,12 @@ export class FakeSonarQubeServerBuilder {
   private remediationAgentEntitlement = { eligible: true, delegateIssuesEnabled: true };
   private orgsLookupReturnsEmpty = false;
   private orgsLookupErrorCode?: number;
+  private serverMode: 'MQR' | 'STANDARD' = 'STANDARD';
+
+  withMode(mode: 'MQR' | 'STANDARD'): this {
+    this.serverMode = mode;
+    return this;
+  }
 
   withProject(key: string, fn?: (p: ProjectBuilder) => void): this {
     const builder = new ProjectBuilder(key);
@@ -291,6 +297,7 @@ export class FakeSonarQubeServerBuilder {
       projectSettings,
       agentJobErrorCode,
       agentJobErrorMessage,
+      serverMode,
       remediationAgentEntitlement,
       orgsLookupReturnsEmpty,
       orgsLookupErrorCode,
@@ -365,6 +372,12 @@ export class FakeSonarQubeServerBuilder {
 
         if (path === '/api/authentication/validate') {
           return new Response(JSON.stringify({ valid: true }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        if (path === '/api/v2/clean-code-policy/mode') {
+          return new Response(JSON.stringify({ mode: serverMode }), {
             headers: { 'Content-Type': 'application/json' },
           });
         }

--- a/tests/integration/specs/list/list-issues.test.ts
+++ b/tests/integration/specs/list/list-issues.test.ts
@@ -281,10 +281,69 @@ describe('list issues — argument validation', () => {
   it(
     'exits with code 2 when --severities is not a recognised value',
     async () => {
-      // Validation runs inside the handler — auth must pass first
       harness.withAuth('http://localhost:19999', 'fake-token');
 
       const result = await harness.run('list issues --project my-project --severities UNKNOWN');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout + result.stderr).toContain('Invalid severity');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'sends impactSeverities param on MQR server',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMode('MQR')
+        .withProject('my-project', (p) =>
+          p.withIssue({ ruleKey: 'java:S1234', message: 'An issue', severity: 'MAJOR' }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run('list issues --project my-project --severities HIGH,MEDIUM');
+
+      expect(result.exitCode).toBe(0);
+      const recorded = server.getRecordedRequests();
+      const issuesReq = recorded.find((r) => r.path === '/api/issues/search');
+      expect(issuesReq?.query.impactSeverities).toBe('HIGH,MEDIUM');
+      expect(issuesReq?.query.severities).toBeUndefined();
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'exits with code 2 when Standard-only value is used on MQR server',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMode('MQR')
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run('list issues --project my-project --severities MAJOR');
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stdout + result.stderr).toContain('Invalid severity');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'exits with code 2 when MQR-only value is used on Standard server',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMode('STANDARD')
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run('list issues --project my-project --severities HIGH');
 
       expect(result.exitCode).toBe(2);
       expect(result.stdout + result.stderr).toContain('Invalid severity');

--- a/tests/unit/cli/commands/list/list.test.ts
+++ b/tests/unit/cli/commands/list/list.test.ts
@@ -450,20 +450,20 @@ describe('issuesSearchCommand', () => {
   });
 
   it('normalizes severities to uppercase before passing to API', async () => {
-    let capturedSeverities: string | undefined;
+    let capturedParams: Record<string, string> | undefined;
     const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockImplementation(
       <T>(_endpoint: string, params?: Record<string, string | number | boolean>) => {
-        capturedSeverities = (params as Record<string, string>)?.severities;
+        capturedParams = params as Record<string, string>;
         return Promise.resolve(emptyApiResponse as unknown as T);
       },
     );
 
     try {
       await listIssues(
-        { project: 'my-project', severities: 'major', page: 1, pageSize: 500 },
+        { project: 'my-project', severities: 'high', page: 1, pageSize: 500 },
         mockAuth,
       );
-      expect(capturedSeverities).toBe('MAJOR');
+      expect(capturedParams?.impactSeverities).toBe('HIGH');
     } finally {
       getSpy.mockRestore();
     }
@@ -476,6 +476,85 @@ describe('issuesSearchCommand', () => {
       await listIssues({ project: 'my-project', page: 1, pageSize: 500 }, mockAuth);
     } finally {
       getSpy.mockRestore();
+    }
+  });
+
+  it('routes MQR severities to impactSeverities param on MQR server (SonarQube Cloud)', async () => {
+    let capturedParams: Record<string, string> | undefined;
+    const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockImplementation(
+      <T>(_endpoint: string, params?: Record<string, string | number | boolean>) => {
+        capturedParams = params as Record<string, string>;
+        return Promise.resolve(emptyApiResponse as unknown as T);
+      },
+    );
+    try {
+      await listIssues(
+        { project: 'my-project', severities: 'HIGH,MEDIUM', page: 1, pageSize: 500 },
+        mockAuth,
+      );
+      expect(capturedParams?.impactSeverities).toBe('HIGH,MEDIUM');
+      expect(capturedParams?.severities).toBeUndefined();
+    } finally {
+      getSpy.mockRestore();
+    }
+  });
+
+  it('routes BLOCKER and INFO to impactSeverities on MQR server', async () => {
+    let capturedParams: Record<string, string> | undefined;
+    const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockImplementation(
+      <T>(_endpoint: string, params?: Record<string, string | number | boolean>) => {
+        capturedParams = params as Record<string, string>;
+        return Promise.resolve(emptyApiResponse as unknown as T);
+      },
+    );
+    try {
+      await listIssues(
+        { project: 'my-project', severities: 'BLOCKER,INFO', page: 1, pageSize: 500 },
+        mockAuth,
+      );
+      expect(capturedParams?.impactSeverities).toBe('BLOCKER,INFO');
+      expect(capturedParams?.severities).toBeUndefined();
+    } finally {
+      getSpy.mockRestore();
+    }
+  });
+
+  it('throws when Standard-only value is used on MQR server', () => {
+    expect(
+      listIssues({ project: 'proj', severities: 'MAJOR', page: 1, pageSize: 500 }, mockAuth),
+    ).rejects.toThrow('Invalid severity');
+  });
+
+  it('routes Standard severities to severities param on Standard server', async () => {
+    let capturedParams: Record<string, string> | undefined;
+    const getSpy = spyOn(SonarQubeClient.prototype, 'get').mockImplementation(
+      <T>(_endpoint: string, params?: Record<string, string | number | boolean>) => {
+        capturedParams = params as Record<string, string>;
+        return Promise.resolve(emptyApiResponse as unknown as T);
+      },
+    );
+    const modeSpy = spyOn(SonarQubeClient.prototype, 'getServerMode').mockResolvedValue('standard');
+    try {
+      await listIssues(
+        { project: 'my-project', severities: 'MAJOR,CRITICAL', page: 1, pageSize: 500 },
+        mockAuth,
+      );
+      expect(capturedParams?.severities).toBe('MAJOR,CRITICAL');
+      expect(capturedParams?.impactSeverities).toBeUndefined();
+    } finally {
+      getSpy.mockRestore();
+      modeSpy.mockRestore();
+    }
+  });
+
+  it('throws when MQR-only value is used on Standard server', () => {
+    const modeSpy = spyOn(SonarQubeClient.prototype, 'getServerMode').mockResolvedValue('standard');
+    try {
+      expect(
+        listIssues({ project: 'proj', severities: 'HIGH', page: 1, pageSize: 500 }, mockAuth),
+      ).rejects.toThrow('Invalid severity');
+    } finally {
+      modeSpy.mockRestore();
     }
   });
 

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -1507,4 +1507,45 @@ describe('SonarQubeClient', () => {
       expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('getServerMode', () => {
+    it('returns mqr immediately for SonarQube Cloud without calling the API', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = spyOn(globalThis, 'fetch');
+      expect(await cloudClient.getServerMode()).toBe('mqr');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('returns mqr when server responds with MQR mode', async () => {
+      fetchSpy = mockFetch({ mode: 'MQR' });
+      expect(await client.getServerMode()).toBe('mqr');
+    });
+
+    it('returns standard when server responds with STANDARD mode', async () => {
+      fetchSpy = mockFetch({ mode: 'STANDARD' });
+      expect(await client.getServerMode()).toBe('standard');
+    });
+
+    it('returns standard when endpoint returns 404 (old server without MQR support)', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve('Not Found'),
+      } as Response);
+      expect(await client.getServerMode()).toBe('standard');
+    });
+
+    it('throws when endpoint returns a server error', () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(''),
+      } as Response);
+      expect(client.getServerMode()).rejects.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **CLI improvements:**
  - Updated `--severities` filter to support both impact severity values (`HIGH`, `MEDIUM`, `LOW`) and legacy severity values.
  - Added validation logic to prevent mixing impact and legacy severities in the same command.
- **API and internal updates:**
  - Added `impactSeverities` parameter to `IssuesSearchParams` and request handlers to correctly route filtered requests to the API.
  - Updated command-line help text to clarify supported severity types for users.
- **Testing:**
  - Added comprehensive unit and integration tests to verify parameter routing and invalid input handling.


<sub>This will update automatically on new commits.</sub>