### PR TITLE
CLI-716 Fix type issues in git integration tests

### DIFF
--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -617,6 +617,7 @@ describe('generic integration installer', () => {
     const container: FeatureContainer = {
       id: 'container',
       displayName: 'Container Feature',
+      defaultInstallSubfeatureIds: ['subfeature-1', 'subfeature-2'],
       subfeatures: [
         { id: 'subfeature-1', displayName: 'Subfeature One' },
         { id: 'subfeature-2', displayName: 'Subfeature Two' },
@@ -649,6 +650,7 @@ describe('generic integration installer', () => {
     const container: FeatureContainer<{ enableOptional?: boolean }> = {
       id: 'container',
       displayName: 'Container Feature',
+      defaultInstallSubfeatureIds: ['subfeature-1'],
       subfeatures: [
         { id: 'subfeature-1', displayName: 'Subfeature One' },
         {


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **Test fixtures:**
  - Added `defaultInstallSubfeatureIds` property to `FeatureContainer` objects in `installer.test.ts` to satisfy type requirements.

<sub>This will update automatically on new commits.</sub>