### PR TITLE
CLI-394 Add distribution build flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,6 @@ jobs:
     outputs:
       BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
       PROJECT_VERSION: ${{ steps.project_version.outputs.PROJECT_VERSION }}
-      PACKAGE_VERSION: ${{ steps.project_version.outputs.PACKAGE_VERSION }}
-      ARTIFACT_LINUX: ${{ steps.project_version.outputs.ARTIFACT_LINUX }}
-      ARTIFACT_LINUX_ARM64: ${{ steps.project_version.outputs.ARTIFACT_LINUX_ARM64 }}
-      ARTIFACT_MACOS: ${{ steps.project_version.outputs.ARTIFACT_MACOS }}
-      ARTIFACT_WINDOWS: ${{ steps.project_version.outputs.ARTIFACT_WINDOWS }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -49,13 +44,8 @@ jobs:
         env:
           BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
         run: |
-          PACKAGE_VERSION=$(bun build-scripts/set-build-number.ts "${BUILD_NUMBER}")
-          echo "PACKAGE_VERSION=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
-          echo "PROJECT_VERSION=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
-          echo "ARTIFACT_LINUX=sonarqube-cli-${PACKAGE_VERSION}-linux-x86-64.bin" >> $GITHUB_OUTPUT
-          echo "ARTIFACT_LINUX_ARM64=sonarqube-cli-${PACKAGE_VERSION}-linux-arm64.bin" >> $GITHUB_OUTPUT
-          echo "ARTIFACT_MACOS=sonarqube-cli-${PACKAGE_VERSION}-macos-arm64.bin" >> $GITHUB_OUTPUT
-          echo "ARTIFACT_WINDOWS=sonarqube-cli-${PACKAGE_VERSION}-windows-x86-64.exe" >> $GITHUB_OUTPUT
+          PROJECT_VERSION=$(bun build-scripts/set-build-number.ts "${BUILD_NUMBER}")
+          echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_OUTPUT
 
   build-binaries:
     name: Build All Binaries
@@ -86,21 +76,46 @@ jobs:
         run: bun run fetch:signatures
 
       - name: Cross-compile all platform binaries
+        shell: bash
+        env:
+          PROJECT_VERSION: ${{ needs.prepare.outputs.PROJECT_VERSION }}
         run: |
-          bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_LINUX }} --target bun-linux-x64
-          bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_ARM64 }} --target bun-linux-arm64
-          bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }} --target bun-darwin-arm64
-          bun build src/index.ts --compile --outfile dist/${{ needs.prepare.outputs.ARTIFACT_WINDOWS }} --target bun-windows-x64
+          set -euo pipefail
+
+          build_binary() {
+            local distribution="$1"
+            local target="$2"
+            local classifier="$3"
+            local extension="$4"
+            local filename
+
+            if [ "$distribution" = "standalone" ]; then
+              filename="sonarqube-cli-${PROJECT_VERSION}-${classifier}.${extension}"
+            else
+              filename="sonarqube-cli-${PROJECT_VERSION}-${distribution}-${classifier}.${extension}"
+            fi
+
+            SONARQUBE_CLI_DISTRIBUTION="$distribution" SONARQUBE_CLI_TARGET="$target" SONARQUBE_CLI_OUTFILE="dist/${filename}" bun build-scripts/build-binary.ts
+          }
+
+          for distribution in standalone homebrew; do
+            build_binary "$distribution" bun-linux-x64 linux-x86-64 bin
+            build_binary "$distribution" bun-linux-arm64 linux-arm64 bin
+            build_binary "$distribution" bun-darwin-arm64 macos-arm64 bin
+            build_binary "$distribution" bun-windows-x64 windows-x86-64 exe
+          done
 
       - name: GPG-sign all binaries
+        shell: bash
         env:
           GPG_SIGNING_KEY: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_KEY }}
           GPG_SIGNING_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_PASSPHRASE }}
         run: |
-          bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_LINUX }}
-          bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_LINUX_ARM64 }}
-          bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}
-          bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_WINDOWS }}
+          set -euo pipefail
+
+          while IFS= read -r -d '' binary; do
+            bun build-scripts/sign.ts "$binary"
+          done < <(find dist -maxdepth 1 -type f \( -name '*.bin' -o -name '*.exe' \) -print0)
 
       - name: Upload all binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -109,7 +124,7 @@ jobs:
           path: dist/
 
   sign-macos:
