### PR TITLE
CLI-712 Print subfeatures selected for installation

### DIFF
--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -35,6 +35,7 @@ import { renderCompletionSummary } from './completion-summary';
 import type { IntegrationRegistry } from './core';
 import type { FeatureApplication } from './installer';
 import { integrationInstaller } from './installer';
+import { isFeatureContainer } from './selection';
 import type {
   FeatureDeclaration,
   IntegrationContext,
@@ -111,6 +112,11 @@ export async function installIntegration<TOptions>({
         callbacks: {
           onFeatureApplyStart: (feature) => {
             text(`     Installing ${feature.displayName}...`);
+            if (isFeatureContainer(feature)) {
+              for (const subfeature of feature.subfeatures) {
+                text(`       - ${subfeature.displayName}`);
+              }
+            }
           },
           onDependencySkipped: (dependency) => {
             text(`     ${dependency.displayName ?? dependency.id} already installed`);

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -28,6 +28,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error';
 import {
   type DependencyDeclaration,
+  type FeatureContainer,
   type FeatureDeclaration,
   installIntegration,
   type IntegrationDeclaration,
@@ -610,6 +611,78 @@ describe('generic integration installer', () => {
         features: [{ featureId: 'first' }],
       },
     ]);
+  });
+
+  it('prints container display name then each active subfeature on a separate indented line', async () => {
+    const container: FeatureContainer = {
+      id: 'container',
+      displayName: 'Container Feature',
+      subfeatures: [
+        { id: 'subfeature-1', displayName: 'Subfeature One' },
+        { id: 'subfeature-2', displayName: 'Subfeature Two' },
+      ],
+      resources: [
+        wholeFile({
+          id: 'container-file',
+          displayName: 'Container file',
+          targetPath: join(tempDir, 'container.txt'),
+          content: 'enabled=true\n',
+        }),
+      ],
+    };
+    const integration = registerIntegration(registry, 'installer-container-messages', [container]);
+
+    await installIntegration({
+      registry,
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(hasUiCall('text', '     Installing Container Feature...')).toBe(true);
+    expect(hasUiCall('text', '       - Subfeature One')).toBe(true);
+    expect(hasUiCall('text', '       - Subfeature Two')).toBe(true);
+  });
+
+  it('only lists active subfeatures when some are filtered out by shouldInstall', async () => {
+    const container: FeatureContainer<{ enableOptional?: boolean }> = {
+      id: 'container',
+      displayName: 'Container Feature',
+      subfeatures: [
+        { id: 'subfeature-1', displayName: 'Subfeature One' },
+        {
+          id: 'subfeature-2',
+          displayName: 'Subfeature Two',
+          shouldInstall: ({ options }) => options.enableOptional === true,
+        },
+      ],
+      resources: [
+        wholeFile({
+          id: 'container-file',
+          displayName: 'Container file',
+          targetPath: join(tempDir, 'container.txt'),
+          content: 'enabled=true\n',
+        }),
+      ],
+    };
+    const integration = registerIntegration<{ enableOptional?: boolean }>(
+      registry,
+      'installer-container-filtered-subfeatures',
+      [container],
+    );
+
+    await installIntegration({
+      registry,
+      integrationId: integration.id,
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+    });
+
+    expect(hasUiCall('text', '     Installing Container Feature...')).toBe(true);
+    expect(hasUiCall('text', '       - Subfeature One')).toBe(true);
+    expect(hasUiCall('text', '       - Subfeature Two')).toBe(false);
   });
 
   it('warns and continues when reading or writing state fails', async () => {


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **CLI display improvements:**
  - Added logic to `installIntegration` to print subfeatures for `FeatureContainer` during installation.
  - Enhanced terminal output to list active subfeatures as indented bullet points under the main feature.

<sub>This will update automatically on new commits.</sub>