### PR TITLE
CLI-711 Add feature container migration

### DIFF
--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -128,6 +128,7 @@ export interface FeatureContainer<
   TOptions = Record<string, unknown>,
 > extends FeatureDeclaration<TOptions> {
   subfeatures: SubfeatureDeclaration<TOptions>[];
+  defaultInstallSubfeatureIds: string[];
 }
 
 export interface LegacyFeatureDeclaration {

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -27,8 +27,10 @@ import { installScaScannerBinary } from '../cli/commands/_common/install/sca-sca
 import { installSecretsBinary } from '../cli/commands/_common/install/secrets';
 import { supportedIntegrations } from '../cli/commands/integrate';
 import {
+  type FeatureDeclaration,
   integrationInstaller,
   type IntegrationRegistry,
+  isFeatureContainer,
 } from '../cli/commands/integrate/_common/registry';
 import { CLAUDE_INTEGRATION_ID } from '../cli/commands/integrate/claude/declaration';
 import { installHooks } from '../cli/commands/integrate/claude/hooks.js';
@@ -41,7 +43,7 @@ import {
   removeObsoleteHookArtifacts,
 } from './migration.js';
 import { loadState, saveState, stateFileExists } from './repository/state-repository';
-import type { CliState, HookExtension } from './state.js';
+import type { CliState, HookExtension, InstalledIntegrationFeature } from './state.js';
 import { isNewerVersion } from './version';
 
 /**
@@ -111,7 +113,7 @@ export async function migrateDeclarativeIntegrations(
 
     const applications = [];
     for (const installedFeature of knownFeatures) {
-      const feature = featuresById.get(installedFeature.featureId);
+      const feature = getFeature(featuresById, installedFeature);
       if (!feature) {
         continue;
       }
@@ -124,7 +126,7 @@ export async function migrateDeclarativeIntegrations(
       }
 
       applications.push({
-        feature,
+        feature: feature,
         targetRoot: installedFeature.targetRoot,
         scope: installedFeature.scope,
         attrs: installedFeature.attrs,
@@ -157,6 +159,31 @@ export async function migrateDeclarativeIntegrations(
   if (stateChanged) {
     saveState(state);
   }
+}
+
+function getFeature(
+  featuresById: Map<string, FeatureDeclaration>,
+  installedFeature: InstalledIntegrationFeature,
+): FeatureDeclaration | undefined {
+  const feature = featuresById.get(installedFeature.featureId);
+  if (!feature) {
+    return undefined;
+  }
+
+  let applicationFeature = feature;
+  if (isFeatureContainer(feature)) {
+    const activeIds = new Set(
+      installedFeature.subfeatures !== undefined
+        ? installedFeature.subfeatures.map((s) => s.featureId)
+        : feature.defaultInstallSubfeatureIds,
+    );
+    const filteredContainer = {
+      ...feature,
+      subfeatures: feature.subfeatures.filter((s) => activeIds.has(s.id)),
+    };
+    applicationFeature = filteredContainer;
+  }
+  return applicationFeature;
 }
 
 /**

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -282,6 +282,7 @@ describe('declarative integration framework', () => {
       id: 'container',
       displayName: 'Container',
       subfeatures: [],
+      defaultInstallSubfeatureIds: [],
     };
 
     expect(isFeatureContainer(plain)).toBe(false);
@@ -306,6 +307,7 @@ describe('declarative integration framework', () => {
           shouldInstall: ({ options }) => (options.enableSca ? install() : skip()),
         },
       ],
+      defaultInstallSubfeatureIds: [],
     };
     const integration = makeIntegration<{ enableSca?: boolean }>({ features: [container] });
 
@@ -354,6 +356,7 @@ describe('declarative integration framework', () => {
           },
         },
       ],
+      defaultInstallSubfeatureIds: [],
     };
     const integration = makeIntegration<{ enableSca?: boolean }>({ features: [container] });
     const state = getDefaultState('test');
@@ -379,6 +382,7 @@ describe('declarative integration framework', () => {
         { id: 'sub-a', displayName: 'Sub A', shouldInstall: () => install(), dependencies: [dep] },
         { id: 'sub-b', displayName: 'Sub B', shouldInstall: () => skip() },
       ],
+      defaultInstallSubfeatureIds: [],
     };
     const integration = makeIntegration({ features: [container] });
     const state = getDefaultState('test');
@@ -408,6 +412,7 @@ describe('declarative integration framework', () => {
       id: 'container',
       displayName: 'Container',
       subfeatures: [{ id: 'sub-a', displayName: 'Sub A', dependencies: [dep] }],
+      defaultInstallSubfeatureIds: [],
     });
 
     const integration = makeIntegration({ features: [makeContainer(depOld)] });
@@ -467,6 +472,7 @@ describe('declarative integration framework', () => {
         { id: 'sub-b', displayName: 'Sub B' },
         { id: 'sub-c', displayName: 'Sub C' },
       ],
+      defaultInstallSubfeatureIds: [],
     };
     const integration = makeIntegration({ features: [container] });
 
@@ -491,6 +497,7 @@ describe('declarative integration framework', () => {
       id: 'container',
       displayName: 'Container',
       subfeatures: [{ id: 'valid', displayName: 'Valid' }],
+      defaultInstallSubfeatureIds: [],
     };
     const integration = makeIntegration({ features: [container] });
 

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -28,7 +28,9 @@ import { version as CURRENT_VERSION } from '../../../../../package.json';
 import * as scaScannerInstall from '../../../../../src/cli/commands/_common/install/sca-scanner';
 import * as secretsInstall from '../../../../../src/cli/commands/_common/install/secrets';
 import {
+  type ContainerIntegrationContext,
   type DependencyDeclaration,
+  type FeatureContainer,
   type IntegrationContext,
   IntegrationRegistry,
   wholeFile,
@@ -470,6 +472,196 @@ describe('migrateDeclarativeIntegrations', () => {
     expect(fs.readFileSync(dependencyPathA, 'utf-8')).toBe('/new/shared-dependency');
     expect(fs.readFileSync(dependencyPathB, 'utf-8')).toBe('/new/shared-dependency');
     expect(saveStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('activates only migrationDefaultSubfeatureIds when upgrading from old plain-feature state', async () => {
+    const capturedContexts: IntegrationContext[] = [];
+    const now = '2026-01-01T00:00:00.000Z';
+
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: now,
+      updatedByCliVersion: '0.9.0',
+      updatedAt: now,
+      features: [
+        {
+          featureId: 'container-feature',
+          scope: 'project',
+          targetRoot: tempDir,
+          installedByCliVersion: '0.9.0',
+          installedAt: now,
+          updatedByCliVersion: '0.9.0',
+          updatedAt: now,
+          dependencies: [],
+          resources: [],
+          operations: [],
+          // no subfeatures — simulates an old plain-feature install
+        },
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const container: FeatureContainer = {
+      id: 'container-feature',
+      displayName: 'Container feature',
+      defaultInstallSubfeatureIds: ['sub-a'],
+      subfeatures: [
+        { id: 'sub-a', displayName: 'Sub A' },
+        { id: 'sub-b', displayName: 'Sub B' },
+      ],
+      operations: [
+        {
+          id: 'test-op',
+          apply: (ctx) => {
+            capturedContexts.push(ctx);
+          },
+        },
+      ],
+    };
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [container],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(capturedContexts).toHaveLength(1);
+    expect('activeSubfeatures' in capturedContexts[0]).toBeTrue();
+    expect(
+      (capturedContexts[0] as ContainerIntegrationContext).activeSubfeatures.map((s) => s.id),
+    ).toEqual(['sub-a']);
+
+    const savedFeature = saveStateSpy.mock.calls[0][0].integrations.installed[0].features[0];
+    expect(savedFeature.subfeatures).toHaveLength(1);
+    expect(savedFeature.subfeatures![0]).toMatchObject({ featureId: 'sub-a' });
+  });
+
+  it('restores previously active container subfeatures from recorded state, excluding newly added ones', async () => {
+    const capturedContexts: IntegrationContext[] = [];
+    const now = '2026-01-01T00:00:00.000Z';
+
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: now,
+      updatedByCliVersion: '0.9.0',
+      updatedAt: now,
+      features: [
+        {
+          featureId: 'container-feature',
+          scope: 'project',
+          targetRoot: tempDir,
+          installedByCliVersion: '0.9.0',
+          installedAt: now,
+          updatedByCliVersion: '0.9.0',
+          updatedAt: now,
+          dependencies: [],
+          resources: [],
+          operations: [],
+          subfeatures: [{ featureId: 'sub-a', dependencies: [] }],
+        },
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const container: FeatureContainer = {
+      id: 'container-feature',
+      displayName: 'Container feature',
+      subfeatures: [
+        { id: 'sub-a', displayName: 'Sub A' },
+        { id: 'sub-b', displayName: 'Sub B' },
+        { id: 'sub-c', displayName: 'Sub C' }, // newly added, not in recorded state
+      ],
+      defaultInstallSubfeatureIds: ['sub-b'],
+      operations: [
+        {
+          id: 'test-op',
+          apply: (ctx) => {
+            capturedContexts.push(ctx);
+          },
+        },
+      ],
+    };
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [container],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(capturedContexts).toHaveLength(1);
+    expect(
+      (capturedContexts[0] as ContainerIntegrationContext).activeSubfeatures.map((s) => s.id),
+    ).toEqual(['sub-a']);
+
+    const savedFeature = saveStateSpy.mock.calls[0][0].integrations.installed[0].features[0];
+    expect(savedFeature.subfeatures).toHaveLength(1);
+    expect(savedFeature.subfeatures![0]).toMatchObject({ featureId: 'sub-a' });
+  });
+
+  it('applies plain feature normally when old state has container subfeatures recorded', async () => {
+    const capturedContexts: IntegrationContext[] = [];
+    const now = '2026-01-01T00:00:00.000Z';
+
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: now,
+      updatedByCliVersion: '0.9.0',
+      updatedAt: now,
+      features: [
+        {
+          featureId: 'plain-feature',
+          scope: 'project',
+          targetRoot: tempDir,
+          installedByCliVersion: '0.9.0',
+          installedAt: now,
+          updatedByCliVersion: '0.9.0',
+          updatedAt: now,
+          dependencies: [],
+          resources: [],
+          operations: [],
+          subfeatures: [{ featureId: 'old-sub', dependencies: [] }],
+        },
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [
+        {
+          id: 'plain-feature',
+          displayName: 'Plain feature',
+          operations: [
+            {
+              id: 'test-op',
+              apply: (ctx) => {
+                capturedContexts.push(ctx);
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(capturedContexts).toHaveLength(1);
+    expect('activeSubfeatures' in capturedContexts[0]).toBeFalse();
   });
 });
 


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **Feature container migration:**
  - Added `defaultInstallSubfeatureIds` to `FeatureContainer` type for subfeature selection.
  - Implemented `getFeature` to handle migration of features into containers by filtering subfeatures based on state or defaults.
  - Updated `migrateDeclarativeIntegrations` to resolve and apply container-specific subfeature configurations.
- **Test coverage:**
  - Added comprehensive unit tests for container migration logic, covering scenarios for both old plain-feature states and existing subfeature states.
  - Updated registry tests to include `defaultInstallSubfeatureIds` in mock `FeatureContainer` declarations.


<sub>This will update automatically on new commits.</sub>