-    name: Sign and Notarize macOS Binary
+    name: Sign and Notarize macOS Binaries
     runs-on: macos-latest-xlarge
     needs: [prepare, build-binaries]
     if: github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')
@@ -146,7 +161,8 @@ jobs:
           artifactory-username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
           artifactory-password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
 
-      - name: Code-sign and notarize macOS binary
+      - name: Code-sign and notarize macOS binaries
+        shell: bash
         env:
           CERTIFICATE: ${{ fromJSON(steps.secrets.outputs.vault).CERTIFICATE }}
           CSC_KEY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).CSC_KEY_PASSWORD }}
@@ -154,6 +170,8 @@ jobs:
           APPLE_ID: ${{ fromJSON(steps.secrets.outputs.vault).APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).APPLE_APP_SPECIFIC_PASSWORD }}
         run: |
+          set -euo pipefail
+
           echo "$CERTIFICATE" | base64 --decode > /tmp/certificate.p12
           security create-keychain -p "" build.keychain
           security default-keychain -s build.keychain
@@ -162,21 +180,21 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
           rm /tmp/certificate.p12
 
-          codesign \
-            --sign "Developer ID Application: SonarSource SA ($APPLE_TEAM_ID)" \
-            --identifier sonarqube-cli \
-            --options runtime \
-            --timestamp \
-            dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}
-          codesign --verify --verbose dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}
+          sign_macos_binary() {
+            local binary="$1"
+            local archive="/tmp/$(basename "$binary").zip"
 
-          zip /tmp/notarize.zip dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}
-          xcrun notarytool submit /tmp/notarize.zip \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait
-          rm /tmp/notarize.zip
+            codesign --sign "Developer ID Application: SonarSource SA ($APPLE_TEAM_ID)" --identifier sonarqube-cli --options runtime --timestamp "$binary"
+            codesign --verify --verbose "$binary"
+
+            zip "$archive" "$binary"
+            xcrun notarytool submit "$archive" --apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+            rm "$archive"
+          }
+
+          while IFS= read -r -d '' binary; do
+            sign_macos_binary "$binary"
+          done < <(find dist -maxdepth 1 -type f -name '*-macos-arm64.bin' -print0)
 
       - name: Clean up build keychain
         if: always()
@@ -184,19 +202,25 @@ jobs:
           security default-keychain -s ~/Library/Keychains/login.keychain-db 2>/dev/null || true
           security delete-keychain build.keychain 2>/dev/null || true
 
-      - name: Re-GPG-sign macOS binary
+      - name: Re-GPG-sign macOS binaries
+        shell: bash
         env:
           GPG_SIGNING_KEY: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_KEY }}
           GPG_SIGNING_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_PASSPHRASE }}
-        run: bun build-scripts/sign.ts dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}
+        run: |
+          set -euo pipefail
 
-      - name: Upload signed macOS binary
+          while IFS= read -r -d '' binary; do
+            bun build-scripts/sign.ts "$binary"
+          done < <(find dist -maxdepth 1 -type f -name '*-macos-arm64.bin' -print0)
+
+      - name: Upload signed macOS binaries
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: binary-macos-signed
+          name: binaries-macos-signed
           path: |
