### PR TITLE
CLI-687 Update GoogleTagManager values

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -1,6 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- GTM -->
+  <script>
+    window.addEventListener('hashchange', function() {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        'event': 'hashChange',
+        'pagePath': window.location.pathname + window.location.hash
+      });
+    });
+  </script>
+  <!-- GTM -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Commands — SonarQube CLI</title>

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -3,8 +3,16 @@
 <head>
   <!-- GTM -->
   <script>
+    window.dataLayer = window.dataLayer || [];
+
+    // Initial page load
+    window.dataLayer.push({
+      'event': 'pageView',
+      'pagePath': window.location.pathname + window.location.hash
+    });
+
+    // Hash/anchor changes
     window.addEventListener('hashchange', function() {
-      window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         'event': 'hashChange',
         'pagePath': window.location.pathname + window.location.hash

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,13 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-56DR48M');</script>
-  <!-- End Google Tag Manager -->
+  <!-- GTM -->
+  <script>
+    window.addEventListener('hashchange', function() {
+      window.dataLayer = window.dataLayer || [];
+      window.dataLayer.push({
+        'event': 'hashChange',
+        'pagePath': window.location.pathname + window.location.hash
+      });
+    });
+  </script>
+  <!-- GTM -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>SonarQube CLI — cli.sonarqube.com</title>
@@ -47,13 +51,6 @@
   <script>if(localStorage.getItem('clidoc-theme')==='light')document.documentElement.setAttribute('data-theme','light');</script>
 </head>
 <body>
-
-<!-- Google Tag Manager (noscript) -->
-<noscript>
-  <iframe title="Tag Manager" src="https://www.googletagmanager.com/ns.html?id=GTM-56DR48M" height="0" width="0" style="display:none;visibility:hidden">
-  </iframe>
-</noscript>
-<!-- End Google Tag Manager (noscript) -->
 
 <!-- ─── Nav ──────────────────────────────────────────────────── -->
 <nav class="nav">

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,16 @@
 <head>
   <!-- GTM -->
   <script>
+    window.dataLayer = window.dataLayer || [];
+
+    // Initial page load
+    window.dataLayer.push({
+      'event': 'pageView',
+      'pagePath': window.location.pathname + window.location.hash
+    });
+
+    // Hash/anchor changes
     window.addEventListener('hashchange', function() {
-      window.dataLayer = window.dataLayer || [];
       window.dataLayer.push({
         'event': 'hashChange',
         'pagePath': window.location.pathname + window.location.hash


### PR DESCRIPTION
----
## Summary by Gitar

- **Analytics migration:**
  - Replaced legacy Google Tag Manager `GTM-56DR48M` implementation with `gtag.js` using property `GT-P8QQMC8` in `docs/index.html` and `docs/commands.html`.
  - Added event tracking for `hashchange` events in `docs/index.html` and `docs/commands.html`.

<sub>This will update automatically on new commits.</sub>