### PR TITLE
CLI-714 Update git hook messaging for multi scan type

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -233,7 +233,7 @@ const integrateCommand = COMMAND_TREE.command('integrate')
 integrateCommand
   .command('git')
   .description(
-    'Install a Git pre-commit hook that scans staged files for secrets before each commit, or a Git pre-push hook that scans committed files for secrets before each push.',
+    'Install a Git pre-commit hook that scans staged files for secrets and dependency risks before each commit, or a Git pre-push hook that scans committed files for secrets before each push.',
   )
   .option(
     '--hook <type>',

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -27,7 +27,7 @@ import { GLOBAL_HOOKS_DIR } from '../../../../lib/config-constants';
 import { normalizePath } from '../../../../lib/fs-utils';
 import { findGitRoot } from '../../../../lib/project-workspace';
 import { blank, confirmPrompt, info, intro, text, warn } from '../../../../ui';
-import { yellow } from '../../../../ui/colors.ts';
+import { yellow } from '../../../../ui/colors.js';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
 import { resolveIntegrateScope } from '../_common/integrate-scope';

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -26,7 +26,8 @@ import { join } from 'node:path';
 import { GLOBAL_HOOKS_DIR } from '../../../../lib/config-constants';
 import { normalizePath } from '../../../../lib/fs-utils';
 import { findGitRoot } from '../../../../lib/project-workspace';
-import { blank, confirmPrompt, intro, text, warn } from '../../../../ui';
+import { blank, confirmPrompt, info, intro, text, warn } from '../../../../ui';
+import { yellow } from '../../../../ui/colors.ts';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
 import { resolveIntegrateScope } from '../_common/integrate-scope';
@@ -140,7 +141,9 @@ export async function integrateGit(options: IntegrateGitOptions): Promise<void> 
     throw new InvalidOptionError('--dependency-risks and -p are not supported with --global.');
   }
 
