### PR TITLE
CLI-724 Add dependency risk eligibility check for git integrate

### DIFF
--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -109,7 +109,7 @@ export function validateHookOption(hook: string | undefined): void {
   }
 }
 
-async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
+async function integrateGitGlobal(options: IntegrateGitOptions, auth: ResolvedAuth): Promise<void> {
   validateHookOption(options.hook);
 
   warn('Global hook installation');
@@ -132,7 +132,7 @@ async function integrateGitGlobal(options: IntegrateGitOptions): Promise<void> {
   }
   blank();
 
-  await installGitFeatures(options, GLOBAL_HOOKS_DIR, 'global');
+  await installGitFeatures(options, GLOBAL_HOOKS_DIR, 'global', auth);
 }
 
 export async function integrateGit(
@@ -150,7 +150,7 @@ export async function integrateGit(
   info(yellow('Some scan types may be unavailable for certain hook types.'));
 
   if (options.global) {
-    return integrateGitGlobal(options);
+    return integrateGitGlobal(options, auth);
   }
 
   const { gitRoot, isGit } = findGitRoot(process.cwd());
@@ -165,7 +165,7 @@ export async function integrateGit(
     projectRoot: isGit ? gitRoot : process.cwd(),
   });
   if (scope === 'global') {
-    return integrateGitGlobal(options);
+    return integrateGitGlobal(options, auth);
   }
 
   if (!isGit) {
@@ -177,7 +177,7 @@ export async function integrateGit(
 
   const resolvedOptions = await resolveProjectKey(options, gitRoot, auth);
 
-  await installGitFeatures(resolvedOptions, gitRoot, 'project');
+  await installGitFeatures(resolvedOptions, gitRoot, 'project', auth);
 }
 
 async function resolveProjectKey(
@@ -206,6 +206,7 @@ async function installGitFeatures(
   options: IntegrateGitOptions,
   targetRoot: string,
   scope: 'project' | 'global',
+  auth: ResolvedAuth,
 ): Promise<void> {
   const integrationId = await resolveGitIntegrationId(targetRoot, scope);
   await installIntegration({
@@ -214,6 +215,7 @@ async function installGitFeatures(
     options,
     targetRoot,
     scope,
+    auth,
     force: options.force,
     nonInteractive: options.nonInteractive,
     // Attrs are project-scope only; global hooks do not support a project key.

--- a/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
+++ b/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import type { ResolvedAuth } from '../../../../../lib/auth-resolver';
 import { SonarQubeClient } from '../../../../../sonarqube/client';
 import { CommandFailedError, InvalidOptionError } from '../../../_common/error';
 import { assertScaAvailable } from '../../../_common/sca-availability';
@@ -30,6 +31,19 @@ import type { SubfeatureDeclaration } from '../../_common/registry/types';
 import type { IntegrateGitOptions } from '../options';
 
 export const PRE_COMMIT_DEP_RISKS_SUBFEATURE_ID = 'pre-commit-dependency-risks';
+
+async function scaSkipReason(auth: ResolvedAuth) {
+  const client = new SonarQubeClient(auth.serverUrl, auth.token);
+  try {
+    await assertScaAvailable(client, auth);
+    return null;
+  } catch (err) {
+    if (err instanceof CommandFailedError) {
+      return skip(err.message);
+    }
+    throw err;
+  }
+}
 
 export function createSecretsSubfeature(): SubfeatureDeclaration<IntegrateGitOptions> {
   return {
@@ -56,17 +70,9 @@ export function createDepRisksSubfeature(): SubfeatureDeclaration<IntegrateGitOp
       if (!options.project) {
         return skip('Dependency-risks scanning is not available without a project key.');
       }
-      if (auth) {
-        const client = new SonarQubeClient(auth.serverUrl, auth.token);
-        try {
-          await assertScaAvailable(client, auth);
-        } catch (err) {
-          if (err instanceof CommandFailedError) {
-            return skip(err.message);
-          }
-          throw err;
-        }
-      }
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const skipDecision = await scaSkipReason(auth!);
+      if (skipDecision) return skipDecision;
       if (options.dependencyRisks) return install();
       return askUser('Enable dependency-risks scanning on the pre-commit hook?');
     },

--- a/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
+++ b/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
@@ -18,7 +18,9 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { InvalidOptionError } from '../../../_common/error';
+import { SonarQubeClient } from '../../../../../sonarqube/client';
+import { CommandFailedError, InvalidOptionError } from '../../../_common/error';
+import { assertScaAvailable } from '../../../_common/sca-availability';
 import {
   scaScannerBinaryDependency,
   sonarSecretsBinaryDependency,
@@ -43,7 +45,7 @@ export function createDepRisksSubfeature(): SubfeatureDeclaration<IntegrateGitOp
   return {
     id: PRE_COMMIT_DEP_RISKS_SUBFEATURE_ID,
     displayName: 'pre-commit dependency-risks scan',
-    shouldInstall: ({ options, scope }) => {
+    shouldInstall: async ({ options, scope, auth }) => {
       if (scope === 'global') {
         return skip('Dependency-risks scanning is not available for global hooks');
       }
@@ -53,6 +55,17 @@ export function createDepRisksSubfeature(): SubfeatureDeclaration<IntegrateGitOp
       }
       if (!options.project) {
         return skip('Dependency-risks scanning is not available without a project key.');
+      }
+      if (auth) {
+        const client = new SonarQubeClient(auth.serverUrl, auth.token);
+        try {
+          await assertScaAvailable(client, auth);
+        } catch (err) {
+          if (err instanceof CommandFailedError) {
+            return skip(err.message);
+          }
+          throw err;
+        }
       }
       if (options.dependencyRisks) return install();
       return askUser('Enable dependency-risks scanning on the pre-commit hook?');

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -219,13 +219,17 @@ function readYamlFile<T>(path: string): T {
   return yaml.load(readFileSync(path, 'utf-8')) as T;
 }
 
-type SetupAuthOptions = { withSecretsBinary?: boolean };
+type SetupAuthOptions = { withSecretsBinary?: boolean; scaEnabled?: boolean };
 
 async function setupAuthenticated(
   harness: TestHarness,
   options: SetupAuthOptions = {},
 ): Promise<void> {
-  const server = await harness.newFakeServer().withAuthToken(INTEGRATION_TEST_TOKEN).start();
+  const serverBuilder = harness.newFakeServer().withAuthToken(INTEGRATION_TEST_TOKEN);
+  if (options.scaEnabled) {
+    serverBuilder.withScaEnabled(true);
+  }
+  const server = await serverBuilder.start();
   const chain = harness
     .state()
     .withActiveConnection(server.baseUrl())
@@ -545,7 +549,7 @@ describe('integrate git (native hooks)', () => {
   it(
     'prompts for dep-risks and bakes it in when user accepts with project key provided',
     async () => {
-      await setupAuthenticated(harness, { withSecretsBinary: true });
+      await setupAuthenticated(harness, { withSecretsBinary: true, scaEnabled: true });
       harness.state().withScaScannerBinaryInstalled();
       initGitRepo(harness);
 
@@ -578,7 +582,7 @@ describe('integrate git (native hooks)', () => {
   it(
     'prompts for dep-risks and omits it when user declines with project key provided',
     async () => {
-      await setupAuthenticated(harness, { withSecretsBinary: true });
+      await setupAuthenticated(harness, { withSecretsBinary: true, scaEnabled: true });
       initGitRepo(harness);
 
       // -p implies project scope (no scope prompt). 'n' declines 'Enable dependency-risks scanning?'.
@@ -602,6 +606,57 @@ describe('integrate git (native hooks)', () => {
       expect(
         feature.subfeatures?.find((s) => s.featureId === 'pre-commit-dependency-risks'),
       ).toBeUndefined();
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'skips dep-risks prompt when SCA is not enabled on the server',
+    async () => {
+      // No scaEnabled: true → fake server returns 404 for the SCA endpoint → check_failed → skip.
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      // Only '\r' needed: scope prompt. Dep-risks prompt is suppressed because SCA is unavailable.
+      const result = await harness.run('integrate git --hook pre-commit -p my-project', {
+        stdinChunks: ['\r'],
+        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
+      });
+
+      expect(result.exitCode).toBe(0);
+      const hookContent = readFileSync(
+        join(harness.cwd.path, '.git', 'hooks', 'pre-commit'),
+        'utf-8',
+      );
+      expect(hookContent).not.toContain('--dependency-risks');
+
+      const state = harness.stateJsonFile.asJson() as InstalledStateJson;
+      const gitIntegration = getInstalledIntegration(state, 'native-git');
+      const feature = gitIntegration.features[0];
+      expect(
+        feature.subfeatures?.find((s) => s.featureId === 'pre-commit-dependency-risks'),
+      ).toBeUndefined();
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'skips dep-risks and prints a message when --dependency-risks is set but SCA is not enabled',
+    async () => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      const result = await harness.run(
+        'integrate git --hook pre-commit --dependency-risks -p my-project --non-interactive',
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).toContain('Dependency-risks scanning is not available');
+      const hookContent = readFileSync(
+        join(harness.cwd.path, '.git', 'hooks', 'pre-commit'),
+        'utf-8',
+      );
+      expect(hookContent).not.toContain('--dependency-risks');
     },
     { timeout: 15000 },
   );
@@ -762,7 +817,7 @@ describe('integrate git (native hooks)', () => {
   it(
     'bakes the project key into the native pre-commit hook when --dependency-risks is set',
     async () => {
-      await setupAuthenticated(harness, { withSecretsBinary: true });
+      await setupAuthenticated(harness, { withSecretsBinary: true, scaEnabled: true });
       harness.state().withScaScannerBinaryInstalled();
       initGitRepo(harness);
 
@@ -926,7 +981,7 @@ describe('integrate git (husky)', () => {
   it(
     'bakes the project key into the husky pre-commit hook when --dependency-risks is set',
     async () => {
-      await setupAuthenticated(harness, { withSecretsBinary: true });
+      await setupAuthenticated(harness, { withSecretsBinary: true, scaEnabled: true });
       harness.state().withScaScannerBinaryInstalled();
       initGitRepoWithHusky(harness);
 
@@ -1258,7 +1313,7 @@ describe('integrate git (pre-commit framework)', () => {
   it(
     'bakes the project key into the pre-commit config hook entry when --dependency-risks is set',
     async () => {
-      await setupAuthenticated(harness, { withSecretsBinary: true });
+      await setupAuthenticated(harness, { withSecretsBinary: true, scaEnabled: true });
       harness.state().withScaScannerBinaryInstalled();
       initGitRepoWithPreCommitConfig(harness);
       const preCommitLog = join(harness.cwd.path, 'pre-commit.log');

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -227,7 +227,7 @@ async function setupAuthenticated(
 ): Promise<void> {
   const serverBuilder = harness.newFakeServer().withAuthToken(INTEGRATION_TEST_TOKEN);
   if (options.scaEnabled) {
-    serverBuilder.withScaEnabled(true);
+    serverBuilder.withVersion('2026.4.0.0').withScaEnabled(true);
   }
   const server = await serverBuilder.start();
   const chain = harness
@@ -643,7 +643,18 @@ describe('integrate git (native hooks)', () => {
   it(
     'skips dep-risks and prints a message when --dependency-risks is set but SCA is not enabled',
     async () => {
-      await setupAuthenticated(harness, { withSecretsBinary: true });
+      // Version-compatible server but SCA feature disabled: assertScaAvailable passes the
+      // version check then throws on the enablement check, so dep-risks is skipped.
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(INTEGRATION_TEST_TOKEN)
+        .withVersion('2026.4.0.0')
+        .start();
+      harness
+        .state()
+        .withActiveConnection(server.baseUrl())
+        .withKeychainToken(server.baseUrl(), INTEGRATION_TEST_TOKEN)
+        .withSecretsBinaryInstalled();
       initGitRepo(harness);
 
       const result = await harness.run(
@@ -651,7 +662,9 @@ describe('integrate git (native hooks)', () => {
       );
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout + result.stderr).toContain('Dependency-risks scanning is not available');
+      expect(result.stdout + result.stderr).toContain(
+        'Software Composition Analysis is not available for the current connection.',
+      );
       const hookContent = readFileSync(
         join(harness.cwd.path, '.git', 'hooks', 'pre-commit'),
         'utf-8',
@@ -664,7 +677,7 @@ describe('integrate git (native hooks)', () => {
   it(
     'opts into dependency-risks interactively and auto-discovers project key',
     async () => {
-      await setupAuthenticated(harness, { withSecretsBinary: true });
+      await setupAuthenticated(harness, { withSecretsBinary: true, scaEnabled: true });
       harness.state().withScaScannerBinaryInstalled();
       initGitRepo(harness);
       harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=auto-project\n');

--- a/tests/unit/cli/commands/integrate/git/git-integration-subfeatures.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-integration-subfeatures.test.ts
@@ -95,31 +95,6 @@ describe('createDepRisksSubfeature', () => {
     });
   });
 
-  it('installs when --dependency-risks and project key are both set (no auth)', async () => {
-    const sub = createDepRisksSubfeature();
-    expect(
-      await sub.shouldInstall!(
-        makeInvocation({ options: { dependencyRisks: true, project: 'my-project' } }),
-      ),
-    ).toMatchObject({ action: 'install' });
-  });
-
-  it('asks user when project key is set but --dependency-risks is not (no auth)', async () => {
-    const sub = createDepRisksSubfeature();
-    expect(
-      await sub.shouldInstall!(makeInvocation({ options: { project: 'my-project' } })),
-    ).toMatchObject({ action: 'ask' });
-  });
-
-  it('asks user in non-interactive mode when --dependency-risks is not set (installer converts ask+nonInteractive to install)', async () => {
-    const sub = createDepRisksSubfeature();
-    expect(
-      await sub.shouldInstall!(
-        makeInvocation({ options: { project: 'my-project' }, nonInteractive: true }),
-      ),
-    ).toMatchObject({ action: 'ask' });
-  });
-
   describe('with auth', () => {
     let checkScaEnabledSpy: ReturnType<typeof spyOn>;
 
@@ -144,7 +119,20 @@ describe('createDepRisksSubfeature', () => {
       });
     });
 
-    it('asks user when SCA is available and --dependency-risks is not set', async () => {
+    it('installs when --dependency-risks and project key are both set', async () => {
+      checkScaEnabledSpy.mockResolvedValue(true);
+      const sub = createDepRisksSubfeature();
+      expect(
+        await sub.shouldInstall!(
+          makeInvocation({
+            options: { dependencyRisks: true, project: 'my-project' },
+            auth: CLOUD_AUTH,
+          }),
+        ),
+      ).toMatchObject({ action: 'install' });
+    });
+
+    it('asks user when project key is set but --dependency-risks is not', async () => {
       checkScaEnabledSpy.mockResolvedValue(true);
       const sub = createDepRisksSubfeature();
       expect(
@@ -154,17 +142,18 @@ describe('createDepRisksSubfeature', () => {
       ).toMatchObject({ action: 'ask' });
     });
 
-    it('installs when SCA is available and --dependency-risks is set', async () => {
+    it('asks user in non-interactive mode when --dependency-risks is not set (installer converts ask+nonInteractive to install)', async () => {
       checkScaEnabledSpy.mockResolvedValue(true);
       const sub = createDepRisksSubfeature();
       expect(
         await sub.shouldInstall!(
           makeInvocation({
-            options: { project: 'my-project', dependencyRisks: true },
+            options: { project: 'my-project' },
+            nonInteractive: true,
             auth: CLOUD_AUTH,
           }),
         ),
-      ).toMatchObject({ action: 'install' });
+      ).toMatchObject({ action: 'ask' });
     });
   });
 });

--- a/tests/unit/cli/commands/integrate/git/git-integration-subfeatures.test.ts
+++ b/tests/unit/cli/commands/integrate/git/git-integration-subfeatures.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { InvalidOptionError } from '../../../../../../src/cli/commands/_common/error.js';
 import type { IntegrateGitOptions } from '../../../../../../src/cli/commands/integrate/git/options.js';
@@ -26,26 +26,38 @@ import {
   createDepRisksSubfeature,
   createSecretsSubfeature,
 } from '../../../../../../src/cli/commands/integrate/git/tools/git-integration-subfeatures.js';
+import type { ResolvedAuth } from '../../../../../../src/lib/auth-resolver.js';
+import { SonarQubeClient } from '../../../../../../src/sonarqube/client.js';
 
 type PartialInvocation = {
   options?: Partial<IntegrateGitOptions>;
   nonInteractive?: boolean;
   scope?: 'project' | 'global';
+  auth?: ResolvedAuth;
 };
 
 function makeInvocation({
   options = {},
   nonInteractive = false,
   scope = 'project',
+  auth,
 }: PartialInvocation = {}) {
   return {
     options,
     nonInteractive,
     scope,
+    auth,
     targetRoot: '/tmp',
     state: {} as never,
   };
 }
+
+const CLOUD_AUTH: ResolvedAuth = {
+  serverUrl: 'https://sonarcloud.io',
+  token: 'test-token',
+  connectionType: 'cloud',
+  orgKey: 'my-org',
+};
 
 describe('createSecretsSubfeature', () => {
   it('always installs with an explanatory message', () => {
@@ -58,45 +70,101 @@ describe('createSecretsSubfeature', () => {
 });
 
 describe('createDepRisksSubfeature', () => {
-  it('skips for global scope', () => {
+  it('skips for global scope', async () => {
     const sub = createDepRisksSubfeature();
-    expect(sub.shouldInstall!(makeInvocation({ scope: 'global' }))).toMatchObject({
+    expect(await sub.shouldInstall!(makeInvocation({ scope: 'global' }))).toMatchObject({
       action: 'skip',
+      message: 'Dependency-risks scanning is not available for global hooks',
     });
   });
 
-  it('throws InvalidOptionError when --dependency-risks is set without a project key', () => {
+  it('throws InvalidOptionError when --dependency-risks is set without a project key', async () => {
     const sub = createDepRisksSubfeature();
-    expect(() =>
+    /* eslint-disable @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable */
+    await expect(
       sub.shouldInstall!(makeInvocation({ options: { dependencyRisks: true } })),
-    ).toThrow(InvalidOptionError);
+    ).rejects.toThrow(InvalidOptionError);
+    /* eslint-enable @typescript-eslint/await-thenable */
   });
 
-  it('skips with message when no project key is available', () => {
+  it('skips with message when no project key is available', async () => {
     const sub = createDepRisksSubfeature();
-    const result = sub.shouldInstall!(makeInvocation());
-    expect(result).toMatchObject({ action: 'skip' });
+    expect(await sub.shouldInstall!(makeInvocation())).toMatchObject({
+      action: 'skip',
+      message: 'Dependency-risks scanning is not available without a project key.',
+    });
   });
 
-  it('installs when --dependency-risks and project key are both set', () => {
+  it('installs when --dependency-risks and project key are both set (no auth)', async () => {
     const sub = createDepRisksSubfeature();
-    const result = sub.shouldInstall!(
-      makeInvocation({ options: { dependencyRisks: true, project: 'my-project' } }),
-    );
-    expect(result).toMatchObject({ action: 'install' });
+    expect(
+      await sub.shouldInstall!(
+        makeInvocation({ options: { dependencyRisks: true, project: 'my-project' } }),
+      ),
+    ).toMatchObject({ action: 'install' });
   });
 
-  it('asks user when project key is set but --dependency-risks is not', () => {
+  it('asks user when project key is set but --dependency-risks is not (no auth)', async () => {
     const sub = createDepRisksSubfeature();
-    const result = sub.shouldInstall!(makeInvocation({ options: { project: 'my-project' } }));
-    expect(result).toMatchObject({ action: 'ask' });
+    expect(
+      await sub.shouldInstall!(makeInvocation({ options: { project: 'my-project' } })),
+    ).toMatchObject({ action: 'ask' });
   });
 
-  it('asks user in non-interactive mode when --dependency-risks is not set (installer converts ask+nonInteractive to install)', () => {
+  it('asks user in non-interactive mode when --dependency-risks is not set (installer converts ask+nonInteractive to install)', async () => {
     const sub = createDepRisksSubfeature();
-    const result = sub.shouldInstall!(
-      makeInvocation({ options: { project: 'my-project' }, nonInteractive: true }),
-    );
-    expect(result).toMatchObject({ action: 'ask' });
+    expect(
+      await sub.shouldInstall!(
+        makeInvocation({ options: { project: 'my-project' }, nonInteractive: true }),
+      ),
+    ).toMatchObject({ action: 'ask' });
+  });
+
+  describe('with auth', () => {
+    let checkScaEnabledSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      checkScaEnabledSpy = spyOn(SonarQubeClient.prototype, 'checkScaEnabled');
+    });
+
+    afterEach(() => {
+      checkScaEnabledSpy.mockRestore();
+    });
+
+    it('skips with SCA unavailability message when SCA is not enabled on the connection', async () => {
+      checkScaEnabledSpy.mockResolvedValue(false);
+      const sub = createDepRisksSubfeature();
+      expect(
+        await sub.shouldInstall!(
+          makeInvocation({ options: { project: 'my-project' }, auth: CLOUD_AUTH }),
+        ),
+      ).toMatchObject({
+        action: 'skip',
+        message: 'Software Composition Analysis is not available for the current connection.',
+      });
+    });
+
+    it('asks user when SCA is available and --dependency-risks is not set', async () => {
+      checkScaEnabledSpy.mockResolvedValue(true);
+      const sub = createDepRisksSubfeature();
+      expect(
+        await sub.shouldInstall!(
+          makeInvocation({ options: { project: 'my-project' }, auth: CLOUD_AUTH }),
+        ),
+      ).toMatchObject({ action: 'ask' });
+    });
+
+    it('installs when SCA is available and --dependency-risks is set', async () => {
+      checkScaEnabledSpy.mockResolvedValue(true);
+      const sub = createDepRisksSubfeature();
+      expect(
+        await sub.shouldInstall!(
+          makeInvocation({
+            options: { project: 'my-project', dependencyRisks: true },
+            auth: CLOUD_AUTH,
+          }),
+        ),
+      ).toMatchObject({ action: 'install' });
+    });
   });
 });


### PR DESCRIPTION
Part of CLI-505

----
## Summary by Gitar

- **Eligibility check:**
  - Implemented `assertScaAvailable` to verify Software Composition Analysis (SCA) eligibility for git integration.
  - Updated `createDepRisksSubfeature` to skip dependency-risks scanning if the current connection does not support SCA.
- **Integration flow:**
  - Propagated `auth` context throughout the git integration flow to enable server-side eligibility checks.
- **Testing:**
  - Added integration and unit tests to verify behavior when SCA is unavailable or disabled, ensuring proper skipping and user feedback.

<sub>This will update automatically on new commits.</sub>