### PR TITLE
CLI-710 Add distribution to command telemetry

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -21,6 +21,7 @@
 import { type Command, Help, Option } from 'commander';
 
 import { version as VERSION } from '../../package.json';
+import { IS_STANDALONE_DISTRIBUTION } from '../lib/distribution';
 import { loadState } from '../lib/repository/state-repository';
 import { initSentry } from '../lib/sentry';
 import { GENERIC_HTTP_METHODS } from '../sonarqube/client';
@@ -32,6 +33,7 @@ import {
   TELEMETRY_FLUSH_MODE_ENV,
 } from '../telemetry';
 import { blank, error, warn } from '../ui';
+import { CommandFailedError } from './commands/_common/error';
 import { parseInteger } from './commands/_common/parsing';
 import { SonarCommand } from './commands/_common/sonar-command.js';
 import { analyzeAll, type AnalyzeAllOptions } from './commands/analyze/analyze-all';
@@ -99,6 +101,7 @@ export const COMMAND_TREE = new SonarCommand();
 
 COMMAND_TREE.name('sonar')
   .description('SonarQube CLI')
+  .argument('[command]')
   .version(VERSION, '-v, --version', 'display version for command')
   .enablePositionalOptions()
   .configureOutput({
@@ -115,7 +118,12 @@ COMMAND_TREE.name('sonar')
       return getBanner(VERSION) + '\n' + Help.prototype.formatHelp.call(helper, cmd, helper);
     },
   })
