### PR TITLE
CLI-663 SQAA validation and structured HTTP error handling

### DIFF
--- a/.cursor/rules/sonarqube-cli.mdc
+++ b/.cursor/rules/sonarqube-cli.mdc
@@ -14,8 +14,13 @@ The entry point is generated. To add or change commands, edit `src/cli/command-t
 ## Always use `runCommand()` for command handlers
 Every command action must be wrapped in `runCommand()` from `src/lib/run-command.ts`. Never catch or handle errors manually in command handlers.
 
-## After editing any `.ts` file, format
-Run `bun run format` before finishing. Non-negotiable.
+## After editing any `.ts` file, format and fix imports
+Before finishing, run both — non-negotiable:
+
+1. `bun run format` — Prettier
+2. `bun run lint:fix` — ESLint autofix, including `simple-import-sort/imports` for import order
+
+If only one file changed, `bun x eslint --fix <file>` is fine for step 2.
 
 ## Constants from `config-constants.ts`
 All paths and URLs must be imported from `src/lib/config-constants.ts`. Never hardcode paths or URLs inline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ bun run test:e2e          # end-to-end tests
 - Always fix TypeScript errors before considering a task done.
 - Never attempt to fix linting issues until the implementation is correct.
 - Use `import type` for type-only imports.
-- **MANDATORY**: After editing any `.ts` file, run `bun run format` to format all source files at once, or `bun x prettier --write <file>` for a single file.
+- **MANDATORY**: After editing any `.ts` file, run `bun run format` (or `bun x prettier --write <file>`), then `bun run lint:fix` (or `bun x eslint --fix <file>`) so ESLint autofix applies `simple-import-sort/imports` and other safe fixes.
 
 ## Commands
 

--- a/src/cli/commands/analyze/sqaa-analysis.ts
+++ b/src/cli/commands/analyze/sqaa-analysis.ts
@@ -23,7 +23,6 @@
 import { getSqaaRetry503BaseDelayMs } from '../../../lib/config-constants';
 import type { SqaaIssue } from '../../../sonarqube/client';
 import type { SqaaProgress } from '../../../ui/components/sqaa-progress.js';
-import { CommandFailedError } from '../_common/error.js';
 import {
   fetchChunkWith413Split,
   MAX_503_RETRIES,
@@ -33,6 +32,7 @@ import {
 } from './sqaa-api';
 import type { CloudAuth } from './sqaa-auth';
 import { type SqaaChunk, type SqaaChunkFile } from './sqaa-chunking';
+import { isPayloadTooLargeCommandError } from './sqaa-errors.js';
 
 export type FileSuccess = {
   file: string;
@@ -44,9 +44,6 @@ export type FileFailure = { file: string; filePath: string; failure: Error };
 export type FileResult = FileSuccess | FileFailure;
 
 type ChunkPath = { file: string; filePath: string };
-
-const PAYLOAD_TOO_LARGE_FAILURE_MESSAGE =
-  'SonarQube Agentic Analysis failed.\n  Request payload too large.';
 
 export interface RunContext {
   files: string[];
@@ -130,7 +127,13 @@ function prepareChunks(
 
   const chunks: SqaaChunk[] = [{ files: readableChunkFiles }];
   const chunkFileIndices = [
-    readableChunkFiles.map((f) => fileIndexByAbsolutePath.get(f.absolutePath)!),
+    readableChunkFiles.map((f) => {
+      const idx = fileIndexByAbsolutePath.get(f.absolutePath);
+      if (idx === undefined) {
+        throw new Error(`Missing file index for ${f.absolutePath}`);
+      }
+      return idx;
+    }),
   ];
   return { chunks, chunkFileIndices };
 }
@@ -143,7 +146,10 @@ function chunkPathsForFiles(
   const partPaths: ChunkPath[] = [];
   const partIndices: number[] = [];
   for (const chunkFile of chunkFiles) {
-    const idx = fileIndexByAbsolutePath.get(chunkFile.absolutePath)!;
+    const idx = fileIndexByAbsolutePath.get(chunkFile.absolutePath);
+    if (idx === undefined) {
+      continue;
+    }
     partPaths.push({ file: chunkFile.absolutePath, filePath: ctx.allPaths[idx] });
     partIndices.push(idx);
   }
@@ -170,28 +176,6 @@ function recordSuccessfulParts(
     }
     const { partPaths, partIndices } = chunkPathsForFiles(ctx, part.files, fileIndexByAbsolutePath);
     recordChunkSuccess(progress, tally, partIndices, partPaths, part.response);
-  }
-}
-
-function recordPayloadTooLargeFailures(
-  ctx: RunContext,
-  tally: RunTally,
-  progress: SqaaProgress,
-  failedFiles: SqaaChunkFile[],
-  fileIndexByAbsolutePath: Map<string, number>,
-): void {
-  for (const failed of failedFiles) {
-    const idx = fileIndexByAbsolutePath.get(failed.absolutePath);
-    if (idx === undefined) {
-      continue;
-    }
-    recordFileFailure(
-      progress,
-      tally,
-      idx,
-      { file: failed.absolutePath, filePath: ctx.allPaths[idx] },
-      new CommandFailedError(PAYLOAD_TOO_LARGE_FAILURE_MESSAGE),
-    );
   }
 }
 
@@ -222,12 +206,12 @@ function recordGroupFetchErrors(
 /** Whether to continue remaining chunks after a mixed or successful chunk fetch. */
 export function shouldContinueAfterChunk(
   parts: Array<{ response: SqaaChunkResponse; files: SqaaChunkFile[] }>,
-  failedFiles: SqaaChunkFile[],
   groupErrors: SqaaChunkGroupError[],
 ): boolean {
-  const totalChunkFailure =
-    parts.length === 0 && failedFiles.length === 0 && groupErrors.length > 0;
-  return !totalChunkFailure;
+  if (groupErrors.length === 0 || parts.length > 0) {
+    return true;
+  }
+  return groupErrors.every((group) => isPayloadTooLargeCommandError(group.error));
 }
 
 async function processChunk(
@@ -242,7 +226,7 @@ async function processChunk(
   markChunkAnalyzing(ctx.progress, chunkIndex, fileIndices);
 
   try {
-    const { parts, failedFiles, groupErrors } = await fetchChunkWith413Split(
+    const { parts, groupErrors } = await fetchChunkWith413Split(
       ctx.cloudAuth,
       ctx.projectKey,
       chunk.files,
@@ -260,11 +244,10 @@ async function processChunk(
     );
 
     recordSuccessfulParts(ctx, tally, ctx.progress, parts, fileIndexByAbsolutePath);
-    recordPayloadTooLargeFailures(ctx, tally, ctx.progress, failedFiles, fileIndexByAbsolutePath);
     recordGroupFetchErrors(ctx, tally, ctx.progress, groupErrors, fileIndexByAbsolutePath);
 
     ctx.progress.updateChunk(chunkIndex, 'done');
-    return shouldContinueAfterChunk(parts, failedFiles, groupErrors);
+    return shouldContinueAfterChunk(parts, groupErrors);
   } catch (err) {
     recordChunkFailure(ctx.progress, tally, chunkIndex, fileIndices, chunkPaths, err as Error);
     return false;

--- a/src/cli/commands/analyze/sqaa-api.ts
+++ b/src/cli/commands/analyze/sqaa-api.ts
@@ -30,16 +30,19 @@ import { RequestPayloadTooLargeError, ServiceUnavailableError } from '../../../s
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
 import type { CloudAuth } from './sqaa-auth';
 import { type PackChunksLimits, packFilesIntoChunks, type SqaaChunkFile } from './sqaa-chunking';
-import { displaySqaaResults } from './sqaa-display';
+import { displaySqaaResults, printSingleFileTextFailure } from './sqaa-display';
+import {
+  payloadTooLargeCommandError,
+  sqaaCommandFailedError,
+  toSqaaCommandError,
+} from './sqaa-errors.js';
+import { partitionSqaaAnalysisFiles, type SqaaFileValidationRejection } from './sqaa-validation.js';
 
 /** Maximum number of retries on 503 responses. */
 export const MAX_503_RETRIES = 3;
 
 /** Interval for the live countdown tick in milliseconds. */
 const COUNTDOWN_TICK_MS = 1000;
-
-const SQAA_FAILURE_HINT =
-  'Check your SonarQube Cloud authentication, project key, and network connectivity, then retry.';
 
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -78,34 +81,75 @@ function isRetryableSqaaError(err: unknown, includePayloadTooLarge: boolean): bo
   return includePayloadTooLarge && err instanceof RequestPayloadTooLargeError;
 }
 
+export type SqaaPostResult = {
+  response: SqaaChunkResponse;
+  rejected: SqaaFileValidationRejection[];
+};
+
+function validChunkFilesAfterRejection(
+  chunkFiles: SqaaChunkFile[],
+  rejected: SqaaFileValidationRejection[],
+): SqaaChunkFile[] {
+  const rejectedIndices = new Set<number>(rejected.map((entry) => entry.index));
+  return chunkFiles.filter((_, index) => !rejectedIndices.has(index));
+}
+
+function validationGroupErrors(
+  rejected: SqaaFileValidationRejection[],
+  chunkFiles: SqaaChunkFile[],
+): SqaaChunkGroupError[] {
+  return rejected.map(({ index, error }) => ({
+    files: chunkFiles[index] ? [chunkFiles[index]] : [],
+    error,
+  }));
+}
+
 async function postSqaaAnalysis(
   auth: CloudAuth,
   projectKey: string,
   branch: string | undefined,
   files: SqaaAnalysisFile[],
   options: { analysisDepth?: 'DEEP'; includePayloadTooLarge?: boolean } = {},
-): Promise<SqaaChunkResponse> {
+): Promise<SqaaPostResult> {
+  const { valid, rejected } = partitionSqaaAnalysisFiles(files, {
+    analysisDepth: options.analysisDepth,
+  });
+
+  if (valid.length === 0) {
+    throw (
+      rejected[0]?.error ?? sqaaCommandFailedError('files[] must contain at least one valid file.')
+    );
+  }
+
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
   try {
-    return await client.createAnalysis({
+    const response = await client.createAnalysis({
       organizationKey: auth.orgKey,
       projectKey,
       ...(branch ? { branchName: branch } : {}),
       ...(options.analysisDepth ? { analysisDepth: options.analysisDepth } : {}),
-      files,
+      files: valid,
     });
+    return { response, rejected };
   } catch (err) {
     if (isRetryableSqaaError(err, options.includePayloadTooLarge ?? false)) {
       throw err;
     }
-    throw new CommandFailedError(
-      `SonarQube Agentic Analysis failed.\n  ${(err as Error).message}`,
-      {
-        cause: err,
-        remediationHint: SQAA_FAILURE_HINT,
-      },
-    );
+    throw toSqaaCommandError(err);
   }
+}
+
+/** Validated SQAA POST for hook and other callers outside the analyze command. */
+export async function submitValidatedSqaaAnalysis(
+  auth: CloudAuth,
+  projectKey: string,
+  files: SqaaAnalysisFile[],
+  options: { branch?: string; analysisDepth?: 'DEEP' } = {},
+): Promise<SqaaChunkResponse> {
+  const { response } = await postSqaaAnalysis(auth, projectKey, options.branch, files, {
+    analysisDepth: options.analysisDepth,
+  });
+  return response;
 }
 
 /**
@@ -125,7 +169,13 @@ export async function fetchSqaaResponse(
   pathBase?: string,
 ): Promise<{ issues: SqaaIssue[]; errors?: Array<{ code: string; message: string }> | null }> {
   const filePath = toRelativePosixPath(file, pathBase);
-  return postSqaaAnalysis(auth, projectKey, branch, [{ path: filePath, content: fileContent }]);
+  const { response, rejected } = await postSqaaAnalysis(auth, projectKey, branch, [
+    { path: filePath, content: fileContent },
+  ]);
+  if (rejected.length > 0) {
+    throw rejected[0].error;
+  }
+  return response;
 }
 
 async function with503Retry<T>(
@@ -182,7 +232,6 @@ export type SqaaChunkPart = {
 
 export type SqaaChunkFetchResult = {
   parts: SqaaChunkPart[];
-  failedFiles: SqaaChunkFile[];
   groupErrors: SqaaChunkGroupError[];
 };
 
@@ -226,7 +275,7 @@ export async function fetchChunkResponse(
   projectKey: string,
   files: SqaaAnalysisFile[],
   branch: string | undefined,
-): Promise<SqaaChunkResponse> {
+): Promise<SqaaPostResult> {
   return postSqaaAnalysis(auth, projectKey, branch, files, {
     analysisDepth: 'DEEP',
     includePayloadTooLarge: true,
@@ -242,7 +291,7 @@ export async function fetchChunkWithRetry(
   files: SqaaAnalysisFile[],
   branch: string | undefined,
   onRetry?: (attempt: number) => Promise<void>,
-): Promise<SqaaChunkResponse> {
+): Promise<SqaaPostResult> {
   return with503Retry(() => fetchChunkResponse(auth, projectKey, files, branch), onRetry);
 }
 
@@ -276,7 +325,6 @@ async function fetchSplitParts(
   onPayloadSplit?: () => void,
 ): Promise<SqaaChunkFetchResult> {
   const parts: SqaaChunkPart[] = [];
-  const failedFiles: SqaaChunkFile[] = [];
   const groupErrors: SqaaChunkGroupError[] = [];
   for (const group of partGroups) {
     try {
@@ -289,7 +337,6 @@ async function fetchSplitParts(
         onPayloadSplit,
       );
       parts.push(...result.parts);
-      failedFiles.push(...result.failedFiles);
       groupErrors.push(...result.groupErrors);
     } catch (err) {
       if (isTransientChunkFetchError(err)) {
@@ -298,7 +345,7 @@ async function fetchSplitParts(
       groupErrors.push({ files: group, error: err as Error });
     }
   }
-  return { parts, failedFiles, groupErrors };
+  return { parts, groupErrors };
 }
 
 /**
@@ -313,37 +360,63 @@ export async function fetchChunkWith413Split(
   onRetry?: (attempt: number) => Promise<void>,
   onPayloadSplit?: () => void,
 ): Promise<SqaaChunkFetchResult> {
+  const analysisFiles = toAnalysisFiles(chunkFiles);
+  const preflight = partitionSqaaAnalysisFiles(analysisFiles, { analysisDepth: 'DEEP' });
+  if (preflight.valid.length === 0) {
+    return {
+      parts: [],
+      groupErrors: validationGroupErrors(preflight.rejected, chunkFiles),
+    };
+  }
+
   try {
-    const response = await fetchChunkWithRetry(
+    const { response, rejected } = await fetchChunkWithRetry(
       auth,
       projectKey,
-      toAnalysisFiles(chunkFiles),
+      analysisFiles,
       branch,
       onRetry,
     );
+    const validationErrors = validationGroupErrors(rejected, chunkFiles);
+    const validChunkFiles = validChunkFilesAfterRejection(chunkFiles, rejected);
+
     return {
-      parts: [{ response, files: chunkFiles }],
-      failedFiles: [],
-      groupErrors: [],
+      parts: [{ response, files: validChunkFiles }],
+      groupErrors: validationErrors,
     };
   } catch (err) {
     if (!(err instanceof RequestPayloadTooLargeError)) {
       throw err;
     }
-    if (chunkFiles.length === 1) {
-      return { parts: [], failedFiles: chunkFiles, groupErrors: [] };
+
+    const { rejected } = preflight;
+    const validationErrors = validationGroupErrors(rejected, chunkFiles);
+    const validChunkFiles = validChunkFilesAfterRejection(chunkFiles, rejected);
+
+    if (validChunkFiles.length === 1) {
+      return {
+        parts: [],
+        groupErrors: [
+          ...validationErrors,
+          { files: validChunkFiles, error: payloadTooLargeCommandError(err) },
+        ],
+      };
     }
 
     onPayloadSplit?.();
 
-    return fetchSplitParts(
+    const splitResult = await fetchSplitParts(
       auth,
       projectKey,
-      splitChunkFiles(chunkFiles, packLimitsFrom413Error(auth, projectKey, branch, err)),
+      splitChunkFiles(validChunkFiles, packLimitsFrom413Error(auth, projectKey, branch, err)),
       branch,
       onRetry,
       onPayloadSplit,
     );
+    return {
+      parts: splitResult.parts,
+      groupErrors: [...validationErrors, ...splitResult.groupErrors],
+    };
   }
 }
 
@@ -386,7 +459,7 @@ export async function defaultRetryCountdown(
 
 /**
  * Call the SQAA API and display the results for the single-file path.
- * Returns the number of issues found. Throws CommandFailedError on API failure.
+ * Returns the number of issues found. Analysis failures render as a ✗ file row (exit 1).
  */
 export async function callSqaaApiAndDisplay(
   auth: CloudAuth,
@@ -395,6 +468,12 @@ export async function callSqaaApiAndDisplay(
   fileContent: string,
   branch: string | undefined,
 ): Promise<number> {
-  const response = await fetchWithRetry(auth, projectKey, file, fileContent, branch);
-  return displaySqaaResults(response.issues, response.errors, toRelativePosixPath(file));
+  const filePath = toRelativePosixPath(file);
+  try {
+    const response = await fetchWithRetry(auth, projectKey, file, fileContent, branch);
+    return displaySqaaResults(response.issues, response.errors, filePath);
+  } catch (err) {
+    printSingleFileTextFailure(filePath, err as Error);
+    return 0;
+  }
 }

--- a/src/cli/commands/analyze/sqaa-display.ts
+++ b/src/cli/commands/analyze/sqaa-display.ts
@@ -25,9 +25,11 @@ import { basename, dirname } from 'node:path';
 import type { SqaaIssue } from '../../../sonarqube/client';
 import { print, text } from '../../../ui';
 import { bold, dim, green, red, softBlue, yellow } from '../../../ui/colors.js';
+import { CliError } from '../_common/error.js';
 import type { FileFailure, FileResult, FileSuccess, RunTally } from './sqaa-analysis';
 import { toRelativePosixPath } from './sqaa-api';
 import type { IgnoredFile } from './sqaa-changeset';
+import { SQAA_FAILURE_HEADING } from './sqaa-errors.js';
 
 /** When analyzed file count exceeds this, clean files collapse to one summary row. */
 export const SQAA_COLLAPSE_CLEAN_THRESHOLD = 20;
@@ -36,6 +38,40 @@ export const SQAA_COLLAPSE_CLEAN_THRESHOLD = 20;
 export const EXIT_CODE_ISSUES_FOUND = 51;
 
 const ISSUE_LINE_INDENT = '     ';
+
+function stripSqaaFailureHeading(text: string): string | null {
+  const trimmed = text.trim();
+  if (trimmed.length === 0 || trimmed === SQAA_FAILURE_HEADING) {
+    return null;
+  }
+  const headingPrefix = `${SQAA_FAILURE_HEADING} `;
+  if (trimmed.startsWith(headingPrefix)) {
+    return trimmed.slice(headingPrefix.length);
+  }
+  return trimmed;
+}
+
+function failureDetailLines(message: string): string[] {
+  return message
+    .split('\n')
+    .map((line) => stripSqaaFailureHeading(line))
+    .filter((line): line is string => line != null && line.length > 0);
+}
+
+/** Indented detail + optional remediation hint for a failed file row. */
+export function renderFailureDetailLines(error: Error, colored: boolean): string[] {
+  const lines: string[] = [];
+  for (const detail of failureDetailLines(error.message)) {
+    const line = `${ISSUE_LINE_INDENT}${detail}`;
+    lines.push(colored ? dim(line) : line);
+  }
+  const hint = error instanceof CliError ? error.remediationHint : undefined;
+  if (hint) {
+    const line = `${ISSUE_LINE_INDENT}→ ${hint}`;
+    lines.push(colored ? dim(line) : line);
+  }
+  return lines;
+}
 
 export interface SqaaJsonReport {
   files: Array<{
@@ -226,22 +262,40 @@ export function computeRunSummaryStats(tally: RunTally, allPaths: string[]): Sqa
 
 function formatSqaaRunSummary(stats: SqaaRunSummaryStats, colored: boolean): string {
   const num = (n: number) => (colored ? yellow(String(n)) : String(n));
+  const failNum = (n: number) => (colored ? red(String(n)) : String(n));
   const lbl = (s: string) => (colored ? bold(s) : s);
   const okIcon = colored ? green('✓') : '✓';
 
-  if (stats.totalFailures > 0) {
+  const hasFailures = stats.totalFailures > 0;
+  const hasIssues = stats.totalIssues > 0;
+  const hasErrors = stats.totalErrors > 0;
+
+  if (!hasFailures && !hasIssues && !hasErrors) {
+    return `${okIcon} ${lbl('No issues found')} · ${num(stats.filesAnalyzed)} ${lbl('files analyzed')}`;
+  }
+
+  const parts: string[] = [`${num(stats.filesAnalyzed)} ${lbl('files analyzed')}`];
+
+  if (hasFailures) {
     const failureWord = stats.totalFailures === 1 ? 'failure' : 'failures';
-    return `${num(stats.filesAnalyzed)} ${lbl('files analyzed')} · ${num(stats.totalFailures)} ${lbl(failureWord)}`;
+    parts.push(`${failNum(stats.totalFailures)} ${lbl(failureWord)}`);
   }
-  if (stats.totalIssues > 0) {
+  if (hasIssues) {
     const issueWord = stats.totalIssues === 1 ? 'issue' : 'issues';
-    return `${num(stats.filesAnalyzed)} ${lbl('files analyzed')} · ${num(stats.filesWithIssues)} ${lbl('with issues')} · ${num(stats.totalIssues)} ${lbl(issueWord)} found`;
+    parts.push(
+      `${num(stats.filesWithIssues)} ${lbl('with issues')}`,
+      `${num(stats.totalIssues)} ${lbl(issueWord)} found`,
+    );
   }
-  if (stats.totalErrors > 0) {
+  if (hasErrors) {
     const errorWord = stats.totalErrors === 1 ? 'error' : 'errors';
-    return `${num(stats.filesAnalyzed)} ${lbl('files analyzed')} · ${num(stats.filesWithErrors)} ${lbl('with errors')} · ${num(stats.totalErrors)} ${lbl(errorWord)}`;
+    parts.push(
+      `${num(stats.filesWithErrors)} ${lbl('with errors')}`,
+      `${num(stats.totalErrors)} ${lbl(errorWord)}`,
+    );
   }
-  return `${okIcon}  ${lbl('No issues found')} · ${num(stats.filesAnalyzed)} ${lbl('files analyzed')}`;
+
+  return parts.join(' · ');
 }
 
 /** Plain-text run summary footer. */
@@ -304,10 +358,10 @@ function renderFileEntryLines(
   }
 
   if ('failure' in result) {
-    const messageLine = colored
-      ? dim(`     ${result.failure.message}`)
-      : `     ${result.failure.message}`;
-    return [formatFailedFileRow(path, colored), messageLine];
+    return [
+      formatFailedFileRow(path, colored),
+      ...renderFailureDetailLines(result.failure, colored),
+    ];
   }
 
   if (fileHasFindings(result)) {
@@ -411,6 +465,17 @@ export function printSqaaTextReport(options: PrintSqaaTextReportOptions): void {
   text('');
   text(formatSqaaRunSummaryColored(stats));
   applyExitCode(stats);
+}
+
+/** Single `--file` failure: same ✗ row + summary footer as change-set analysis. */
+export function printSingleFileTextFailure(filePath: string, error: Error): void {
+  const tally: RunTally = {
+    allResults: [{ file: filePath, filePath, failure: error }],
+    totalIssues: 0,
+    totalErrors: 0,
+    totalFailures: 1,
+  };
+  printSqaaTextReport({ tally, allPaths: [filePath] });
 }
 
 export function makeReport(

--- a/src/cli/commands/analyze/sqaa-errors.ts
+++ b/src/cli/commands/analyze/sqaa-errors.ts
@@ -1,0 +1,136 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Map SQAA API errors to CLI errors with remediation hints.
+
+import { BadRequestError, RequestPayloadTooLargeError } from '../../../sonarqube/errors.js';
+import { CommandFailedError, type CommandFailedErrorOptions } from '../_common/error.js';
+
+const GENERIC_SQAA_FAILURE_HINT =
+  'Check your SonarQube Cloud authentication, project key, and network connectivity, then retry.';
+
+/** Shown on command-level failures; stripped from per-file ✗ rows in sqaa-display. */
+export const SQAA_FAILURE_HEADING = 'SonarQube Agentic Analysis failed.';
+
+export function sqaaFailureMessage(detail: string): string {
+  return `${SQAA_FAILURE_HEADING} ${detail}`;
+}
+
+export function sqaaCommandFailedError(
+  detail: string,
+  options?: CommandFailedErrorOptions,
+): CommandFailedError {
+  return new CommandFailedError(sqaaFailureMessage(detail), options);
+}
+
+function formatBytesLimit(bytes: number): string {
+  if (bytes >= 1024 * 1024) {
+    return `${Math.round(bytes / (1024 * 1024))} MB`;
+  }
+  if (bytes >= 1024) {
+    return `${Math.round(bytes / 1024)} KB`;
+  }
+  return `${bytes} bytes`;
+}
+
+export function payloadTooLargeRemediationHint(err?: RequestPayloadTooLargeError): string {
+  const maxBytes = err?.meta?.maxRequestSize;
+  const maxFiles = err?.meta?.maxFiles;
+
+  if (err?.code === 'TOO_MANY_FILES') {
+    if (maxFiles != null) {
+      return `Send fewer files per request (server limit: ${maxFiles} files). Split the change set into smaller batches.`;
+    }
+    return 'Send fewer files per request. Split the change set into smaller batches.';
+  }
+
+  if (err?.code === 'REQUEST_TOO_LARGE') {
+    if (maxBytes != null) {
+      return `Reduce file sizes or send fewer files per request (server limit: ${formatBytesLimit(maxBytes)}).`;
+    }
+    return 'Reduce file sizes or send fewer files per request.';
+  }
+
+  if (maxBytes != null || maxFiles != null) {
+    const parts: string[] = [];
+    if (maxBytes != null) {
+      parts.push(`max request size ${formatBytesLimit(maxBytes)}`);
+    }
+    if (maxFiles != null) {
+      parts.push(`max ${maxFiles} files per request`);
+    }
+    return `The request exceeds server limits (${parts.join(', ')}). Send fewer or smaller files.`;
+  }
+
+  return 'The analysis request exceeds server size limits. Try analyzing fewer or smaller files.';
+}
+
+export function payloadTooLargeCommandError(err?: RequestPayloadTooLargeError): CommandFailedError {
+  const message = err?.message ?? 'Request payload too large.';
+  return sqaaCommandFailedError(message, {
+    cause: err,
+    remediationHint: payloadTooLargeRemediationHint(err),
+  });
+}
+
+export function isPayloadTooLargeCommandError(error: Error): boolean {
+  return error instanceof CommandFailedError && error.cause instanceof RequestPayloadTooLargeError;
+}
+
+function badRequestRemediationHint(err: BadRequestError): string | undefined {
+  switch (err.code) {
+    case undefined:
+      return undefined;
+    case 'INVALID_FILE_PATH':
+      return "Use project-relative POSIX paths (e.g. 'src/index.ts') without '..' or absolute prefixes.";
+    case 'INVALID_ANALYSIS_DEPTH':
+      return "Use analysisDepth 'STANDARD' or 'DEEP'.";
+    case 'INVALID_SCOPE':
+      return "Use scope 'MAIN' or 'TEST' when set, or omit scope.";
+    case 'DUPLICATE_FILE_PATH':
+      return 'Remove duplicate paths from files[] before retrying.';
+    default:
+      return undefined;
+  }
+}
+
+export function badRequestCommandError(err: BadRequestError): CommandFailedError {
+  return sqaaCommandFailedError(err.message, {
+    cause: err,
+    remediationHint: badRequestRemediationHint(err),
+  });
+}
+
+/** Convert an API-layer error into a user-facing {@link CommandFailedError}. */
+export function toSqaaCommandError(err: unknown): CommandFailedError {
+  if (err instanceof CommandFailedError) {
+    return err;
+  }
+  if (err instanceof BadRequestError) {
+    return badRequestCommandError(err);
+  }
+  if (err instanceof RequestPayloadTooLargeError) {
+    return payloadTooLargeCommandError(err);
+  }
+  return sqaaCommandFailedError((err as Error).message, {
+    cause: err,
+    remediationHint: GENERIC_SQAA_FAILURE_HINT,
+  });
+}

--- a/src/cli/commands/analyze/sqaa-validation.ts
+++ b/src/cli/commands/analyze/sqaa-validation.ts
@@ -179,8 +179,8 @@ export function validateSqaaAnalysisFiles(
     throw emptyFilesValidationError();
   }
 
-  const { valid, rejected } = partitionSqaaAnalysisFiles(files, options);
-  if (rejected.length > 0 || valid.length === 0) {
-    throw rejected[0]?.error ?? emptyFilesValidationError();
+  const { rejected } = partitionSqaaAnalysisFiles(files, options);
+  if (rejected.length > 0) {
+    throw rejected[0].error;
   }
 }

--- a/src/cli/commands/analyze/sqaa-validation.ts
+++ b/src/cli/commands/analyze/sqaa-validation.ts
@@ -1,0 +1,186 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Pre-flight validation for SQAA analysis requests (before POST).
+
+import type { SqaaAnalysisDepth, SqaaAnalysisFile, SqaaFileScope } from '../../../sonarqube/client';
+import type { CommandFailedError } from '../_common/error.js';
+import { sqaaCommandFailedError } from './sqaa-errors.js';
+
+const VALID_SCOPES = new Set<SqaaFileScope>(['MAIN', 'TEST']);
+const VALID_DEPTHS = new Set<SqaaAnalysisDepth>(['STANDARD', 'DEEP']);
+
+const ABSOLUTE_PATH_PATTERN = /^([a-zA-Z]:[/\\]|\/)/;
+
+export interface ValidateSqaaAnalysisOptions {
+  analysisDepth?: SqaaAnalysisDepth;
+}
+
+export type SqaaFileValidationRejection = {
+  /** Index in the original files[] array (used to map rejections back to chunk files). */
+  index: number;
+  file: SqaaAnalysisFile;
+  error: CommandFailedError;
+};
+
+export type PartitionSqaaAnalysisFilesResult = {
+  valid: SqaaAnalysisFile[];
+  rejected: SqaaFileValidationRejection[];
+};
+
+function makeValidationError(message: string, remediationHint: string): CommandFailedError {
+  return sqaaCommandFailedError(message, { remediationHint });
+}
+
+function relativePathValidationError(path: string): CommandFailedError | undefined {
+  if (ABSOLUTE_PATH_PATTERN.test(path)) {
+    return makeValidationError(
+      `File path must be project-relative, not absolute: '${path}'`,
+      "Use a path relative to the repository root (e.g. 'src/index.ts'), not an absolute path.",
+    );
+  }
+  if (path.includes('\\')) {
+    return makeValidationError(
+      `File path must use forward slashes: '${path}'`,
+      "Normalize paths to POSIX form (e.g. 'src/index.ts').",
+    );
+  }
+  const segments = path.split('/');
+  if (segments.includes('..')) {
+    return makeValidationError(
+      `File path must not contain '..': '${path}'`,
+      'Remove parent-directory segments and use a path inside the repository.',
+    );
+  }
+  if (segments.some((segment) => segment === '.' && path !== '.')) {
+    return makeValidationError(
+      `File path must not contain '.' segments: '${path}'`,
+      'Use a clean project-relative path without ./ prefixes.',
+    );
+  }
+  if (path.length === 0) {
+    return makeValidationError(
+      'File path must not be empty.',
+      'Provide a non-empty project-relative path for each file entry.',
+    );
+  }
+  return undefined;
+}
+
+function scopeValidationError(
+  scope: SqaaFileScope | undefined,
+  path: string,
+): CommandFailedError | undefined {
+  if (scope === undefined) {
+    return undefined;
+  }
+  if (!VALID_SCOPES.has(scope)) {
+    return makeValidationError(
+      `Invalid scope '${scope}' for file '${path}'.`,
+      "Use scope 'MAIN' or 'TEST' when set, or omit scope entirely.",
+    );
+  }
+  return undefined;
+}
+
+function analysisDepthValidationError(
+  analysisDepth: SqaaAnalysisDepth | undefined,
+): CommandFailedError | undefined {
+  if (analysisDepth === undefined) {
+    return undefined;
+  }
+  if (!VALID_DEPTHS.has(analysisDepth)) {
+    return makeValidationError(
+      `Invalid analysisDepth '${analysisDepth}'.`,
+      "Use analysisDepth 'STANDARD' or 'DEEP'.",
+    );
+  }
+  return undefined;
+}
+
+function duplicatePathValidationError(path: string): CommandFailedError {
+  return makeValidationError(
+    `Duplicate file path in request: '${path}'`,
+    'Remove duplicate entries from files[] before retrying.',
+  );
+}
+
+function emptyFilesValidationError(): CommandFailedError {
+  return makeValidationError(
+    'files[] must contain at least one file.',
+    'Include at least one file with path and content in the analysis request.',
+  );
+}
+
+function validateSqaaAnalysisFile(file: SqaaAnalysisFile): CommandFailedError | undefined {
+  return relativePathValidationError(file.path) ?? scopeValidationError(file.scope, file.path);
+}
+
+/**
+ * Validate each file independently. Invalid entries are returned in `rejected`;
+ * valid entries are posted in `valid`. Duplicate paths reject later occurrences.
+ */
+export function partitionSqaaAnalysisFiles(
+  files: SqaaAnalysisFile[],
+  options: ValidateSqaaAnalysisOptions = {},
+): PartitionSqaaAnalysisFilesResult {
+  const depthError = analysisDepthValidationError(options.analysisDepth);
+  if (depthError) {
+    throw depthError;
+  }
+
+  const valid: SqaaAnalysisFile[] = [];
+  const rejected: SqaaFileValidationRejection[] = [];
+  const seen = new Set<string>();
+
+  for (const [index, file] of files.entries()) {
+    const fileError = validateSqaaAnalysisFile(file);
+    if (fileError) {
+      rejected.push({ index, file, error: fileError });
+      continue;
+    }
+    if (seen.has(file.path)) {
+      rejected.push({ index, file, error: duplicatePathValidationError(file.path) });
+      continue;
+    }
+    seen.add(file.path);
+    valid.push(file);
+  }
+
+  return { valid, rejected };
+}
+
+/**
+ * Strict validation for callers that require every file to be valid.
+ * Throws {@link CommandFailedError} (exit 1) when any file fails or files[] is empty.
+ */
+export function validateSqaaAnalysisFiles(
+  files: SqaaAnalysisFile[],
+  options: ValidateSqaaAnalysisOptions = {},
+): void {
+  if (files.length === 0) {
+    throw emptyFilesValidationError();
+  }
+
+  const { valid, rejected } = partitionSqaaAnalysisFiles(files, options);
+  if (rejected.length > 0 || valid.length === 0) {
+    throw rejected[0]?.error ?? emptyFilesValidationError();
+  }
+}

--- a/src/cli/commands/analyze/sqaa.ts
+++ b/src/cli/commands/analyze/sqaa.ts
@@ -20,7 +20,7 @@
 import { existsSync } from 'node:fs';
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
-import { blank, print, text, warn } from '../../../ui';
+import { print, text, warn } from '../../../ui';
 import { SqaaProgress } from '../../../ui/components/sqaa-progress.js';
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
 import type { RunContext } from './sqaa-analysis';
@@ -125,13 +125,11 @@ export async function analyzeSqaa(
   const changeSet = await resolveChangeSet(process.cwd(), { staged, base });
 
   if (changeSet.files.length === 0 && changeSet.ignored.length === 0) {
-    blank();
     text('SonarQube Agentic Analysis: no files in the change set to analyze.');
     return;
   }
 
   if (changeSet.files.length === 0) {
-    blank();
     text(
       'SonarQube Agentic Analysis: no files to analyze — all change set files were excluded (binary or oversized).',
     );
@@ -217,9 +215,11 @@ async function runSqaaAnalysisOnFiles(
   };
   try {
     const tally = await runAnalyses(ctx);
-    printSqaaTextReport({ tally, allPaths, ignoredPaths });
-  } finally {
     progress.finish();
+    printSqaaTextReport({ tally, allPaths, ignoredPaths });
+  } catch (err) {
+    progress.finish();
+    throw err;
   }
 }
 

--- a/src/cli/commands/hook/agent-post-tool-use.ts
+++ b/src/cli/commands/hook/agent-post-tool-use.ts
@@ -26,7 +26,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolveAuth } from '../../../lib/auth-resolver';
 import { canonicalizePath, toRelativePosixPath } from '../../../lib/fs-utils';
 import logger from '../../../lib/logger';
-import { SonarQubeClient } from '../../../sonarqube/client';
+import { submitValidatedSqaaAnalysis } from '../analyze/sqaa-api';
 import { formatSqaaIssuesForHook, writePostToolUseHookOutput } from './format-sqaa-hook-context';
 import { readStdinJson } from './stdin';
 
@@ -68,13 +68,12 @@ export async function agentPostToolUse(options: AgentPostToolUseOptions): Promis
 
   try {
     const fileContent = readFileSync(canonicalPath, 'utf-8');
-    const client = new SonarQubeClient(auth.serverUrl, auth.token);
 
-    const response = await client.createAnalysis({
-      organizationKey: auth.orgKey,
+    const response = await submitValidatedSqaaAnalysis(
+      { serverUrl: auth.serverUrl, token: auth.token, orgKey: auth.orgKey },
       projectKey,
-      files: [{ path: normalizedPath, content: fileContent }],
-    });
+      [{ path: normalizedPath, content: fileContent }],
+    );
 
     const text = formatSqaaIssuesForHook(response.issues, response.errors, normalizedPath);
     writePostToolUseHookOutput(text);

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -26,6 +26,7 @@ import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import logger from '../lib/logger';
 import { print } from '../ui';
 import {
+  BadRequestError,
   RateLimitError,
   RequestPayloadTooLargeError,
   type RequestPayloadTooLargeMeta,
@@ -38,6 +39,7 @@ const GET_REQUEST_TIMEOUT_MS = 30000; // 30 seconds
 const POST_REQUEST_TIMEOUT_MS = 60000; // 60 seconds for analysis
 /** Best-effort token revocation should fail fast when the server is unreachable. */
 const REVOKE_USER_TOKEN_TIMEOUT_MS = 10_000;
+const HTTP_STATUS_BAD_REQUEST = 400;
 const HTTP_STATUS_FORBIDDEN = 403;
 const HTTP_STATUS_NOT_FOUND = 404;
 const HTTP_STATUS_PAYLOAD_TOO_LARGE = 413;
@@ -89,6 +91,9 @@ export class SonarQubeClient {
     }
     if (response.status === HTTP_STATUS_SERVICE_UNAVAILABLE) {
       throw new ServiceUnavailableError();
+    }
+    if (method === 'POST' && response.status === HTTP_STATUS_BAD_REQUEST) {
+      throw await parseBadRequestError(response);
     }
     if (method === 'POST' && response.status === HTTP_STATUS_PAYLOAD_TOO_LARGE) {
       throw await parseRequestPayloadTooLargeError(response);
@@ -172,7 +177,10 @@ export class SonarQubeClient {
 
     await this.raiseForStatus(result.response, 'GET');
 
-    return result.value!;
+    if (result.value === undefined) {
+      throw new Error('SonarQube API error: empty response body');
+    }
+    return result.value;
   }
 
   // false positive
@@ -658,26 +666,55 @@ function redactSensitiveHeaders(headers: Record<string, string>): Record<string,
   return headers;
 }
 
+interface StructuredErrorBody {
+  message?: string;
+  code?: string;
+  meta?: RequestPayloadTooLargeMeta | Record<string, unknown>;
+}
+
+async function readStructuredErrorBody(response: Response): Promise<{
+  body?: StructuredErrorBody;
+  text: string;
+}> {
+  const text = await response.text();
+  try {
+    return { body: JSON.parse(text) as StructuredErrorBody, text };
+  } catch {
+    return { text };
+  }
+}
+
+function badRequestFallbackMessage(response: Response, text: string): string {
+  const detail = text ? ' - ' + text : '';
+  return `SonarQube API error: ${response.status} ${response.statusText}${detail}`;
+}
+
+async function parseBadRequestError(response: Response): Promise<BadRequestError> {
+  const { body, text } = await readStructuredErrorBody(response);
+  const fallback = badRequestFallbackMessage(response, text);
+  if (!body) {
+    return new BadRequestError(fallback);
+  }
+  return new BadRequestError(
+    body.message ?? fallback,
+    body.code,
+    body.meta as Record<string, unknown> | undefined,
+  );
+}
+
 async function parseRequestPayloadTooLargeError(
   response: Response,
 ): Promise<RequestPayloadTooLargeError> {
-  const fallback = new RequestPayloadTooLargeError(
-    `SonarQube API error: ${response.status} ${response.statusText}`,
-  );
-  try {
-    const body = (await response.json()) as {
-      message?: string;
-      code?: string;
-      meta?: RequestPayloadTooLargeMeta;
-    };
-    const message =
-      body.message ?? `SonarQube API error: ${response.status} ${response.statusText}`;
-    const code =
-      body.code === 'REQUEST_TOO_LARGE' || body.code === 'TOO_MANY_FILES' ? body.code : undefined;
-    return new RequestPayloadTooLargeError(message, code, body.meta);
-  } catch {
-    return fallback;
+  const { body, text } = await readStructuredErrorBody(response);
+  const fallback = badRequestFallbackMessage(response, text);
+  if (!body) {
+    return new RequestPayloadTooLargeError(fallback);
   }
+  const message = body.message ?? fallback;
+  const code =
+    body.code === 'REQUEST_TOO_LARGE' || body.code === 'TOO_MANY_FILES' ? body.code : undefined;
+  const meta = body.meta;
+  return new RequestPayloadTooLargeError(message, code, meta);
 }
 
 export interface AgentJobRequest {

--- a/src/sonarqube/errors.ts
+++ b/src/sonarqube/errors.ts
@@ -34,6 +34,19 @@ export class ServiceUnavailableError extends Error {
   }
 }
 
+/** Thrown by the API client on HTTP 400 (Bad Request) for structured SQAA/API errors. */
+export class BadRequestError extends Error {
+  readonly code?: string;
+  readonly meta?: Record<string, unknown>;
+
+  constructor(message: string, code?: string, meta?: Record<string, unknown>) {
+    super(message);
+    this.name = 'BadRequestError';
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
 export type RequestPayloadTooLargeCode = 'REQUEST_TOO_LARGE' | 'TOO_MANY_FILES';
 
 export interface RequestPayloadTooLargeMeta {

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -1769,6 +1769,37 @@ describe('analyze agentic — --format json', () => {
     },
     { timeout: 15000 },
   );
+
+  it(
+    'single oversized file exits 1 with structured 413 message (--file)',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .withSqaaPayloadLimit({ maxRequestSize: 64 })
+        .start();
+
+      harness
+        .state()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaExtension(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      harness.cwd.writeFile('large.ts', 'x'.repeat(256));
+
+      const result = await harness.run('analyze agentic --file large.ts');
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('Request payload too large');
+      expect(output).toContain('→ Reduce file sizes');
+      const sqaaCalls = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/a3s-analysis/analyses');
+      expect(sqaaCalls).toHaveLength(1);
+    },
+    { timeout: 15000 },
+  );
 });
 
 describe('analyze agentic — running from a subdirectory', () => {

--- a/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
@@ -109,6 +109,7 @@ beforeEach(() => {
 
 afterEach(() => {
   setMockUi(false);
+  process.exitCode = 0;
   loadStateSpy.mockRestore();
   saveStateSpy.mockRestore();
   existsSpy.mockRestore();
@@ -208,12 +209,20 @@ describe('analyzeSqaa: API call and result display', () => {
     expect(request.branchName).toBe('feature/my-branch');
   });
 
-  it('throws CommandFailedError when SQAA API call fails', () => {
+  it('renders per-file failure rows when a single --file analysis fails', async () => {
     createAnalysisSpy.mockRejectedValue(new Error('Network error'));
 
-    expect(analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH)).rejects.toThrow(
-      'SonarQube Agentic Analysis failed',
-    );
+    await analyzeSqaa({ file: 'src/index.ts' }, FAKE_AUTH);
+
+    expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
+    const lines = getMockUiCalls()
+      .filter((c) => c.method === 'text')
+      .map((c) => String(c.args[0]));
+    expect(lines.some((line) => line.includes('src/index.ts'))).toBe(true);
+    expect(lines.some((line) => line.includes('Network error'))).toBe(true);
+    expect(lines.some((line) => line.includes('SonarQube Agentic Analysis failed'))).toBe(false);
+    expect(lines.at(-1)).toContain('1 failure');
+    expect(process.exitCode).toBe(1);
   });
 
   it('renders file row and summary footer for a clean single-file result', async () => {

--- a/tests/unit/cli/commands/analyze/sqaa-analysis.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-analysis.test.ts
@@ -20,6 +20,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
+import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.js';
 import {
   distributeChunkResponse,
   runAnalyses,
@@ -28,6 +29,8 @@ import {
 import * as sqaaApi from '../../../../../src/cli/commands/analyze/sqaa-api';
 import type { CloudAuth } from '../../../../../src/cli/commands/analyze/sqaa-auth';
 import type { SqaaChunkFile } from '../../../../../src/cli/commands/analyze/sqaa-chunking';
+import { payloadTooLargeCommandError } from '../../../../../src/cli/commands/analyze/sqaa-errors.js';
+import { RequestPayloadTooLargeError } from '../../../../../src/sonarqube/errors.js';
 import { SqaaProgress } from '../../../../../src/ui/components/sqaa-progress.js';
 
 describe('distributeChunkResponse', () => {
@@ -63,24 +66,58 @@ describe('shouldContinueAfterChunk', () => {
     expect(
       shouldContinueAfterChunk(
         [{ response: { issues: [], errors: null }, files: [] }],
-        [],
         [{ files: [], error: new Error('fail') }],
       ),
     ).toBe(true);
   });
 
-  it('stops when the entire chunk failed via group errors only', () => {
-    expect(shouldContinueAfterChunk([], [], [{ files: [], error: new Error('fail') }])).toBe(false);
+  it('continues when validation failures are recorded alongside successes', () => {
+    expect(
+      shouldContinueAfterChunk(
+        [{ response: { issues: [], errors: null }, files: [] }],
+        [{ files: [], error: new CommandFailedError('invalid path') }],
+      ),
+    ).toBe(true);
   });
 
-  it('continues when only 413 per-file failures were recorded', () => {
+  it('stops when the entire chunk failed via non-413 group errors only', () => {
+    expect(shouldContinueAfterChunk([], [{ files: [], error: new Error('fail') }])).toBe(false);
+  });
+
+  it('continues when only 413 per-file failures were recorded in groupErrors', () => {
     expect(
       shouldContinueAfterChunk(
         [],
-        [{ absolutePath: '/repo/a.ts', relativePath: 'a.ts', content: 'x' }],
-        [],
+        [
+          {
+            files: [{ absolutePath: '/repo/a.ts', relativePath: 'a.ts', content: 'x' }],
+            error: payloadTooLargeCommandError(
+              new RequestPayloadTooLargeError('Request payload too large', 'REQUEST_TOO_LARGE'),
+            ),
+          },
+        ],
       ),
     ).toBe(true);
+  });
+
+  it('stops when groupErrors mix 413 and non-413 failures', () => {
+    expect(
+      shouldContinueAfterChunk(
+        [],
+        [
+          {
+            files: [{ absolutePath: '/repo/a.ts', relativePath: 'a.ts', content: 'x' }],
+            error: payloadTooLargeCommandError(
+              new RequestPayloadTooLargeError('Request payload too large', 'REQUEST_TOO_LARGE'),
+            ),
+          },
+          {
+            files: [{ absolutePath: '/repo/b.ts', relativePath: 'b.ts', content: 'x' }],
+            error: new Error('network down'),
+          },
+        ],
+      ),
+    ).toBe(false);
   });
 });
 
@@ -120,8 +157,14 @@ describe('runAnalyses partial 413', () => {
           files: [c],
         },
       ],
-      failedFiles: [b],
-      groupErrors: [],
+      groupErrors: [
+        {
+          files: [b],
+          error: payloadTooLargeCommandError(
+            new RequestPayloadTooLargeError('Payload too large', 'REQUEST_TOO_LARGE'),
+          ),
+        },
+      ],
     });
 
     const files = ['/repo/a.ts', '/repo/b.ts', '/repo/c.ts'];
@@ -152,7 +195,6 @@ describe('runAnalyses partial 413', () => {
     });
     fetchSpy.mockResolvedValue({
       parts: [{ response: { issues: [], errors: null }, files: [ok] }],
-      failedFiles: [],
       groupErrors: [],
     });
 

--- a/tests/unit/cli/commands/analyze/sqaa-api-chunk-fetch.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-api-chunk-fetch.test.ts
@@ -94,8 +94,8 @@ describe('fetchChunkWith413Split', () => {
     expect(result.parts[0]?.response.issues).toHaveLength(1);
     expect(result.parts[0]?.response.issues[0]?.filePath).toBe('a.ts');
     expect(result.parts[0]?.files).toEqual([makeFile('a.ts')]);
-    expect(result.failedFiles).toEqual([makeFile('b.ts')]);
-    expect(result.groupErrors).toEqual([]);
+    expect(result.groupErrors).toHaveLength(1);
+    expect(result.groupErrors[0]?.files).toEqual([makeFile('b.ts')]);
   });
 
   it('keeps earlier sub-chunk successes when a later sub-chunk hits a non-413 error', async () => {
@@ -186,14 +186,86 @@ describe('fetchChunkWith413Split', () => {
 
   it('marks a single file as failed when it exceeds the payload limit', async () => {
     createAnalysisSpy.mockRejectedValue(
-      new RequestPayloadTooLargeError('Payload too large', 'REQUEST_TOO_LARGE'),
+      new RequestPayloadTooLargeError('Request payload too large', 'REQUEST_TOO_LARGE', {
+        maxRequestSize: 1024,
+      }),
     );
 
     const file = makeFile('large.ts');
     const result = await fetchChunkWith413Split(AUTH, 'project', [file], undefined);
 
     expect(result.parts).toEqual([]);
-    expect(result.failedFiles).toEqual([file]);
-    expect(result.groupErrors).toEqual([]);
+    expect(result.groupErrors).toHaveLength(1);
+    expect(result.groupErrors[0]?.files).toEqual([file]);
+    expect(result.groupErrors[0]?.error.message).toContain('Request payload too large');
+    expect((result.groupErrors[0]?.error as CommandFailedError).remediationHint).toContain('1 KB');
+  });
+
+  it('skips invalid paths and analyzes valid files in the same chunk', async () => {
+    createAnalysisSpy.mockResolvedValue({
+      issues: [{ rule: 'ts:S1', message: 'issue', filePath: 'a.ts' }],
+      errors: null,
+    });
+
+    const result = await fetchChunkWith413Split(
+      AUTH,
+      'project',
+      [makeFile('a.ts'), makeFile('src\\bad.ts')],
+      undefined,
+    );
+
+    expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
+    expect(createAnalysisSpy.mock.calls[0]?.[0].files).toEqual([
+      { path: 'a.ts', content: 'const x = 1;' },
+    ]);
+    expect(result.parts).toHaveLength(1);
+    expect(result.parts[0]?.files).toEqual([makeFile('a.ts')]);
+    expect(result.groupErrors).toHaveLength(1);
+    expect(result.groupErrors[0]?.files).toEqual([makeFile('src\\bad.ts')]);
+    expect(result.groupErrors[0]?.error.message).toMatch(/forward slashes/);
+  });
+
+  it('does not call the API when every file path fails pre-flight validation', async () => {
+    const file = makeFile('/absolute/large.ts');
+
+    const result = await fetchChunkWith413Split(AUTH, 'project', [file], undefined);
+
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
+    expect(result.parts).toEqual([]);
+    expect(result.groupErrors).toHaveLength(1);
+    expect(result.groupErrors[0]?.error.message).toMatch(/project-relative/);
+  });
+
+  it('rejects every invalid path in a chunk without calling the API', async () => {
+    const a = makeFile('a\\.ts');
+    const b = makeFile('b\\.ts');
+    const result = await fetchChunkWith413Split(AUTH, 'project', [a, b], undefined);
+
+    expect(createAnalysisSpy).not.toHaveBeenCalled();
+    expect(result.parts).toEqual([]);
+    expect(result.groupErrors).toHaveLength(2);
+    expect(result.groupErrors[0]?.files).toEqual([a]);
+    expect(result.groupErrors[1]?.files).toEqual([b]);
+    expect(result.groupErrors[0]?.error.message).toMatch(/forward slashes/);
+    expect(result.groupErrors[1]?.error.message).toMatch(/forward slashes/);
+  });
+
+  it('does not double-count duplicate paths in parts and groupErrors', async () => {
+    createAnalysisSpy.mockResolvedValue({
+      issues: [],
+      errors: null,
+    });
+
+    const first = makeFile('dup.ts');
+    const second = makeFile('dup.ts');
+    const result = await fetchChunkWith413Split(AUTH, 'project', [first, second], undefined);
+
+    expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
+    expect(createAnalysisSpy.mock.calls[0]?.[0].files).toHaveLength(1);
+    expect(result.parts).toHaveLength(1);
+    expect(result.parts[0]?.files).toEqual([first]);
+    expect(result.groupErrors).toHaveLength(1);
+    expect(result.groupErrors[0]?.files).toEqual([second]);
+    expect(result.groupErrors[0]?.error.message).toMatch(/Duplicate file path/);
   });
 });

--- a/tests/unit/cli/commands/analyze/sqaa-display.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-display.test.ts
@@ -20,6 +20,7 @@
 
 import { afterEach, describe, expect, it } from 'bun:test';
 
+import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.js';
 import type { FileResult, RunTally } from '../../../../../src/cli/commands/analyze/sqaa-analysis';
 import {
   computeRunSummaryStats,
@@ -27,6 +28,7 @@ import {
   formatSqaaPathPlain,
   formatSqaaRunSummaryPlain,
   printSqaaTextReport,
+  renderFailureDetailLines,
   SQAA_COLLAPSE_CLEAN_THRESHOLD,
 } from '../../../../../src/cli/commands/analyze/sqaa-display';
 import type { SqaaIssue } from '../../../../../src/sonarqube/client';
@@ -88,7 +90,7 @@ describe('formatSqaaRunSummaryPlain', () => {
         totalFailures: 0,
         totalErrors: 0,
       }),
-    ).toBe('✓  No issues found · 7 files analyzed');
+    ).toBe('✓ No issues found · 7 files analyzed');
   });
 
   it('formats issues summary', () => {
@@ -184,6 +186,79 @@ describe('printSqaaTextReport', () => {
     expect(texts.some((l) => l.includes('[SKIPPED]') && l.includes('src/c.ts'))).toBe(true);
     expect(texts.at(-1)).toContain('1 failure');
   });
+
+  it('renders per-file failure detail and remediation hint without redundant heading', () => {
+    setMockUi(true);
+    clearMockUiCalls();
+
+    const tally: RunTally = {
+      allResults: [
+        {
+          file: 'b.ts',
+          filePath: 'b.ts',
+          failure: new CommandFailedError("File path must use forward slashes: 'b\\.ts'", {
+            remediationHint: "Normalize paths to POSIX form (e.g. 'src/index.ts').",
+          }),
+        },
+      ],
+      totalIssues: 0,
+      totalErrors: 0,
+      totalFailures: 1,
+    };
+
+    printSqaaTextReport({ tally, allPaths: ['b.ts'] });
+
+    const texts = getMockTextLines();
+    expect(texts.some((l) => l.includes('SonarQube Agentic Analysis failed'))).toBe(false);
+    expect(texts.some((l) => l.includes("File path must use forward slashes: 'b\\.ts'"))).toBe(
+      true,
+    );
+    expect(texts.some((l) => l.includes('→ Normalize paths to POSIX form'))).toBe(true);
+  });
+
+  it('renders all failed files with a failures-only summary', () => {
+    setMockUi(true);
+    clearMockUiCalls();
+
+    const validationError = new CommandFailedError(
+      'SonarQube Agentic Analysis failed. File path must use forward slashes.',
+      { remediationHint: "Normalize paths to POSIX form (e.g. 'src/index.ts')." },
+    );
+    const tally: RunTally = {
+      allResults: [
+        { file: '/repo/a.ts', filePath: 'a.ts', failure: validationError },
+        { file: '/repo/b.ts', filePath: 'b.ts', failure: validationError },
+      ],
+      totalIssues: 0,
+      totalErrors: 0,
+      totalFailures: 2,
+    };
+
+    printSqaaTextReport({ tally, allPaths: ['a.ts', 'b.ts'] });
+
+    const texts = getMockTextLines();
+    expect(texts.filter((l) => l.includes('a.ts') || l.includes('b.ts'))).toHaveLength(2);
+    expect(texts.some((l) => l.includes('forward slashes'))).toBe(true);
+    expect(texts.at(-1)).toBe('2 files analyzed · 2 failures');
+  });
+});
+
+describe('renderFailureDetailLines', () => {
+  it('strips heading prefix from a single-line message', () => {
+    const lines = renderFailureDetailLines(
+      new CommandFailedError('SonarQube Agentic Analysis failed. network error'),
+      false,
+    );
+    expect(lines).toEqual(['     network error']);
+  });
+
+  it('strips legacy multiline heading and indents each detail line', () => {
+    const lines = renderFailureDetailLines(
+      new CommandFailedError('SonarQube Agentic Analysis failed.\n  network error'),
+      false,
+    );
+    expect(lines).toEqual(['     network error']);
+  });
 });
 
 describe('computeRunSummaryStats', () => {
@@ -218,5 +293,31 @@ describe('computeRunSummaryStats', () => {
         totalErrors: 2,
       }),
     ).toBe('3 files analyzed · 1 with errors · 2 errors');
+  });
+
+  it('includes failures and issues in the same summary', () => {
+    expect(
+      formatSqaaRunSummaryPlain({
+        filesAnalyzed: 5,
+        filesWithIssues: 2,
+        filesWithErrors: 0,
+        totalIssues: 2,
+        totalFailures: 1,
+        totalErrors: 0,
+      }),
+    ).toBe('5 files analyzed · 1 failure · 2 with issues · 2 issues found');
+  });
+
+  it('summarizes when every analyzed file failed', () => {
+    expect(
+      formatSqaaRunSummaryPlain({
+        filesAnalyzed: 2,
+        filesWithIssues: 0,
+        filesWithErrors: 0,
+        totalIssues: 0,
+        totalFailures: 2,
+        totalErrors: 0,
+      }),
+    ).toBe('2 files analyzed · 2 failures');
   });
 });

--- a/tests/unit/cli/commands/analyze/sqaa-errors.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-errors.test.ts
@@ -1,0 +1,109 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.js';
+import {
+  badRequestCommandError,
+  isPayloadTooLargeCommandError,
+  payloadTooLargeCommandError,
+  payloadTooLargeRemediationHint,
+  sqaaFailureMessage,
+  toSqaaCommandError,
+} from '../../../../../src/cli/commands/analyze/sqaa-errors.js';
+import {
+  BadRequestError,
+  RequestPayloadTooLargeError,
+} from '../../../../../src/sonarqube/errors.js';
+
+describe('sqaaFailureMessage', () => {
+  it('keeps heading and detail on one line for command-level errors', () => {
+    expect(sqaaFailureMessage('File path must use forward slashes.')).toBe(
+      'SonarQube Agentic Analysis failed. File path must use forward slashes.',
+    );
+  });
+});
+
+describe('payloadTooLargeRemediationHint', () => {
+  it('includes max file count for TOO_MANY_FILES', () => {
+    const hint = payloadTooLargeRemediationHint(
+      new RequestPayloadTooLargeError('Too many files', 'TOO_MANY_FILES', { maxFiles: 50 }),
+    );
+    expect(hint).toContain('50 files');
+  });
+
+  it('includes max request size for REQUEST_TOO_LARGE', () => {
+    const hint = payloadTooLargeRemediationHint(
+      new RequestPayloadTooLargeError('Too large', 'REQUEST_TOO_LARGE', {
+        maxRequestSize: 5 * 1024 * 1024,
+      }),
+    );
+    expect(hint).toContain('5 MB');
+  });
+});
+
+describe('payloadTooLargeCommandError', () => {
+  it('wraps structured 413 errors with remediation hint', () => {
+    const err = payloadTooLargeCommandError(
+      new RequestPayloadTooLargeError('Request payload too large', 'REQUEST_TOO_LARGE', {
+        maxRequestSize: 1024,
+      }),
+    );
+    expect(err).toBeInstanceOf(CommandFailedError);
+    expect(err.message).toContain('Request payload too large');
+    expect(err.remediationHint).toContain('1 KB');
+  });
+});
+
+describe('badRequestCommandError', () => {
+  it('adds remediation hint for recognized codes', () => {
+    const err = badRequestCommandError(
+      new BadRequestError('Invalid file path', 'INVALID_FILE_PATH'),
+    );
+    expect(err.remediationHint).toContain('project-relative');
+  });
+});
+
+describe('isPayloadTooLargeCommandError', () => {
+  it('returns true for payloadTooLargeCommandError wrappers', () => {
+    const err = payloadTooLargeCommandError(
+      new RequestPayloadTooLargeError('Request payload too large', 'REQUEST_TOO_LARGE'),
+    );
+    expect(isPayloadTooLargeCommandError(err)).toBe(true);
+  });
+
+  it('returns false for other errors', () => {
+    expect(isPayloadTooLargeCommandError(new Error('network down'))).toBe(false);
+  });
+});
+
+describe('toSqaaCommandError', () => {
+  it('passes through CommandFailedError', () => {
+    const original = new CommandFailedError('already wrapped');
+    expect(toSqaaCommandError(original)).toBe(original);
+  });
+
+  it('maps BadRequestError to CommandFailedError', () => {
+    const err = toSqaaCommandError(new BadRequestError('Bad input', 'INVALID_SCOPE'));
+    expect(err).toBeInstanceOf(CommandFailedError);
+    expect(err.message).toContain('Bad input');
+  });
+});

--- a/tests/unit/cli/commands/analyze/sqaa-validation.test.ts
+++ b/tests/unit/cli/commands/analyze/sqaa-validation.test.ts
@@ -1,0 +1,120 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.js';
+import {
+  partitionSqaaAnalysisFiles,
+  validateSqaaAnalysisFiles,
+} from '../../../../../src/cli/commands/analyze/sqaa-validation.js';
+
+describe('validateSqaaAnalysisFiles', () => {
+  it('rejects empty files[]', () => {
+    expect(() => validateSqaaAnalysisFiles([])).toThrow(CommandFailedError);
+    expect(() => validateSqaaAnalysisFiles([])).toThrow(/at least one file/);
+  });
+
+  it('rejects absolute paths', () => {
+    expect(() => validateSqaaAnalysisFiles([{ path: '/src/index.ts', content: 'x' }])).toThrow(
+      /project-relative/,
+    );
+  });
+
+  it('rejects parent-directory segments', () => {
+    expect(() =>
+      validateSqaaAnalysisFiles([{ path: 'src/../../etc/passwd', content: 'x' }]),
+    ).toThrow(/\.\./);
+  });
+
+  it('rejects backslash paths', () => {
+    expect(() => validateSqaaAnalysisFiles([{ path: 'src\\a.ts', content: 'x' }])).toThrow(
+      /forward slashes/,
+    );
+  });
+
+  it("rejects '.' segments", () => {
+    expect(() => validateSqaaAnalysisFiles([{ path: 'src/./a.ts', content: 'x' }])).toThrow(
+      /'\.' segments/,
+    );
+  });
+
+  it('rejects duplicate paths', () => {
+    expect(() =>
+      validateSqaaAnalysisFiles([
+        { path: 'src/a.ts', content: 'a' },
+        { path: 'src/a.ts', content: 'b' },
+      ]),
+    ).toThrow(/Duplicate file path/);
+  });
+
+  it('rejects invalid scope', () => {
+    expect(() =>
+      validateSqaaAnalysisFiles([{ path: 'src/a.ts', content: 'a', scope: 'INVALID' as 'MAIN' }]),
+    ).toThrow(/Invalid scope/);
+  });
+
+  it('rejects invalid analysisDepth option', () => {
+    expect(() =>
+      validateSqaaAnalysisFiles([{ path: 'src/a.ts', content: 'a' }], {
+        analysisDepth: 'QUICK' as 'DEEP',
+      }),
+    ).toThrow(/Invalid analysisDepth/);
+  });
+
+  it('accepts valid files', () => {
+    expect(() =>
+      validateSqaaAnalysisFiles(
+        [
+          { path: 'src/main.ts', content: 'a', scope: 'MAIN' },
+          { path: 'src/main.test.ts', content: 'b', scope: 'TEST' },
+        ],
+        { analysisDepth: 'DEEP' },
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe('partitionSqaaAnalysisFiles', () => {
+  it('keeps valid files and rejects invalid ones in the same batch', () => {
+    const result = partitionSqaaAnalysisFiles([
+      { path: 'src/ok.ts', content: 'ok' },
+      { path: 'src\\bad.ts', content: 'bad' },
+      { path: 'src/also-ok.ts', content: 'ok' },
+    ]);
+
+    expect(result.valid.map((file) => file.path)).toEqual(['src/ok.ts', 'src/also-ok.ts']);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]?.index).toBe(1);
+    expect(result.rejected[0]?.file.path).toBe('src\\bad.ts');
+    expect(result.rejected[0]?.error.message).toMatch(/forward slashes/);
+  });
+
+  it('rejects duplicate paths after the first occurrence', () => {
+    const result = partitionSqaaAnalysisFiles([
+      { path: 'src/a.ts', content: 'first' },
+      { path: 'src/a.ts', content: 'second' },
+    ]);
+
+    expect(result.valid).toHaveLength(1);
+    expect(result.rejected).toHaveLength(1);
+    expect(result.rejected[0]?.error.message).toMatch(/Duplicate file path/);
+  });
+});

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -1106,11 +1106,21 @@ describe('SonarQubeClient', () => {
       expect(messages.some((m) => m.includes('request method:'))).toBe(false);
     });
 
-    it('throws on non-ok POST response', () => {
+    it('throws BadRequestError on non-ok POST response', () => {
       fetchSpy = mockFetch({ message: 'Bad request' }, false, 400);
       expect(
         client.genericRequest('POST', '/api/issues/do_transition', '{"k":"v"}', 'form'),
-      ).rejects.toThrow('400');
+      ).rejects.toMatchObject({ name: 'BadRequestError', message: 'Bad request' });
+    });
+
+    it('preserves raw body for non-SQAA POST 400 responses', () => {
+      fetchSpy = mockFetch({ errors: [{ msg: 'Transition failed' }] }, false, 400);
+      expect(
+        client.genericRequest('POST', '/api/issues/do_transition', '{"k":"v"}', 'form'),
+      ).rejects.toMatchObject({
+        name: 'BadRequestError',
+        message: expect.stringContaining('Transition failed'),
+      });
     });
 
     it('throws access denied on GET 403', () => {
@@ -1231,10 +1241,37 @@ describe('SonarQubeClient', () => {
       expect(result.issues).toHaveLength(1);
     });
 
-    it('throws on non-OK response', () => {
-      fetchSpy = mockFetch({ message: 'Invalid request body' }, false, 400);
+    it('throws BadRequestError on structured 400 response', () => {
+      fetchSpy = mockFetch(
+        { message: 'Invalid request body', code: 'INVALID_FILE_PATH' },
+        false,
+        400,
+      );
 
-      expect(client.createAnalysis(singleFileRequest)).rejects.toThrow('400');
+      expect(client.createAnalysis(singleFileRequest)).rejects.toMatchObject({
+        name: 'BadRequestError',
+        message: 'Invalid request body',
+        code: 'INVALID_FILE_PATH',
+      });
+    });
+
+    it('throws RequestPayloadTooLargeError on structured 413 response', () => {
+      fetchSpy = mockFetch(
+        {
+          message: 'Request payload too large',
+          code: 'REQUEST_TOO_LARGE',
+          meta: { maxRequestSize: 512_000 },
+        },
+        false,
+        413,
+      );
+
+      expect(client.createAnalysis(singleFileRequest)).rejects.toMatchObject({
+        name: 'RequestPayloadTooLargeError',
+        message: 'Request payload too large',
+        code: 'REQUEST_TOO_LARGE',
+        meta: { maxRequestSize: 512_000 },
+      });
     });
   });
 


### PR DESCRIPTION
<img width="289" height="84" alt="image" src="https://github.com/user-attachments/assets/42ef81a6-e75e-4dfb-b4fd-aee90d0051ea" />

<img width="748" height="214" alt="image" src="https://github.com/user-attachments/assets/4a334f72-5f4a-40cb-bf60-ebc3f967e1e3" />

<img width="1077" height="333" alt="image" src="https://github.com/user-attachments/assets/79f1de26-22ce-41e6-8a06-21efa5fd65f3" />

<img width="499" height="122" alt="image" src="https://github.com/user-attachments/assets/74d68a41-a9ed-443d-9e89-ec21ad998398" />

----
## Summary by Gitar

- **SQAA Validation:**
  - Added pre-flight validation for analysis files to detect absolute paths, invalid segments, duplicates, and unsupported scopes.
- **Structured Error Handling:**
  - Implemented `BadRequestError` and `RequestPayloadTooLargeError` parsing to provide actionable remediation hints (e.g., max bytes/file limits).
  - Unified API error handling via `toSqaaCommandError` to map technical failures to user-facing CLI messages.
- **Refactoring:**
  - Centralized SQAA analysis submission into `submitValidatedSqaaAnalysis` and refactored chunking logic to handle pre-flight validation integration.
  - Replaced `failedFiles` with structured `groupErrors` for more granular reporting of API and validation failures.
- **Documentation & Workflow:**
  - Updated `.cursor/rules/sonarqube-cli.mdc` and `CLAUDE.md` to mandate `bun run lint:fix` alongside `format` for consistent import sorting.

<sub>This will update automatically on new commits.</sub>