### PR TITLE
CLI-728 Queue analysis findings in a local file and drain them through the background telemetry flush

### DIFF
--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -222,6 +222,12 @@ export function getTelemetryDir(): string {
   return join(getCliDir(), 'telemetry');
 }
 
+/** Telemetry ingest endpoint shared by all event types. */
+export const TELEMETRY_ENDPOINT = 'https://events.sonardata.io/cli';
+
+/** Write-only ingest API key — intentionally embedded in the binary. */
+export const TELEMETRY_API_KEY = 'hJPRohLsOsasZeOhSCSNDiL4h2yR96S5fOWJqRch';
+
 // ---------------------------------------------------------------------------
 // Sentry
 // ---------------------------------------------------------------------------

--- a/src/telemetry/findings.ts
+++ b/src/telemetry/findings.ts
@@ -1,0 +1,189 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { version as VERSION } from '../../package.json';
+import { detectCallerAgent } from '../lib/agent-detector.js';
+import type { ResolvedAuth } from '../lib/auth-resolver.js';
+import { getTelemetryDir, TELEMETRY_API_KEY, TELEMETRY_ENDPOINT } from '../lib/config-constants.js';
+import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
+import { INVOCATION_ID } from '../lib/invocation-id.js';
+import type { AnalysisFindingEventPayload, StoredFindingEvent } from '../lib/state.js';
+import { getActiveConnection, loadState } from '../lib/state-manager.js';
+import { isTelemetryEnabled } from './enabled.js';
+import { getOrCreateUserId } from './user.js';
+
+const FINDINGS_FILENAME = 'findings.ndjson';
+const FINDINGS_RETENTION_DAYS = 7;
+const FINDINGS_RETENTION_MS = FINDINGS_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+function getFindingsPath(): string {
+  return join(getTelemetryDir(), FINDINGS_FILENAME);
+}
+
+/**
+ * Appends one CliAnalysisFindingDetected event to findings.ndjson. Fire-and-forget:
+ * creates the directory if missing and silently swallows all I/O errors.
+ */
+export function appendFinding(payload: AnalysisFindingEventPayload): void {
+  try {
+    const event: StoredFindingEvent = {
+      metadata: {
+        event_id: randomUUID(),
+        source: { domain: 'CLI' },
+        event_type: 'Analytics.Cli.CliAnalysisFindingDetected',
+        event_timestamp: String(Date.now()),
+      },
+      event_payload: payload,
+    };
+    mkdirSync(getTelemetryDir(), { recursive: true });
+    appendFileSync(getFindingsPath(), JSON.stringify(event) + '\n');
+  } catch {
+    // fire-and-forget
+  }
+}
+
+/**
+ * Emits one CliAnalysisFindingDetected event per issue from a sonar-secrets scan.
+ * No-ops on clean scans (empty issues) and when telemetry is disabled.
+ * Identity fields are resolved from state + auth on each call.
+ */
+export function emitSecretsFindings(
+  callerCommand: string,
+  auth: ResolvedAuth,
+  issues: ReadonlyArray<{ ruleKey: string }>,
+  durationMs: number,
+): void {
+  if (issues.length === 0) return;
+  const state = loadState();
+  if (!isTelemetryEnabled(state)) return;
+  const installationId = state.telemetry.installationId;
+  if (!installationId) return;
+
+  const conn = getActiveConnection(state);
+  const base: Omit<
+    AnalysisFindingEventPayload,
+    'caller_command' | 'analyzer' | 'rule_key' | 'scan_duration_ms'
+  > = {
+    cli_installation_id: installationId,
+    machine_id: getOrCreateUserId(),
+    cli_version: VERSION,
+    invocation_id: INVOCATION_ID,
+    os: process.platform,
+    connection_type: auth.connectionType === 'cloud' ? 'sqc' : 'sqs',
+    user_uuid: conn?.userUuid ?? null,
+    organization_uuid_v4: conn?.organizationUuidV4 ?? null,
+    sqs_installation_id: conn?.sqsInstallationId ?? null,
+    caller_agent: detectCallerAgent(),
+  };
+
+  for (const issue of issues) {
+    appendFinding({
+      ...base,
+      caller_command: callerCommand,
+      analyzer: 'sonar-secrets',
+      rule_key: issue.ruleKey,
+      scan_duration_ms: durationMs,
+    });
+  }
+}
+
+function parseValidEvents(content: string, now: number): StoredFindingEvent[] {
+  const events: StoredFindingEvent[] = [];
+  for (const line of content.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const event = JSON.parse(line) as StoredFindingEvent;
+      const ts = Number(event.metadata.event_timestamp);
+      if (!Number.isNaN(ts) && now - ts <= FINDINGS_RETENTION_MS) {
+        events.push(event);
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return events;
+}
+
+/**
+ * Atomically drains findings.ndjson: renames it to a UUID-suffixed .sending file so
+ * concurrent flush workers each get their own slice, parses valid lines, discards
+ * events older than 7 days, then POSTs each remaining event to the telemetry backend.
+ * Unsent events (deadline reached or send error) are re-appended to findings.ndjson
+ * for the next flush attempt. The .sending file is deleted in all cases.
+ */
+export async function flushFindings(deadline: number): Promise<void> {
+  const findingsPath = getFindingsPath();
+  if (!existsSync(findingsPath)) return;
+
+  const sendingPath = join(getTelemetryDir(), `findings.${randomUUID()}.sending`);
+  try {
+    renameSync(findingsPath, sendingPath);
+  } catch {
+    // ENOENT: another flush worker won the rename race — nothing to drain.
+    // Any other error is also swallowed: flushFindings only runs in the detached
+    // flush-telemetry worker, so failures here never surface to the user.
+    return;
+  }
+
+  const unsent: StoredFindingEvent[] = [];
+
+  try {
+    const events = parseValidEvents(readFileSync(sendingPath, 'utf-8'), Date.now());
+    const sentIndices = new Set<number>();
+
+    for (let i = 0; i < events.length; i++) {
+      const remainingTime = deadline - Date.now();
+      if (remainingTime <= 0) break;
+      try {
+        await fetchGuarded(
+          TELEMETRY_ENDPOINT,
+          buildFetchInit(
+            'POST',
+            { 'Content-Type': 'application/json', 'x-api-key': TELEMETRY_API_KEY },
+            remainingTime,
+            JSON.stringify(events[i], (_key, value) => (value === null ? undefined : value)),
+          ),
+        );
+        sentIndices.add(i);
+      } catch {
+        // event remains in unsent for the next flush attempt
+      }
+    }
+
+    unsent.push(...events.filter((_, i) => !sentIndices.has(i)));
+  } finally {
+    if (unsent.length > 0) {
+      try {
+        appendFileSync(getFindingsPath(), unsent.map((e) => JSON.stringify(e)).join('\n') + '\n');
+      } catch {
+        // fire-and-forget
+      }
+    }
+    try {
+      rmSync(sendingPath);
+    } catch {
+      // ignore cleanup failures
+    }
+  }
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -24,12 +24,14 @@ import { type Command } from 'commander';
 
 import { version as VERSION } from '../../package.json';
 import { detectCallerAgent } from '../lib/agent-detector.js';
+import { TELEMETRY_API_KEY, TELEMETRY_ENDPOINT } from '../lib/config-constants.js';
 import { DISTRIBUTION } from '../lib/distribution.js';
 import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import { INVOCATION_ID } from '../lib/invocation-id.js';
 import type { StoredTelemetryEvent, TelemetryEventPayload } from '../lib/state.js';
 import { getActiveConnection, loadState, saveState } from '../lib/state-manager.js';
 import { isTelemetryEnabled } from './enabled.js';
+import { flushFindings } from './findings.js';
 import { getOrCreateUserId } from './user.js';
 
 export const TELEMETRY_FLUSH_MODE_ENV = '__SQ_CLI_TELEMETRY_FLUSH__';
@@ -42,9 +44,6 @@ const passthroughSubcommands = new WeakMap<Command, string | null>();
 export function setPassthroughSubcommand(command: Command, subcommand: string | null): void {
   passthroughSubcommands.set(command, subcommand);
 }
-
-const TELEMETRY_ENDPOINT = 'https://events.sonardata.io/cli';
-const TELEMETRY_API_KEY = 'hJPRohLsOsasZeOhSCSNDiL4h2yR96S5fOWJqRch';
 
 /**
  * Append one event to the pending batch and spawn a detached flush worker.
@@ -145,37 +144,40 @@ export async function flushTelemetry(): Promise<void> {
   if (!isTelemetryEnabled(state)) {
     return;
   }
-  const telemetry = state.telemetry;
-
-  if (!telemetry.events.length) return;
 
   const deadline = Date.now() + FLUSH_TIMEOUT_MS;
-  const sentIndices = new Set<number>();
+  const telemetry = state.telemetry;
 
-  for (let i = 0; i < telemetry.events.length; i++) {
-    const remainingTime = deadline - Date.now();
-    if (remainingTime <= 0) break;
-    try {
-      await fetchGuarded(
-        TELEMETRY_ENDPOINT,
-        buildFetchInit(
-          'POST',
-          { 'Content-Type': 'application/json', 'x-api-key': TELEMETRY_API_KEY },
-          remainingTime,
-          JSON.stringify(telemetry.events[i], (_key, value) =>
-            value === null ? undefined : value,
+  if (telemetry.events.length > 0) {
+    const sentIndices = new Set<number>();
+
+    for (let i = 0; i < telemetry.events.length; i++) {
+      const remainingTime = deadline - Date.now();
+      if (remainingTime <= 0) break;
+      try {
+        await fetchGuarded(
+          TELEMETRY_ENDPOINT,
+          buildFetchInit(
+            'POST',
+            { 'Content-Type': 'application/json', 'x-api-key': TELEMETRY_API_KEY },
+            remainingTime,
+            JSON.stringify(telemetry.events[i], (_key, value) =>
+              value === null ? undefined : value,
+            ),
           ),
-        ),
-      );
+        );
 
-      sentIndices.add(i);
-    } catch {
-      // Silently fail — event remains for the next flush attempt.
+        sentIndices.add(i);
+      } catch {
+        // Silently fail — event remains for the next flush attempt.
+      }
+    }
+
+    if (sentIndices.size > 0) {
+      telemetry.events = telemetry.events.filter((_, i) => !sentIndices.has(i));
+      saveState(state);
     }
   }
 
-  if (sentIndices.size > 0) {
-    telemetry.events = telemetry.events.filter((_, i) => !sentIndices.has(i));
-    saveState(state);
-  }
+  await flushFindings(deadline);
 }

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -1,0 +1,547 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * Tests for telemetry/findings.ts:
+ *   appendFinding        — NDJSON append, directory creation, fire-and-forget
+ *   emitSecretsFindings  — telemetry gate, identity resolution, per-issue append
+ *   flushFindings        — atomic rename, retention cap, send, re-queue, concurrent safety
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import * as agentDetector from '../../../src/lib/agent-detector.js';
+import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
+import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
+import * as stateRepository from '../../../src/lib/repository/state-repository.js';
+import type { CliState } from '../../../src/lib/state.js';
+import type { AnalysisFindingEventPayload, StoredFindingEvent } from '../../../src/lib/state.js';
+import { getDefaultState } from '../../../src/lib/state.js';
+import * as stateManager from '../../../src/lib/state-manager.js';
+import {
+  appendFinding,
+  emitSecretsFindings,
+  flushFindings,
+} from '../../../src/telemetry/findings.js';
+import * as userModule from '../../../src/telemetry/user.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makePayload(
+  overrides: Partial<AnalysisFindingEventPayload> = {},
+): AnalysisFindingEventPayload {
+  return {
+    cli_installation_id: 'install-id',
+    machine_id: 'machine-id',
+    cli_version: '1.0.0',
+    invocation_id: 'inv-id',
+    os: 'linux',
+    connection_type: null,
+    user_uuid: null,
+    organization_uuid_v4: null,
+    sqs_installation_id: null,
+    caller_agent: null,
+    caller_command: 'git-pre-commit',
+    analyzer: 'sonar-secrets',
+    rule_key: 'secrets:S6290',
+    scan_duration_ms: 123,
+    ...overrides,
+  };
+}
+
+function findingsPath(sonarUserHome: string): string {
+  return join(sonarUserHome, 'sonarqube-cli', 'telemetry', 'findings.ndjson');
+}
+
+function readLines(sonarUserHome: string): StoredFindingEvent[] {
+  const path = findingsPath(sonarUserHome);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as StoredFindingEvent);
+}
+
+function mockFetch(ok = true): ReturnType<typeof spyOn> {
+  return spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok,
+    status: ok ? 200 : 500,
+    statusText: ok ? 'OK' : 'Internal Server Error',
+    json: () => Promise.resolve({}),
+    text: () => Promise.resolve('{}'),
+  } as Response);
+}
+
+function makeTelemetryState(enabled = true): CliState {
+  const state = getDefaultState('1.0.0');
+  state.telemetry.enabled = enabled;
+  state.telemetry.installationId = 'install-id';
+  return state;
+}
+
+// ─── Setup ────────────────────────────────────────────────────────────────────
+
+let testSonarUserHome: string;
+const previousSonarUserHome = process.env[ENV_SONAR_USER_HOME];
+
+beforeEach(async () => {
+  testSonarUserHome = await mkdtemp(join(tmpdir(), 'cli-findings-test-'));
+  process.env[ENV_SONAR_USER_HOME] = testSonarUserHome;
+});
+
+afterEach(async () => {
+  await rm(testSonarUserHome, { recursive: true, force: true });
+  if (previousSonarUserHome === undefined) {
+    delete process.env[ENV_SONAR_USER_HOME];
+  } else {
+    process.env[ENV_SONAR_USER_HOME] = previousSonarUserHome;
+  }
+});
+
+// ─── appendFinding ─────────────────────────────────────────────────────────────
+
+describe('appendFinding()', () => {
+  it('creates findings.ndjson with one JSON line per call', () => {
+    appendFinding(makePayload());
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('writes a valid StoredFindingEvent envelope', () => {
+    appendFinding(makePayload({ rule_key: 'secrets:S1234', scan_duration_ms: 999 }));
+
+    const [event] = readLines(testSonarUserHome);
+    expect(event.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingDetected');
+    expect(event.metadata.source.domain).toBe('CLI');
+    expect(event.metadata.event_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(typeof event.metadata.event_timestamp).toBe('string');
+    expect(event.event_payload.rule_key).toBe('secrets:S1234');
+    expect(event.event_payload.scan_duration_ms).toBe(999);
+  });
+
+  it('appends one line per invocation', () => {
+    appendFinding(makePayload({ rule_key: 'secrets:A' }));
+    appendFinding(makePayload({ rule_key: 'secrets:B' }));
+    appendFinding(makePayload({ rule_key: 'secrets:C' }));
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(3);
+    expect(lines.map((e) => e.event_payload.rule_key)).toEqual([
+      'secrets:A',
+      'secrets:B',
+      'secrets:C',
+    ]);
+  });
+
+  it('creates the telemetry directory if it does not exist', () => {
+    const telemetryDir = join(testSonarUserHome, 'sonarqube-cli', 'telemetry');
+    expect(existsSync(telemetryDir)).toBe(false);
+
+    appendFinding(makePayload());
+
+    expect(existsSync(telemetryDir)).toBe(true);
+  });
+
+  it('silently swallows errors (e.g. read-only dir)', () => {
+    const cliDir = join(testSonarUserHome, 'sonarqube-cli');
+    mkdirSync(cliDir, { recursive: true });
+    // Create a file where the telemetry dir should be to force an error
+    writeFileSync(join(cliDir, 'telemetry'), 'not-a-dir');
+
+    expect(() => appendFinding(makePayload())).not.toThrow();
+  });
+});
+
+// ─── emitSecretsFindings ───────────────────────────────────────────────────────
+
+describe('emitSecretsFindings()', () => {
+  const AUTH: ResolvedAuth = {
+    connectionType: 'cloud',
+    serverUrl: 'https://sonarcloud.io',
+    token: 'test-token',
+    orgKey: 'my-org',
+  };
+
+  let loadStateSpy: ReturnType<typeof spyOn>;
+  let getConnectionSpy: ReturnType<typeof spyOn>;
+  let getUserIdSpy: ReturnType<typeof spyOn>;
+  let detectAgentSpy: ReturnType<typeof spyOn>;
+
+  let savedDoNotTrack: string | undefined;
+
+  beforeEach(() => {
+    // DO_NOT_TRACK may be set in the test environment — clear it so isTelemetryEnabled returns true
+    savedDoNotTrack = process.env.DO_NOT_TRACK;
+    delete process.env.DO_NOT_TRACK;
+
+    // loadState is re-exported via state-manager — spy on the originating module
+    loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeTelemetryState());
+    getConnectionSpy = spyOn(stateManager, 'getActiveConnection').mockReturnValue(undefined);
+    getUserIdSpy = spyOn(userModule, 'getOrCreateUserId').mockReturnValue('machine-id');
+    detectAgentSpy = spyOn(agentDetector, 'detectCallerAgent').mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    if (savedDoNotTrack !== undefined) {
+      process.env.DO_NOT_TRACK = savedDoNotTrack;
+    }
+    loadStateSpy.mockRestore();
+    getConnectionSpy.mockRestore();
+    getUserIdSpy.mockRestore();
+    detectAgentSpy.mockRestore();
+  });
+
+  it('does not append when issues array is empty', () => {
+    emitSecretsFindings('analyze secrets', AUTH, [], 100);
+
+    expect(readLines(testSonarUserHome)).toHaveLength(0);
+    expect(loadStateSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not append when installationId is absent', () => {
+    const stateWithoutId = makeTelemetryState();
+    stateWithoutId.telemetry.installationId = undefined;
+    loadStateSpy.mockReturnValue(stateWithoutId);
+
+    emitSecretsFindings('analyze secrets', AUTH, [{ ruleKey: 'secrets:S1' }], 100);
+
+    expect(readLines(testSonarUserHome)).toHaveLength(0);
+  });
+
+  it('does not append when telemetry is disabled', () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+
+    emitSecretsFindings('analyze secrets', AUTH, [{ ruleKey: 'secrets:S6290' }], 100);
+
+    expect(readLines(testSonarUserHome)).toHaveLength(0);
+  });
+
+  it('appends one finding per issue', () => {
+    emitSecretsFindings(
+      'analyze secrets',
+      AUTH,
+      [{ ruleKey: 'secrets:S6290' }, { ruleKey: 'secrets:S6691' }],
+      100,
+    );
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(2);
+    expect(lines[0].event_payload.rule_key).toBe('secrets:S6290');
+    expect(lines[1].event_payload.rule_key).toBe('secrets:S6691');
+  });
+
+  it('sets connection_type to sqc for cloud connections', () => {
+    emitSecretsFindings(
+      'analyze secrets',
+      { ...AUTH, connectionType: 'cloud' },
+      [{ ruleKey: 'secrets:S1' }],
+      100,
+    );
+
+    const [event] = readLines(testSonarUserHome);
+    expect(event.event_payload.connection_type).toBe('sqc');
+  });
+
+  it('sets connection_type to sqs for server connections', () => {
+    emitSecretsFindings(
+      'analyze secrets',
+      { ...AUTH, connectionType: 'on-premise' },
+      [{ ruleKey: 'secrets:S1' }],
+      100,
+    );
+
+    const [event] = readLines(testSonarUserHome);
+    expect(event.event_payload.connection_type).toBe('sqs');
+  });
+
+  it('records caller_command, analyzer, and scan_duration_ms', () => {
+    emitSecretsFindings('git-pre-commit', AUTH, [{ ruleKey: 'secrets:S1' }], 456);
+
+    const [event] = readLines(testSonarUserHome);
+    expect(event.event_payload.caller_command).toBe('git-pre-commit');
+    expect(event.event_payload.analyzer).toBe('sonar-secrets');
+    expect(event.event_payload.scan_duration_ms).toBe(456);
+  });
+});
+
+// ─── flushFindings ─────────────────────────────────────────────────────────────
+
+describe('flushFindings()', () => {
+  it('does nothing when findings.ndjson does not exist', async () => {
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('POSTs each finding to the telemetry endpoint', async () => {
+    appendFinding(makePayload({ rule_key: 'secrets:A' }));
+    appendFinding(makePayload({ rule_key: 'secrets:B' }));
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('deletes findings.ndjson after draining', async () => {
+    appendFinding(makePayload());
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      expect(existsSync(findingsPath(testSonarUserHome))).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('sends with correct headers and POST method', async () => {
+    appendFinding(makePayload());
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      expect(init.method).toBe('POST');
+      expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+      expect((init.headers as Record<string, string>)['x-api-key']).toBeTruthy();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('serialises the finding event in the request body', async () => {
+    appendFinding(makePayload({ rule_key: 'secrets:S6290', analyzer: 'sonar-secrets' }));
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const parsed = JSON.parse(init.body as string) as StoredFindingEvent;
+      expect(parsed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingDetected');
+      expect(parsed.event_payload.rule_key).toBe('secrets:S6290');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('omits null values from the serialised body', async () => {
+    appendFinding(makePayload({ user_uuid: null }));
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const parsed = JSON.parse(init.body as string) as StoredFindingEvent;
+      expect('user_uuid' in parsed.event_payload).toBe(false);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('discards events older than 7 days', async () => {
+    const eightDaysAgo = String(Date.now() - 8 * 24 * 60 * 60 * 1000);
+    const recentTs = String(Date.now());
+
+    const staleEvent: StoredFindingEvent = {
+      metadata: {
+        event_id: 'stale-id',
+        source: { domain: 'CLI' },
+        event_type: 'Analytics.Cli.CliAnalysisFindingDetected',
+        event_timestamp: eightDaysAgo,
+      },
+      event_payload: makePayload({ rule_key: 'secrets:STALE' }),
+    };
+    const freshEvent: StoredFindingEvent = {
+      metadata: {
+        event_id: 'fresh-id',
+        source: { domain: 'CLI' },
+        event_type: 'Analytics.Cli.CliAnalysisFindingDetected',
+        event_timestamp: recentTs,
+      },
+      event_payload: makePayload({ rule_key: 'secrets:FRESH' }),
+    };
+
+    const telemetryDir = join(testSonarUserHome, 'sonarqube-cli', 'telemetry');
+    mkdirSync(telemetryDir, { recursive: true });
+    writeFileSync(
+      findingsPath(testSonarUserHome),
+      [JSON.stringify(staleEvent), JSON.stringify(freshEvent)].join('\n') + '\n',
+    );
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const init = fetchSpy.mock.calls[0][1] as RequestInit;
+      const parsed = JSON.parse(init.body as string) as StoredFindingEvent;
+      expect(parsed.event_payload.rule_key).toBe('secrets:FRESH');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('discards events with a non-numeric event_timestamp', async () => {
+    const telemetryDir = join(testSonarUserHome, 'sonarqube-cli', 'telemetry');
+    mkdirSync(telemetryDir, { recursive: true });
+    const nanTsEvent: StoredFindingEvent = {
+      metadata: {
+        event_id: 'nan-id',
+        source: { domain: 'CLI' },
+        event_type: 'Analytics.Cli.CliAnalysisFindingDetected',
+        event_timestamp: 'not-a-number',
+      },
+      event_payload: makePayload(),
+    };
+    writeFileSync(findingsPath(testSonarUserHome), JSON.stringify(nanTsEvent) + '\n');
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('skips malformed lines without throwing', async () => {
+    const telemetryDir = join(testSonarUserHome, 'sonarqube-cli', 'telemetry');
+    mkdirSync(telemetryDir, { recursive: true });
+    const validEvent: StoredFindingEvent = {
+      metadata: {
+        event_id: 'ok-id',
+        source: { domain: 'CLI' },
+        event_type: 'Analytics.Cli.CliAnalysisFindingDetected',
+        event_timestamp: String(Date.now()),
+      },
+      event_payload: makePayload({ rule_key: 'secrets:VALID' }),
+    };
+    writeFileSync(
+      findingsPath(testSonarUserHome),
+      ['not-valid-json', JSON.stringify(validEvent), '{broken'].join('\n') + '\n',
+    );
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('re-queues events that fail to send for the next flush', async () => {
+    appendFinding(makePayload({ rule_key: 'secrets:A' }));
+    appendFinding(makePayload({ rule_key: 'secrets:B' }));
+
+    // First event (secrets:A) fails, second (secrets:B) succeeds
+    const fetchSpy = spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    try {
+      await flushFindings(Date.now() + 60_000);
+      const requeued = readLines(testSonarUserHome);
+      expect(requeued).toHaveLength(1);
+      expect(requeued[0].event_payload.rule_key).toBe('secrets:A');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('re-queues all events when the deadline has already passed', async () => {
+    appendFinding(makePayload({ rule_key: 'secrets:A' }));
+    appendFinding(makePayload({ rule_key: 'secrets:B' }));
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() - 1);
+      expect(fetchSpy).not.toHaveBeenCalled();
+      const requeued = readLines(testSonarUserHome);
+      expect(requeued).toHaveLength(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('is a no-op when a concurrent flush already renamed the file (ENOENT race)', async () => {
+    appendFinding(makePayload());
+
+    // Remove the file between existsSync and renameSync to simulate a concurrent winner
+    const path = findingsPath(testSonarUserHome);
+    const { renameSync: realRename } = await import('node:fs');
+    let calls = 0;
+    const renameSpy = spyOn(await import('node:fs'), 'renameSync').mockImplementation(
+      (...args: Parameters<typeof realRename>) => {
+        calls++;
+        if (calls === 1) {
+          realRename(...args); // first call: do the real rename...
+          realRename(args[1], path); // ...then rename it back to simulate another process already having taken it
+          throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+        }
+        return realRename(...args);
+      },
+    );
+
+    const fetchSpy = mockFetch();
+    try {
+      await flushFindings(Date.now() + 60_000);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      renameSpy.mockRestore();
+    }
+  });
+
+  it('silently swallows individual send failures', async () => {
+    appendFinding(makePayload({ rule_key: 'secrets:A' }));
+    appendFinding(makePayload({ rule_key: 'secrets:B' }));
+
+    const fetchSpy = spyOn(globalThis, 'fetch')
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce({ ok: true } as Response);
+
+    try {
+      let threw = false;
+      try {
+        await flushFindings(Date.now() + 60_000);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false);
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/telemetry/telemetry.test.ts
+++ b/tests/unit/telemetry/telemetry.test.ts
@@ -24,6 +24,10 @@
  * flushTelemetry (fetch calls, partial failure handling, disabled state)
  */
 
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Command } from 'commander';
 
@@ -31,7 +35,7 @@ import * as agentDetector from '../../../src/lib/agent-detector.js';
 import { ENV_DO_NOT_TRACK, ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
 import { DISTRIBUTION } from '../../../src/lib/distribution.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
-import type { CliState, StoredTelemetryEvent } from '../../../src/lib/state.js';
+import type { CliState, StoredFindingEvent, StoredTelemetryEvent } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as stateManager from '../../../src/lib/state-manager.js';
 import {
@@ -105,8 +109,11 @@ let loadStateSpy: ReturnType<typeof spyOn>;
 let saveStateSpy: ReturnType<typeof spyOn>;
 let getUserIdSpy: ReturnType<typeof spyOn>;
 let spawnSpy: ReturnType<typeof spyOn>;
+let testDir: string;
 
 beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'telemetry-test-'));
+  process.env[ENV_SONAR_USER_HOME] = testDir;
   loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
   saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
   getUserIdSpy = spyOn(userModule, 'getOrCreateUserId').mockReturnValue('test-machine-id');
@@ -120,6 +127,7 @@ afterEach(() => {
   saveStateSpy.mockRestore();
   getUserIdSpy.mockRestore();
   spawnSpy.mockRestore();
+  delete process.env[ENV_SONAR_USER_HOME];
   delete process.env[TELEMETRY_FLUSH_MODE_ENV];
   delete process.env[ENV_DO_NOT_TRACK];
   delete process.env.CLAUDECODE;
@@ -128,6 +136,7 @@ afterEach(() => {
   delete process.env.CURSOR_AGENT;
   delete process.env.CURSOR_PROJECT_DIR;
   delete process.env.CURSOR_TRACE_ID;
+  rmSync(testDir, { recursive: true, force: true });
 });
 
 // ─── storeEvent ───────────────────────────────────────────────────────────────
@@ -372,22 +381,11 @@ describe('storeEvent', () => {
     });
 
     it('inherits the parent environment and sets the flush worker flag', async () => {
-      const previousSonarUserHome = process.env[ENV_SONAR_USER_HOME];
-      process.env[ENV_SONAR_USER_HOME] = '/custom/sonar-home';
+      await storeEvent(makeCommand('auth login'), true);
 
-      try {
-        await storeEvent(makeCommand('auth login'), true);
-
-        const spawnOptions = spawnSpy.mock.calls[0][1] as { env: Record<string, string> };
-        expect(spawnOptions.env[TELEMETRY_FLUSH_MODE_ENV]).toBe('1');
-        expect(spawnOptions.env[ENV_SONAR_USER_HOME]).toBe('/custom/sonar-home');
-      } finally {
-        if (previousSonarUserHome === undefined) {
-          delete process.env[ENV_SONAR_USER_HOME];
-        } else {
-          process.env[ENV_SONAR_USER_HOME] = previousSonarUserHome;
-        }
-      }
+      const spawnOptions = spawnSpy.mock.calls[0][1] as { env: Record<string, string> };
+      expect(spawnOptions.env[TELEMETRY_FLUSH_MODE_ENV]).toBe('1');
+      expect(spawnOptions.env[ENV_SONAR_USER_HOME]).toBe(testDir);
     });
   });
 });
