### PR TITLE
CLI-672 Set up Renovate post-upgrade task for lock file regeneration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,8 +14,7 @@
           "bun install"
         ],
         "fileFilters": [
-          "bun.lock",
-          "bun.lockb"
+          "bun.lock"
         ],
         "executionMode": "branch"
       }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:ide-xp-team"
+  ],
+  "packageRules": [
+    {
+      "description": "Regenerate Bun lockfile after dependency updates",
+      "matchManagers": [
+        "bun"
+      ],
+      "postUpgradeTasks": {
+        "commands": [
+          "bun install"
+        ],
+        "fileFilters": [
+          "bun.lock",
+          "bun.lockb"
+        ],
+        "executionMode": "branch"
+      }
+    }
   ]
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Renovate configuration:**
  - Added a `postUpgradeTasks` rule to trigger `bun install` after dependency updates.
  - Configured `fileFilters` to automatically commit the updated `bun.lock` file.
- **Cleanup:**
  - Removed `bun.lockb` from the `fileFilters` configuration to align with the current project lockfile strategy.

<sub>This will update automatically on new commits.</sub>