### PR TITLE
CLI-698 Add automatic project discovery for pre-commit hook

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -253,7 +253,7 @@ integrateCommand
     '-p, --project <project>',
     'Project key baked into the dependency-risks hook (required with --dependency-risks)',
   )
-  .authenticatedAction((_auth, options: IntegrateGitOptions) => integrateGit(options));
+  .authenticatedAction((auth, options: IntegrateGitOptions) => integrateGit(options, auth));
 
 const projectKeyExtraHelp = `
 Instead of providing an explicit --project, you can add sonar.projectKey to sonar-project.properties at the repository root.

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -23,10 +23,11 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { GLOBAL_HOOKS_DIR } from '../../../../lib/config-constants';
 import { normalizePath } from '../../../../lib/fs-utils';
-import { findGitRoot } from '../../../../lib/project-workspace';
-import { blank, confirmPrompt, info, intro, text, warn } from '../../../../ui';
+import { discoverProject, findGitRoot } from '../../../../lib/project-workspace';
+import { blank, confirmPrompt, info, intro, phase, phaseItem, text, warn } from '../../../../ui';
 import { yellow } from '../../../../ui/colors.js';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
@@ -134,7 +135,10 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   await installGitFeatures(options, GLOBAL_HOOKS_DIR, 'global');
 }
 
-export async function integrateGit(options: IntegrateGitOptions): Promise<void> {
+export async function integrateGit(
+  options: IntegrateGitOptions,
+  auth: ResolvedAuth,
+): Promise<void> {
   validateHookOption(options.hook);
 
   if (options.global && (options.dependencyRisks || options.project)) {
@@ -164,6 +168,8 @@ export async function integrateGit(options: IntegrateGitOptions): Promise<void> 
     return integrateGitGlobal(options);
   }
 
+  const resolvedOptions = await resolveProjectKey(options, isGit ? gitRoot : process.cwd(), auth);
+
   if (!isGit) {
     throw new CommandFailedError('No git repository found.', {
       remediationHint:
@@ -171,7 +177,29 @@ export async function integrateGit(options: IntegrateGitOptions): Promise<void> 
     });
   }
 
-  await installGitFeatures(options, gitRoot, 'project');
+  await installGitFeatures(resolvedOptions, gitRoot, 'project');
+}
+
+async function resolveProjectKey(
+  options: IntegrateGitOptions,
+  root: string,
+  auth: ResolvedAuth,
+): Promise<IntegrateGitOptions> {
+  if (options.project) {
+    phase('Project', [phaseItem('Key', 'done', options.project)]);
+    return options;
+  }
+
+  const discovered = await discoverProject(root, true, { auth });
+  if (discovered.projectKey) {
+    phase('Project', [phaseItem('Key', 'done', discovered.projectKey)]);
+    return { ...options, project: discovered.projectKey };
+  }
+
+  warn(
+    'No project key detected — some features will not be available. Run `sonar integrate git --help` for ways to define a project.',
+  );
+  return options;
 }
 
 async function installGitFeatures(

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -168,14 +168,14 @@ export async function integrateGit(
     return integrateGitGlobal(options);
   }
 
-  const resolvedOptions = await resolveProjectKey(options, isGit ? gitRoot : process.cwd(), auth);
-
   if (!isGit) {
     throw new CommandFailedError('No git repository found.', {
       remediationHint:
         'Run this command from inside a git repository, or use --global to install a global hook.',
     });
   }
+
+  const resolvedOptions = await resolveProjectKey(options, gitRoot, auth);
 
   await installGitFeatures(resolvedOptions, gitRoot, 'project');
 }

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -607,6 +607,44 @@ describe('integrate git (native hooks)', () => {
   );
 
   it(
+    'opts into dependency-risks interactively and auto-discovers project key',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      harness.state().withScaScannerBinaryInstalled();
+      initGitRepo(harness);
+      harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=auto-project\n');
+
+      // '\r' selects project scope, '\r' accepts 'Install pre-commit hook?',
+      // '\r' accepts 'Enable dependency-risks?' (dep-risks is a pre-commit subfeature,
+      // so it prompts immediately after pre-commit is accepted), 'n' declines
+      // 'Install pre-push hook?'. Project key discovered from sonar-project.properties.
+      const result = await harness.run('integrate git', {
+        stdinChunks: ['\r', '\r', '\r', 'n'],
+        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
+      });
+
+      expect(result.exitCode).toBe(0);
+      const hookContent = readFileSync(
+        join(harness.cwd.path, '.git', 'hooks', 'pre-commit'),
+        'utf-8',
+      );
+      expect(hookContent).toContain('--dependency-risks -p');
+      expect(hookContent).toContain('auto-project');
+
+      const state = harness.stateJsonFile.asJson() as InstalledStateJson;
+      const gitIntegration = getInstalledIntegration(state, 'native-git');
+      const feature = gitIntegration.features[0];
+      expect(feature.featureId).toBe('pre-commit-hook');
+      expect(feature.attrs?.projectKey).toBe('auto-project');
+      expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
+      expectSubfeatureHasDependency(feature, 'pre-commit-dependency-risks', 'sca-scanner-cli');
+      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sca-scanner-cli', 'sonarsource-binary');
+    },
+    { timeout: 30000 },
+  );
+
+  it(
     'fails with an explicit notice when the user declines every per-feature prompt',
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -339,8 +339,15 @@ describe('detectHookInstallation', () => {
   });
 });
 
+const MOCK_AUTH = {
+  serverUrl: 'https://sonarqube.example.com',
+  token: 'test-token',
+  connectionType: 'on-premise' as const,
+};
+
 describe('integrateGit', () => {
   let findGitRootSpy: ReturnType<typeof spyOn>;
+  let discoverProjectSpy: ReturnType<typeof spyOn>;
   let printGitPreflightSummarySpy: ReturnType<typeof spyOn>;
   let installBinarySpy: ReturnType<typeof spyOn>;
   let resolveBinaryPathSpy: ReturnType<typeof spyOn>;
@@ -352,6 +359,12 @@ describe('integrateGit', () => {
     setMockUi(true);
     clearMockUiCalls();
     findGitRootSpy = spyOn(discovery, 'findGitRoot');
+    discoverProjectSpy = spyOn(discovery, 'discoverProject').mockResolvedValue({
+      rootDir: TEMP_DIR,
+      projectKey: undefined,
+      isGitRepo: true,
+      configSources: [],
+    });
     printGitPreflightSummarySpy = spyOn(
       preflightSummary,
       'printGitPreflightSummary',
@@ -369,6 +382,7 @@ describe('integrateGit', () => {
   afterEach(() => {
     setMockUi(false);
     findGitRootSpy.mockRestore();
+    discoverProjectSpy.mockRestore();
     printGitPreflightSummarySpy.mockRestore();
     installBinarySpy.mockRestore();
     resolveBinaryPathSpy.mockRestore();
@@ -379,49 +393,69 @@ describe('integrateGit', () => {
   /* eslint-disable @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable */
   it('throws InvalidOptionError when --hook is invalid before git checks', async () => {
     await expect(
-      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
+      integrateGit(
+        { nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions,
+        MOCK_AUTH,
+      ),
     ).rejects.toBeInstanceOf(InvalidOptionError);
     await expect(
-      integrateGit({ nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions),
+      integrateGit(
+        { nonInteractive: true, hook: 'typo' } as unknown as IntegrateGitOptions,
+        MOCK_AUTH,
+      ),
     ).rejects.toThrow('--hook must be pre-commit or pre-push');
   });
 
   it('throws InvalidOptionError for invalid --hook on global install before other work', async () => {
     await expect(
-      integrateGit({
-        global: true,
-        nonInteractive: true,
-        hook: 'typo',
-      } as unknown as IntegrateGitOptions),
+      integrateGit(
+        {
+          global: true,
+          nonInteractive: true,
+          hook: 'typo',
+        } as unknown as IntegrateGitOptions,
+        MOCK_AUTH,
+      ),
     ).rejects.toBeInstanceOf(InvalidOptionError);
     await expect(
-      integrateGit({
-        global: true,
-        nonInteractive: true,
-        hook: 'typo',
-      } as unknown as IntegrateGitOptions),
+      integrateGit(
+        {
+          global: true,
+          nonInteractive: true,
+          hook: 'typo',
+        } as unknown as IntegrateGitOptions,
+        MOCK_AUTH,
+      ),
     ).rejects.toThrow('--hook must be pre-commit or pre-push');
   });
 
   it('throws InvalidOptionError when --global is combined with --dependency-risks', async () => {
     await expect(
-      integrateGit({ global: true, nonInteractive: true, dependencyRisks: true, project: 'k' }),
+      integrateGit(
+        { global: true, nonInteractive: true, dependencyRisks: true, project: 'k' },
+        MOCK_AUTH,
+      ),
     ).rejects.toBeInstanceOf(InvalidOptionError);
     await expect(
-      integrateGit({ global: true, nonInteractive: true, dependencyRisks: true, project: 'k' }),
+      integrateGit(
+        { global: true, nonInteractive: true, dependencyRisks: true, project: 'k' },
+        MOCK_AUTH,
+      ),
     ).rejects.toThrow('--dependency-risks and -p are not supported with --global');
   });
 
   it('throws InvalidOptionError when --global is combined with -p alone', async () => {
     await expect(
-      integrateGit({ global: true, nonInteractive: true, project: 'k' }),
+      integrateGit({ global: true, nonInteractive: true, project: 'k' }, MOCK_AUTH),
     ).rejects.toBeInstanceOf(InvalidOptionError);
   });
   /* eslint-enable @typescript-eslint/await-thenable */
 
   it('throws CommandFailedError when not inside a git repository', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: '/not-a-repo', isGit: false });
-    expect(integrateGit({ nonInteractive: true })).rejects.toThrow('No git repository found');
+    expect(integrateGit({ nonInteractive: true }, MOCK_AUTH)).rejects.toThrow(
+      'No git repository found',
+    );
   });
 
   it('shows repository summary before the scope prompt when in a git repository', async () => {
@@ -429,7 +463,7 @@ describe('integrateGit', () => {
     queueMockResponse('project');
     queueMockResponse(null); // user cancels at the hook-type prompt
     try {
-      await integrateGit({});
+      await integrateGit({}, MOCK_AUTH);
     } catch {
       // expected cancellation
     }
@@ -445,7 +479,7 @@ describe('integrateGit', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ nonInteractive: true, hook: 'pre-commit' }, MOCK_AUTH);
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('husky');
       expect(feature).toMatchObject({
@@ -489,7 +523,7 @@ describe('integrateGit', () => {
       throw new Error(`Unexpected command: ${command} ${args.join(' ')}`);
     });
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ nonInteractive: true, hook: 'pre-commit' }, MOCK_AUTH);
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('pre-commit');
       expect(feature).toMatchObject({
@@ -522,7 +556,7 @@ describe('integrateGit', () => {
     findGitRootSpy.mockReturnValue({ gitRoot: TEMP_DIR, isGit: true });
     const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(NO_HOOKS_PATH);
     try {
-      await integrateGit({ nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ nonInteractive: true, hook: 'pre-commit' }, MOCK_AUTH);
       expect(existsSync(join(TEMP_DIR, '.git', 'hooks', 'pre-commit'))).toBe(true);
       const feature = state.integrations.installed[0]?.features[0];
       expect(state.integrations.installed[0]?.integrationId).toBe('native-git');
@@ -549,6 +583,32 @@ describe('integrateGit', () => {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });
     }
+  });
+
+  it('throws CommandFailedError when user cancels at the dependency-risks prompt', async () => {
+    mkdirSync(join(TEMP_DIR, '.git', 'hooks'), { recursive: true });
+    findGitRootSpy.mockReturnValue({ gitRoot: TEMP_DIR, isGit: true });
+    discoverProjectSpy.mockResolvedValue({
+      rootDir: TEMP_DIR,
+      projectKey: 'my-project',
+      isGitRepo: true,
+      configSources: [],
+    });
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(NO_HOOKS_PATH);
+    queueMockResponse('project');
+    queueMockResponse(true);
+    queueMockResponse(null);
+    let caughtError: unknown;
+    try {
+      await integrateGit({}, MOCK_AUTH);
+    } catch (err) {
+      caughtError = err;
+    } finally {
+      spawnSpy.mockRestore();
+      rmSync(TEMP_DIR, { recursive: true, force: true });
+    }
+    expect(caughtError).toBeInstanceOf(CommandFailedError);
+    expect((caughtError as Error).message).toContain('Installation cancelled');
   });
 });
 
@@ -584,7 +644,7 @@ describe('integrateGitGlobal', () => {
     queueMockResponse(null);
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: false, hook: 'pre-commit' });
+      await integrateGit({ global: true, nonInteractive: false, hook: 'pre-commit' }, MOCK_AUTH);
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -595,7 +655,7 @@ describe('integrateGitGlobal', () => {
     installBinarySpy.mockRejectedValue(new Error('download failed'));
     let caughtMessage = '';
     try {
-      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' }, MOCK_AUTH);
     } catch (e) {
       caughtMessage = e instanceof Error ? e.message : '';
     }
@@ -609,7 +669,7 @@ describe('integrateGitGlobal', () => {
       stderr: '',
     });
     try {
-      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+      await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' }, MOCK_AUTH);
       const calls = getMockUiCalls();
       const summaryCall = calls.find((c) => c.method === 'phase' && c.args[0] === 'Installed');
       expect(summaryCall).toBeDefined();
@@ -631,7 +691,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' }, MOCK_AUTH);
       } catch (e) {
         caughtError = e;
       }
@@ -653,7 +713,7 @@ describe('integrateGitGlobal', () => {
     try {
       let caughtError: unknown;
       try {
-        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' });
+        await integrateGit({ global: true, nonInteractive: true, hook: 'pre-commit' }, MOCK_AUTH);
       } catch (e) {
         caughtError = e;
       }

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -451,11 +451,14 @@ describe('integrateGit', () => {
   });
   /* eslint-enable @typescript-eslint/await-thenable */
 
-  it('throws CommandFailedError when not inside a git repository', () => {
+  it('throws CommandFailedError when not inside a git repository', async () => {
     findGitRootSpy.mockReturnValue({ gitRoot: '/not-a-repo', isGit: false });
-    expect(integrateGit({ nonInteractive: true }, MOCK_AUTH)).rejects.toThrow(
+    /* eslint-disable @typescript-eslint/await-thenable */
+    await expect(integrateGit({ nonInteractive: true }, MOCK_AUTH)).rejects.toThrow(
       'No git repository found',
     );
+    /* eslint-enable @typescript-eslint/await-thenable */
+    expect(discoverProjectSpy).not.toHaveBeenCalled();
   });
 
   it('shows repository summary before the scope prompt when in a git repository', async () => {
@@ -607,6 +610,7 @@ describe('integrateGit', () => {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });
     }
+    expect(discoverProjectSpy).toHaveBeenCalledWith(TEMP_DIR, true, { auth: MOCK_AUTH });
     expect(caughtError).toBeInstanceOf(CommandFailedError);
     expect((caughtError as Error).message).toContain('Installation cancelled');
   });


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **Project discovery:**
  - Integrated `discoverProject` to automatically resolve the project key from `sonar-project.properties` during git integration.
  - Added `resolveProjectKey` to streamline automatic discovery or manual CLI flag usage.
- **Interactive workflow:**
  - Updated `integrateGit` to include a project key discovery phase in the interactive prompt flow with visual feedback.
- **Refactoring:**
  - Updated `integrateGit` signature to accept `ResolvedAuth` for consistent authentication handling.
- **Validation:**
  - Added comprehensive test coverage for the new discovery flow, including integration tests with auto-project key resolution and handling of cancellation scenarios.

<sub>This will update automatically on new commits.</sub>