-  .anonymousAction(function (this: Command) {
+  .anonymousAction(function (this: Command, command?: string) {
+    if (command) {
+      throw new CommandFailedError(`unknown command '${command}'`, {
+        remediationHint: "Run 'sonar --help' to see the list of available commands.",
+      });
+    }
     this.outputHelp();
   });
 
@@ -498,14 +506,16 @@ system
   .anonymousAction((options: SystemResetOptions) => systemReset(options));
 
 // Update the CLI to the latest version
-COMMAND_TREE.command('self-update')
-  .description('Update SonarQube CLI to the latest version')
-  .rootHelp({
-    category: 'cli-management',
-  })
-  .option('--status', 'Check for a newer version without installing')
-  .option('--force', 'Install the latest version even if already up to date')
-  .anonymousAction((options: SelfUpdateOptions) => selfUpdate(options));
+if (IS_STANDALONE_DISTRIBUTION) {
+  COMMAND_TREE.command('self-update')
+    .description('Update SonarQube CLI to the latest version')
+    .rootHelp({
+      category: 'cli-management',
+    })
+    .option('--status', 'Check for a newer version without installing')
+    .option('--force', 'Install the latest version even if already up to date')
+    .anonymousAction((options: SelfUpdateOptions) => selfUpdate(options));
+}
 
 const runCommand = COMMAND_TREE.command('run', { hidden: true }).description(
   'Run SonarQube services',

--- a/src/cli/commands/self-update/self-update.ts
+++ b/src/cli/commands/self-update/self-update.ts
@@ -23,73 +23,11 @@ import { writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { version as CURRENT_VERSION } from '../../../../package.json';
-
-const UPDATE_CHECK_TIMEOUT_MS = 5000;
-import { UPDATE_SCRIPT_BASE_URL } from '../../../lib/config-constants';
 import { isWindows } from '../../../lib/platform-detector';
-import { isNewerVersion, stripBuildNumber } from '../../../lib/version';
+import { stripBuildNumber } from '../../../lib/version';
 import { blank, info, success, text, warn } from '../../../ui';
 import { CommandFailedError } from '../_common/error';
-
-const VERSION_PATTERNS = [
-  // Shell:       version="1.2.3"  or  version='1.2.3'
-  /\bversion\s*=\s*["'](\d+\.\d+\.\d+(?:\.\d+)?)["']/,
-  // PowerShell:  $SonarVersion = "1.2.3"
-  /\$SonarVersion\s*=\s*["'](\d+\.\d+\.\d+(?:\.\d+)?)["']/i,
-];
-
-/** Extract the pinned version from an install script. Returns null if not found. */
-export function extractVersion(scriptContent: string): string | null {
-  for (const pattern of VERSION_PATTERNS) {
-    const match = pattern.exec(scriptContent);
-    if (match) return match[1];
-  }
-  return null;
-}
-
-export interface UpdateCheckResult {
-  currentVersion: string;
-  latestVersion: string;
-  updateAvailable: boolean;
-  /** Downloaded script content — reuse in selfUpdate() to avoid a second fetch. */
-  scriptContent: string;
-  /** Platform-appropriate script filename ('install.sh' or 'install.ps1'). */
-  scriptName: string;
-}
-
-/**
- * Fetches the install script from GitHub and returns version comparison data.
- * Throws on network failure or when the version cannot be extracted from the script.
- */
-export async function checkForUpdate(baseUrl?: string): Promise<UpdateCheckResult> {
-  const scriptName = isWindows() ? 'install.ps1' : 'install.sh';
-  const scriptUrl = `${baseUrl ?? UPDATE_SCRIPT_BASE_URL}/${scriptName}`;
-
-  const response = await fetch(scriptUrl, { signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) });
-  if (!response.ok) {
-    throw new CommandFailedError(`Failed to fetch update script: HTTP ${response.status}`, {
-      remediationHint: 'Check network access and retry.',
-    });
-  }
-
-  const scriptContent = await response.text();
-  const latestVersion = extractVersion(scriptContent);
-  if (latestVersion === null) {
-    throw new CommandFailedError(
-      'Could not determine the latest version from the install script.',
-      { remediationHint: 'Retry later or update manually using the installer script.' },
-    );
-  }
-
-  return {
-    currentVersion: CURRENT_VERSION,
-    latestVersion,
-    updateAvailable: isNewerVersion(CURRENT_VERSION, stripBuildNumber(latestVersion)),
-    scriptContent,
-    scriptName,
-  };
-}
+import { checkForUpdate } from './update-check';
 
 export interface SelfUpdateOptions {
   status?: boolean;

--- a/src/cli/commands/self-update/update-check.ts
+++ b/src/cli/commands/self-update/update-check.ts
@@ -1,0 +1,85 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { version as CURRENT_VERSION } from '../../../../package.json';
+import { UPDATE_SCRIPT_BASE_URL } from '../../../lib/config-constants';
+import { isWindows } from '../../../lib/platform-detector';
+import { isNewerVersion, stripBuildNumber } from '../../../lib/version';
+import { CommandFailedError } from '../_common/error';
+
+const UPDATE_CHECK_TIMEOUT_MS = 5000;
+const VERSION_PATTERNS = [
+  // Shell:       version="1.2.3"  or  version='1.2.3'
+  /\bversion\s*=\s*["'](\d+\.\d+\.\d+(?:\.\d+)?)["']/,
+  // PowerShell:  $SonarVersion = "1.2.3"
+  /\$SonarVersion\s*=\s*["'](\d+\.\d+\.\d+(?:\.\d+)?)["']/i,
+];
+
+/** Extract the pinned version from an install script. Returns null if not found. */
+export function extractVersion(scriptContent: string): string | null {
+  for (const pattern of VERSION_PATTERNS) {
+    const match = pattern.exec(scriptContent);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+export interface UpdateCheckResult {
+  currentVersion: string;
+  latestVersion: string;
+  updateAvailable: boolean;
+  /** Downloaded script content — reuse in selfUpdate() to avoid a second fetch. */
+  scriptContent: string;
+  /** Platform-appropriate script filename ('install.sh' or 'install.ps1'). */
+  scriptName: string;
+}
+
+/**
+ * Fetches the install script from GitHub and returns version comparison data.
+ * Throws on network failure or when the version cannot be extracted from the script.
+ */
+export async function checkForUpdate(baseUrl?: string): Promise<UpdateCheckResult> {
+  const scriptName = isWindows() ? 'install.ps1' : 'install.sh';
+  const scriptUrl = `${baseUrl ?? UPDATE_SCRIPT_BASE_URL}/${scriptName}`;
+
+  const response = await fetch(scriptUrl, { signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) });
+  if (!response.ok) {
+    throw new CommandFailedError(`Failed to fetch update script: HTTP ${response.status}`, {
+      remediationHint: 'Check network access and retry.',
+    });
+  }
+
+  const scriptContent = await response.text();
+  const latestVersion = extractVersion(scriptContent);
+  if (latestVersion === null) {
+    throw new CommandFailedError(
+      'Could not determine the latest version from the install script.',
+      { remediationHint: 'Retry later or update manually using the installer script.' },
+    );
+  }
+
+  return {
+    currentVersion: CURRENT_VERSION,
+    latestVersion,
+    updateAvailable: isNewerVersion(CURRENT_VERSION, stripBuildNumber(latestVersion)),
+    scriptContent,
+    scriptName,
+  };
+}

--- a/src/cli/commands/system/status.ts
+++ b/src/cli/commands/system/status.ts
@@ -28,6 +28,7 @@ import { version as VERSION } from '../../../../package.json';
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import { resolveAuth } from '../../../lib/auth-resolver';
 import { CLI_DIR, GLOBAL_HOOKS_DIR, LOG_DIR } from '../../../lib/config-constants';
+import { IS_STANDALONE_DISTRIBUTION } from '../../../lib/distribution';
 import {
   CONTEXT_AUGMENTATION_BINARY_NAME,
   SCA_SCANNER_BINARY_NAME,
@@ -48,7 +49,7 @@ import { checkTokenStatus } from '../_common/token';
 import { supportedIntegrations } from '../integrate';
 import { checkAntigravitySecretsHookFile } from '../integrate/antigravity/health';
 import { resolveAntigravityHooksJsonPathForScope } from '../integrate/antigravity/hooks';
-import { checkForUpdate } from '../self-update/self-update';
+import { checkForUpdate } from '../self-update/update-check';
 
 const SCA_SCANNER_CACHE_DIR = join(CLI_DIR, 'sca-scanner-cache');
 
@@ -85,6 +86,11 @@ interface IntegrationInfo {
   mcp?: McpStatus;
   hooks?: HooksStatus;
 }
+
+type CliUpdateInfo = {
+  latestVersion: string;
+  updateAvailable: boolean;
+};
 
 function abbreviatePath(p: string): string {
   return p.replace(homedir(), '~');
@@ -137,7 +143,7 @@ function checkMcpConfigFile(configPath: string): IntegrationConfigStatus {
   try {
     const raw = readFileSync(configPath, 'utf-8');
     if (configPath.endsWith('.toml')) {
-      const parsed = parseToml(raw) as Record<string, unknown>;
+      const parsed = parseToml(raw);
       const mcpServers = parsed.mcp_servers as Record<string, unknown> | undefined;
       if (!mcpServers || !('sonarqube' in mcpServers)) return 'not_configured';
       const entry = mcpServers.sonarqube;
@@ -335,13 +341,29 @@ function integrationConfigStatusLine(status: IntegrationConfigStatus): string {
   return 'CONFIGURED';
 }
 
+async function getCliUpdateInfo(): Promise<CliUpdateInfo | null> {
+  if (!IS_STANDALONE_DISTRIBUTION) {
+    return null;
+  }
+
+  try {
+    const result = await checkForUpdate(process.env.SONARQUBE_CLI_UPDATE_SCRIPT_BASE_URL);
+    return {
+      latestVersion: result.latestVersion,
+      updateAvailable: result.updateAvailable,
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function systemStatus(options: SystemStatusOptions): Promise<void> {
   const state = loadState();
   const integrations = getInstalledIntegrations(state);
 
   const [auth, updateResult] = await Promise.all([
     resolveAuth().catch(() => null),
-    checkForUpdate(process.env.SONARQUBE_CLI_UPDATE_SCRIPT_BASE_URL).catch(() => null),
+    getCliUpdateInfo(),
   ]);
 
   const tokenStatus: TokenStatus | null = auth

--- a/src/lib/distribution.ts
+++ b/src/lib/distribution.ts
@@ -50,4 +50,5 @@ if (rawDistribution !== undefined) {
 }
 
 // Channel builds inject this env access at compile time via Bun's `define`.
-export const DISTRIBUTION = rawDistribution ?? DEFAULT_DISTRIBUTION;
+export const DISTRIBUTION: Distribution = rawDistribution ?? DEFAULT_DISTRIBUTION;
+export const IS_STANDALONE_DISTRIBUTION = DISTRIBUTION === 'standalone';

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -26,6 +26,7 @@
 import { randomUUID } from 'node:crypto';
 
 import type { CallerAgent } from './agent-detector.js';
+import type { Distribution } from './distribution.js';
 
 /**
  * Region for SonarCloud instances
@@ -439,7 +440,9 @@ export interface TelemetryEventPayload {
   organization_uuid_v4: string | null;
   /** Installation ID of the SonarQube Server, null when not authenticated or SQC */
   sqs_installation_id: string | null;
-  /** Inferred caller agent from the process environment. See `detectCallerAgent`. */
+  /** Distribution channel of the running CLI binary. */
+  distribution: Distribution;
+  /** Inferred caller (Cursor, Claude Code, or Copilot CLI) from the process environment. See `detectCallerAgent`. */
   caller_agent: CallerAgent | null;
 }
 

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -24,6 +24,7 @@ import { type Command } from 'commander';
 
 import { version as VERSION } from '../../package.json';
 import { detectCallerAgent } from '../lib/agent-detector.js';
+import { DISTRIBUTION } from '../lib/distribution.js';
 import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import { INVOCATION_ID } from '../lib/invocation-id.js';
 import type { StoredTelemetryEvent, TelemetryEventPayload } from '../lib/state.js';
@@ -90,6 +91,7 @@ export function storeEvent(command: Command, success: boolean): Promise<void> {
     user_uuid: conn?.userUuid ?? null,
     organization_uuid_v4: conn?.organizationUuidV4 ?? null,
     sqs_installation_id: conn?.sqsInstallationId ?? null,
+    distribution: DISTRIBUTION,
     caller_agent: detectCallerAgent(),
   };
 

--- a/tests/integration/harness/cli-runner.ts
+++ b/tests/integration/harness/cli-runner.ts
@@ -36,8 +36,8 @@ const DEFAULT_BINARY = join(
 );
 const DEFAULT_TIMEOUT_MS = 30000;
 
-function getBinaryPath(coverageMode: boolean): string {
-  const binaryPath = coverageMode ? COVERAGE_BINARY : DEFAULT_BINARY;
+function getBinaryPath(coverageMode: boolean, overridePath?: string): string {
+  const binaryPath = overridePath ?? (coverageMode ? COVERAGE_BINARY : DEFAULT_BINARY);
   if (!existsSync(binaryPath)) {
     throw new Error(
       `CLI binary not found at: ${binaryPath}\n` + `Run 'bun run build:binary' to build it first.`,
@@ -64,10 +64,11 @@ export async function runCli(
     cwd: string;
     browserToken?: string;
     browserTokenName?: string;
+    binaryPath?: string;
   },
 ): Promise<CliResult> {
   const coverageMode = process.env.SONARQUBE_CLI_USE_COVERAGE === '1';
-  const binaryPath = getBinaryPath(coverageMode);
+  const binaryPath = getBinaryPath(coverageMode, options.binaryPath);
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const startTime = Date.now();
   mkdirSync(options.cwd, { recursive: true });

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -37,16 +37,9 @@ import { File } from './file';
 import { buildHomeEnv, IS_WINDOWS } from './platform';
 import type { CliResult, RunOptions } from './types.js';
 
-export { EnvironmentBuilder } from './environment-builder.js';
-export { FakeBinariesServer, FakeBinariesServerBuilder } from './fake-binaries-server.js';
-export {
-  FakeSonarQubeServer,
-  FakeSonarQubeServerBuilder,
-  ProjectBuilder,
-} from './fake-sonarqube-server.js';
-export { FakeUpdateScriptServer } from './fake-update-script-server.js';
-export { hookScriptName, hookScriptPath, IS_WINDOWS, normalizePath, SCRIPT_EXT } from './platform';
-export type { CliResult, RecordedRequest, RunOptions } from './types.js';
+export { FakeSonarQubeServer, FakeSonarQubeServerBuilder } from './fake-sonarqube-server.js';
+export { hookScriptName, hookScriptPath, IS_WINDOWS, normalizePath } from './platform';
+export type { CliResult, RecordedRequest } from './types.js';
 
 export class TestHarness {
   public readonly cwd: Dir;
@@ -210,6 +203,7 @@ export class TestHarness {
       cwd: options?.cwd ?? this.cwd.path,
       browserToken: options?.browserToken,
       browserTokenName: options?.browserTokenName,
+      binaryPath: options?.binaryPath,
     });
   }
 

--- a/tests/integration/harness/types.ts
+++ b/tests/integration/harness/types.ts
@@ -54,6 +54,8 @@ export interface RunOptions {
    */
   browserToken?: string;
   browserTokenName?: string;
+  /** Override the compiled CLI binary path for this invocation. */
+  binaryPath?: string;
 }
 
 export interface RecordedRequest {

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -107,6 +107,21 @@ describe('root help', () => {
   );
 
   it(
+    'sonar <unknown> reports an unknown command instead of an argument-count error',
+    async () => {
+      const result = await harness.run('totally-unknown-command');
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout + result.stderr).toContain("unknown command 'totally-unknown-command'");
+      expect(result.stdout + result.stderr).toContain(
+        "Run 'sonar --help' to see the list of available commands.",
+      );
+      expect(result.stdout + result.stderr).not.toContain('Expected 0 arguments');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'sonar auth -h shows subcommand help without hanging',
     async () => {
       const result = await harness.run('auth -h');

--- a/tests/integration/specs/self-update/distribution.test.ts
+++ b/tests/integration/specs/self-update/distribution.test.ts
@@ -1,0 +1,118 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+
+import { IS_WINDOWS, TestHarness } from '../../harness';
+
+const PROJECT_ROOT = join(import.meta.dir, '../../../..');
+const NEWER_VERSION = '99.0.0';
+
+function buildHomebrewBinary(): { binaryPath: string; tempDir: string } {
+  const tempDir = mkdtempSync(join(tmpdir(), 'sonar-cli-homebrew-distribution-'));
+  const binaryPath = join(
+    tempDir,
+    IS_WINDOWS ? 'sonarqube-cli-homebrew.exe' : 'sonarqube-cli-homebrew',
+  );
+
+  const result = spawnSync(process.execPath, ['build-scripts/build-binary.ts'], {
+    cwd: PROJECT_ROOT,
+    env: {
+      ...process.env,
+      SONARQUBE_CLI_DISTRIBUTION: 'homebrew',
+      SONARQUBE_CLI_OUTFILE: binaryPath,
+    },
+    encoding: 'utf8',
+  });
+
+  if (result.status !== 0) {
+    const logs = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(logs || 'Failed to build homebrew binary');
+  }
+
+  return { binaryPath, tempDir };
+}
+
+describe('self-update distribution gating', () => {
+  let harness: TestHarness;
+  let homebrewBinaryPath: string;
+  let homebrewBuildDir: string;
+
+  beforeAll(() => {
+    const build = buildHomebrewBinary();
+    homebrewBinaryPath = build.binaryPath;
+    homebrewBuildDir = build.tempDir;
+  });
+
+  afterAll(() => {
+    rmSync(homebrewBuildDir, { recursive: true, force: true });
+  });
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'keeps self-update available on the standalone build',
+    async () => {
+      const helpResult = await harness.run('-h');
+      expect(helpResult.exitCode).toBe(0);
+      expect(helpResult.stdout).toContain('self-update');
+
+      const commandHelp = await harness.run('self-update --help');
+      expect(commandHelp.exitCode).toBe(0);
+      expect(commandHelp.stdout).toContain('Usage: sonar self-update');
+      expect(commandHelp.stdout).toContain('--status');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'removes self-update from homebrew builds',
+    async () => {
+      harness.newFakeUpdateScriptServer(NEWER_VERSION);
+
+      const helpResult = await harness.run('-h', { binaryPath: homebrewBinaryPath });
+      expect(helpResult.exitCode).toBe(0);
+      expect(helpResult.stdout).not.toContain('self-update');
+
+      const updateStatus = await harness.run('self-update', {
+        binaryPath: homebrewBinaryPath,
+      });
+      expect(updateStatus.exitCode).toBe(1);
+
+      const systemStatus = await harness.run('system status', {
+        binaryPath: homebrewBinaryPath,
+      });
+      expect(systemStatus.exitCode).toBe(0);
+      expect(systemStatus.stdout).not.toContain('sonar self-update');
+    },
+    { timeout: 15000 },
+  );
+});

--- a/tests/unit/cli/commands/self-update/self-update.test.ts
+++ b/tests/unit/cli/commands/self-update/self-update.test.ts
@@ -49,8 +49,9 @@ void mock.module('../../../../../src/lib/version', () => ({
   stripBuildNumber: mock(realStripBuildNumber),
 }));
 
-const { extractVersion, checkForUpdate, selfUpdate } =
-  await import('../../../../../src/cli/commands/self-update/self-update');
+const { extractVersion, checkForUpdate } =
+  await import('../../../../../src/cli/commands/self-update/update-check');
+const { selfUpdate } = await import('../../../../../src/cli/commands/self-update/self-update');
 
 describe('extractVersion', () => {
   it('extracts version from a shell script (double quotes)', () => {

--- a/tests/unit/telemetry/telemetry.test.ts
+++ b/tests/unit/telemetry/telemetry.test.ts
@@ -29,6 +29,7 @@ import type { Command } from 'commander';
 
 import * as agentDetector from '../../../src/lib/agent-detector.js';
 import { ENV_DO_NOT_TRACK, ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
+import { DISTRIBUTION } from '../../../src/lib/distribution.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
 import type { CliState, StoredTelemetryEvent } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
@@ -91,6 +92,7 @@ function makeStoredEvent(overrides: Partial<StoredTelemetryEvent> = {}): StoredT
       user_uuid: null,
       organization_uuid_v4: null,
       sqs_installation_id: null,
+      distribution: DISTRIBUTION,
       caller_agent: null,
     },
     ...overrides,
@@ -228,6 +230,13 @@ describe('storeEvent', () => {
 
       const event = saveStateSpy.mock.calls[0][0].telemetry.events[0] as StoredTelemetryEvent;
       expect(event.event_payload.result).toBe('failure');
+    });
+
+    it('sets distribution from the resolved CLI distribution', async () => {
+      await storeEvent(makeCommand('auth login'), true);
+
+      const event = saveStateSpy.mock.calls[0][0].telemetry.events[0] as StoredTelemetryEvent;
+      expect(event.event_payload.distribution).toBe(DISTRIBUTION);
     });
 
     it('sets event_payload.caller from detectCallerAgent', async () => {


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry enhancement:**
  - Added `distribution` field to `TelemetryEventPayload` in `src/lib/state.ts` to track CLI binary source.
  - Included `DISTRIBUTION` constant in command telemetry event payload within `src/telemetry/index.ts`.
  - Added unit test to verify that `distribution` is correctly captured in telemetry events.

<sub>This will update automatically on new commits.</sub>