### PR TITLE
CLI-684 Provide feedback on SCA analysis progress

### DIFF
--- a/src/cli/commands/_common/install/binary.ts
+++ b/src/cli/commands/_common/install/binary.ts
@@ -33,7 +33,7 @@ import {
   verifyBinarySignature,
 } from '../../../../lib/sonarsource-releases';
 import { recordInstallationInState } from '../../../../lib/state-manager';
-import { print, text, withSpinner } from '../../../../ui';
+import { type OutputChannel, print, text, withSpinner } from '../../../../ui';
 import {
   cleanupOldVersionBinaries,
   ensureBinDirectory,
@@ -52,7 +52,7 @@ export interface BinarySpec {
 export interface InstallOptions {
   force?: boolean;
   binDir?: string;
-  stream?: NodeJS.WriteStream;
+  channel?: OutputChannel;
 }
 
 export interface InstallResult {
@@ -99,22 +99,22 @@ async function downloadAndInstall(
     return { skipped: true, binaryPath };
   }
 
-  const stream = options.stream ?? process.stdout;
+  const channel = options.channel ?? 'stdout';
 
-  text(`     Installing ${spec.name} ${spec.version}`, undefined, stream);
+  text(`     Installing ${spec.name} ${spec.version}`, undefined, channel);
 
   const downloadUrl = buildDownloadUrl(spec.name, spec.version, spec.distPrefix, platform);
   await withSpinner(
     `Downloading ${spec.name} ${spec.version}`,
     () => downloadBinary(downloadUrl, binaryPath),
-    stream,
+    channel,
   );
 
   try {
     await withSpinner(
       'Verifying signature',
       () => verifyBinarySignature(binaryPath, platform, spec.signatures, spec.publicKey),
-      stream,
+      channel,
     );
   } catch (err) {
     rmSync(binaryPath, { force: true });
@@ -128,9 +128,9 @@ async function downloadAndInstall(
   const installedVersion = await withSpinner(
     'Verifying installation',
     () => verifyInstallation(binaryPath),
-    stream,
+    channel,
   );
-  print(`     ${spec.name} ${installedVersion}`, stream);
+  print(`     ${spec.name} ${installedVersion}`, channel);
 
   recordInstallationInState(spec.name, installedVersion, binaryPath);
   cleanupOldVersionBinaries(resolvedBinDir, spec.name, binaryName);

--- a/src/cli/commands/_common/install/binary.ts
+++ b/src/cli/commands/_common/install/binary.ts
@@ -33,7 +33,7 @@ import {
   verifyBinarySignature,
 } from '../../../../lib/sonarsource-releases';
 import { recordInstallationInState } from '../../../../lib/state-manager';
-import { print, text, withSpinner } from '../../../../ui';
+import { print, withSpinner } from '../../../../ui';
 import {
   cleanupOldVersionBinaries,
   ensureBinDirectory,
@@ -52,6 +52,7 @@ export interface BinarySpec {
 export interface InstallOptions {
   force?: boolean;
   binDir?: string;
+  stream?: NodeJS.WriteStream;
 }
 
 export interface InstallResult {
@@ -98,16 +99,22 @@ async function downloadAndInstall(
     return { skipped: true, binaryPath };
   }
 
-  text(`     Installing ${spec.name} ${spec.version}`);
+  const stream = options.stream ?? process.stdout;
+
+  print(`     Installing ${spec.name} ${spec.version}`, stream);
 
   const downloadUrl = buildDownloadUrl(spec.name, spec.version, spec.distPrefix, platform);
-  await withSpinner(`Downloading ${spec.name} ${spec.version}`, () =>
-    downloadBinary(downloadUrl, binaryPath),
+  await withSpinner(
+    `Downloading ${spec.name} ${spec.version}`,
+    () => downloadBinary(downloadUrl, binaryPath),
+    stream,
   );
 
   try {
-    await withSpinner('Verifying signature', () =>
-      verifyBinarySignature(binaryPath, platform, spec.signatures, spec.publicKey),
+    await withSpinner(
+      'Verifying signature',
+      () => verifyBinarySignature(binaryPath, platform, spec.signatures, spec.publicKey),
+      stream,
     );
   } catch (err) {
     rmSync(binaryPath, { force: true });
@@ -118,10 +125,12 @@ async function downloadAndInstall(
     await makeExecutable(binaryPath);
   }
 
-  const installedVersion = await withSpinner('Verifying installation', () =>
-    verifyInstallation(binaryPath),
+  const installedVersion = await withSpinner(
+    'Verifying installation',
+    () => verifyInstallation(binaryPath),
+    stream,
   );
-  print(`     ${spec.name} ${installedVersion}`);
+  print(`     ${spec.name} ${installedVersion}`, stream);
 
   recordInstallationInState(spec.name, installedVersion, binaryPath);
   cleanupOldVersionBinaries(resolvedBinDir, spec.name, binaryName);

--- a/src/cli/commands/_common/install/binary.ts
+++ b/src/cli/commands/_common/install/binary.ts
@@ -33,7 +33,7 @@ import {
   verifyBinarySignature,
 } from '../../../../lib/sonarsource-releases';
 import { recordInstallationInState } from '../../../../lib/state-manager';
-import { print, withSpinner } from '../../../../ui';
+import { print, text, withSpinner } from '../../../../ui';
 import {
   cleanupOldVersionBinaries,
   ensureBinDirectory,
@@ -101,7 +101,7 @@ async function downloadAndInstall(
 
   const stream = options.stream ?? process.stdout;
 
-  print(`     Installing ${spec.name} ${spec.version}`, stream);
+  text(`     Installing ${spec.name} ${spec.version}`, undefined, stream);
 
   const downloadUrl = buildDownloadUrl(spec.name, spec.version, spec.distPrefix, platform);
   await withSpinner(

--- a/src/cli/commands/_common/install/sca-scanner.ts
+++ b/src/cli/commands/_common/install/sca-scanner.ts
@@ -43,12 +43,12 @@ export const SCA_SCANNER_SPEC: BinarySpec = {
   publicKey: SONARSOURCE_PUBLIC_KEY,
 };
 
-export async function installScaScannerBinary(
-  stream: NodeJS.WriteStream = process.stdout,
-): Promise<string> {
-  const { binaryPath, freshlyInstalled } = await installBinary(SCA_SCANNER_SPEC, { stream });
+export async function installScaScannerBinary(): Promise<string> {
+  const { binaryPath, freshlyInstalled } = await installBinary(SCA_SCANNER_SPEC, {
+    stream: process.stderr,
+  });
   if (freshlyInstalled) {
-    discreetSuccess(`${SCA_SCANNER_BINARY_NAME} installed at ${binaryPath}`, stream);
+    discreetSuccess(`${SCA_SCANNER_BINARY_NAME} installed at ${binaryPath}`, process.stderr);
   }
   return binaryPath;
 }
@@ -70,10 +70,8 @@ export interface ScaScannerInstaller {
 }
 
 export class DefaultScaScannerInstaller implements ScaScannerInstaller {
-  constructor(private readonly stream: NodeJS.WriteStream = process.stdout) {}
-
   install(): Promise<string> {
-    return installScaScannerBinary(this.stream);
+    return installScaScannerBinary();
   }
 }
 

--- a/src/cli/commands/_common/install/sca-scanner.ts
+++ b/src/cli/commands/_common/install/sca-scanner.ts
@@ -45,10 +45,10 @@ export const SCA_SCANNER_SPEC: BinarySpec = {
 
 export async function installScaScannerBinary(): Promise<string> {
   const { binaryPath, freshlyInstalled } = await installBinary(SCA_SCANNER_SPEC, {
-    stream: process.stderr,
+    channel: 'stderr',
   });
   if (freshlyInstalled) {
-    discreetSuccess(`${SCA_SCANNER_BINARY_NAME} installed at ${binaryPath}`, process.stderr);
+    discreetSuccess(`${SCA_SCANNER_BINARY_NAME} installed at ${binaryPath}`, 'stderr');
   }
   return binaryPath;
 }

--- a/src/cli/commands/_common/install/sca-scanner.ts
+++ b/src/cli/commands/_common/install/sca-scanner.ts
@@ -43,10 +43,12 @@ export const SCA_SCANNER_SPEC: BinarySpec = {
   publicKey: SONARSOURCE_PUBLIC_KEY,
 };
 
-export async function installScaScannerBinary(): Promise<string> {
-  const { binaryPath, freshlyInstalled } = await installBinary(SCA_SCANNER_SPEC);
+export async function installScaScannerBinary(
+  stream: NodeJS.WriteStream = process.stdout,
+): Promise<string> {
+  const { binaryPath, freshlyInstalled } = await installBinary(SCA_SCANNER_SPEC, { stream });
   if (freshlyInstalled) {
-    discreetSuccess(`${SCA_SCANNER_BINARY_NAME} installed at ${binaryPath}`);
+    discreetSuccess(`${SCA_SCANNER_BINARY_NAME} installed at ${binaryPath}`, stream);
   }
   return binaryPath;
 }
@@ -68,8 +70,10 @@ export interface ScaScannerInstaller {
 }
 
 export class DefaultScaScannerInstaller implements ScaScannerInstaller {
+  constructor(private readonly stream: NodeJS.WriteStream = process.stdout) {}
+
   install(): Promise<string> {
-    return installScaScannerBinary();
+    return installScaScannerBinary(this.stream);
   }
 }
 

--- a/src/cli/commands/_common/install/secrets.ts
+++ b/src/cli/commands/_common/install/secrets.ts
@@ -27,7 +27,7 @@ import {
   SONAR_SECRETS_VERSION,
   SONARSOURCE_PUBLIC_KEY,
 } from '../../../../lib/signatures';
-import { discreetSuccess } from '../../../../ui';
+import { discreetSuccess, type OutputChannel } from '../../../../ui';
 import {
   type BinarySpec,
   buildLocalBinaryName as buildBinaryName,
@@ -49,15 +49,15 @@ export const SECRETS_SPEC: BinarySpec = {
  * Use this in commands where the user implicitly consents to installation by running the command.
  */
 export async function installSecretsBinary(): Promise<string> {
-  const { binaryPath, freshlyInstalled } = await resolveSecretsBinary({ stream: process.stderr });
+  const { binaryPath, freshlyInstalled } = await resolveSecretsBinary({ channel: 'stderr' });
   if (freshlyInstalled) {
-    discreetSuccess(`sonar-secrets installed at ${binaryPath}`, process.stderr);
+    discreetSuccess(`sonar-secrets installed at ${binaryPath}`, 'stderr');
   }
   return binaryPath;
 }
 
 export async function resolveSecretsBinary(
-  options: { force?: boolean; stream?: NodeJS.WriteStream },
+  options: { force?: boolean; channel?: OutputChannel },
   { binDir }: { binDir?: string } = {},
 ): Promise<InstallResult> {
   return installBinary(SECRETS_SPEC, { ...options, binDir });

--- a/src/cli/commands/_common/install/secrets.ts
+++ b/src/cli/commands/_common/install/secrets.ts
@@ -48,16 +48,18 @@ export const SECRETS_SPEC: BinarySpec = {
  * Install sonar-secrets if not already present, and report success if freshly installed.
  * Use this in commands where the user implicitly consents to installation by running the command.
  */
-export async function installSecretsBinary(): Promise<string> {
-  const { binaryPath, freshlyInstalled } = await resolveSecretsBinary({});
+export async function installSecretsBinary(
+  stream: NodeJS.WriteStream = process.stdout,
+): Promise<string> {
+  const { binaryPath, freshlyInstalled } = await resolveSecretsBinary({ stream });
   if (freshlyInstalled) {
-    discreetSuccess(`sonar-secrets installed at ${binaryPath}`);
+    discreetSuccess(`sonar-secrets installed at ${binaryPath}`, stream);
   }
   return binaryPath;
 }
 
 export async function resolveSecretsBinary(
-  options: { force?: boolean },
+  options: { force?: boolean; stream?: NodeJS.WriteStream },
   { binDir }: { binDir?: string } = {},
 ): Promise<InstallResult> {
   return installBinary(SECRETS_SPEC, { ...options, binDir });
@@ -92,8 +94,10 @@ export interface SecretsInstaller {
  * cannot be installed, aborting the caller.
  */
 export class DefaultSecretsInstaller implements SecretsInstaller {
+  constructor(private readonly stream: NodeJS.WriteStream = process.stdout) {}
+
   install(): Promise<string> {
-    return installSecretsBinary();
+    return installSecretsBinary(this.stream);
   }
 }
 

--- a/src/cli/commands/_common/install/secrets.ts
+++ b/src/cli/commands/_common/install/secrets.ts
@@ -48,12 +48,10 @@ export const SECRETS_SPEC: BinarySpec = {
  * Install sonar-secrets if not already present, and report success if freshly installed.
  * Use this in commands where the user implicitly consents to installation by running the command.
  */
-export async function installSecretsBinary(
-  stream: NodeJS.WriteStream = process.stdout,
-): Promise<string> {
-  const { binaryPath, freshlyInstalled } = await resolveSecretsBinary({ stream });
+export async function installSecretsBinary(): Promise<string> {
+  const { binaryPath, freshlyInstalled } = await resolveSecretsBinary({ stream: process.stderr });
   if (freshlyInstalled) {
-    discreetSuccess(`sonar-secrets installed at ${binaryPath}`, stream);
+    discreetSuccess(`sonar-secrets installed at ${binaryPath}`, process.stderr);
   }
   return binaryPath;
 }
@@ -94,10 +92,8 @@ export interface SecretsInstaller {
  * cannot be installed, aborting the caller.
  */
 export class DefaultSecretsInstaller implements SecretsInstaller {
-  constructor(private readonly stream: NodeJS.WriteStream = process.stdout) {}
-
   install(): Promise<string> {
-    return installSecretsBinary(this.stream);
+    return installSecretsBinary();
   }
 }
 

--- a/src/cli/commands/_common/sonar-command.ts
+++ b/src/cli/commands/_common/sonar-command.ts
@@ -143,7 +143,7 @@ export class SonarCommand extends Command {
       blank();
       error(thrownError.message);
       if (cliError?.remediationHint) {
-        print(`  → ${cliError.remediationHint}`, process.stderr);
+        print(`  → ${cliError.remediationHint}`, 'stderr');
       }
       logger.error(thrownError.message);
       process.exitCode = cliError?.exitCode ?? 1;

--- a/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
@@ -23,6 +23,7 @@ import { isAbsolute, join } from 'node:path';
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import logger from '../../../../lib/logger';
+import { withSpinner } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 import { formatSpawnOutput } from '../../_common/install/install-utils';
 import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
@@ -49,8 +50,11 @@ export async function preScanManifestsForSecrets(deps: {
     ...invocation,
     workDir: join(tmpdir(), `sonar-sca-discover-${Date.now()}`),
   };
-  const manifestFiles = await new ScaDiscoverManifestsRunner(scaInstaller, scaSpawner).run(
-    discoverInvocation,
+  await scaInstaller.install(); // up front so its download spinners don't nest inside the discovery spinner
+  const manifestFiles = await withSpinner(
+    'Discovering dependency manifests',
+    () => new ScaDiscoverManifestsRunner(scaInstaller, scaSpawner).run(discoverInvocation),
+    process.stderr,
   );
   const resolvedFiles = manifestFiles.map((file) =>
     isAbsolute(file) ? file : join(baseDir, file),
@@ -78,7 +82,11 @@ async function scanManifestsForSecrets(
 
   // Spawn error propagate so the callers decide what it means
   // (the command aborts; the hook's wrapper turns it into a non-blocking warning).
-  const result = await runSecretsBinary(binaryPath, files, auth);
+  const result = await withSpinner(
+    'Scanning manifests for secrets',
+    () => runSecretsBinary(binaryPath, files, auth),
+    process.stderr,
+  );
   const exitCode = result.exitCode ?? 1;
 
   if (exitCode === EXIT_CODE_SECRETS_FOUND) {

--- a/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
@@ -50,11 +50,8 @@ export async function preScanManifestsForSecrets(deps: {
     ...invocation,
     workDir: join(tmpdir(), `sonar-sca-discover-${Date.now()}`),
   };
-  await scaInstaller.install(); // up front so its download spinners don't nest inside the discovery spinner
-  const manifestFiles = await withSpinner(
-    'Discovering dependency manifests',
-    () => new ScaDiscoverManifestsRunner(scaInstaller, scaSpawner).run(discoverInvocation),
-    'stderr',
+  const manifestFiles = await new ScaDiscoverManifestsRunner(scaInstaller, scaSpawner).run(
+    discoverInvocation,
   );
   const resolvedFiles = manifestFiles.map((file) =>
     isAbsolute(file) ? file : join(baseDir, file),

--- a/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
@@ -54,7 +54,7 @@ export async function preScanManifestsForSecrets(deps: {
   const manifestFiles = await withSpinner(
     'Discovering dependency manifests',
     () => new ScaDiscoverManifestsRunner(scaInstaller, scaSpawner).run(discoverInvocation),
-    process.stderr,
+    'stderr',
   );
   const resolvedFiles = manifestFiles.map((file) =>
     isAbsolute(file) ? file : join(baseDir, file),
@@ -85,7 +85,7 @@ async function scanManifestsForSecrets(
   const result = await withSpinner(
     'Scanning manifests for secrets',
     () => runSecretsBinary(binaryPath, files, auth),
-    process.stderr,
+    'stderr',
   );
   const exitCode = result.exitCode ?? 1;
 

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-discover-manifests.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-discover-manifests.ts
@@ -32,11 +32,12 @@ interface DiscoverManifestsPayload {
  * discovered manifest/lockfile paths (relative to the invocation base dir).
  */
 export class ScaDiscoverManifestsRunner extends ScaScannerRunnerBase<string[]> {
+  protected readonly spinnerLabel = 'Discovering dependency manifests';
+  protected readonly errorPrefix = 'Manifest discovery error';
+
   buildArgs(invocation: ScaScannerInvocation): string[] {
     return this.buildBaseArgs('discover-manifests', invocation);
   }
-
-  protected readonly errorPrefix = 'Manifest discovery error';
 
   protected parseResult(result: SpawnResult): string[] {
     const parsed = this.parseJson(result) as DiscoverManifestsPayload;

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -25,6 +25,7 @@ import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { SCA_SCANNER_CACHE_DIR } from '../../../../lib/config-constants';
 import logger, { getLogLevelConfig } from '../../../../lib/logger';
 import { type SonarQubeClient } from '../../../../sonarqube/client';
+import type { SettingsValue } from '../../../../sonarqube/settings-value';
 import { withSpinner } from '../../../../ui';
 import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
 import type { SecretsInstaller } from '../../_common/install/secrets';
@@ -45,14 +46,7 @@ export class ScaScanOrchestrator {
   ) {}
 
   async run(auth: ResolvedAuth, projectKey: string): Promise<AnalyzeProjectResponse> {
-    const settings = await withSpinner(
-      'Checking dependency analysis availability',
-      async () => {
-        await assertScaAvailable(this.client, auth);
-        return this.client.getProjectSettings(projectKey);
-      },
-      process.stderr,
-    );
+    const settings = await this.synchronizeSettings(auth, projectKey);
     const properties = parseAnalysisProperties(settings);
     logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
     const { apiBaseUrl, downloadBaseUrl } = buildScaUrls(auth);
@@ -80,6 +74,23 @@ export class ScaScanOrchestrator {
       secretsInstaller: this.secretsInstaller,
     });
 
+    return this.analyzeDependencyRisks(invocation);
+  }
+
+  private synchronizeSettings(auth: ResolvedAuth, projectKey: string): Promise<SettingsValue[]> {
+    return withSpinner(
+      'Synchronizing settings',
+      async () => {
+        await assertScaAvailable(this.client, auth);
+        return this.client.getProjectSettings(projectKey);
+      },
+      process.stderr,
+    );
+  }
+
+  private analyzeDependencyRisks(
+    invocation: ScaScannerInvocation,
+  ): Promise<AnalyzeProjectResponse> {
     return withSpinner(
       'Analyzing dependency risks',
       () => new ScaScannerRunner(this.installer, this.spawner).run(invocation),

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -84,7 +84,7 @@ export class ScaScanOrchestrator {
         await assertScaAvailable(this.client, auth);
         return this.client.getProjectSettings(projectKey);
       },
-      process.stderr,
+      'stderr',
     );
   }
 
@@ -94,7 +94,7 @@ export class ScaScanOrchestrator {
     return withSpinner(
       'Analyzing dependency risks',
       () => new ScaScannerRunner(this.installer, this.spawner).run(invocation),
-      process.stderr,
+      'stderr',
     );
   }
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -91,10 +91,6 @@ export class ScaScanOrchestrator {
   private analyzeDependencyRisks(
     invocation: ScaScannerInvocation,
   ): Promise<AnalyzeProjectResponse> {
-    return withSpinner(
-      'Analyzing dependency risks',
-      () => new ScaScannerRunner(this.installer, this.spawner).run(invocation),
-      'stderr',
-    );
+    return new ScaScannerRunner(this.installer, this.spawner).run(invocation);
   }
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -25,6 +25,7 @@ import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { SCA_SCANNER_CACHE_DIR } from '../../../../lib/config-constants';
 import logger, { getLogLevelConfig } from '../../../../lib/logger';
 import { type SonarQubeClient } from '../../../../sonarqube/client';
+import { withSpinner } from '../../../../ui';
 import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
 import type { SecretsInstaller } from '../../_common/install/secrets';
 import { assertScaAvailable } from '../../_common/sca-availability';
@@ -44,8 +45,14 @@ export class ScaScanOrchestrator {
   ) {}
 
   async run(auth: ResolvedAuth, projectKey: string): Promise<AnalyzeProjectResponse> {
-    await assertScaAvailable(this.client, auth);
-    const settings = await this.client.getProjectSettings(projectKey);
+    const settings = await withSpinner(
+      'Checking dependency analysis availability',
+      async () => {
+        await assertScaAvailable(this.client, auth);
+        return this.client.getProjectSettings(projectKey);
+      },
+      process.stderr,
+    );
     const properties = parseAnalysisProperties(settings);
     logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
     const { apiBaseUrl, downloadBaseUrl } = buildScaUrls(auth);
@@ -73,6 +80,10 @@ export class ScaScanOrchestrator {
       secretsInstaller: this.secretsInstaller,
     });
 
-    return new ScaScannerRunner(this.installer, this.spawner).run(invocation);
+    return withSpinner(
+      'Analyzing dependency risks',
+      () => new ScaScannerRunner(this.installer, this.spawner).run(invocation),
+      process.stderr,
+    );
   }
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-runner-base.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-runner-base.ts
@@ -23,7 +23,7 @@ import { rmSync } from 'node:fs';
 import { LOG_FILE } from '../../../../lib/config-constants.ts';
 import logger from '../../../../lib/logger.ts';
 import type { SpawnResult } from '../../../../lib/process.ts';
-import { warn } from '../../../../ui';
+import { warn, withSpinner } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error.ts';
 import { type ScaScannerInstaller } from '../../_common/install/sca-scanner.ts';
 import { type ScaScannerSpawner } from './sca-scanner-spawner.ts';
@@ -67,7 +67,11 @@ export abstract class ScaScannerRunnerBase<T> {
     const env = { [SONAR_TOKEN_ENV]: invocation.sonarToken };
     const binaryPath = await this.installer.install();
     try {
-      const result = await this.spawnScanner(binaryPath, args, env);
+      const result = await withSpinner(
+        this.spinnerLabel,
+        () => this.spawnScanner(binaryPath, args, env),
+        'stderr',
+      );
       logger.info(`SCA Scanner stdout\n${result.stdout}`);
       logger.warn(`SCA Scanner stderr\n${result.stderr}`);
       this.assertSuccessfulExit(result);
@@ -109,6 +113,9 @@ export abstract class ScaScannerRunnerBase<T> {
     }
     return args;
   }
+
+  /** Spinner label for this runner's subcommand execution. */
+  protected abstract readonly spinnerLabel: string;
 
   /** Prefix prepended to every error message (e.g. `Manifest discovery error: failed to parse output (…)`). */
   protected abstract readonly errorPrefix: string;

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner.ts
@@ -100,13 +100,14 @@ export interface AnalysisErrorResource {
 }
 
 export class ScaScannerRunner extends ScaScannerRunnerBase<AnalyzeProjectResponse> {
+  protected readonly spinnerLabel = 'Analyzing dependency risks';
+  protected readonly errorPrefix = 'Dependency risk analysis error';
+
   buildArgs(invocation: ScaScannerInvocation): string[] {
     return this.buildBaseArgs('analyze-project', invocation, [
       `--project-key=${invocation.projectKey}`,
     ]);
   }
-
-  protected readonly errorPrefix = 'Dependency risk analysis error';
 
   protected parseResult(result: SpawnResult): AnalyzeProjectResponse {
     return this.parseJson(result) as AnalyzeProjectResponse;

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -63,9 +63,9 @@ export async function analyzeDependencyRisks(
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
   const result = await new ScaScanOrchestrator(
     client,
-    new DefaultScaScannerInstaller(process.stderr),
+    new DefaultScaScannerInstaller(),
     new DefaultScaScannerSpawner(),
-    new DefaultSecretsInstaller(process.stderr),
+    new DefaultSecretsInstaller(),
   ).run(auth, projectKey);
 
   const viewModel = buildDependencyRisksViewModel(result, filter);

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -63,9 +63,9 @@ export async function analyzeDependencyRisks(
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
   const result = await new ScaScanOrchestrator(
     client,
-    new DefaultScaScannerInstaller(),
+    new DefaultScaScannerInstaller(process.stderr),
     new DefaultScaScannerSpawner(),
-    new DefaultSecretsInstaller(),
+    new DefaultSecretsInstaller(process.stderr),
   ).run(auth, projectKey);
 
   const viewModel = buildDependencyRisksViewModel(result, filter);
@@ -88,13 +88,13 @@ async function resolveProjectKey(
   auth: ResolvedAuth,
 ): Promise<string> {
   if (explicitProject) {
-    print(`Using project key: ${explicitProject}`, process.stderr);
+    print(`     Using project key: ${explicitProject}`, process.stderr);
     return explicitProject;
   }
 
   const discovered = await discoverProject(process.cwd(), true, { auth });
   if (discovered.projectKey) {
-    print(`Using auto-detected project key: ${discovered.projectKey}`, process.stderr);
+    print(`     Using auto-detected project key: ${discovered.projectKey}`, process.stderr);
     return discovered.projectKey;
   }
 

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -88,13 +88,13 @@ async function resolveProjectKey(
   auth: ResolvedAuth,
 ): Promise<string> {
   if (explicitProject) {
-    print(`     Using project key: ${explicitProject}`, process.stderr);
+    print(`     Using project key: ${explicitProject}`, 'stderr');
     return explicitProject;
   }
 
   const discovered = await discoverProject(process.cwd(), true, { auth });
   if (discovered.projectKey) {
-    print(`     Using auto-detected project key: ${discovered.projectKey}`, process.stderr);
+    print(`     Using auto-detected project key: ${discovered.projectKey}`, 'stderr');
     return discovered.projectKey;
   }
 

--- a/src/cli/commands/integrate/_common/context-augmentation.ts
+++ b/src/cli/commands/integrate/_common/context-augmentation.ts
@@ -27,7 +27,14 @@ import logger from '../../../../lib/logger';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../../lib/signatures';
 import type { IntegrationStateAttribute } from '../../../../lib/state';
 import { SonarQubeClient } from '../../../../sonarqube/client';
-import { discreetSuccess, print, text, warn, withSpinner } from '../../../../ui';
+import {
+  discreetSuccess,
+  type OutputChannel,
+  print,
+  text,
+  warn,
+  withSpinner,
+} from '../../../../ui';
 import { buildContextAugmentationEnv } from '../../_common/context-augmentation-env';
 import { CommandFailedError } from '../../_common/error';
 
@@ -316,8 +323,8 @@ function reportCagFailure(result: CagSubprocessResult): void {
   if (result.failureMessage) {
     warn(result.failureMessage);
   }
-  printIndented(result.stdout, process.stdout);
-  printIndented(result.stderr, process.stderr);
+  printIndented(result.stdout, 'stdout');
+  printIndented(result.stderr, 'stderr');
 }
 
 function reportCagFailureFromError(error: unknown): void {
@@ -328,12 +335,12 @@ function reportCagFailureFromError(error: unknown): void {
   warn((error as Error).message);
 }
 
-function printIndented(buffer: string, target: NodeJS.WriteStream): void {
+function printIndented(buffer: string, channel: OutputChannel): void {
   if (buffer.length === 0) {
     return;
   }
   const trimmed = buffer.endsWith('\n') ? buffer.slice(0, -1) : buffer;
   for (const line of trimmed.split('\n')) {
-    print(`  ${line}`, target);
+    print(`  ${line}`, channel);
   }
 }

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -142,17 +142,17 @@ export class SonarQubeClient {
     const url = `${transformedServerURL}${endpoint}`;
 
     if (debug) {
-      print(`request method: ${method}`, process.stderr);
-      print(`request url: ${url}`, process.stderr);
-      print(`request headers: ${JSON.stringify(redactSensitiveHeaders(headers))}`, process.stderr);
-      print(`request body: ${requestBody}`, process.stderr);
+      print(`request method: ${method}`, 'stderr');
+      print(`request url: ${url}`, 'stderr');
+      print(`request headers: ${JSON.stringify(redactSensitiveHeaders(headers))}`, 'stderr');
+      print(`request body: ${requestBody}`, 'stderr');
     }
 
     const response = await fetchGuarded(url, buildFetchInit(method, headers, timeout, requestBody));
 
     if (debug) {
-      print(`response status: ${response.status}`, process.stderr);
-      print(`response headers: ${JSON.stringify(response.headers)}`, process.stderr);
+      print(`response status: ${response.status}`, 'stderr');
+      print(`response headers: ${JSON.stringify(response.headers)}`, 'stderr');
     }
 
     await this.raiseForStatus(response, method);

--- a/src/ui/components/spinner.ts
+++ b/src/ui/components/spinner.ts
@@ -30,31 +30,35 @@ const INTERVAL_MS = 80;
  * Run task with animated spinner. Shows ✓ on success, ✗ on failure.
  * Falls back to plain print in non-TTY or mock mode.
  */
-export async function withSpinner<T>(message: string, task: () => Promise<T>): Promise<T> {
+export async function withSpinner<T>(
+  message: string,
+  task: () => Promise<T>,
+  stream: NodeJS.WriteStream = process.stdout,
+): Promise<T> {
   if (isMockActive()) {
     recordCall('spinner', message);
     return await task();
   }
 
-  if (!process.stdout.isTTY) {
-    process.stdout.write(`${message}...\n`);
+  if (!stream.isTTY) {
+    stream.write(`${message}...\n`);
     return await task();
   }
 
   let frame = 0;
   const interval = setInterval(() => {
-    process.stdout.write(`\r  ${cyan(FRAMES[frame])}  ${message}`);
+    stream.write(`\r  ${cyan(FRAMES[frame])}  ${message}`);
     frame = (frame + 1) % FRAMES.length;
   }, INTERVAL_MS);
 
   try {
     const result = await task();
     clearInterval(interval);
-    process.stdout.write(`\r  ${green('✓')}  ${message}\n`);
+    stream.write(`\r  ${green('✓')}  ${message}\n`);
     return result;
   } catch (err) {
     clearInterval(interval);
-    process.stdout.write(`\r  ${red('✗')}  ${message}\n`);
+    stream.write(`\r  ${red('✗')}  ${message}\n`);
     throw err;
   }
 }

--- a/src/ui/components/spinner.ts
+++ b/src/ui/components/spinner.ts
@@ -21,7 +21,9 @@
 // Spinner — animated indicator for long-running async operations
 
 import { cyan, green, red } from '../colors.js';
+import { channelStream } from '../messages.js';
 import { isMockActive, recordCall } from '../mock.js';
+import type { OutputChannel } from '../types.js';
 
 const FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const INTERVAL_MS = 80;
@@ -33,12 +35,14 @@ const INTERVAL_MS = 80;
 export async function withSpinner<T>(
   message: string,
   task: () => Promise<T>,
-  stream: NodeJS.WriteStream = process.stdout,
+  channel: OutputChannel = 'stdout',
 ): Promise<T> {
   if (isMockActive()) {
     recordCall('spinner', message);
     return await task();
   }
+
+  const stream = channelStream(channel);
 
   if (!stream.isTTY) {
     stream.write(`${message}...\n`);

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -56,4 +56,4 @@ export {
   queueMockResponse,
   setMockUi,
 } from './mock.js';
-export type { ColorFn, LogOptions, NoteOptions, PhaseOptions } from './types.js';
+export type { ColorFn, LogOptions, NoteOptions, OutputChannel, PhaseOptions } from './types.js';

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -22,7 +22,7 @@
 
 import { cyan, green, isTTY, red, yellow } from './colors.js';
 import { isMockActive, recordCall } from './mock.js';
-import type { ColorFn } from './types.js';
+import type { ColorFn, OutputChannel } from './types.js';
 
 let _formattedOutputMode = false;
 const _collectedMessages: string[] = [];
@@ -49,6 +49,10 @@ function write(stream: NodeJS.WriteStream, line: string): void {
   stream.write(line + '\n');
 }
 
+export function channelStream(channel: OutputChannel): NodeJS.WriteStream {
+  return channel === 'stderr' ? process.stderr : process.stdout;
+}
+
 export function info(message: string): void {
   if (isMockActive()) {
     recordCall('info', message);
@@ -73,21 +77,18 @@ export function success(message: string): void {
   write(process.stdout, `✅ ${green(message)}`);
 }
 
-export function discreetSuccess(
-  message: string,
-  stream: NodeJS.WriteStream = process.stdout,
-): void {
+export function discreetSuccess(message: string, channel: OutputChannel = 'stdout'): void {
   if (isMockActive()) {
     recordCall('discreetSuccess', message);
     return;
   }
   // Only stdout participates in formatted-output buffering; an explicit stderr
-  // stream writes through immediately since stderr does not carry the payload.
-  if (stream === process.stdout && _formattedOutputMode) {
+  // channel writes through immediately since stderr does not carry the payload.
+  if (channel === 'stdout' && _formattedOutputMode) {
     _collectedMessages.push(`  ✓  ${message}`);
     return;
   }
-  write(stream, `  ${green('✓')}  ${message}`);
+  write(channelStream(channel), `  ${green('✓')}  ${message}`);
 }
 
 export function warn(message: string): void {
@@ -107,32 +108,28 @@ export function error(message: string): void {
 }
 
 // Plain terminal output — human-readable, no semantic icon, optional color
-export function text(
-  message: string,
-  color?: ColorFn,
-  stream: NodeJS.WriteStream = process.stdout,
-): void {
+export function text(message: string, color?: ColorFn, channel: OutputChannel = 'stdout'): void {
   if (isMockActive()) {
     recordCall('text', message);
     return;
   }
   // Only stdout participates in formatted-output buffering; an explicit stderr
-  // stream writes through immediately since stderr does not carry the payload.
-  if (stream === process.stdout && _formattedOutputMode) {
+  // channel writes through immediately since stderr does not carry the payload.
+  if (channel === 'stdout' && _formattedOutputMode) {
     _collectedMessages.push(message);
     return;
   }
   const formatted = color ? color(message) : message;
-  write(stream, formatted);
+  write(channelStream(channel), formatted);
 }
 
 // Raw stream output — no color, no prefix — safe for piping: sonar issues search | jq
-export function print(message: string, stream: NodeJS.WriteStream = process.stdout): void {
+export function print(message: string, channel: OutputChannel = 'stdout'): void {
   if (isMockActive()) {
     recordCall('print', message);
     return;
   }
-  stream.write(message + (message.endsWith('\n') ? '' : '\n'));
+  channelStream(channel).write(message + (message.endsWith('\n') ? '' : '\n'));
 }
 
 // Newline separator

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -107,17 +107,23 @@ export function error(message: string): void {
 }
 
 // Plain terminal output — human-readable, no semantic icon, optional color
-export function text(message: string, color?: ColorFn): void {
+export function text(
+  message: string,
+  color?: ColorFn,
+  stream: NodeJS.WriteStream = process.stdout,
+): void {
   if (isMockActive()) {
     recordCall('text', message);
     return;
   }
-  if (_formattedOutputMode) {
+  // Only stdout participates in formatted-output buffering; an explicit stderr
+  // stream writes through immediately since stderr does not carry the payload.
+  if (stream === process.stdout && _formattedOutputMode) {
     _collectedMessages.push(message);
     return;
   }
   const formatted = color ? color(message) : message;
-  write(process.stdout, formatted);
+  write(stream, formatted);
 }
 
 // Raw stream output — no color, no prefix — safe for piping: sonar issues search | jq

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -73,16 +73,21 @@ export function success(message: string): void {
   write(process.stdout, `✅ ${green(message)}`);
 }
 
-export function discreetSuccess(message: string): void {
+export function discreetSuccess(
+  message: string,
+  stream: NodeJS.WriteStream = process.stdout,
+): void {
   if (isMockActive()) {
     recordCall('discreetSuccess', message);
     return;
   }
-  if (_formattedOutputMode) {
+  // Only stdout participates in formatted-output buffering; an explicit stderr
+  // stream writes through immediately since stderr does not carry the payload.
+  if (stream === process.stdout && _formattedOutputMode) {
     _collectedMessages.push(`  ✓  ${message}`);
     return;
   }
-  write(process.stdout, `  ${green('✓')}  ${message}`);
+  write(stream, `  ${green('✓')}  ${message}`);
 }
 
 export function warn(message: string): void {

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -22,6 +22,8 @@
 
 export type ColorFn = (text: string) => string;
 
+export type OutputChannel = 'stdout' | 'stderr';
+
 export type StepStatus =
   | 'done' // ✓  green
   | 'running' // →  cyan

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -146,10 +146,10 @@ describe('analyze dependency-risks', () => {
       });
 
       // Progress one-liner + spinner labels belong on stderr.
-      expect(result.stderr).toContain('Checking dependency analysis availability');
+      expect(result.stderr).toContain('Synchronizing settings');
       expect(result.stderr).toContain('Discovering dependency manifests');
       // stdout must stay clean: no progress text leaks into the payload stream.
-      expect(result.stdout).not.toContain('Checking dependency analysis availability');
+      expect(result.stdout).not.toContain('Synchronizing settings');
       expect(result.stdout).not.toContain('Discovering dependency manifests');
       expect(result.stdout).not.toContain('Analyzing dependency risks');
     },

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -58,20 +58,26 @@ describe('analyze dependency-risks', () => {
     { timeout: 15000 },
   );
 
-  it('exits with code 1 when project does not exist (settings 404)', async () => {
-    const server = await harness
-      .newFakeServer()
-      .withAuthToken(VALID_TOKEN)
-      .withScaEnabled(true)
-      .start();
-    harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+  it(
+    'exits with code 1 when project does not exist (settings 404)',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withScaEnabled(true)
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-    const result = await harness.run('analyze dependency-risks --project demo');
+      const result = await harness.run('analyze dependency-risks --project demo');
 
-    expect(result.exitCode).toBe(1);
-    expect(result.stdout + result.stderr).toContain('Project demo not found');
-    expect(server.getRecordedRequests().some((r) => r.path === '/api/settings/values')).toBe(true);
-  });
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain('Project demo not found');
+      expect(server.getRecordedRequests().some((r) => r.path === '/api/settings/values')).toBe(
+        true,
+      );
+    },
+    { timeout: 15000 },
+  );
 
   it(
     'exits with code 1 when SCA is disabled on the server',

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -123,6 +123,34 @@ describe('analyze dependency-risks', () => {
   );
 
   it(
+    'routes progress to stderr and keeps stdout free of progress noise',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withScaEnabled(true)
+        .withProject('demo')
+        .withProjectSettings('demo', [])
+        .start();
+      harness.state().withScaScannerBinaryInstalled();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      const result = await harness.run('analyze dependency-risks --project demo --format json', {
+        timeoutMs: 30_000,
+      });
+
+      // Progress one-liner + spinner labels belong on stderr.
+      expect(result.stderr).toContain('Checking dependency analysis availability');
+      expect(result.stderr).toContain('Discovering dependency manifests');
+      // stdout must stay clean: no progress text leaks into the payload stream.
+      expect(result.stdout).not.toContain('Checking dependency analysis availability');
+      expect(result.stdout).not.toContain('Discovering dependency manifests');
+      expect(result.stdout).not.toContain('Analyzing dependency risks');
+    },
+    { timeout: 30000 },
+  );
+
+  it(
     'auto-installs sca-scanner-cli when binary is absent',
     async () => {
       await harness.newFakeBinariesServer().start();

--- a/tests/unit/ui/messages.test.ts
+++ b/tests/unit/ui/messages.test.ts
@@ -182,7 +182,7 @@ describe('messages: real output (non-mock)', () => {
       return true;
     });
     try {
-      text('to stderr', undefined, process.stderr);
+      text('to stderr', undefined, 'stderr');
       expect(output.join('')).toContain('to stderr');
     } finally {
       spy.mockRestore();
@@ -197,7 +197,7 @@ describe('messages: real output (non-mock)', () => {
     });
     setFormattedOutputMode(true);
     try {
-      text('to stderr', undefined, process.stderr);
+      text('to stderr', undefined, 'stderr');
       expect(output.join('')).toContain('to stderr');
       expect(getMessagesForFormattedOutput()).toEqual([]);
     } finally {
@@ -268,7 +268,7 @@ describe('messages: real output (non-mock)', () => {
       return true;
     });
     try {
-      discreetSuccess('installed', process.stderr);
+      discreetSuccess('installed', 'stderr');
       expect(output.join('')).toContain('installed');
     } finally {
       spy.mockRestore();
@@ -283,7 +283,7 @@ describe('messages: real output (non-mock)', () => {
     });
     setFormattedOutputMode(true);
     try {
-      discreetSuccess('installed', process.stderr);
+      discreetSuccess('installed', 'stderr');
       expect(output.join('')).toContain('installed');
       expect(getMessagesForFormattedOutput()).toEqual([]);
     } finally {

--- a/tests/unit/ui/messages.test.ts
+++ b/tests/unit/ui/messages.test.ts
@@ -23,7 +23,18 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import { blank, error, info, print, success, text, warn } from '../../../src/ui';
+import {
+  blank,
+  discreetSuccess,
+  error,
+  getMessagesForFormattedOutput,
+  info,
+  print,
+  setFormattedOutputMode,
+  success,
+  text,
+  warn,
+} from '../../../src/ui';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../src/ui';
 
 // ─── Mock mode ────────────────────────────────────────────────────────────────
@@ -189,6 +200,64 @@ describe('messages: real output (non-mock)', () => {
       expect(output.join('')).toBe('line\n');
     } finally {
       spy.mockRestore();
+    }
+  });
+
+  it('discreetSuccess writes to stdout by default', () => {
+    const output: string[] = [];
+    const spy = spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    try {
+      discreetSuccess('installed');
+      expect(output.join('')).toContain('installed');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('discreetSuccess writes to stderr when an explicit stderr stream is passed', () => {
+    const output: string[] = [];
+    const spy = spyOn(process.stderr, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    try {
+      discreetSuccess('installed', process.stderr);
+      expect(output.join('')).toContain('installed');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('discreetSuccess on stderr is not buffered in formatted-output mode', () => {
+    const output: string[] = [];
+    const spy = spyOn(process.stderr, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    setFormattedOutputMode(true);
+    try {
+      discreetSuccess('installed', process.stderr);
+      expect(output.join('')).toContain('installed');
+      expect(getMessagesForFormattedOutput()).toEqual([]);
+    } finally {
+      setFormattedOutputMode(false);
+      spy.mockRestore();
+    }
+  });
+
+  it('discreetSuccess on stdout is buffered in formatted-output mode', () => {
+    const stdoutSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    setFormattedOutputMode(true);
+    try {
+      discreetSuccess('buffered line');
+      expect(getMessagesForFormattedOutput().some((m) => m.includes('buffered line'))).toBe(true);
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    } finally {
+      setFormattedOutputMode(false);
+      stdoutSpy.mockRestore();
     }
   });
 });

--- a/tests/unit/ui/messages.test.ts
+++ b/tests/unit/ui/messages.test.ts
@@ -175,6 +175,50 @@ describe('messages: real output (non-mock)', () => {
     }
   });
 
+  it('text writes to stderr when an explicit stderr stream is passed', () => {
+    const output: string[] = [];
+    const spy = spyOn(process.stderr, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    try {
+      text('to stderr', undefined, process.stderr);
+      expect(output.join('')).toContain('to stderr');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('text on stderr is not buffered in formatted-output mode', () => {
+    const output: string[] = [];
+    const spy = spyOn(process.stderr, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    setFormattedOutputMode(true);
+    try {
+      text('to stderr', undefined, process.stderr);
+      expect(output.join('')).toContain('to stderr');
+      expect(getMessagesForFormattedOutput()).toEqual([]);
+    } finally {
+      setFormattedOutputMode(false);
+      spy.mockRestore();
+    }
+  });
+
+  it('text on stdout is buffered in formatted-output mode', () => {
+    const stdoutSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    setFormattedOutputMode(true);
+    try {
+      text('buffered text');
+      expect(getMessagesForFormattedOutput().some((m) => m.includes('buffered text'))).toBe(true);
+      expect(stdoutSpy).not.toHaveBeenCalled();
+    } finally {
+      setFormattedOutputMode(false);
+      stdoutSpy.mockRestore();
+    }
+  });
+
   it('print writes message to stdout', () => {
     const output: string[] = [];
     const spy = spyOn(process.stdout, 'write').mockImplementation((s) => {

--- a/tests/unit/ui/ui-components.test.ts
+++ b/tests/unit/ui/ui-components.test.ts
@@ -384,7 +384,7 @@ describe('withSpinner: non-TTY output', () => {
       return true;
     });
     try {
-      await withSpinner('On stderr', () => Promise.resolve('done'), process.stderr);
+      await withSpinner('On stderr', () => Promise.resolve('done'), 'stderr');
       expect(stderr.some((s) => s.includes('On stderr'))).toBe(true);
       expect(stdout.join('')).not.toContain('On stderr');
     } finally {

--- a/tests/unit/ui/ui-components.test.ts
+++ b/tests/unit/ui/ui-components.test.ts
@@ -371,4 +371,25 @@ describe('withSpinner: non-TTY output', () => {
       writeSpy.mockRestore();
     }
   });
+
+  it('writes to the provided stream (stderr) instead of stdout', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, 'write').mockImplementation((s) => {
+      stdout.push(String(s));
+      return true;
+    });
+    const stderrSpy = spyOn(process.stderr, 'write').mockImplementation((s) => {
+      stderr.push(String(s));
+      return true;
+    });
+    try {
+      await withSpinner('On stderr', () => Promise.resolve('done'), process.stderr);
+      expect(stderr.some((s) => s.includes('On stderr'))).toBe(true);
+      expect(stdout.join('')).not.toContain('On stderr');
+    } finally {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **UI & UX improvements:**
  - Added `OutputChannel` type to route terminal output to either `stdout` or `stderr`.
  - Updated `withSpinner`, `text`, `discreetSuccess`, and `print` helpers to support explicit stream selection.
- **Refactor:**
  - Redirected CLI progress indicators (spinners and status text) to `stderr` in `ScaScanOrchestrator` and `manifest-secrets-guard` to keep `stdout` clean for programmatic (JSON) output.
  - Updated binary installers and debug logging to default or route appropriately to `stderr`.
- **Tests:**
  - Added integration test `routes progress to stderr and keeps stdout free of progress noise` to verify stream isolation.
  - Added unit tests for UI stream routing in `messages.test.ts` and `ui-components.test.ts`.

<sub>This will update automatically on new commits.</sub>