-            dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}
-            dist/${{ needs.prepare.outputs.ARTIFACT_MACOS }}.asc
+            dist/*-macos-arm64.bin
+            dist/*-macos-arm64.bin.asc
 
   publish-binaries:
     name: Publish Binaries to Artifactory
@@ -237,11 +261,11 @@ jobs:
           name: binaries
           path: dist/
 
-      - name: Download signed macOS binary
+      - name: Download signed macOS binaries
         if: needs.sign-macos.result == 'success'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: binary-macos-signed
+          name: binaries-macos-signed
           path: dist/
 
       - name: Copy user scripts to dist
@@ -260,7 +284,7 @@ jobs:
           ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
           PROJECT: ${{ github.event.repository.name }}
           BUILD_NUMBER: ${{ needs.prepare.outputs.BUILD_NUMBER }}
-          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:bin:linux-x86-64,org.sonarsource.cli:sonarqube-cli:bin:linux-arm64,org.sonarsource.cli:sonarqube-cli:bin:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64'
+          ARTIFACTS_TO_PUBLISH: 'org.sonarsource.cli:sonarqube-cli:bin:linux-x86-64,org.sonarsource.cli:sonarqube-cli:bin:linux-arm64,org.sonarsource.cli:sonarqube-cli:bin:macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:windows-x86-64,org.sonarsource.cli:sonarqube-cli:bin:homebrew-linux-x86-64,org.sonarsource.cli:sonarqube-cli:bin:homebrew-linux-arm64,org.sonarsource.cli:sonarqube-cli:bin:homebrew-macos-arm64,org.sonarsource.cli:sonarqube-cli:exe:homebrew-windows-x86-64'
         run: |
           jf config add repox \
             --artifactory-url="${ARTIFACTORY_URL}" \
@@ -405,12 +429,18 @@ jobs:
 
       - name: Place platform binary
         shell: bash
+        env:
+          PROJECT_VERSION: ${{ needs.prepare.outputs.PROJECT_VERSION }}
         run: |
+          set -euo pipefail
+
           if [ "${{ matrix.os }}" = "linux" ]; then
-            cp "dist/${{ needs.prepare.outputs.ARTIFACT_LINUX }}" dist/sonarqube-cli
+            artifact="sonarqube-cli-${PROJECT_VERSION}-linux-x86-64.bin"
+            cp "dist/${artifact}" dist/sonarqube-cli
             chmod +x dist/sonarqube-cli
           else
-            cp "dist/${{ needs.prepare.outputs.ARTIFACT_WINDOWS }}" dist/sonarqube-cli.exe
+            artifact="sonarqube-cli-${PROJECT_VERSION}-windows-x86-64.exe"
+            cp "dist/${artifact}" dist/sonarqube-cli.exe
           fi
 
       - name: Setup integration resources

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,8 @@
 
 A CLI tool (`sonar`) that integrates SonarQube Server and Cloud into developer workflows.
 
-Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `macos-arm64`, and `windows-x86-64`. binaries.sonarsource.com artifacts use the `.bin` suffix on Linux/macOS and `.exe` on Windows (e.g. `sonarqube-cli-{version}-linux-x86-64.bin`); versions published before that convention remain `.exe` on the CDN. Dependency binaries (sonar-secrets, sca-scanner-cli) still use `.exe` in download URLs. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`) and try `.bin` then `.exe` when downloading.
+Release builds publish standalone executables for `linux-x86-64`, `linux-arm64`, `macos-arm64`, and `windows-x86-64`, plus `homebrew` variants for the same platforms. Standalone filenames remain `sonarqube-cli-{version}-{platform}.{bin|exe}`; Homebrew filenames use `sonarqube-cli-{version}-homebrew-{platform}.{bin|exe}`. binaries.sonarsource.com artifacts use the `.bin` suffix on Linux/macOS and `.exe` on Windows (e.g. `sonarqube-cli-{version}-linux-x86-64.bin`); versions published before that convention remain `.exe` on the CDN. Dependency binaries (sonar-secrets, sca-scanner-cli) still use `.exe` in download URLs. The `user-scripts/install.sh` and `user-scripts/install-prerelease.sh` installers select the Linux artifact using `uname -m` (`aarch64` / `arm64` → `linux-arm64`, `x86_64` / `amd64` → `linux-x86-64`) and try `.bin` then `.exe` when downloading.
+Binary builds inject `SONARQUBE_CLI_DISTRIBUTION` as a compile-time constant through Bun's `define`; supported values are `standalone` (default) and `homebrew`. CI cross-builds those binaries through `build-scripts/build-binary.ts` with `SONARQUBE_CLI_DISTRIBUTION`, `SONARQUBE_CLI_TARGET`, and `SONARQUBE_CLI_OUTFILE`.
 
 # Running checks
 

--- a/build-scripts/build-binary.ts
+++ b/build-scripts/build-binary.ts
@@ -1,0 +1,57 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * Builds the compiled CLI binary and injects the distribution channel as a
+ * compile-time constant for downstream channel-specific behavior.
+ *
+ * Run via: bun build-scripts/build-binary.ts
+ */
+
+import { join } from 'node:path';
+
+import { resolveDistribution } from '../src/lib/distribution.js';
+
+const PROJECT_ROOT = join(import.meta.dir, '..');
+const DEFAULT_OUTFILE = join(PROJECT_ROOT, 'dist', 'sonarqube-cli');
+const DISTRIBUTION_DEFINE_KEY = 'process.env.SONARQUBE_CLI_DISTRIBUTION';
+type BuildTarget = Bun.Build.CompileTarget;
+
+const distribution = resolveDistribution(process.env.SONARQUBE_CLI_DISTRIBUTION);
+const outfile = process.env.SONARQUBE_CLI_OUTFILE ?? DEFAULT_OUTFILE;
+const target = process.env.SONARQUBE_CLI_TARGET as BuildTarget | undefined;
+
+console.log(`Building CLI binary for distribution: ${distribution} (${target ?? 'host'})`);
+
+const result = await Bun.build({
+  entrypoints: [join(PROJECT_ROOT, 'src/index.ts')],
+  compile: target ? { target, outfile } : { outfile },
+  define: {
+    [DISTRIBUTION_DEFINE_KEY]: JSON.stringify(distribution),
+  },
+});
+
+if (!result.success) {
+  const logs = result.logs.map((log) => log.message ?? JSON.stringify(log)).join('\n');
+  process.stderr.write(`${logs || 'Failed to build CLI binary'}\n`);
+  process.exit(1);
+}
+
+console.log(`CLI binary built: ${outfile}`);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "sonar": "./dist/index.js"
   },
   "scripts": {
-    "build:binary": "bun build src/index.ts --compile --outfile dist/sonarqube-cli",
+    "build:binary": "bun build-scripts/build-binary.ts",
     "postbuild:binary": "bun build-scripts/codesign-local.ts",
     "dev": "bun run src/index.ts",
     "test:unit": "bun test --parallel ./tests/unit/",

--- a/src/lib/distribution.ts
+++ b/src/lib/distribution.ts
@@ -1,0 +1,53 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+export const DISTRIBUTIONS = ['standalone', 'homebrew'] as const;
+const DEFAULT_DISTRIBUTION = 'standalone';
+
+export type Distribution = (typeof DISTRIBUTIONS)[number];
+
+function invalidDistributionError(rawDistribution: string): Error {
+  return new Error(
+    `Unknown distribution '${rawDistribution}'. Expected one of: ${DISTRIBUTIONS.join(', ')}.`,
+  );
+}
+
+function assertDistribution(rawDistribution: string): asserts rawDistribution is Distribution {
+  if (!(DISTRIBUTIONS as readonly string[]).includes(rawDistribution)) {
+    throw invalidDistributionError(rawDistribution);
+  }
+}
+
+export function resolveDistribution(rawDistribution: string | undefined): Distribution {
+  if (rawDistribution === undefined) {
+    return DEFAULT_DISTRIBUTION;
+  }
+
+  assertDistribution(rawDistribution);
+  return rawDistribution;
+}
+
+const rawDistribution = process.env.SONARQUBE_CLI_DISTRIBUTION;
+if (rawDistribution !== undefined) {
+  assertDistribution(rawDistribution);
+}
+
+// Channel builds inject this env access at compile time via Bun's `define`.
+export const DISTRIBUTION = rawDistribution ?? DEFAULT_DISTRIBUTION;

--- a/tests/unit/lib/distribution.test.ts
+++ b/tests/unit/lib/distribution.test.ts
@@ -1,0 +1,39 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { resolveDistribution } from '../../../src/lib/distribution';
+
+describe('distribution', () => {
+  it('defaults to standalone when no distribution is provided', () => {
+    expect(resolveDistribution(undefined)).toBe('standalone');
+  });
+
+  it('returns the configured distribution for known values', () => {
+    expect(resolveDistribution('homebrew')).toBe('homebrew');
+  });
+
+  it('throws for unknown values', () => {
+    expect(() => resolveDistribution('custom-channel')).toThrow(
+      "Unknown distribution 'custom-channel'. Expected one of: standalone, homebrew.",
+    );
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Distribution system:**
  - Added `src/lib/distribution.ts` to manage distribution channels (`standalone`, `homebrew`).
  - Added `build-scripts/build-binary.ts` to inject distribution channel as a compile-time constant.
- **Build pipeline:**
  - Updated `.github/workflows/build.yml` to cross-compile and sign binaries for both `standalone` and `homebrew` variants.
  - Updated artifact publishing logic to include homebrew-prefixed binary artifacts.
- **Testing:**
  - Added `tests/unit/lib/distribution.test.ts` to verify distribution resolution.
- **Documentation:**
  - Updated `CLAUDE.md` to reflect new build processes and naming conventions.

<sub>This will update automatically on new commits.</sub>