@@ -561,6 +559,52 @@ describe('flushTelemetry', () => {
         await flushTelemetry();
         const savedState: CliState = saveStateSpy.mock.calls[0][0];
         expect(savedState.telemetry.events).toHaveLength(1);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('findings drain', () => {
+    it('drains findings.ndjson to the telemetry backend', async () => {
+      const telemetryDir = join(testDir, 'sonarqube-cli', 'telemetry');
+      mkdirSync(telemetryDir, { recursive: true });
+      const finding: StoredFindingEvent = {
+        metadata: {
+          event_id: 'finding-id',
+          source: { domain: 'CLI' },
+          event_type: 'Analytics.Cli.CliAnalysisFindingDetected',
+          event_timestamp: String(Date.now()),
+        },
+        event_payload: {
+          cli_installation_id: 'install-id',
+          machine_id: 'machine-id',
+          cli_version: '1.0.0',
+          invocation_id: 'inv-id',
+          os: 'linux',
+          connection_type: null,
+          user_uuid: null,
+          organization_uuid_v4: null,
+          sqs_installation_id: null,
+          caller_agent: null,
+          caller_command: 'analyze secrets',
+          analyzer: 'sonar-secrets',
+          rule_key: 'secrets:S6290',
+          scan_duration_ms: 123,
+        },
+      };
+      writeFileSync(join(telemetryDir, 'findings.ndjson'), JSON.stringify(finding) + '\n');
+      loadStateSpy.mockReturnValue(makeStateWithEvents([]));
+
+      const fetchSpy = mockFetch();
+      try {
+        await flushTelemetry();
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const body = JSON.parse(
+          (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+        ) as StoredFindingEvent;
+        expect(body.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingDetected');
+        expect(body.event_payload.rule_key).toBe('secrets:S6290');
       } finally {
         fetchSpy.mockRestore();
       }


### PR DESCRIPTION
## Summary

- Move `TELEMETRY_ENDPOINT` and `TELEMETRY_API_KEY` from module-level constants in `src/telemetry/index.ts` to exported constants in `src/lib/config-constants.ts` so they can be shared across telemetry modules
- Add `src/telemetry/findings.ts` with three exports:
  - `appendFinding(payload)` — fire-and-forget low-level write: creates the telemetry dir if missing, appends one JSON line to `~/.sonar/sonarqube-cli/telemetry/findings.ndjson`, silently swallows all I/O errors
  - `emitSecretsFindings(callerCommand, auth, issues, durationMs)` — higher-level helper that gates on `isTelemetryEnabled`, resolves identity fields from state/auth, and calls `appendFinding()` per issue; call sites added in CLI-730
  - `flushFindings(deadline)` — atomically renames `findings.ndjson` → `findings.<uuid>.sending`, drops events older than 7 days, POSTs one event per HTTP call, deletes the `.sending` file in a `finally` block; a worker that loses the rename race exits immediately
- Extend `flushTelemetry()` in `src/telemetry/index.ts` to call `flushFindings(deadline)` after the existing `state.telemetry.events[]` drain

----
## Summary by Gitar

- **New utility:**
  - Added `timed` helper in `src/lib/timed.ts` to measure execution duration of asynchronous tasks.
- **Type definitions:**
  - Added `AnalysisFindingEventPayload` and `StoredFindingEvent` to `src/lib/state.ts` for structured finding data.
- **Configuration:**
  - Added `getTelemetryDir()` in `src/lib/config-constants.ts` to centralize the location for telemetry artifacts.
- **Testing:**
  - Added comprehensive unit tests for findings logic in `tests/unit/telemetry/findings.test.ts`.
  - Integrated findings drain verification into `tests/unit/telemetry/telemetry.test.ts`.
  - Added coverage for `timed()` helper in `tests/unit/lib/timed.test.ts`.
- **Test infrastructure:**
  - Updated `bunfig.toml` and `package.json` to include coverage instrumentation preloading for unit tests.

<sub>This will update automatically on new commits.</sub>