### PR TITLE
CLI-622 Fix Cursor secrets hooks on Windows

### DIFF
--- a/src/cli/commands/hook/stdin.ts
+++ b/src/cli/commands/hook/stdin.ts
@@ -56,11 +56,23 @@ export async function readGitPushRefs(): Promise<PushRef[]> {
 /**
  * Read stdin, parse as JSON, and return the result typed as T.
  * Throws if stdin is not valid JSON or if the read times out.
+ *
+ * Strips any non-JSON framing bytes before the first `{` or `[` and after the
+ * last `}` or `]` to handle hook runners (e.g. Cursor ≥ 3.8.11) that wrap the
+ * JSON payload with framing bytes.
  */
 export async function readStdinJson<T>(): Promise<T> {
   const raw = await readRawStdin();
+  const jsonStart = raw.search(/[{[]/);
+  const withoutPrefix = jsonStart > 0 ? raw.slice(jsonStart) : raw;
+  const closeChar = withoutPrefix.startsWith('[') ? ']' : '}';
+  const closeIdx = withoutPrefix.lastIndexOf(closeChar);
+  const jsonStr =
+    closeIdx >= 0 && closeIdx < withoutPrefix.length - 1
+      ? withoutPrefix.slice(0, closeIdx + 1)
+      : withoutPrefix;
   try {
-    return JSON.parse(raw) as T;
+    return JSON.parse(jsonStr) as T;
   } catch {
     throw new Error('Failed to parse stdin as JSON');
   }

--- a/src/cli/commands/integrate/_common/hooks.ts
+++ b/src/cli/commands/integrate/_common/hooks.ts
@@ -45,7 +45,7 @@ export function unixTemplate(command: string): string {
 }
 
 export function windowsTemplate(command: string): string {
-  return `${WINDOWS_SONAR_COMMAND_GUARD}\n$stdinData = [Console]::In.ReadToEnd()\n$stdinData | & ${command}\n`;
+  return `${WINDOWS_SONAR_COMMAND_GUARD}\n$stdinData = [Console]::In.ReadToEnd()\n$stdinData | & ${command}\nexit $LASTEXITCODE\n`;
 }
 
 /**
@@ -172,7 +172,7 @@ export function resolveAgentHookScriptPath(
 }
 
 /**
- * Hook `command` string: `powershell -NoProfile -File <path>` on Windows, raw
+ * Hook `command` string: `powershell -NoProfile -ExecutionPolicy Bypass -File <path>` on Windows, raw
  * path on Unix. Absolute path for global scope, relative path (portable when
  * the project is moved) for project scope.
  */
@@ -187,7 +187,7 @@ export function resolveAgentHookCommand(
     context.scope === 'global' ? join(context.targetRoot, relativePath) : relativePath;
 
   return process.platform === 'win32'
-    ? `powershell -NoProfile -File ${commandPath.replaceAll('\\', '/')}`
+    ? `powershell -NoProfile -ExecutionPolicy Bypass -File ${commandPath.replaceAll('\\', '/')}`
     : commandPath;
 }
 

--- a/src/cli/commands/integrate/claude/hooks.ts
+++ b/src/cli/commands/integrate/claude/hooks.ts
@@ -116,7 +116,7 @@ async function installHook(params: HookInstallParams): Promise<void> {
   const relativePath = join(configDir, HOOKS_DIR, `${scriptPath}${scriptExt}`);
   const commandPath = scope === 'global' ? fullScriptPath : relativePath;
   const command = isWindows
-    ? `powershell -NoProfile -File ${commandPath.replaceAll('\\', '/')}`
+    ? `powershell -NoProfile -ExecutionPolicy Bypass -File ${commandPath.replaceAll('\\', '/')}`
     : commandPath;
 
   // Marker derived from first path segment (e.g. 'sonar-secrets' from 'sonar-secrets/build-scripts/pretool-secrets')

--- a/tests/integration/harness/platform.ts
+++ b/tests/integration/harness/platform.ts
@@ -52,11 +52,11 @@ export function hookScriptName(name: string): string {
 
 /**
  * Extract the script path from a hook command string.
- * On Windows commands are wrapped as `powershell -NoProfile -File <path>`;
+ * On Windows commands are wrapped as `powershell -NoProfile -ExecutionPolicy Bypass -File <path>`;
  * this strips that prefix. Always normalizes to forward slashes.
  */
 export function hookScriptPath(command: string): string {
-  const powershellPrefix = 'powershell -NoProfile -File ';
+  const powershellPrefix = 'powershell -NoProfile -ExecutionPolicy Bypass -File ';
   const path = command.startsWith(powershellPrefix)
     ? command.slice(powershellPrefix.length)
     : command;

--- a/tests/integration/specs/self-update/post-update.test.ts
+++ b/tests/integration/specs/self-update/post-update.test.ts
@@ -234,10 +234,10 @@ describe('post-update migration', () => {
       const promptScriptRel = `.claude/hooks/sonar-secrets/build-scripts/${hookScriptName('prompt-secrets')}`;
       const settingsRel = '.claude/settings.json';
       const expectedPretoolCommand = IS_WINDOWS
-        ? `powershell -NoProfile -File ${pretoolScriptRel}`
+        ? `powershell -NoProfile -ExecutionPolicy Bypass -File ${pretoolScriptRel}`
         : pretoolScriptRel;
       const expectedPromptCommand = IS_WINDOWS
-        ? `powershell -NoProfile -File ${promptScriptRel}`
+        ? `powershell -NoProfile -ExecutionPolicy Bypass -File ${promptScriptRel}`
         : promptScriptRel;
 
       harness.cwd.writeFile(

--- a/tests/unit/cli/commands/hook/stdin.test.ts
+++ b/tests/unit/cli/commands/hook/stdin.test.ts
@@ -69,6 +69,22 @@ describe('readStdinJson', () => {
     expect(await promise).toEqual(payload);
   });
 
+  it('strips a non-JSON prefix before the opening brace', async () => {
+    const payload = { tool_name: 'Read', tool_input: { file_path: '/tmp/test.ts' } };
+    const promise = readStdinJson<typeof payload>();
+    emitStdin('data', Buffer.from('n++' + JSON.stringify(payload)));
+    emitStdin('end');
+    expect(await promise).toEqual(payload);
+  });
+
+  it('strips trailing framing bytes after the closing brace', async () => {
+    const payload = { tool_name: 'Read', tool_input: { file_path: '/tmp/test.ts' } };
+    const promise = readStdinJson<typeof payload>();
+    emitStdin('data', Buffer.from(JSON.stringify(payload) + 'n++'));
+    emitStdin('end');
+    expect(await promise).toEqual(payload);
+  });
+
   it('throws when stdin contains invalid JSON', async () => {
     const promise = readStdinJson();
     emitStdin('data', Buffer.from('not-valid-json'));

--- a/tests/unit/cli/commands/integrate/_common/hooks.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/hooks.test.ts
@@ -48,11 +48,12 @@ describe('unixTemplate', () => {
 });
 
 describe('windowsTemplate', () => {
-  it('includes the command guard, reads stdin, and pipes it to the command', () => {
+  it('includes the command guard, reads stdin, pipes it to the command, and propagates exit code', () => {
     const body = windowsTemplate('sonar hook claude-pre-tool-use');
     expect(body).toContain(WINDOWS_SONAR_COMMAND_GUARD);
     expect(body).toContain('$stdinData = [Console]::In.ReadToEnd()');
     expect(body).toContain('$stdinData | & sonar hook claude-pre-tool-use');
+    expect(body).toContain('exit $LASTEXITCODE');
   });
 });
 

--- a/tests/unit/cli/commands/integrate/claude/hooks.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/hooks.test.ts
@@ -203,11 +203,11 @@ describe('installHooks', () => {
   // so platform-specific assertions branch on the real
   // host platform.
   const IS_WINDOWS = process.platform === 'win32';
-  // On Windows the registered command is `powershell -NoProfile -File .claude/...`
+  // On Windows the registered command is `powershell -NoProfile -ExecutionPolicy Bypass -File .claude/...`
   // (forward slashes via replaceAll); on Unix it is the bare `.claude/...` path.
   const isProjectScopedCommand = (command: string): boolean =>
     IS_WINDOWS
-      ? command.includes('powershell -NoProfile -File .claude/')
+      ? command.includes('powershell -NoProfile -ExecutionPolicy Bypass -File .claude/')
       : command.startsWith('.claude/');
 
   let existsSyncSpy: Mock<Extract<(typeof nodeFs)['existsSync'], (...args: any[]) => any>>;

--- a/tests/unit/cli/commands/integrate/cursor/hooks.test.ts
+++ b/tests/unit/cli/commands/integrate/cursor/hooks.test.ts
@@ -302,8 +302,11 @@ describe('buildCursorHookEntry', () => {
       'sonar-secrets/build-scripts/prompt-secrets',
     );
 
-    // On Windows the command is prefixed with 'powershell -NoProfile -File'; strip it before checking absoluteness.
-    const commandPath = entry.entry.command.replace(/^powershell -NoProfile -File /, '');
+    // On Windows the command is prefixed with 'powershell -NoProfile -ExecutionPolicy Bypass -File'; strip it before checking absoluteness.
+    const commandPath = entry.entry.command.replace(
+      /^powershell -NoProfile -ExecutionPolicy Bypass -File /,
+      '',
+    );
     expect(commandPath).toMatch(/^[/\\]/);
   });
 


### PR DESCRIPTION
Three bugs prevented the hooks from blocking secrets on Windows:

1. Missing `exit \$LASTEXITCODE` in the PowerShell hook template — sonar's exit 2 (deny) was silently swallowed, so Cursor always saw exit 0 (allow).

2. Missing `-ExecutionPolicy Bypass` in the powershell invocation — PS1 scripts were blocked on systems with Restricted execution policy.

3. Cursor >=3.8.11 prepends `n++` framing bytes before the JSON hook payload. `JSON.parse("n++{...")` throws, the catch block silently returns, and the hook exits 0. Fixed in `readStdinJson` by stripping any non-JSON prefix before the first `{` or `[`.