### PR TITLE
CLI-521 Reference documentation in SCA flow

### DIFF
--- a/src/cli/commands/_common/sca-availability.ts
+++ b/src/cli/commands/_common/sca-availability.ts
@@ -36,12 +36,20 @@ export async function assertScaAvailable(
     } catch (err) {
       throw new CommandFailedError(
         `Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later.`,
-        { cause: err },
+        {
+          cause: err,
+          remediationHint:
+            'Learn more: https://docs.sonarsource.com/sonarqube-cli/analysis/sca#prerequisites',
+        },
       );
     }
     if (!isAtLeast(serverVersion, MIN_SCA_SQS_VERSION)) {
       throw new CommandFailedError(
         `Running Software Composition Analysis from this CLI requires SonarQube Server ${MIN_SCA_SQS_VERSION} or later (server is ${serverVersion}).`,
+        {
+          remediationHint:
+            'Learn more: https://docs.sonarsource.com/sonarqube-cli/analysis/sca#prerequisites',
+        },
       );
     }
   }

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -55,7 +55,10 @@ export async function analyzeDependencyRisks(
 ): Promise<void> {
   const filter = buildRiskFilter(options.statuses);
   if (!filter) {
-    throw new InvalidOptionError(`Invalid --statuses value: '${options.statuses}'`);
+    throw new InvalidOptionError(
+      `Invalid --statuses value: '${options.statuses}'`,
+      'See https://docs.sonarsource.com/sonarqube-cli/analysis/sca#filter-by-status for valid presets and status values.',
+    );
   }
 
   const projectKey = await resolveProjectKey(options.project, auth);

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -213,9 +213,13 @@ describe('analyze dependency-risks', () => {
     harness.withAuth('http://unused.example', VALID_TOKEN, TEST_ORG);
 
     const result = await harness.run('analyze dependency-risks --project demo --statuses bogus');
+    const output = result.stdout + result.stderr;
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stdout + result.stderr).toContain("Invalid --statuses value: 'bogus'");
+    expect(output).toContain("Invalid --statuses value: 'bogus'");
+    expect(output).toContain(
+      'https://docs.sonarsource.com/sonarqube-cli/analysis/sca#filter-by-status',
+    );
   });
 
   it('exits with code 1 when the SCA endpoint is absent (404)', async () => {
@@ -244,10 +248,14 @@ describe('analyze dependency-risks', () => {
     harness.withAuth(server.baseUrl(), VALID_TOKEN);
 
     const result = await harness.run('analyze dependency-risks --project demo');
+    const output = result.stdout + result.stderr;
 
     expect(result.exitCode).toBe(1);
-    expect(result.stdout + result.stderr).toContain(
+    expect(output).toContain(
       'Running Software Composition Analysis from this CLI requires SonarQube Server 2026.4 or later (server is 26.3)',
+    );
+    expect(output).toContain(
+      'https://docs.sonarsource.com/sonarqube-cli/analysis/sca#prerequisites',
     );
     // Version check runs before the SCA feature-enabled probe.
     expect(server.getRecordedRequests().some((r) => r.path.endsWith('/sca/feature-enabled'))).toBe(
@@ -283,10 +291,14 @@ describe('analyze dependency-risks', () => {
     harness.withAuth(server.baseUrl(), VALID_TOKEN);
 
     const result = await harness.run('analyze dependency-risks --project demo');
+    const output = result.stdout + result.stderr;
 
     expect(result.exitCode).toBe(1);
-    expect(result.stdout + result.stderr).toContain(
+    expect(output).toContain(
       'Could not determine SonarQube Server version. Running Software Composition Analysis from this CLI requires SonarQube Server 2026.4 or later.',
+    );
+    expect(output).toContain(
+      'https://docs.sonarsource.com/sonarqube-cli/analysis/sca#prerequisites',
     );
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation enhancements:**
  - Added direct links to SCA documentation for troubleshooting prerequisites in `sca-availability.ts`.
  - Included a reference link for valid status values in `dependency-risks.ts` error messages.
- **Testing:**
  - Updated integration tests to verify the presence of documentation links in CLI error outputs.

<sub>This will update automatically on new commits.</sub>