-  intro('SonarQube Git Integration (secrets scanning)');
+  intro('SonarQube Git Integration (source code scanning)');
+  info('This integration includes secrets and dependency risks detection in your git repository.');
+  info(yellow('Some scan types may be unavailable for certain hook types.'));
 
   if (options.global) {
     return integrateGitGlobal(options);

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -60,7 +60,7 @@ function createHuskyFeature(
 ): FeatureContainer<IntegrateGitOptions> | FeatureDeclaration<IntegrateGitOptions> {
   const base: FeatureDeclaration<IntegrateGitOptions> = {
     id: `${hook}-hook`,
-    displayName: `${hook} hook`,
+    displayName: `${hook} code scanning hook`,
     shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     resources: [

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -60,7 +60,7 @@ function createNativeGitFeature(
 ): FeatureContainer<IntegrateGitOptions> | FeatureDeclaration<IntegrateGitOptions> {
   const base: FeatureDeclaration<IntegrateGitOptions> = {
     id: `${hook}-hook`,
-    displayName: `${hook} hook`,
+    displayName: `${hook} code scanning hook`,
     shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     resources: [

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -58,7 +58,7 @@ function createPreCommitFeature(
 ): FeatureContainer<IntegrateGitOptions> | FeatureDeclaration<IntegrateGitOptions> {
   const base: FeatureDeclaration<IntegrateGitOptions> = {
     id: `${hook}-hook`,
-    displayName: `${hook} hook`,
+    displayName: `${hook} code scanning hook`,
     shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     resources: [

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -413,15 +413,15 @@ describe('integrate git (native hooks)', () => {
       // and resolveGitHooksDir() resolves to .git/hooks as expected
       initGitRepo(harness);
 
-      // '\r' selects project scope, '\r' accepts 'Install pre-commit hook?',
-      // dep-risks is auto-skipped (no project key), 'n' declines 'Install pre-push hook?'.
+      // '\r' selects project scope, '\r' accepts 'Install pre-commit code scanning hook?',
+      // dep-risks is auto-skipped (no project key), 'n' declines 'Install pre-push code scanning hook?'.
       const result = await harness.run('integrate git', {
         stdinChunks: ['\r', '\r', 'n'],
         stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit code scanning hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(false);
     },
@@ -440,8 +440,8 @@ describe('integrate git (native hooks)', () => {
 
       expect(result.exitCode).toBe(0);
       const bothHooksOutput = result.stdout + result.stderr;
-      expect(bothHooksOutput).toContain('✓  pre-commit hook');
-      expect(bothHooksOutput).toContain('✓  pre-push hook');
+      expect(bothHooksOutput).toContain('✓  pre-commit code scanning hook');
+      expect(bothHooksOutput).toContain('✓  pre-push code scanning hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
 
@@ -494,15 +494,15 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' selects project scope, 'n' declines the 'Install pre-commit hook?'
-      // prompt, '\r' accepts 'Install pre-push hook?'.
+      // '\r' selects project scope, 'n' declines the 'Install pre-commit code scanning hook?'
+      // prompt, '\r' accepts 'Install pre-push code scanning hook?'.
       const result = await harness.run('integrate git', {
         stdinChunks: ['\r', 'n', '\r'],
         stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push code scanning hook');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(false);
     },
@@ -515,8 +515,8 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' selects project scope, '\r' accepts 'Install pre-commit hook?',
-      // dep-risks is auto-skipped (no project key), '\r' accepts 'Install pre-push hook?'.
+      // '\r' selects project scope, '\r' accepts 'Install pre-commit code scanning hook?',
+      // dep-risks is auto-skipped (no project key), '\r' accepts 'Install pre-push code scanning hook?'.
       const result = await harness.run('integrate git', {
         stdinChunks: ['\r', '\r', '\r'],
         stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
@@ -524,8 +524,8 @@ describe('integrate git (native hooks)', () => {
 
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('Install pre-commit hook?');
-      expect(output).toContain('Install pre-push hook?');
+      expect(output).toContain('Install pre-commit code scanning hook?');
+      expect(output).toContain('Install pre-push code scanning hook?');
       expect(harness.cwd.exists('.git', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.cwd.exists('.git', 'hooks', 'pre-push')).toBe(true);
 
@@ -613,7 +613,7 @@ describe('integrate git (native hooks)', () => {
       initGitRepo(harness);
 
       // '\r' selects project scope, then 'n' declines both the
-      // 'Install pre-commit hook?' and 'Install pre-push hook?' prompts.
+      // 'Install pre-commit code scanning hook?' and 'Install pre-push code scanning hook?' prompts.
       const result = await harness.run('integrate git', {
         stdinChunks: ['\r', 'n', 'n'],
         stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
@@ -635,13 +635,13 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
       // Per-feature confirm flow: '\r' confirms the global hook warning, '\r' accepts
-      // 'Install pre-commit hook?', 'n' declines 'Install pre-push hook?'.
+      // 'Install pre-commit code scanning hook?', 'n' declines 'Install pre-push code scanning hook?'.
       const result = await harness.run('integrate git --global', {
         stdinChunks: ['\r', '\r', 'n'],
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit code scanning hook');
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-push')).toBe(false);
     },
@@ -675,13 +675,13 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
       // Per-feature confirm flow: '\r' confirms the global hook warning, 'n' declines
-      // 'Install pre-commit hook?', '\r' accepts 'Install pre-push hook?'.
+      // 'Install pre-commit code scanning hook?', '\r' accepts 'Install pre-push code scanning hook?'.
       const result = await harness.run('integrate git --global', {
         stdinChunks: ['\r', 'n', '\r'],
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push code scanning hook');
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-push')).toBe(true);
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-commit')).toBe(false);
     },
@@ -795,8 +795,10 @@ describe('integrate git (husky)', () => {
       const result = await harness.run('integrate git --hook pre-commit --non-interactive');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installing pre-commit hook...');
-      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
+      expect(result.stdout + result.stderr).toContain(
+        'Installing pre-commit code scanning hook...',
+      );
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit code scanning hook');
       expect(harness.cwd.exists('.husky', 'pre-commit')).toBe(true);
       const hookContent = readFileSync(join(harness.cwd.path, '.husky', 'pre-commit'), 'utf-8');
       expect(hookContent).toContain('hook git-pre-commit');
@@ -860,8 +862,8 @@ describe('integrate git (husky)', () => {
       const result = await harness.run('integrate git --hook pre-push --non-interactive');
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installing pre-push hook...');
-      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
+      expect(result.stdout + result.stderr).toContain('Installing pre-push code scanning hook...');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push code scanning hook');
       expect(harness.cwd.exists('.husky', 'pre-push')).toBe(true);
       const hookContent = readFileSync(join(harness.cwd.path, '.husky', 'pre-push'), 'utf-8');
       expect(hookContent).toContain('hook git-pre-push');
@@ -974,8 +976,10 @@ describe('integrate git (pre-commit framework)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installing pre-commit hook...');
-      expect(result.stdout + result.stderr).toContain('✓  pre-commit hook');
+      expect(result.stdout + result.stderr).toContain(
+        'Installing pre-commit code scanning hook...',
+      );
+      expect(result.stdout + result.stderr).toContain('✓  pre-commit code scanning hook');
 
       const config = readYamlFile<PreCommitYamlConfig>(
         join(harness.cwd.path, '.pre-commit-config.yaml'),
@@ -1016,8 +1020,8 @@ describe('integrate git (pre-commit framework)', () => {
       });
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Installing pre-push hook...');
-      expect(result.stdout + result.stderr).toContain('✓  pre-push hook');
+      expect(result.stdout + result.stderr).toContain('Installing pre-push code scanning hook...');
+      expect(result.stdout + result.stderr).toContain('✓  pre-push code scanning hook');
 
       const config = readYamlFile<PreCommitYamlConfig>(
         join(harness.cwd.path, '.pre-commit-config.yaml'),

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -614,7 +614,7 @@ describe('integrateGitGlobal', () => {
       const summaryCall = calls.find((c) => c.method === 'phase' && c.args[0] === 'Installed');
       expect(summaryCall).toBeDefined();
       const items = (summaryCall?.args[1] ?? []) as Array<{ text: string }>;
-      expect(items.some((item) => item.text === 'pre-commit hook')).toBe(true);
+      expect(items.some((item) => item.text === 'pre-commit code scanning hook')).toBe(true);
       expect(state.integrations.installed[0]?.integrationId).toBe('native-git');
     } finally {
       spawnSpy.mockRestore();


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **CLI messaging improvements:**
  - Renamed all Git hooks to `code scanning hook` in logs, prompts, and documentation to reflect multi-scan capabilities.
  - Updated `integrate git` description to explicitly mention both secrets and dependency risks scanning.
- **CLI output enhancements:**
  - Added introductory messages to clarify that hooks cover both scan types and that availability may vary.

<sub>This will update automatically on new commits.</sub>