### PR TITLE
CLI-765 Switch default MCP Docker image to sonarsource/sonarqube-mcp

### DIFF
--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -211,6 +211,13 @@ export const CURSOR_IGNORE_FILE = '.cursorignore';
 export const SONAR_CONTEXT_INVOCATION = 'sonar context';
 
 // ---------------------------------------------------------------------------
+// MCP Server
+// ---------------------------------------------------------------------------
+
+/** Default Docker image for `sonar run mcp`. */
+export const MCP_DOCKER_IMAGE = 'sonarsource/sonarqube-mcp';
+
+// ---------------------------------------------------------------------------
 // Telemetry
 // ---------------------------------------------------------------------------
 

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -215,7 +215,7 @@ export const SONAR_CONTEXT_INVOCATION = 'sonar context';
 // ---------------------------------------------------------------------------
 
 /** Default Docker image for `sonar run mcp`. */
-export const MCP_DOCKER_IMAGE = 'sonarsource/sonarqube-mcp';
+export const SONARQUBE_MCP_DOCKER_IMAGE_NAME = 'sonarsource/sonarqube-mcp';
 
 // ---------------------------------------------------------------------------
 // Telemetry

--- a/src/lib/mcp/mcp-helper.ts
+++ b/src/lib/mcp/mcp-helper.ts
@@ -24,7 +24,10 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import type { ResolvedAuth } from '../auth-resolver';
-import { ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON, MCP_DOCKER_IMAGE } from '../config-constants';
+import {
+  ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON,
+  SONARQUBE_MCP_DOCKER_IMAGE_NAME,
+} from '../config-constants';
 import { normalizePath } from '../fs-utils';
 import type { ContainerRuntime } from '../tool-detector';
 
@@ -133,7 +136,7 @@ export function getMcpContainerCommand(
   args.push('-e', 'SONARQUBE_TOOLSETS');
   env.SONARQUBE_TOOLSETS = toolsets;
 
-  args.push(MCP_DOCKER_IMAGE);
+  args.push(SONARQUBE_MCP_DOCKER_IMAGE_NAME);
 
   return { command: runtime, args, env };
 }

--- a/src/lib/mcp/mcp-helper.ts
+++ b/src/lib/mcp/mcp-helper.ts
@@ -24,7 +24,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import type { ResolvedAuth } from '../auth-resolver';
-import { ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON } from '../config-constants';
+import { ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON, MCP_DOCKER_IMAGE } from '../config-constants';
 import { normalizePath } from '../fs-utils';
 import type { ContainerRuntime } from '../tool-detector';
 
@@ -133,7 +133,7 @@ export function getMcpContainerCommand(
   args.push('-e', 'SONARQUBE_TOOLSETS');
   env.SONARQUBE_TOOLSETS = toolsets;
 
-  args.push('mcp/sonarqube');
+  args.push(MCP_DOCKER_IMAGE);
 
   return { command: runtime, args, env };
 }

--- a/tests/integration/specs/run/mcp.test.ts
+++ b/tests/integration/specs/run/mcp.test.ts
@@ -25,7 +25,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import { MCP_DOCKER_IMAGE } from '../../../../src/lib/config-constants.js';
+import { SONARQUBE_MCP_DOCKER_IMAGE_NAME } from '../../../../src/lib/config-constants.js';
 import { IS_WINDOWS, TestHarness } from '../../harness';
 
 const EXECUTABLE_MODE = 0o755;
