### PR TITLE
CLI-723 Cleanup legacy resources unconditionally to support downgrades

### DIFF
--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -31,7 +31,7 @@ import { confirmPrompt, discreetSuccess, info } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
 import type { DependencyDeclaration } from './dependencies';
 import { recordInstalledFeature } from './installation-recorder';
-import type { RemovableResource, ResourceDeclaration, ResourceIdentity } from './resources';
+import type { ResourceDeclaration } from './resources';
 import { isFeatureContainer, normalizeDecision } from './selection';
 import type {
   AppliedFeature,
@@ -279,19 +279,6 @@ export class IntegrationInstaller {
     );
   }
 
-  legacyCleanupNeedsApply(
-    installedFeature: InstalledIntegrationFeature | undefined,
-    cleanup: ResourceIdentity & RemovableResource,
-  ): boolean {
-    if (installedFeature === undefined) {
-      // Integration not yet recorded in state: only run version-0 cleanups to remove
-      // artifacts that predate declarative state tracking.
-      return resolveVersion(cleanup.version) === '0';
-    }
-    const installedResource = installedFeature.resources.find((r) => r.id === cleanup.id);
-    return resolveVersion(installedResource?.version) === resolveVersion(cleanup.version);
-  }
-
   async applyAndRecordFeatures<TOptions>(
     state: CliState,
     integration: IntegrationDeclaration<TOptions>,
@@ -478,7 +465,7 @@ export class IntegrationInstaller {
     );
     const featureContext = this.buildFeatureContext(context, feature, resolvedDependencies);
 
-    await this.cleanupRecordedLegacyInstallations(feature, installedFeature, featureContext);
+    await this.cleanupRecordedLegacyInstallations(feature, featureContext);
 
     for (const resource of feature.resources ?? []) {
       if (!(await this.resourceNeedsApply(featureContext, installedFeature, resource))) {
@@ -518,11 +505,9 @@ export class IntegrationInstaller {
 
   private async cleanupRecordedLegacyInstallations<TOptions>(
     feature: FeatureDeclaration<TOptions>,
-    installedFeature: InstalledIntegrationFeature | undefined,
     featureContext: IntegrationContext,
   ) {
     for (const cleanup of feature.legacyCleanups ?? []) {
-      if (!this.legacyCleanupNeedsApply(installedFeature, cleanup)) continue;
       await cleanup.remove(featureContext);
     }
   }

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -52,6 +52,7 @@ const {
   SonarSourceBinary,
   sonarSourceBinary,
   textSnippet,
+  textSnippetRemover,
   tomlPatch,
   wholeFile,
   yamlPatch,
@@ -744,6 +745,55 @@ describe('declarative integration framework', () => {
 
     expect(selected.map((feature) => feature.id)).toEqual(['asked', 'defaulted']);
     expect(getMockUiCalls().filter((call) => call.method === 'confirmPrompt')).toHaveLength(0);
+  });
+
+  it('runs legacy cleanups unconditionally even when state records resource at a higher version', async () => {
+    const state = getDefaultState('test');
+    const targetPath = join(tempDir, 'managed-file');
+    const legacyStartMarker = '# legacy:begin';
+    const legacyEndMarker = '# legacy:end';
+    const currentStartMarker = '# sonar:begin';
+
+    const feature: FeatureDeclaration = {
+      id: 'feature',
+      displayName: 'Feature',
+      resources: [
+        textSnippet({
+          id: 'resource',
+          version: '1',
+          targetPath,
+          content: 'new content',
+          startMarker: currentStartMarker,
+        }),
+      ],
+      legacyCleanups: [
+        textSnippetRemover({
+          id: 'resource',
+          version: '0',
+          targetPath,
+          startMarker: legacyStartMarker,
+          endMarker: legacyEndMarker,
+        }),
+      ],
+    };
+    const integration = makeIntegration({ features: [feature] });
+    const context = makeContext(state, tempDir);
+
+    // First install: state is empty so legacy cleanup runs, recording resource at version '1'.
+    await writeFile(targetPath, `${legacyStartMarker}\nold\n${legacyEndMarker}\n`);
+    await applyAndRecord(installer, context, integration, feature);
+    expect(state.integrations.installed[0]?.features[0]?.resources[0]?.version).toBe('1');
+
+    // Simulate file reversion (e.g. git reset) while state still records version '1'.
+    await writeFile(targetPath, `${legacyStartMarker}\nold\n${legacyEndMarker}\n`);
+
+    // Re-install: legacy cleanup must run unconditionally despite state having version '1'.
+    await applyAndRecord(installer, context, integration, feature);
+
+    const content = await readFile(targetPath, 'utf-8');
+    expect(content).not.toContain(legacyStartMarker);
+    expect(content).toContain(currentStartMarker);
+    expect(content).toContain('new content');
   });
 
   it('applies declared resources and records the feature once', async () => {


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **Integration cleanup logic:**
  - Modified `IntegrationInstaller` to invoke `cleanupRecordedLegacyInstallations` unconditionally before processing resources.
  - This ensures legacy resources are removed even if the current state records a newer version, supporting downgrade scenarios.
- **Testing:**
  - Added a unit test in `registry.test.ts` to verify that legacy cleanups execute during re-installation after a file state reversion.

<sub>This will update automatically on new commits.</sub>