### PR TITLE
CLI-697 Add FeatureContainer + SubfeatureDeclaration to the declarative integration registry

### DIFF
--- a/src/cli/commands/integrate/_common/registry/core.ts
+++ b/src/cli/commands/integrate/_common/registry/core.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { isFeatureContainer } from './selection';
 import type { IntegrationDeclaration } from './types';
 
 export class IntegrationRegistry {
@@ -67,6 +68,15 @@ export class IntegrationRegistry {
       }
       for (const operation of feature.operations ?? []) {
         this.ensureNonEmptyId(operation.id, 'Operation');
+      }
+      if (isFeatureContainer(feature)) {
+        this.ensureUnique(
+          feature.subfeatures.map((sub) => sub.id),
+          `Duplicate subfeature id in container ${declaration.id}.${feature.id}`,
+        );
+        for (const subfeature of feature.subfeatures) {
+          this.ensureNonEmptyId(subfeature.id, 'Subfeature');
+        }
       }
     }
     this.ensureUnique(

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -71,12 +71,13 @@ export {
   yamlPatchRemover,
   type YamlPatchRemoverOptions,
 } from './resources';
-export { askUser, install, type InstallDecision, skip } from './selection';
+export { askUser, install, type InstallDecision, isFeatureContainer, skip } from './selection';
 export type {
   AppliedFeature,
   AppliedOperation,
   AppliedResource,
   DependencyInstallContext,
+  FeatureContainer,
   FeatureDeclaration,
   FeatureOperation,
   InstalledDependency,
@@ -87,4 +88,5 @@ export type {
   LegacyFeatureDeclaration,
   MaybePromise,
   PostInstallExample,
+  SubfeatureDeclaration,
 } from './types';

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -76,6 +76,7 @@ export type {
   AppliedFeature,
   AppliedOperation,
   AppliedResource,
+  ContainerIntegrationContext,
   DependencyInstallContext,
   FeatureContainer,
   FeatureDeclaration,

--- a/src/cli/commands/integrate/_common/registry/installation-recorder.ts
+++ b/src/cli/commands/integrate/_common/registry/installation-recorder.ts
@@ -29,6 +29,7 @@ import type {
   InstalledIntegrationFeature,
   InstalledIntegrationOperation,
   InstalledIntegrationResource,
+  InstalledSubfeature,
   IntegrationScope,
 } from '../../../../../lib/state';
 import type {
@@ -39,6 +40,7 @@ import type {
   InstalledDependency,
   IntegrationContext,
   IntegrationDeclaration,
+  SubfeatureDeclaration,
 } from './types';
 
 export function recordInstalledFeature<TOptions>(
@@ -47,6 +49,7 @@ export function recordInstalledFeature<TOptions>(
   integration: IntegrationDeclaration<TOptions>,
   feature: FeatureDeclaration<TOptions>,
   applied: AppliedFeature,
+  activeSubfeatures?: SubfeatureDeclaration<TOptions>[],
 ): InstalledIntegrationFeature {
   const now = new Date().toISOString();
   const installedIntegration = upsertInstalledIntegration(state, integration, now);
@@ -81,6 +84,17 @@ export function recordInstalledFeature<TOptions>(
       new Set((feature.operations ?? []).map((operation) => operation.id)),
     ),
     attrs: context.attrs,
+    subfeatures: activeSubfeatures
+      ? activeSubfeatures.map(
+          (sub): InstalledSubfeature => ({
+            featureId: sub.id,
+            dependencies: upsertDependencyReferences(
+              existing?.subfeatures?.find((s) => s.featureId === sub.id)?.dependencies ?? [],
+              new Set((sub.dependencies ?? []).map((d) => d.id)),
+            ),
+          }),
+        )
+      : existing?.subfeatures,
   };
 
   if (existing) {
@@ -102,9 +116,10 @@ export function recordInstalledFeature<TOptions>(
 export function collectReferencedDependencyIds(state: CliState): Set<string> {
   return new Set(
     state.integrations.installed.flatMap((integration) =>
-      integration.features.flatMap((feature) =>
-        feature.dependencies.map((dependency) => dependency.id),
-      ),
+      integration.features.flatMap((feature) => [
+        ...feature.dependencies.map((d) => d.id),
+        ...(feature.subfeatures?.flatMap((sub) => sub.dependencies.map((d) => d.id)) ?? []),
+      ]),
     ),
   );
 }

--- a/src/cli/commands/integrate/_common/registry/installation-recorder.ts
+++ b/src/cli/commands/integrate/_common/registry/installation-recorder.ts
@@ -113,13 +113,17 @@ export function recordInstalledFeature<TOptions>(
   return existing ?? next;
 }
 
+function featureDependencyIds(feature: InstalledIntegrationFeature): string[] {
+  return [
+    ...feature.dependencies.map((d) => d.id),
+    ...(feature.subfeatures?.flatMap((sub) => sub.dependencies.map((d) => d.id)) ?? []),
+  ];
+}
+
 export function collectReferencedDependencyIds(state: CliState): Set<string> {
   return new Set(
     state.integrations.installed.flatMap((integration) =>
-      integration.features.flatMap((feature) => [
-        ...feature.dependencies.map((d) => d.id),
-        ...(feature.subfeatures?.flatMap((sub) => sub.dependencies.map((d) => d.id)) ?? []),
-      ]),
+      integration.features.flatMap(featureDependencyIds),
     ),
   );
 }

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -125,7 +125,19 @@ export class IntegrationInstaller {
         throw new Error(`Unknown feature ${integration.id}.${featureId}`);
       }
 
-      if (subfeatureIds !== undefined && isFeatureContainer(feature)) {
+      if (subfeatureIds !== undefined) {
+        if (!isFeatureContainer(feature)) {
+          throw new Error(
+            `Feature ${integration.id}.${featureId} is not a container and does not support subfeature selection`,
+          );
+        }
+        const validIds = new Set(feature.subfeatures.map((s) => s.id));
+        const unknown = subfeatureIds.filter((id) => !validIds.has(id));
+        if (unknown.length > 0) {
+          throw new Error(
+            `Unknown subfeature(s) ${unknown.map((id) => `${integration.id}.${featureId}.${id}`).join(', ')}`,
+          );
+        }
         return {
           ...feature,
           subfeatures: feature.subfeatures.filter((s) => subfeatureIds.includes(s.id)),
@@ -549,13 +561,13 @@ export class IntegrationInstaller {
     return [...dependencies.values()];
   }
 
-  private makeResolvedDependencies(
+  private makeResolvedDependencies<TOptions>(
     state: CliState,
-    feature: Pick<FeatureDeclaration, 'dependencies'>,
+    feature: FeatureDeclaration<TOptions>,
     overrides: ReadonlyMap<string, InstalledDependency> = new Map(),
   ): Map<string, InstalledDependency> {
     const resolvedDependencies = new Map<string, InstalledDependency>();
-    for (const dependency of feature.dependencies ?? []) {
+    for (const dependency of resolveAllDeps(feature)) {
       const installedDependency =
         overrides.get(dependency.id) ?? this.findInstalledDependency(state, dependency);
       if (installedDependency) {

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -32,11 +32,12 @@ import { CommandFailedError } from '../../../_common/error';
 import type { DependencyDeclaration } from './dependencies';
 import { recordInstalledFeature } from './installation-recorder';
 import type { RemovableResource, ResourceDeclaration, ResourceIdentity } from './resources';
-import { normalizeDecision } from './selection';
+import { isFeatureContainer, normalizeDecision } from './selection';
 import type {
   AppliedFeature,
   AppliedOperation,
   AppliedResource,
+  FeatureContainer,
   FeatureDeclaration,
   FeatureOperation,
   InstalledDependency,
@@ -44,10 +45,20 @@ import type {
   IntegrationDeclaration,
   IntegrationExecutionMode,
   IntegrationInvocation,
+  SubfeatureDeclaration,
 } from './types';
 
 function resolveVersion(version: string | undefined): string {
   return version ?? '0';
+}
+
+function resolveAllDeps<TOptions>(feature: FeatureDeclaration<TOptions>): DependencyDeclaration[] {
+  return [
+    ...(feature.dependencies ?? []),
+    ...(isFeatureContainer(feature)
+      ? feature.subfeatures.flatMap((s) => s.dependencies ?? [])
+      : []),
+  ];
 }
 
 interface ApplyFeatureCallbacks<TOptions = Record<string, unknown>> {
@@ -101,14 +112,26 @@ export interface RemoveFeatureCallbacks {
 export class IntegrationInstaller {
   selectFeatures<TOptions>(
     integration: IntegrationDeclaration<TOptions>,
-    featureIds: string[],
+    featureIds: (string | { featureId: string; subfeatureIds: string[] })[],
   ): FeatureDeclaration<TOptions>[] {
     const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
-    return featureIds.map((id) => {
-      const feature = featuresById.get(id);
+
+    return featureIds.map((entry) => {
+      const featureId = typeof entry === 'string' ? entry : entry.featureId;
+      const subfeatureIds = typeof entry === 'string' ? undefined : entry.subfeatureIds;
+
+      const feature = featuresById.get(featureId);
       if (!feature) {
-        throw new Error(`Unknown feature ${integration.id}.${id}`);
+        throw new Error(`Unknown feature ${integration.id}.${featureId}`);
       }
+
+      if (subfeatureIds !== undefined && isFeatureContainer(feature)) {
+        return {
+          ...feature,
+          subfeatures: feature.subfeatures.filter((s) => subfeatureIds.includes(s.id)),
+        };
+      }
+
       return feature;
     });
   }
@@ -118,12 +141,28 @@ export class IntegrationInstaller {
     invocation: IntegrationInvocation<TOptions>,
   ): Promise<FeatureDeclaration<TOptions>[]> {
     const selected: FeatureDeclaration<TOptions>[] = [];
-    for (const feature of integration.features) {
+    for (let feature of integration.features) {
       if (await this.shouldInstallFeature(feature, invocation)) {
+        if (isFeatureContainer(feature)) {
+          feature = await this.selectActiveSubfeatures(feature, invocation);
+        }
         selected.push(feature);
       }
     }
     return selected;
+  }
+
+  private async selectActiveSubfeatures<TOptions>(
+    container: FeatureContainer<TOptions>,
+    invocation: IntegrationInvocation<TOptions>,
+  ): Promise<FeatureContainer<TOptions>> {
+    const active: SubfeatureDeclaration<TOptions>[] = [];
+    for (const subfeature of container.subfeatures) {
+      if (await this.shouldInstallFeature(subfeature, invocation)) {
+        active.push(subfeature);
+      }
+    }
+    return { ...container, subfeatures: active };
   }
 
   private async shouldInstallFeature<TOptions>(
@@ -270,13 +309,15 @@ export class IntegrationInstaller {
           preparedDependencies,
           options.callbacks ?? {},
         );
+        const feature = execution.application.feature;
         installedFeatures.push(
           recordInstalledFeature(
             state,
             execution.context,
             integration,
-            execution.application.feature,
+            feature,
             applied,
+            isFeatureContainer(feature) ? feature.subfeatures : undefined,
           ),
         );
       } catch (error) {
@@ -402,7 +443,7 @@ export class IntegrationInstaller {
     const resources: AppliedResource[] = [];
     const operations: AppliedOperation[] = [];
 
-    for (const dependency of feature.dependencies ?? []) {
+    for (const dependency of resolveAllDeps(feature)) {
       const dependencyError = preparedDependencies.failedDependencies.get(dependency.id);
       if (dependencyError) {
         throw dependencyError;
@@ -492,7 +533,7 @@ export class IntegrationInstaller {
     const dependencies = new Map<string, UniqueDependencyExecution<TOptions>>();
 
     for (const execution of executions) {
-      for (const dependency of execution.application.feature.dependencies ?? []) {
+      for (const dependency of resolveAllDeps(execution.application.feature)) {
         const existing = dependencies.get(dependency.id);
         if (existing && existing.dependency !== dependency) {
           throw new Error(

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -37,6 +37,7 @@ import type {
   AppliedFeature,
   AppliedOperation,
   AppliedResource,
+  ContainerIntegrationContext,
   FeatureContainer,
   FeatureDeclaration,
   FeatureOperation,
@@ -472,7 +473,7 @@ export class IntegrationInstaller {
       feature,
       preparedDependencies.resolvedDependencies,
     );
-    const featureContext = { ...context, resolvedDependencies };
+    const featureContext = this.buildFeatureContext(context, feature, resolvedDependencies);
 
     await this.cleanupRecordedLegacyInstallations(feature, installedFeature, featureContext);
 
@@ -495,6 +496,21 @@ export class IntegrationInstaller {
     }
 
     return { dependencies, resources, operations };
+  }
+
+  private buildFeatureContext<TOptions>(
+    context: IntegrationContext,
+    feature: FeatureDeclaration<TOptions>,
+    resolvedDependencies: ReadonlyMap<string, InstalledDependency>,
+  ): IntegrationContext {
+    if (!isFeatureContainer(feature)) {
+      return { ...context, resolvedDependencies };
+    }
+    return {
+      ...context,
+      resolvedDependencies,
+      activeSubfeatures: feature.subfeatures,
+    } as ContainerIntegrationContext;
   }
 
   private async cleanupRecordedLegacyInstallations<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -134,9 +134,8 @@ export class IntegrationInstaller {
         const validIds = new Set(feature.subfeatures.map((s) => s.id));
         const unknown = subfeatureIds.filter((id) => !validIds.has(id));
         if (unknown.length > 0) {
-          throw new Error(
-            `Unknown subfeature(s) ${unknown.map((id) => `${integration.id}.${featureId}.${id}`).join(', ')}`,
-          );
+          const prefix = `${integration.id}.${featureId}.`;
+          throw new Error(`Unknown subfeature(s) ${unknown.map((id) => prefix + id).join(', ')}`);
         }
         return {
           ...feature,

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import type { FeatureContainer, FeatureDeclaration } from './types';
+
 /**
  * Outcome of a feature's `shouldInstall` evaluation. Integrations declare the
  * intent; the installer resolves it (prompting / skip messaging) centrally.
@@ -60,4 +62,11 @@ export function normalizeDecision(result: boolean | InstallDecision | undefined)
     return skip();
   }
   return result;
+}
+
+/** Type guard — returns true when `feature` is a {@link FeatureContainer}. */
+export function isFeatureContainer<TOptions>(
+  feature: FeatureDeclaration<TOptions>,
+): feature is FeatureContainer<TOptions> {
+  return 'subfeatures' in feature;
 }

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -46,6 +46,12 @@ export interface ContainerIntegrationContext extends IntegrationContext {
   activeSubfeatures: readonly SubfeatureDeclaration[];
 }
 
+export function isContainerIntegrationContext(
+  ctx: IntegrationContext,
+): ctx is ContainerIntegrationContext {
+  return 'activeSubfeatures' in ctx;
+}
+
 export interface IntegrationInvocation<TOptions = Record<string, unknown>> {
   options: TOptions;
   targetRoot: string;

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -99,6 +99,27 @@ export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
   postInstallExample?: PostInstallExample;
 }
 
+/**
+ * Thin subfeature declaration — metadata, install condition, and binary dependencies only.
+ * No resources or operations; those belong to the owning {@link FeatureContainer}.
+ */
+export type SubfeatureDeclaration<TOptions = Record<string, unknown>> = Pick<
+  FeatureDeclaration<TOptions>,
+  'id' | 'displayName' | 'shouldInstall' | 'dependencies'
+>;
+
+/**
+ * A {@link FeatureDeclaration} that groups thin {@link SubfeatureDeclaration}s under it.
+ * The container owns the centralized resource; subfeatures contribute only binary
+ * dependencies and install conditions (no resources, no operations).
+ * Use {@link isFeatureContainer} from `selection` to downcast before accessing `subfeatures`.
+ */
+export interface FeatureContainer<
+  TOptions = Record<string, unknown>,
+> extends FeatureDeclaration<TOptions> {
+  subfeatures: SubfeatureDeclaration<TOptions>[];
+}
+
 export interface LegacyFeatureDeclaration {
   id: string;
   removable: boolean;

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -42,6 +42,10 @@ export interface IntegrationContext {
   resolvedDependencies: ReadonlyMap<string, InstalledDependency>;
 }
 
+export interface ContainerIntegrationContext extends IntegrationContext {
+  activeSubfeatures: readonly SubfeatureDeclaration[];
+}
+
 export interface IntegrationInvocation<TOptions = Record<string, unknown>> {
   options: TOptions;
   targetRoot: string;

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -331,6 +331,16 @@ export interface InstalledIntegrationDependencyReference {
 }
 
 /**
+ * Recorded state for an active thin subfeature nested inside a {@link InstalledIntegrationFeature}.
+ */
+export interface InstalledSubfeature {
+  /** Subfeature identifier from the integration declaration */
+  featureId: string;
+  /** Binary dependencies declared by this subfeature */
+  dependencies: InstalledIntegrationDependencyReference[];
+}
+
+/**
  * Installed declarative integration feature.
  */
 export interface InstalledIntegrationFeature {
@@ -356,6 +366,8 @@ export interface InstalledIntegrationFeature {
   operations: InstalledIntegrationOperation[];
   /** Optional command-specific metadata */
   attrs?: Record<string, IntegrationStateAttribute>;
+  /** Active thin subfeatures nested inside this container feature, if any */
+  subfeatures?: InstalledSubfeature[];
 }
 
 /**

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -32,6 +32,7 @@ import type {
   IntegrationContext,
   IntegrationDeclaration,
 } from '../../../../../../src/cli/commands/integrate/_common/registry';
+import { isContainerIntegrationContext } from '../../../../../../src/cli/commands/integrate/_common/registry/types.ts';
 import { getDefaultState, type InstalledIntegrationFeature } from '../../../../../../src/lib/state';
 
 const binaryInstall = await import('../../../../../../src/cli/commands/_common/install/binary');
@@ -333,7 +334,7 @@ describe('declarative integration framework', () => {
   });
 
   it('populates activeSubfeatures in context for container operations', async () => {
-    let capturedSubfeatures: ContainerIntegrationContext['activeSubfeatures'] | undefined;
+    let integrationContext: IntegrationContext | undefined;
     const container: FeatureContainer<{ enableSca?: boolean }> = {
       id: 'container',
       displayName: 'Container',
@@ -349,7 +350,7 @@ describe('declarative integration framework', () => {
         {
           id: 'capture-op',
           apply: (ctx) => {
-            capturedSubfeatures = (ctx as ContainerIntegrationContext).activeSubfeatures;
+            integrationContext = ctx;
           },
         },
       ],
@@ -362,7 +363,11 @@ describe('declarative integration framework', () => {
       { feature: filteredContainer, targetRoot: tempDir, scope: 'project' },
     ]);
 
-    expect(capturedSubfeatures?.map((s) => s.id)).toEqual(['mandatory']);
+    expect(integrationContext).toBeDefined();
+    expect(isContainerIntegrationContext(integrationContext!)).toBeTrue();
+    expect(
+      (integrationContext as ContainerIntegrationContext)?.activeSubfeatures?.map((s) => s.id),
+    ).toEqual(['mandatory']);
   });
 
   it('records active subfeatures nested under the container feature in state', async () => {

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
 import type {
+  FeatureContainer,
   FeatureDeclaration,
   IntegrationContext,
   IntegrationDeclaration,
@@ -43,6 +44,7 @@ const {
   install,
   IntegrationInstaller,
   IntegrationRegistry,
+  isFeatureContainer,
   jsonPatch,
   skip,
   SonarSourceBinary,
@@ -235,6 +237,128 @@ describe('declarative integration framework', () => {
         }),
       ),
     ).toThrow('Legacy feature id must not be empty');
+  });
+
+  it('rejects duplicate and empty subfeature ids in a FeatureContainer', () => {
+    const registry = new IntegrationRegistry();
+
+    expect(() =>
+      registry.register(
+        makeIntegration({
+          features: [
+            {
+              id: 'container',
+              displayName: 'Container',
+              subfeatures: [
+                { id: 'same', displayName: 'Sub A' },
+                { id: 'same', displayName: 'Sub B' },
+              ],
+            } as FeatureContainer,
+          ],
+        }),
+      ),
+    ).toThrow('Duplicate subfeature id in container test-integration.container');
+
+    expect(() =>
+      registry.register(
+        makeIntegration({
+          features: [
+            {
+              id: 'container',
+              displayName: 'Container',
+              subfeatures: [{ id: ' ', displayName: 'Sub' }],
+            } as FeatureContainer,
+          ],
+        }),
+      ),
+    ).toThrow('Subfeature id must not be empty');
+  });
+
+  it('isFeatureContainer returns true only for features with a subfeatures array', () => {
+    const plain: FeatureDeclaration = { id: 'plain', displayName: 'Plain' };
+    const container: FeatureContainer = {
+      id: 'container',
+      displayName: 'Container',
+      subfeatures: [],
+    };
+
+    expect(isFeatureContainer(plain)).toBe(false);
+    expect(isFeatureContainer(container)).toBe(true);
+  });
+
+  it('selectFeaturesForInvocation filters subfeatures by shouldInstall conditions', async () => {
+    const dep = sonarSourceBinary({ id: 'test-dep', binary: SonarSourceBinary.SonarSecrets });
+    const container: FeatureContainer<{ enableSca?: boolean }> = {
+      id: 'container',
+      displayName: 'Container',
+      subfeatures: [
+        {
+          id: 'mandatory',
+          displayName: 'Mandatory',
+          shouldInstall: () => install(),
+          dependencies: [dep],
+        },
+        {
+          id: 'optional',
+          displayName: 'Optional',
+          shouldInstall: ({ options }) => (options.enableSca ? install() : skip()),
+        },
+      ],
+    };
+    const integration = makeIntegration<{ enableSca?: boolean }>({ features: [container] });
+
+    const withoutSca = await installer.selectFeaturesForInvocation(integration, {
+      options: {},
+      targetRoot: '/tmp',
+      scope: 'project',
+      nonInteractive: true,
+      state: getDefaultState('test'),
+    });
+    expect(withoutSca).toHaveLength(1);
+    expect(
+      (withoutSca[0] as FeatureContainer<{ enableSca?: boolean }>).subfeatures.map((s) => s.id),
+    ).toEqual(['mandatory']);
+
+    const withSca = await installer.selectFeaturesForInvocation(integration, {
+      options: { enableSca: true },
+      targetRoot: '/tmp',
+      scope: 'project',
+      nonInteractive: true,
+      state: getDefaultState('test'),
+    });
+    expect(
+      (withSca[0] as FeatureContainer<{ enableSca?: boolean }>).subfeatures.map((s) => s.id),
+    ).toEqual(['mandatory', 'optional']);
+  });
+
+  it('records active subfeatures nested under the container feature in state', async () => {
+    const dep = sonarSourceBinary({ id: 'sub-dep', binary: SonarSourceBinary.SonarSecrets });
+    const container: FeatureContainer = {
+      id: 'container',
+      displayName: 'Container',
+      subfeatures: [
+        { id: 'sub-a', displayName: 'Sub A', shouldInstall: () => install(), dependencies: [dep] },
+        { id: 'sub-b', displayName: 'Sub B', shouldInstall: () => skip() },
+      ],
+    };
+    const integration = makeIntegration({ features: [container] });
+    const state = getDefaultState('test');
+    const context = makeContext(state, tempDir);
+
+    const filteredContainer = { ...container, subfeatures: [container.subfeatures[0]] };
+    await installer.applyAndRecordFeatures(state, integration, [
+      { feature: filteredContainer, targetRoot: tempDir, scope: 'project' },
+    ]);
+
+    const recorded = state.integrations.installed[0]?.features[0];
+    expect(recorded?.featureId).toBe('container');
+    expect(recorded?.subfeatures).toHaveLength(1);
+    expect(recorded?.subfeatures?.[0]).toMatchObject({
+      featureId: 'sub-a',
+      dependencies: [{ id: 'sub-dep' }],
+    });
+    expect(state.dependencies.installed.some((d) => d.id === 'sub-dep')).toBe(true);
+    void context;
   });
 
   it('lists registered integrations', () => {

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -419,6 +419,24 @@ describe('declarative integration framework', () => {
     );
   });
 
+  it('selectFeatures filters container subfeatures to the requested ids', () => {
+    const container: FeatureContainer = {
+      id: 'container',
+      displayName: 'Container',
+      subfeatures: [
+        { id: 'sub-a', displayName: 'Sub A' },
+        { id: 'sub-b', displayName: 'Sub B' },
+        { id: 'sub-c', displayName: 'Sub C' },
+      ],
+    };
+    const integration = makeIntegration({ features: [container] });
+
+    const [selected] = installer.selectFeatures(integration, [
+      { featureId: 'container', subfeatureIds: ['sub-c', 'sub-a'] },
+    ]);
+    expect((selected as FeatureContainer).subfeatures.map((s) => s.id)).toEqual(['sub-a', 'sub-c']);
+  });
+
   it('selectFeatures rejects subfeatureIds for a non-container feature', () => {
     const integration = makeIntegration({
       features: [{ id: 'plain', displayName: 'Plain' }],

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -361,6 +361,35 @@ describe('declarative integration framework', () => {
     expect(context).toBeDefined();
   });
 
+  it('reconciles subfeature dependency references across re-installs', async () => {
+    const depOld = sonarSourceBinary({ id: 'dep-old', binary: SonarSourceBinary.SonarSecrets });
+    const depNew = sonarSourceBinary({ id: 'dep-new', binary: SonarSourceBinary.SonarSecrets });
+
+    const makeContainer = (dep: typeof depOld): FeatureContainer => ({
+      id: 'container',
+      displayName: 'Container',
+      subfeatures: [{ id: 'sub-a', displayName: 'Sub A', dependencies: [dep] }],
+    });
+
+    const integration = makeIntegration({ features: [makeContainer(depOld)] });
+    const state = getDefaultState('test');
+
+    // First install: subfeature declares dep-old
+    await installer.applyAndRecordFeatures(state, integration, [
+      { feature: makeContainer(depOld), targetRoot: tempDir, scope: 'project' },
+    ]);
+    expect(state.integrations.installed[0]?.features[0]?.subfeatures?.[0]?.dependencies).toEqual([
+      { id: 'dep-old' },
+    ]);
+
+    // Re-install: subfeature now declares dep-new instead
+    await installer.applyAndRecordFeatures(state, integration, [
+      { feature: makeContainer(depNew), targetRoot: tempDir, scope: 'project' },
+    ]);
+    const subfeature = state.integrations.installed[0]?.features[0]?.subfeatures?.[0];
+    expect(subfeature?.dependencies).toEqual([{ id: 'dep-new' }]);
+  });
+
   it('lists registered integrations', () => {
     const registry = new IntegrationRegistry();
     const first = makeIntegration({ id: 'first' });

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -358,7 +358,7 @@ describe('declarative integration framework', () => {
       dependencies: [{ id: 'sub-dep' }],
     });
     expect(state.dependencies.installed.some((d) => d.id === 'sub-dep')).toBe(true);
-    void context;
+    expect(context).toBeDefined();
   });
 
   it('lists registered integrations', () => {

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -390,6 +390,31 @@ describe('declarative integration framework', () => {
     );
   });
 
+  it('selectFeatures rejects subfeatureIds for a non-container feature', () => {
+    const integration = makeIntegration({
+      features: [{ id: 'plain', displayName: 'Plain' }],
+    });
+
+    expect(() =>
+      installer.selectFeatures(integration, [{ featureId: 'plain', subfeatureIds: ['sub'] }]),
+    ).toThrow('Feature test-integration.plain is not a container');
+  });
+
+  it('selectFeatures rejects unknown subfeature ids on a container', () => {
+    const container: FeatureContainer = {
+      id: 'container',
+      displayName: 'Container',
+      subfeatures: [{ id: 'valid', displayName: 'Valid' }],
+    };
+    const integration = makeIntegration({ features: [container] });
+
+    expect(() =>
+      installer.selectFeatures(integration, [
+        { featureId: 'container', subfeatureIds: ['valid', 'typo'] },
+      ]),
+    ).toThrow('Unknown subfeature(s) test-integration.container.typo');
+  });
+
   it('selects features matching an invocation, honoring boolean and decision results', async () => {
     interface GitOptions {
       hook?: 'pre-commit' | 'pre-push';

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
 import type {
+  ContainerIntegrationContext,
   FeatureContainer,
   FeatureDeclaration,
   IntegrationContext,
@@ -329,6 +330,39 @@ describe('declarative integration framework', () => {
     expect(
       (withSca[0] as FeatureContainer<{ enableSca?: boolean }>).subfeatures.map((s) => s.id),
     ).toEqual(['mandatory', 'optional']);
+  });
+
+  it('populates activeSubfeatures in context for container operations', async () => {
+    let capturedSubfeatures: ContainerIntegrationContext['activeSubfeatures'] | undefined;
+    const container: FeatureContainer<{ enableSca?: boolean }> = {
+      id: 'container',
+      displayName: 'Container',
+      subfeatures: [
+        { id: 'mandatory', displayName: 'Mandatory', shouldInstall: () => install() },
+        {
+          id: 'optional',
+          displayName: 'Optional',
+          shouldInstall: ({ options }) => (options.enableSca ? install() : skip()),
+        },
+      ],
+      operations: [
+        {
+          id: 'capture-op',
+          apply: (ctx) => {
+            capturedSubfeatures = (ctx as ContainerIntegrationContext).activeSubfeatures;
+          },
+        },
+      ],
+    };
+    const integration = makeIntegration<{ enableSca?: boolean }>({ features: [container] });
+    const state = getDefaultState('test');
+
+    const filteredContainer = { ...container, subfeatures: [container.subfeatures[0]] };
+    await installer.applyAndRecordFeatures(state, integration, [
+      { feature: filteredContainer, targetRoot: tempDir, scope: 'project' },
+    ]);
+
+    expect(capturedSubfeatures?.map((s) => s.id)).toEqual(['mandatory']);
   });
 
   it('records active subfeatures nested under the container feature in state', async () => {


### PR DESCRIPTION
Part of CLI-504

----
## Summary by Gitar

- **New declarative types:**
  - Added `FeatureContainer` and `SubfeatureDeclaration` to support nested feature structures.
  - Implemented `isFeatureContainer` type guard to distinguish containers from standard features.
  - Introduced `ContainerIntegrationContext` to track active subfeatures during integration.
- **Registry validation:**
  - Added validation in `IntegrationRegistry` to ensure unique and non-empty IDs for subfeatures within a container.
- **Installer logic:**
  - Updated `IntegrationInstaller.selectFeatures` to support explicit subfeature selection via IDs.
  - Updated `IntegrationInstaller` to filter and resolve subfeatures based on `shouldInstall` conditions during integration execution.
  - Refactored dependency resolution to include dependencies from active subfeatures.
- **State management:**
  - Updated `InstallationRecorder` and `CliState` to track and persist active subfeatures and their dependencies within the installed integration state.

<sub>This will update automatically on new commits.</sub>