### PR TITLE
CLI-706 Override flatted to avoid vulnerability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,9 @@
       },
     },
   },
+  "overrides": {
+    "flatted": "3.4.2",
+  },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "https://repox.jfrog.io/artifactory/api/npm/npm/@babel/code-frame/-/code-frame-7.29.0.tgz", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -392,7 +395,7 @@
 
     "flat-cache": ["flat-cache@4.0.1", "https://repox.jfrog.io/artifactory/api/npm/npm/flat-cache/-/flat-cache-4.0.1.tgz", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
-    "flatted": ["flatted@3.3.3", "https://repox.jfrog.io/artifactory/api/npm/npm/flatted/-/flatted-3.3.3.tgz", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
+    "flatted": ["flatted@3.4.2", "https://repox.jfrog.io/artifactory/api/npm/npm/flatted/-/flatted-3.4.2.tgz", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "follow-redirects": ["follow-redirects@1.15.11", "https://repox.jfrog.io/artifactory/api/npm/npm/follow-redirects/-/follow-redirects-1.15.11.tgz", {}, "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -135,6 +135,9 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0"
   },
+  "overrides": {
+    "flatted": "3.4.2"
+  },
   "lint-staged": {
     "*.ts": [
       "prettier --write",


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency management:**
  - Added `overrides` for `flatted` to `package.json` and `bun.lock` to ensure version `3.4.2` is used.

<sub>This will update automatically on new commits.</sub>