### PR TITLE
CLI-713 Add feature/subfeature auto install message option

### DIFF
--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -27,7 +27,7 @@ import type {
   IntegrationScope,
   IntegrationStateAttribute,
 } from '../../../../../lib/state';
-import { confirmPrompt, info } from '../../../../../ui';
+import { confirmPrompt, discreetSuccess, info } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
 import type { DependencyDeclaration } from './dependencies';
 import { recordInstalledFeature } from './installation-recorder';
@@ -184,6 +184,9 @@ export class IntegrationInstaller {
     const decision = normalizeDecision(await feature.shouldInstall?.(invocation));
     switch (decision.action) {
       case 'install':
+        if (decision.message) {
+          discreetSuccess(decision.message);
+        }
         return true;
       case 'skip':
         if (decision.message) {

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -25,13 +25,13 @@ import type { FeatureContainer, FeatureDeclaration } from './types';
  * intent; the installer resolves it (prompting / skip messaging) centrally.
  */
 export type InstallDecision =
-  | { action: 'install' }
+  | { action: 'install'; message?: string }
   | { action: 'skip'; message?: string }
   | { action: 'ask'; question?: string };
 
-/** Install the feature without asking. */
-export function install(): InstallDecision {
-  return { action: 'install' };
+/** Install the feature without asking, optionally printing a message. */
+export function install(message?: string): InstallDecision {
+  return { action: 'install', message };
 }
 
 /** Skip the feature, optionally explaining why. */

--- a/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
+++ b/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
@@ -33,7 +33,8 @@ export function createSecretsSubfeature(): SubfeatureDeclaration<IntegrateGitOpt
   return {
     id: 'pre-commit-secrets',
     displayName: 'pre-commit secrets scan',
-    shouldInstall: () => install(),
+    shouldInstall: () =>
+      install('Secrets scan is required for other hook types and is enabled by default'),
     dependencies: [sonarSecretsBinaryDependency],
   };
 }

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -654,6 +654,31 @@ describe('declarative integration framework', () => {
     expect(getMockUiCalls().filter((call) => call.method === 'info')).toHaveLength(1);
   });
 
+  it('prints an optional message when a feature is installed, and stays silent otherwise', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({
+      features: [
+        {
+          id: 'with-message',
+          displayName: 'With message',
+          shouldInstall: () => install('auto-configured'),
+        },
+        { id: 'silent', displayName: 'Silent', shouldInstall: () => install() },
+      ],
+    });
+
+    const selected = await installer.selectFeaturesForInvocation(integration, {
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+      state: getDefaultState('test'),
+    });
+
+    expect(selected.map((feature) => feature.id)).toEqual(['with-message', 'silent']);
+    expect(findMockUiCall('discreetSuccess', 'auto-configured')).toBeDefined();
+    expect(getMockUiCalls().filter((call) => call.method === 'discreetSuccess')).toHaveLength(1);
+  });
+
   it('prompts the user when a feature asks, installing on confirm and skipping on decline', async () => {
     setMockUi(true);
     const integration = makeIntegration({

--- a/tests/unit/cli/commands/integrate/git/git-integration-subfeatures.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-integration-subfeatures.test.ts
@@ -48,9 +48,12 @@ function makeInvocation({
 }
 
 describe('createSecretsSubfeature', () => {
-  it('always installs', () => {
+  it('always installs with an explanatory message', () => {
     const sub = createSecretsSubfeature();
-    expect(sub.shouldInstall!(makeInvocation())).toMatchObject({ action: 'install' });
+    expect(sub.shouldInstall!(makeInvocation())).toMatchObject({
+      action: 'install',
+      message: 'Secrets scan is required for other hook types and is enabled by default',
+    });
   });
 });
 


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **Feature updates:**
  - Added an optional `message` field to the `install` decision type in `selection.ts`.
  - Implemented automatic message printing via `discreetSuccess` in `IntegrationInstaller` when features are installed.
- **Configuration changes:**
  - Updated `createSecretsSubfeature` to include an explanatory message during auto-installation.

<sub>This will update automatically on new commits.</sub>