@@ -122,7 +122,7 @@ describe('run mcp', () => {
       // workspace was mounted
       expect(result.stdout).toContain('/app/mcp-workspace:ro');
       // correct image
-      expect(result.stdout).toContain(MCP_DOCKER_IMAGE);
+      expect(result.stdout).toContain(SONARQUBE_MCP_DOCKER_IMAGE_NAME);
       // env vars were injected into the docker process
       expect(result.stdout).toContain('ENV_TOKEN=test-token');
       expect(result.stdout).toContain(`ENV_URL=${server.baseUrl()}`);
@@ -149,7 +149,7 @@ describe('run mcp', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('SONARQUBE_PROJECT_KEY');
       expect(result.stdout).not.toContain('/app/mcp-workspace:ro');
-      expect(result.stdout).toContain(MCP_DOCKER_IMAGE);
+      expect(result.stdout).toContain(SONARQUBE_MCP_DOCKER_IMAGE_NAME);
       expect(result.stdout).toContain('ENV_TOKEN=test-token');
     },
     { timeout: 15000 },

--- a/tests/integration/specs/run/mcp.test.ts
+++ b/tests/integration/specs/run/mcp.test.ts
@@ -25,6 +25,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
+import { MCP_DOCKER_IMAGE } from '../../../../src/lib/config-constants.js';
 import { IS_WINDOWS, TestHarness } from '../../harness';
 
 const EXECUTABLE_MODE = 0o755;
@@ -121,7 +122,7 @@ describe('run mcp', () => {
       // workspace was mounted
       expect(result.stdout).toContain('/app/mcp-workspace:ro');
       // correct image
-      expect(result.stdout).toContain('mcp/sonarqube');
+      expect(result.stdout).toContain(MCP_DOCKER_IMAGE);
       // env vars were injected into the docker process
       expect(result.stdout).toContain('ENV_TOKEN=test-token');
       expect(result.stdout).toContain(`ENV_URL=${server.baseUrl()}`);
@@ -148,7 +149,7 @@ describe('run mcp', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('SONARQUBE_PROJECT_KEY');
       expect(result.stdout).not.toContain('/app/mcp-workspace:ro');
-      expect(result.stdout).toContain('mcp/sonarqube');
+      expect(result.stdout).toContain(MCP_DOCKER_IMAGE);
       expect(result.stdout).toContain('ENV_TOKEN=test-token');
     },
     { timeout: 15000 },

--- a/tests/unit/cli/commands/integrate/claude/mcp.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/mcp.test.ts
@@ -26,6 +26,7 @@ import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { setupMcpServer } from '../../../../../../src/cli/commands/integrate/claude/mcp';
 import type { ResolvedAuth } from '../../../../../../src/lib/auth-resolver';
+import { MCP_DOCKER_IMAGE } from '../../../../../../src/lib/config-constants';
 import {
   getMcpConfigFilePath,
   getMcpContainerCommand,
@@ -79,7 +80,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_URL',
         '-e',
         'SONARQUBE_TOOLSETS',
-        'mcp/sonarqube',
+        MCP_DOCKER_IMAGE,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -105,7 +106,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_URL',
         '-e',
         'SONARQUBE_TOOLSETS',
-        'mcp/sonarqube',
+        MCP_DOCKER_IMAGE,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -134,7 +135,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_ORG',
         '-e',
         'SONARQUBE_TOOLSETS',
-        'mcp/sonarqube',
+        MCP_DOCKER_IMAGE,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -164,7 +165,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_ORG',
         '-e',
         'SONARQUBE_TOOLSETS',
-        'mcp/sonarqube',
+        MCP_DOCKER_IMAGE,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -207,7 +208,7 @@ describe('getMcpContainerConfig', () => {
         '/fake/project:/app/mcp-workspace:ro',
         '-e',
         'SONARQUBE_TOOLSETS',
-        'mcp/sonarqube',
+        MCP_DOCKER_IMAGE,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -238,7 +239,7 @@ describe('getMcpContainerConfig', () => {
         '/fake/project:/app/mcp-workspace:ro',
         '-e',
         'SONARQUBE_TOOLSETS',
-        'mcp/sonarqube',
+        MCP_DOCKER_IMAGE,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -272,7 +273,7 @@ describe('getMcpContainerConfig', () => {
         '/fake/project:/app/mcp-workspace:ro',
         '-e',
         'SONARQUBE_TOOLSETS',
-        'mcp/sonarqube',
+        MCP_DOCKER_IMAGE,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',

--- a/tests/unit/cli/commands/integrate/claude/mcp.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/mcp.test.ts
@@ -26,7 +26,7 @@ import { afterEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { setupMcpServer } from '../../../../../../src/cli/commands/integrate/claude/mcp';
 import type { ResolvedAuth } from '../../../../../../src/lib/auth-resolver';
-import { MCP_DOCKER_IMAGE } from '../../../../../../src/lib/config-constants';
+import { SONARQUBE_MCP_DOCKER_IMAGE_NAME } from '../../../../../../src/lib/config-constants';
 import {
   getMcpConfigFilePath,
   getMcpContainerCommand,
@@ -80,7 +80,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_URL',
         '-e',
         'SONARQUBE_TOOLSETS',
-        MCP_DOCKER_IMAGE,
+        SONARQUBE_MCP_DOCKER_IMAGE_NAME,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -106,7 +106,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_URL',
         '-e',
         'SONARQUBE_TOOLSETS',
-        MCP_DOCKER_IMAGE,
+        SONARQUBE_MCP_DOCKER_IMAGE_NAME,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -135,7 +135,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_ORG',
         '-e',
         'SONARQUBE_TOOLSETS',
-        MCP_DOCKER_IMAGE,
+        SONARQUBE_MCP_DOCKER_IMAGE_NAME,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -165,7 +165,7 @@ describe('getMcpContainerConfig', () => {
         'SONARQUBE_ORG',
         '-e',
         'SONARQUBE_TOOLSETS',
-        MCP_DOCKER_IMAGE,
+        SONARQUBE_MCP_DOCKER_IMAGE_NAME,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -208,7 +208,7 @@ describe('getMcpContainerConfig', () => {
         '/fake/project:/app/mcp-workspace:ro',
         '-e',
         'SONARQUBE_TOOLSETS',
-        MCP_DOCKER_IMAGE,
+        SONARQUBE_MCP_DOCKER_IMAGE_NAME,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -239,7 +239,7 @@ describe('getMcpContainerConfig', () => {
         '/fake/project:/app/mcp-workspace:ro',
         '-e',
         'SONARQUBE_TOOLSETS',
-        MCP_DOCKER_IMAGE,
+        SONARQUBE_MCP_DOCKER_IMAGE_NAME,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',
@@ -273,7 +273,7 @@ describe('getMcpContainerConfig', () => {
         '/fake/project:/app/mcp-workspace:ro',
         '-e',
         'SONARQUBE_TOOLSETS',
-        MCP_DOCKER_IMAGE,
+        SONARQUBE_MCP_DOCKER_IMAGE_NAME,
       ],
       env: {
         SONARQUBE_TOKEN: 'squ_test',

--- a/tests/unit/cli/commands/run/mcp.test.ts
+++ b/tests/unit/cli/commands/run/mcp.test.ts
@@ -29,7 +29,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.js';
 import { runMcp } from '../../../../../src/cli/commands/run/mcp.js';
 import type { ResolvedAuth } from '../../../../../src/lib/auth-resolver.js';
-import { MCP_DOCKER_IMAGE } from '../../../../../src/lib/config-constants.js';
+import { SONARQUBE_MCP_DOCKER_IMAGE_NAME } from '../../../../../src/lib/config-constants.js';
 import * as projectInfo from '../../../../../src/lib/project-workspace/project-info.js';
 import * as toolDetector from '../../../../../src/lib/tool-detector.js';
 
@@ -83,7 +83,7 @@ describe('runMcp', () => {
 
     expect(spawnSpy).toHaveBeenCalledWith(
       'podman',
-      expect.arrayContaining(['run', MCP_DOCKER_IMAGE]),
+      expect.arrayContaining(['run', SONARQUBE_MCP_DOCKER_IMAGE_NAME]),
       expect.objectContaining({ stdio: 'inherit' }),
     );
   });

--- a/tests/unit/cli/commands/run/mcp.test.ts
+++ b/tests/unit/cli/commands/run/mcp.test.ts
@@ -29,6 +29,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.js';
 import { runMcp } from '../../../../../src/cli/commands/run/mcp.js';
 import type { ResolvedAuth } from '../../../../../src/lib/auth-resolver.js';
+import { MCP_DOCKER_IMAGE } from '../../../../../src/lib/config-constants.js';
 import * as projectInfo from '../../../../../src/lib/project-workspace/project-info.js';
 import * as toolDetector from '../../../../../src/lib/tool-detector.js';
 
@@ -82,7 +83,7 @@ describe('runMcp', () => {
 
     expect(spawnSpy).toHaveBeenCalledWith(
       'podman',
-      expect.arrayContaining(['run', 'mcp/sonarqube']),
+      expect.arrayContaining(['run', MCP_DOCKER_IMAGE]),
       expect.objectContaining({ stdio: 'inherit' }),
     );
   });


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration updates:**
  - Added `MCP_DOCKER_IMAGE` constant set to `sonarsource/sonarqube-mcp` in `src/lib/config-constants.ts`.
- **Logic updates:**
  - Refactored `mcp-helper.ts` to use `MCP_DOCKER_IMAGE` instead of the hardcoded `mcp/sonarqube` string.
- **Testing updates:**
  - Updated unit and integration tests to import and validate the new `MCP_DOCKER_IMAGE` constant.

<sub>This will update automatically on new commits.</sub>