### PR TITLE
CLI-568 Add severity filter to SCA

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -37,6 +37,7 @@ import { CommandFailedError } from './commands/_common/error';
 import { parseInteger } from './commands/_common/parsing';
 import { SonarCommand } from './commands/_common/sonar-command.js';
 import { analyzeAll, type AnalyzeAllOptions } from './commands/analyze/analyze-all';
+import { SEVERITIES } from './commands/analyze/dependency-risk-helpers/view-model/build/severity';
 import {
   analyzeDependencyRisks,
   type AnalyzeDependencyRisksOptions,
@@ -426,6 +427,11 @@ const dependencyRisksStatusFilterOption = new Option(
     '    --statuses active,safe\n',
 ).default('active');
 
+const dependencyRisksMinSeverityOption = new Option(
+  '--min-severity <severity>',
+  'Minimum severity level to include (default: all severities)',
+).choices(SEVERITIES);
+
 const dependencyRisksExtraHelp = `
 Dependency manifest files (e.g. package-lock.json, pom.xml) will be uploaded to SonarQube for analysis.
 Learn more: https://docs.sonarsource.com/sonarqube-server/advanced-security/analyzing-projects-for-dependencies#supported-languages-and-package-managers
@@ -439,6 +445,7 @@ analyze
   .option('-p, --project <project>', 'Project key (auto-detected when omitted)')
   .addOption(dependencyRisksFormatOption)
   .addOption(dependencyRisksStatusFilterOption)
+  .addOption(dependencyRisksMinSeverityOption)
   .addHelpText('after', dependencyRisksExtraHelp)
   .authenticatedAction((auth, options: AnalyzeDependencyRisksOptions) =>
     analyzeDependencyRisks(options, auth),

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { type Command, Help, Option } from 'commander';
+import { type Command, Help, InvalidArgumentError, Option } from 'commander';
 
 import { version as VERSION } from '../../package.json';
 import { IS_STANDALONE_DISTRIBUTION } from '../lib/distribution';
@@ -37,6 +37,7 @@ import { CommandFailedError } from './commands/_common/error';
 import { parseInteger } from './commands/_common/parsing';
 import { SonarCommand } from './commands/_common/sonar-command.js';
 import { analyzeAll, type AnalyzeAllOptions } from './commands/analyze/analyze-all';
+import type { Severity } from './commands/analyze/dependency-risk-helpers/sca-scanner';
 import { SEVERITIES } from './commands/analyze/dependency-risk-helpers/view-model/build/severity';
 import {
   analyzeDependencyRisks,
@@ -429,8 +430,14 @@ const dependencyRisksStatusFilterOption = new Option(
 
 const dependencyRisksMinSeverityOption = new Option(
   '--min-severity <severity>',
-  'Minimum severity level to include (default: all severities)',
-).choices(SEVERITIES);
+  `Minimum severity level to include. Allowed values: ${SEVERITIES.join(', ')} (default: all severities)`,
+).argParser((v) => {
+  const upper = v.toUpperCase();
+  if (!SEVERITIES.includes(upper as Severity)) {
+    throw new InvalidArgumentError(`Allowed choices are ${SEVERITIES.join(', ')}.`);
+  }
+  return upper;
+});
 
 const dependencyRisksExtraHelp = `
 Dependency manifest files (e.g. package-lock.json, pom.xml) will be uploaded to SonarQube for analysis.

--- a/src/cli/commands/analyze/dependency-risk-helpers/risk-filter.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/risk-filter.ts
@@ -18,13 +18,16 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import type { Severity } from './sca-scanner';
 import type { EffectiveStatus, RiskVM } from './view-model';
+import { severityRank } from './view-model/build/severity';
 
 export type RiskFilterPredicate = (risk: RiskVM) => boolean;
 
 export interface RiskFilterDescription {
   effectiveStatuses: EffectiveStatus[];
   discardedStatuses: EffectiveStatus[];
+  minSeverity?: Severity;
 }
 export interface RiskFilter {
   description: RiskFilterDescription;
@@ -49,8 +52,11 @@ const PRESET_EXPANSIONS: Record<StatusPreset, EffectiveStatus[]> = {
   all: [...EFFECTIVE_STATUSES],
 };
 
-export function buildRiskFilter(input: string): RiskFilter | null {
-  const tokens = input.split(',').map((s) => s.trim().toLowerCase());
+export function buildRiskFilter(statuses: string, minSeverity?: Severity): RiskFilter | null {
+  const tokens = statuses
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s !== '');
   const set = new Set<EffectiveStatus>();
 
   for (const token of tokens) {
@@ -65,12 +71,22 @@ export function buildRiskFilter(input: string): RiskFilter | null {
     }
   }
 
-  if (set.size === 0) return null;
+  if (set.size === 0 && minSeverity === undefined) return null;
+
+  const statusMatches = (status: EffectiveStatus) => set.size === 0 || set.has(status);
+
+  const description: RiskFilterDescription = {
+    effectiveStatuses: EFFECTIVE_STATUSES.filter(statusMatches),
+    discardedStatuses: EFFECTIVE_STATUSES.filter((s) => !statusMatches(s)),
+  };
+  if (minSeverity !== undefined) {
+    description.minSeverity = minSeverity;
+  }
+
   return {
-    description: {
-      effectiveStatuses: EFFECTIVE_STATUSES.filter((s) => set.has(s)),
-      discardedStatuses: EFFECTIVE_STATUSES.filter((s) => !set.has(s)),
-    },
-    predicate: (risk) => set.has(risk.status),
+    description,
+    predicate: (risk) =>
+      statusMatches(risk.status) &&
+      (minSeverity === undefined || severityRank(risk.severity) <= severityRank(minSeverity)),
   };
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/risk-filter.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/risk-filter.ts
@@ -27,7 +27,7 @@ export type RiskFilterPredicate = (risk: RiskVM) => boolean;
 export interface RiskFilterDescription {
   effectiveStatuses: EffectiveStatus[];
   discardedStatuses: EffectiveStatus[];
-  minSeverity?: Severity;
+  minimalSeverity?: Severity;
 }
 export interface RiskFilter {
   description: RiskFilterDescription;
@@ -52,7 +52,7 @@ const PRESET_EXPANSIONS: Record<StatusPreset, EffectiveStatus[]> = {
   all: [...EFFECTIVE_STATUSES],
 };
 
-export function buildRiskFilter(statuses: string, minSeverity?: Severity): RiskFilter | null {
+export function buildRiskFilter(statuses: string, minimalSeverity?: Severity): RiskFilter | null {
   const tokens = statuses
     .split(',')
     .map((s) => s.trim().toLowerCase())
@@ -71,7 +71,7 @@ export function buildRiskFilter(statuses: string, minSeverity?: Severity): RiskF
     }
   }
 
-  if (set.size === 0 && minSeverity === undefined) return null;
+  if (set.size === 0 && minimalSeverity === undefined) return null;
 
   const statusMatches = (status: EffectiveStatus) => set.size === 0 || set.has(status);
 
@@ -79,14 +79,15 @@ export function buildRiskFilter(statuses: string, minSeverity?: Severity): RiskF
     effectiveStatuses: EFFECTIVE_STATUSES.filter(statusMatches),
     discardedStatuses: EFFECTIVE_STATUSES.filter((s) => !statusMatches(s)),
   };
-  if (minSeverity !== undefined) {
-    description.minSeverity = minSeverity;
+  if (minimalSeverity !== undefined) {
+    description.minimalSeverity = minimalSeverity;
   }
 
   return {
     description,
     predicate: (risk) =>
       statusMatches(risk.status) &&
-      (minSeverity === undefined || severityRank(risk.severity) <= severityRank(minSeverity)),
+      (minimalSeverity === undefined ||
+        severityRank(risk.severity) <= severityRank(minimalSeverity)),
   };
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
@@ -154,8 +154,8 @@ function filteringByLine(filter: RiskFilterDescription): string {
     const discarded = formatStatuses(filter.discardedStatuses);
     line += dim(` (discarded: ${discarded})`);
   }
-  if (filter.minSeverity !== undefined) {
-    line += `; severity ${filter.minSeverity.toLowerCase()} or above`;
+  if (filter.minimalSeverity !== undefined) {
+    line += `; severity ${filter.minimalSeverity.toLowerCase()} or above`;
   }
   return line;
 }

--- a/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
@@ -149,12 +149,15 @@ function summaryHeader(summary: SummaryVM): string {
 
 function filteringByLine(filter: RiskFilterDescription): string {
   const kept = formatStatuses(filter.effectiveStatuses);
-  if (filter.discardedStatuses.length === 0) {
-    return `Filtering by: ${kept}`;
+  let line = `Filtering by: ${kept}`;
+  if (filter.discardedStatuses.length > 0) {
+    const discarded = formatStatuses(filter.discardedStatuses);
+    line += ` ${dim(`(discarded: ${discarded})`)}`;
   }
-  const discarded = formatStatuses(filter.discardedStatuses);
-  const discardedText = dim(`(discarded: ${discarded})`);
-  return `Filtering by: ${kept} ${discardedText}`;
+  if (filter.minSeverity !== undefined) {
+    line += `; severity ${filter.minSeverity.toLowerCase()} or above`;
+  }
+  return line;
 }
 
 function formatStatuses(statuses: readonly string[]): string {

--- a/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/table/format-dependency-risks-table.ts
@@ -152,7 +152,7 @@ function filteringByLine(filter: RiskFilterDescription): string {
   let line = `Filtering by: ${kept}`;
   if (filter.discardedStatuses.length > 0) {
     const discarded = formatStatuses(filter.discardedStatuses);
-    line += ` ${dim(`(discarded: ${discarded})`)}`;
+    line += dim(` (discarded: ${discarded})`);
   }
   if (filter.minSeverity !== undefined) {
     line += `; severity ${filter.minSeverity.toLowerCase()} or above`;

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -32,6 +32,7 @@ import { formatDependencyRisksToon } from './dependency-risk-helpers/format-depe
 import { pluralize } from './dependency-risk-helpers/pluralize.ts';
 import { buildRiskFilter } from './dependency-risk-helpers/risk-filter.ts';
 import { ScaScanOrchestrator } from './dependency-risk-helpers/sca-scan-orchestrator.ts';
+import type { Severity } from './dependency-risk-helpers/sca-scanner.ts';
 import { formatDependencyRisksTable } from './dependency-risk-helpers/table';
 import type { DependencyRisksViewModel } from './dependency-risk-helpers/view-model';
 import { buildDependencyRisksViewModel } from './dependency-risk-helpers/view-model/build';
@@ -47,13 +48,14 @@ export interface AnalyzeDependencyRisksOptions {
   project?: string;
   format: string;
   statuses: string;
+  minSeverity?: Severity;
 }
 
 export async function analyzeDependencyRisks(
   options: AnalyzeDependencyRisksOptions,
   auth: ResolvedAuth,
 ): Promise<void> {
-  const filter = buildRiskFilter(options.statuses);
+  const filter = buildRiskFilter(options.statuses, options.minSeverity);
   if (!filter) {
     throw new InvalidOptionError(
       `Invalid --statuses value: '${options.statuses}'`,

--- a/src/cli/commands/hook/git-pre-commit-dependency-risks.ts
+++ b/src/cli/commands/hook/git-pre-commit-dependency-risks.ts
@@ -39,6 +39,7 @@ import { DefaultScaScannerSpawner } from '../analyze/dependency-risk-helpers/def
 import { pluralize } from '../analyze/dependency-risk-helpers/pluralize';
 import { buildRiskFilter } from '../analyze/dependency-risk-helpers/risk-filter';
 import { ScaScanOrchestrator } from '../analyze/dependency-risk-helpers/sca-scan-orchestrator';
+import type { Severity } from '../analyze/dependency-risk-helpers/sca-scanner';
 import {
   anyFileMatches,
   ScaWatchPatternsRunner,
@@ -48,6 +49,7 @@ import { buildDependencyRisksViewModel } from '../analyze/dependency-risk-helper
 import { SEVERITIES } from '../analyze/dependency-risk-helpers/view-model/build/severity';
 
 const HOOK_STATUS_FILTER = 'new';
+const HOOK_MIN_SEVERITY: Severity = 'MEDIUM';
 
 export interface DepRisksStageOptions {
   project: string;
@@ -66,7 +68,7 @@ export async function runDepRisksStage(options: DepRisksStageOptions): Promise<v
     return;
   }
 
-  const filter = buildRiskFilter(HOOK_STATUS_FILTER);
+  const filter = buildRiskFilter(HOOK_STATUS_FILTER, HOOK_MIN_SEVERITY);
   if (!filter) {
     warn(
       `Dependency-risks hook: invalid filter (statuses='${HOOK_STATUS_FILTER}'); commit not blocked.`,

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -229,7 +229,9 @@ describe('analyze dependency-risks', () => {
     );
 
     expect(result.exitCode).not.toBe(0);
-    expect(result.stdout + result.stderr).toContain("error: option '--min-severity <severity>'");
+    expect(result.stdout + result.stderr).toContain(
+      "error: option '--min-severity <severity>' argument 'bogus' is invalid. Allowed choices are BLOCKER, HIGH, MEDIUM, LOW, INFO.",
+    );
   });
 
   it('exits with code 1 when the SCA endpoint is absent (404)', async () => {

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -221,6 +221,17 @@ describe('analyze dependency-risks', () => {
     );
   });
 
+  it('rejects an unknown --min-severity value', async () => {
+    harness.withAuth('http://unused.example', VALID_TOKEN, TEST_ORG);
+
+    const result = await harness.run(
+      'analyze dependency-risks --project demo --min-severity bogus',
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain("error: option '--min-severity <severity>'");
+  });
+
   it('exits with code 1 when the SCA endpoint is absent (404)', async () => {
     const server = await harness
       .newFakeServer()

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/format-dependency-risks-table.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/format-dependency-risks-table.test.ts
@@ -118,6 +118,19 @@ describe('formatDependencyRisksTable — general smoke', () => {
     expect(filterLine).toContain('discarded: accept, safe, fixed');
     expect(filterLine.indexOf('new, open, confirm')).toBeLessThan(filterLine.indexOf('discarded:'));
   });
+
+  it('appends the minimum severity to the filter line when one is set', () => {
+    const filter = buildRiskFilter('active', 'MEDIUM')!.description;
+    const out = formatDependencyRisksTable(
+      mockDependencyRisksViewModel({
+        packages: [],
+        packagesScanned: 0,
+        summary: buildSummaryVM([], 0, filter),
+      }),
+    );
+    const filterLine = lineWith(out, 'Filtering by:');
+    expect(filterLine).toContain('severity medium or above');
+  });
 });
 
 describe('package header', () => {

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/risk-filter.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/risk-filter.test.ts
@@ -29,8 +29,8 @@ import type {
   RiskVM,
 } from '../../../../../../src/cli/commands/analyze/dependency-risk-helpers/view-model';
 
-function risk(status: EffectiveStatus): RiskVM {
-  return { severity: 'HIGH', status };
+function risk(status: EffectiveStatus, severity: RiskVM['severity'] = 'HIGH'): RiskVM {
+  return { severity, status };
 }
 
 const ALL_STATUSES: readonly EffectiveStatus[] = [
@@ -108,5 +108,43 @@ describe('buildRiskFilter — vm', () => {
 
   it('returns null for an unknown token', () => {
     expect(buildRiskFilter('bogus')).toBeNull();
+  });
+});
+
+describe('buildRiskFilter — minSeverity', () => {
+  it('narrows a status filter to risks at or above the given severity', () => {
+    const { predicate } = buildRiskFilter('all', 'MEDIUM')!;
+    expect(predicate(risk('OPEN', 'BLOCKER'))).toBe(true);
+    expect(predicate(risk('OPEN', 'HIGH'))).toBe(true);
+    expect(predicate(risk('OPEN', 'MEDIUM'))).toBe(true);
+    expect(predicate(risk('OPEN', 'LOW'))).toBe(false);
+    expect(predicate(risk('OPEN', 'INFO'))).toBe(false);
+  });
+
+  it('still applies the status constraint alongside the severity constraint', () => {
+    const { predicate } = buildRiskFilter('new', 'MEDIUM')!;
+    expect(predicate(risk('NEW', 'HIGH'))).toBe(true);
+    expect(predicate(risk('OPEN', 'HIGH'))).toBe(false);
+  });
+
+  it('supports a severity-only filter when statuses are empty', () => {
+    const filter = buildRiskFilter('', 'MEDIUM');
+    expect(filter).not.toBeNull();
+    const { predicate, description } = filter!;
+    expect(description.effectiveStatuses).toEqual([
+      'NEW',
+      'OPEN',
+      'CONFIRM',
+      'ACCEPT',
+      'SAFE',
+      'FIXED',
+    ]);
+    expect(description.discardedStatuses).toEqual([]);
+    expect(predicate(risk('SAFE', 'HIGH'))).toBe(true);
+    expect(predicate(risk('FIXED', 'LOW'))).toBe(false);
+  });
+
+  it('returns null when neither statuses nor minSeverity are provided', () => {
+    expect(buildRiskFilter('')).toBeNull();
   });
 });

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/risk-filter.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/risk-filter.test.ts
@@ -111,7 +111,7 @@ describe('buildRiskFilter — vm', () => {
   });
 });
 
-describe('buildRiskFilter — minSeverity', () => {
+describe('buildRiskFilter — minimalSeverity', () => {
   it('narrows a status filter to risks at or above the given severity', () => {
     const { predicate } = buildRiskFilter('all', 'MEDIUM')!;
     expect(predicate(risk('OPEN', 'BLOCKER'))).toBe(true);
@@ -144,7 +144,7 @@ describe('buildRiskFilter — minSeverity', () => {
     expect(predicate(risk('FIXED', 'LOW'))).toBe(false);
   });
 
-  it('returns null when neither statuses nor minSeverity are provided', () => {
+  it('returns null when neither statuses nor minimalSeverity are provided', () => {
     expect(buildRiskFilter('')).toBeNull();
   });
 });

--- a/tests/unit/cli/commands/hook/git-pre-commit-dependency-risks.mocked.test.ts
+++ b/tests/unit/cli/commands/hook/git-pre-commit-dependency-risks.mocked.test.ts
@@ -23,7 +23,10 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.ts';
 import * as scaInstall from '../../../../../src/cli/commands/_common/install/sca-scanner.ts';
 import { ScaScanOrchestrator } from '../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts';
-import type { AnalyzeProjectResponse } from '../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner.ts';
+import type {
+  AnalyzeProjectResponse,
+  Severity,
+} from '../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner.ts';
 import { ScaWatchPatternsRunner } from '../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-watch-patterns.ts';
 import { runDepRisksStage } from '../../../../../src/cli/commands/hook/git-pre-commit-dependency-risks.ts';
 import type { ResolvedAuth } from '../../../../../src/lib/auth-resolver.ts';
@@ -140,6 +143,27 @@ const SCAN_RESULT_MULTI_SEVERITY: AnalyzeProjectResponse = {
   errors: [],
 };
 
+// Derives a scan result from the SCAN_RESULT_WITH_RISK template, replacing its single
+// issue with one NEW VULNERABILITY issue per requested severity.
+function withSeverities(...severities: Severity[]): AnalyzeProjectResponse {
+  const [release] = SCAN_RESULT_WITH_RISK.releases;
+  const [template] = release.issues;
+  return {
+    ...SCAN_RESULT_WITH_RISK,
+    releases: [
+      {
+        ...release,
+        issues: severities.map((severity, i) => ({
+          ...template,
+          key: `issue-${i + 1}`,
+          severity,
+          vulnerabilityId: `CVE-2024-${String(i + 1).padStart(4, '0')}`,
+        })),
+      },
+    ],
+  };
+}
+
 describe('runDepRisksStage', () => {
   let resolveScaScannerBinaryPathSpy: ReturnType<typeof spyOn>;
   let watchPatternsSpy: ReturnType<typeof spyOn>;
@@ -196,6 +220,31 @@ describe('runDepRisksStage', () => {
     expect(thrown).toBeInstanceOf(CommandFailedError);
     expect((thrown as CommandFailedError).message).toBe(
       '3 dependency risks found (1 BLOCKER, 2 HIGH)',
+    );
+  });
+
+  it('does not block when all risks are below MEDIUM severity', async () => {
+    orchestratorRunSpy.mockResolvedValue(withSeverities('LOW', 'INFO'));
+
+    await runDepRisksStage({ project: 'demo', changedFiles: ['package.json'], auth: FAKE_AUTH });
+
+    const successCall = findMockUiCall('discreetSuccess', 'No dependency risks found.');
+    expect(successCall).toBeDefined();
+  });
+
+  it('blocks on MEDIUM-and-above risks while excluding lower severities from the count', async () => {
+    orchestratorRunSpy.mockResolvedValue(withSeverities('HIGH', 'MEDIUM', 'LOW'));
+
+    let thrown: unknown;
+    try {
+      await runDepRisksStage({ project: 'demo', changedFiles: ['package.json'], auth: FAKE_AUTH });
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(CommandFailedError);
+    expect((thrown as CommandFailedError).message).toBe(
+      '2 dependency risks found (1 HIGH, 1 MEDIUM)',
     );
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Filter enhancements:**
  - Added `minSeverity` support to `buildRiskFilter` to filter risks by severity rank.
  - Updated the git pre-commit hook to default the `minSeverity` filter to `MEDIUM`.
- **CLI updates:**
  - Added `--min-severity` option to the `analyze dependency-risks` command.
- **UI and reporting:**
  - Updated `format-dependency-risks-table.ts` to include the active severity filter in the output summary.
- **Testing:**
  - Added unit tests for severity-based filtering in `risk-filter.test.ts`.
  - Added integration tests to validate `--min-severity` input parsing and rejection of invalid values.
  - Updated `git-pre-commit-dependency-risks.mocked.test.ts` to verify blocking behavior for medium-and-above risks.

<sub>This will update automatically on new commits.</sub>