### PR TITLE
CLI-736 Centralized network management

### DIFF
--- a/src/lib/connectivity/network-config.ts
+++ b/src/lib/connectivity/network-config.ts
@@ -1,0 +1,240 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { rootCertificates } from 'node:tls';
+
+import type { BunFile } from 'bun';
+
+import { createRedactedUrl } from '../redacted-url';
+import type {
+  ConfigSource,
+  FetchNetworkOptions,
+  ResolvedNetworkConfig,
+  SourcedValue,
+} from './types';
+
+// --- Proxy group ---
+// proxyHttps, proxyHttp, and noProxy are resolved as a unit: the highest-priority
+// entry in PROXY_CONFIGS that has at least one proxy value wins, and all three
+// fields come from it. A standalone noProxy entry cannot elevate an entry on its own.
+
+type EnvLookup = (env: NodeJS.ProcessEnv, varName: string) => string | undefined;
+
+interface ProxyEnvVars {
+  httpsVar: string;
+  httpVar: string;
+  noProxyVar: string;
+  lookup: EnvLookup;
+}
+
+/** Reads an env var preferring the lowercase form, then falling back to the exact name. */
+function getCaseVariantEnv(env: NodeJS.ProcessEnv, varName: string): string | undefined {
+  return env[varName.toLowerCase()] ?? env[varName];
+}
+
+const PROXY_CONFIGS: Array<SourcedValue<ProxyEnvVars>> = [
+  {
+    value: {
+      httpsVar: 'SONAR_HTTPS_PROXY_URL',
+      httpVar: 'SONAR_HTTP_PROXY_URL',
+      noProxyVar: 'SONAR_NO_PROXY',
+      lookup: (env, name) => env[name],
+    },
+    source: 'sonar-env',
+    explicit: true,
+  },
+  // stored-config slot added here when sonar config is wired
+  {
+    value: {
+      httpsVar: 'HTTPS_PROXY',
+      httpVar: 'HTTP_PROXY',
+      noProxyVar: 'NO_PROXY',
+      lookup: getCaseVariantEnv,
+    },
+    source: 'generic-env',
+    explicit: false,
+  },
+];
+
+function resolveProxyGroup(
+  env: NodeJS.ProcessEnv,
+): Pick<ResolvedNetworkConfig, 'proxyHttps' | 'proxyHttp' | 'noProxy'> {
+  for (const {
+    value: { httpsVar, httpVar, noProxyVar, lookup },
+    source,
+    explicit,
+  } of PROXY_CONFIGS) {
+    const httpsVal = lookup(env, httpsVar);
+    const httpVal = lookup(env, httpVar);
+    if (!httpsVal && !httpVal) {
+      continue;
+    }
+
+    const noProxyVal = lookup(env, noProxyVar);
+    return {
+      proxyHttps: httpsVal ? { value: createRedactedUrl(httpsVal), source, explicit } : null,
+      proxyHttp: httpVal ? { value: createRedactedUrl(httpVal), source, explicit } : null,
+      noProxy: noProxyVal ? { value: noProxyVal, source, explicit } : null,
+    };
+  }
+  return { proxyHttps: null, proxyHttp: null, noProxy: null };
+}
+
+// --- CA cert (resolves independently) ---
+
+function resolveCaCertPath(env: NodeJS.ProcessEnv): SourcedValue<string> | null {
+  return (
+    fromEnv(env, 'SONAR_CA_CERT', 'sonar-env') ??
+    // stored-config slot added here when sonar config is wired
+    fromEnv(env, 'NODE_EXTRA_CA_CERTS', 'generic-env')
+  );
+}
+
+function fromEnv(
+  env: NodeJS.ProcessEnv,
+  varName: string,
+  source: ConfigSource,
+): SourcedValue<string> | null {
+  const val = env[varName];
+  return val ? { value: val, source, explicit: source !== 'generic-env' } : null;
+}
+
+// --- Resolver ---
+
+export function resolveNetworkConfig(env: NodeJS.ProcessEnv = process.env): ResolvedNetworkConfig {
+  return {
+    ...resolveProxyGroup(env),
+    caCertPath: resolveCaCertPath(env),
+  };
+}
+
+// --- Singleton ---
+
+let cachedConfig: ResolvedNetworkConfig | undefined;
+
+export function getNetworkConfig(): ResolvedNetworkConfig {
+  cachedConfig ??= resolveNetworkConfig();
+  return cachedConfig;
+}
+
+/** Test seam — resets the cached singleton. */
+export function clearNetworkConfigCache(): void {
+  cachedConfig = undefined;
+}
+
+const DEFAULT_PORT_HTTPS = 443;
+const DEFAULT_PORT_HTTP = 80;
+
+// --- Fetch options builder ---
+
+export function buildFetchNetworkOptions(
+  url: string,
+  config: ResolvedNetworkConfig = getNetworkConfig(),
+): FetchNetworkOptions {
+  return {
+    ...buildProxyOption(url, config),
+    ...buildTlsOption(config),
+  };
+}
+
+function buildProxyOption(
+  url: string,
+  config: ResolvedNetworkConfig,
+): { proxy: string } | Record<string, never> {
+  const parsed = tryParseUrl(url);
+  if (!parsed) {
+    return {};
+  }
+  const proxyCandidate = parsed.protocol === 'https:' ? config.proxyHttps : config.proxyHttp;
+  if (!proxyCandidate?.explicit) {
+    return {};
+  }
+  const defaultPort = parsed.protocol === 'https:' ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
+  const port = Number.parseInt(parsed.port) || defaultPort;
+  const bypass =
+    config.noProxy !== null && matchesNoProxy(parsed.hostname, port, config.noProxy.value);
+  return bypass ? {} : { proxy: proxyCandidate.value.getUrlWithCredentials() };
+}
+
+function buildTlsOption(
+  config: ResolvedNetworkConfig,
+): { tls: { ca: Array<string | BunFile> } } | Record<string, never> {
+  if (!config.caCertPath?.explicit) {
+    return {};
+  }
+  return { tls: { ca: [...rootCertificates, Bun.file(config.caCertPath.value)] } };
+}
+
+function tryParseUrl(url: string): URL | null {
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function matchesNoProxy(hostname: string, port: number, noProxy: string): boolean {
+  const h = hostname.toLowerCase();
+  if (noProxy.toLowerCase() === '*') {
+    return true;
+  }
+  return noProxy
+    .toLowerCase()
+    .split(/[,\s]/)
+    .filter((entry) => entry.length > 0)
+    .some((entry) => {
+      const parsed = parseNoProxyEntry(entry);
+      if (parsed.port && parsed.port !== port) {
+        return false;
+      }
+      return hostnameMatchesPattern(h, normalizeHostPattern(parsed.host));
+    });
+}
+
+function parseNoProxyEntry(entry: string): { host: string; port: number } {
+  const withPort = /^(.+):(\d+)$/.exec(entry);
+  return {
+    host: (withPort ? withPort[1] : entry).toLowerCase(),
+    port: withPort ? Number.parseInt(withPort[2]) : 0,
+  };
+}
+
+function normalizeHostPattern(host: string): string {
+  if (host.startsWith('*')) {
+    // Strip only the wildcard, keep the leading dot so hostnameMatchesPattern
+    // can apply suffix-only matching (*.corp.com must not match corp.com itself).
+    return host.slice(1);
+  }
+  if (host.startsWith('.')) {
+    return host.slice(1);
+  }
+  return host;
+}
+
+function hostnameMatchesPattern(hostname: string, pattern: string): boolean {
+  if (!pattern) {
+    return true; // bare * → match everything
+  }
+  if (pattern.startsWith('.')) {
+    // Retained dot from *.corp.com normalization → suffix-only, no exact match
+    return hostname.endsWith(pattern);
+  }
+  return hostname === pattern || hostname.endsWith(`.${pattern}`);
+}

--- a/src/lib/connectivity/types.ts
+++ b/src/lib/connectivity/types.ts
@@ -1,0 +1,43 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { BunFile } from 'bun';
+
+import type { RedactedUrl } from '../redacted-url';
+
+export type ConfigSource = 'sonar-env' | 'stored-config' | 'generic-env';
+
+export interface SourcedValue<T> {
+  readonly value: T;
+  readonly source: ConfigSource;
+  readonly explicit: boolean;
+}
+
+export interface FetchNetworkOptions {
+  proxy?: string;
+  tls?: { ca: Array<string | BunFile> };
+}
+
+export interface ResolvedNetworkConfig {
+  readonly proxyHttps: SourcedValue<RedactedUrl> | null;
+  readonly proxyHttp: SourcedValue<RedactedUrl> | null;
+  readonly noProxy: SourcedValue<string> | null;
+  readonly caCertPath: SourcedValue<string> | null;
+}

--- a/src/lib/fetch-guarded.ts
+++ b/src/lib/fetch-guarded.ts
@@ -20,13 +20,17 @@
 
 // Shared fetch utilities: request init builder and redirect guard.
 
+import { buildFetchNetworkOptions } from './connectivity/network-config.js';
+import type { FetchNetworkOptions } from './connectivity/types';
+
 export function buildFetchInit(
   method: string,
   headers: Record<string, string>,
   timeoutMs: number,
   body?: string,
+  networkOptions?: FetchNetworkOptions,
 ): RequestInit {
-  return { method, headers, body, signal: AbortSignal.timeout(timeoutMs) };
+  return { method, headers, body, signal: AbortSignal.timeout(timeoutMs), ...networkOptions };
 }
 
 // Fetch wrapper that prevents bearer token leakage via cross-origin redirects.
@@ -85,6 +89,7 @@ export async function fetchGuarded(url: string, init: RequestInit): Promise<Resp
       response.status === HTTP_307_TEMPORARY_REDIRECT ||
       response.status === HTTP_308_PERMANENT_REDIRECT;
 
+    const schemeChanged = redirectUrl.protocol !== new URL(currentUrl).protocol;
     currentUrl = redirectUrl.toString();
     if (!preservesMethod) {
       currentInit = {
@@ -93,6 +98,12 @@ export async function fetchGuarded(url: string, init: RequestInit): Promise<Resp
         body: undefined,
         headers: withoutContentType(currentInit.headers),
       };
+    }
+    if (schemeChanged) {
+      // Scheme changed (HTTP→HTTPS): stale proxy/tls options from the original
+      // protocol are no longer correct. Strip them and recompute for the new URL.
+      const { proxy: _p, tls: _t, ...rest } = currentInit as RequestInit & FetchNetworkOptions;
+      currentInit = { ...rest, ...buildFetchNetworkOptions(currentUrl) };
     }
   }
 }

--- a/src/lib/redacted-url.ts
+++ b/src/lib/redacted-url.ts
@@ -1,0 +1,46 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+export interface RedactedUrl {
+  /** Redacted URL — safe for display and logging. */
+  getUrl(): string;
+  /** Full URL including credentials — for use in actual network calls only. */
+  getUrlWithCredentials(): string;
+}
+
+export function createRedactedUrl(raw: string): RedactedUrl {
+  let redacted: string;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.username) {
+      parsed.username = '***';
+    }
+    if (parsed.password) {
+      parsed.password = '***';
+    }
+    redacted = parsed.toString();
+  } catch {
+    redacted = '<redacted: malformed url>';
+  }
+  return {
+    getUrl: () => redacted,
+    getUrlWithCredentials: () => raw,
+  };
+}

--- a/src/lib/server-info.ts
+++ b/src/lib/server-info.ts
@@ -19,6 +19,7 @@
  */
 
 import { version as VERSION } from '../../package.json';
+import { buildFetchNetworkOptions } from './connectivity/network-config.js';
 import { ApiCallError } from './errors';
 import { isNewerVersion } from './version';
 
@@ -68,6 +69,7 @@ export async function fetchServerVersion(serverURL: string): Promise<string> {
       Accept: 'application/json',
     },
     signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    ...buildFetchNetworkOptions(url),
   });
   if (!response.ok) {
     throw new ApiCallError(`Server returned HTTP ${response.status} for ${url}`);

--- a/src/lib/sonarsource-releases.ts
+++ b/src/lib/sonarsource-releases.ts
@@ -27,6 +27,7 @@ import {
   SONAR_CONTEXT_AUGMENTATION_DIST_PREFIX,
   SONARSOURCE_BINARIES_URL,
 } from './config-constants.js';
+import { buildFetchNetworkOptions } from './connectivity/network-config.js';
 import { buildCagPlatformSuffix, type PlatformInfo } from './install-types.js';
 import logger from './logger.js';
 
@@ -86,6 +87,7 @@ export async function downloadBinary(url: string, destinationPath: string): Prom
   const response = await fetch(url, {
     headers: { 'User-Agent': `sonarqube-cli/${VERSION}` },
     signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+    ...buildFetchNetworkOptions(url),
   });
 
   if (!response.ok) {

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -22,6 +22,7 @@
 
 import { version as VERSION } from '../../package.json';
 import { isSonarQubeCloud, resolveFromEndpoint } from '../lib/auth-resolver';
+import { buildFetchNetworkOptions } from '../lib/connectivity/network-config.js';
 import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import logger from '../lib/logger';
 import { print } from '../ui';
@@ -153,7 +154,10 @@ export class SonarQubeClient {
       print(`request body: ${requestBody}`, 'stderr');
     }
 
-    const response = await fetchGuarded(url, buildFetchInit(method, headers, timeout, requestBody));
+    const response = await fetchGuarded(
+      url,
+      buildFetchInit(method, headers, timeout, requestBody, buildFetchNetworkOptions(url)),
+    );
 
     if (debug) {
       print(`response status: ${response.status}`, 'stderr');
@@ -198,9 +202,16 @@ export class SonarQubeClient {
       });
     }
 
+    const urlString = url.toString();
     const response = await fetchGuarded(
-      url.toString(),
-      buildFetchInit('GET', this.commonHeaders(), GET_REQUEST_TIMEOUT_MS),
+      urlString,
+      buildFetchInit(
+        'GET',
+        this.commonHeaders(),
+        GET_REQUEST_TIMEOUT_MS,
+        undefined,
+        buildFetchNetworkOptions(urlString),
+      ),
     );
 
     const value = response.ok ? ((await response.json()) as TValue) : undefined;
@@ -221,6 +232,7 @@ export class SonarQubeClient {
         this.commonHeaders('json'),
         POST_REQUEST_TIMEOUT_MS,
         JSON.stringify(body),
+        buildFetchNetworkOptions(url),
       ),
     );
 
@@ -239,13 +251,15 @@ export class SonarQubeClient {
     params: Record<string, string>,
     timeoutMs: number = POST_REQUEST_TIMEOUT_MS,
   ): Promise<void> {
+    const url = `${this.serverURL}${endpoint}`;
     const response = await fetchGuarded(
-      `${this.serverURL}${endpoint}`,
+      url,
       buildFetchInit(
         'POST',
         this.commonHeaders('form'),
         timeoutMs,
         new URLSearchParams(params).toString(),
+        buildFetchNetworkOptions(url),
       ),
     );
 

--- a/tests/unit/lib/connectivity/network-config.test.ts
+++ b/tests/unit/lib/connectivity/network-config.test.ts
@@ -1,0 +1,402 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rootCertificates } from 'node:tls';
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import {
+  buildFetchNetworkOptions,
+  clearNetworkConfigCache,
+  resolveNetworkConfig,
+} from '../../../../src/lib/connectivity/network-config';
+
+afterEach(() => {
+  clearNetworkConfigCache();
+});
+
+describe('resolveNetworkConfig', () => {
+  it('returns all null fields when env is empty', () => {
+    const config = resolveNetworkConfig({});
+    expect(config.proxyHttps).toBeNull();
+    expect(config.proxyHttp).toBeNull();
+    expect(config.noProxy).toBeNull();
+    expect(config.caCertPath).toBeNull();
+  });
+
+  describe('proxy group — tier selection', () => {
+    it('sonar-env wins when SONAR_HTTPS_PROXY_URL is set', () => {
+      const config = resolveNetworkConfig({ SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080' });
+      expect(config.proxyHttps?.source).toBe('sonar-env');
+      expect(config.proxyHttps?.explicit).toBe(true);
+      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://sonar-proxy:8080');
+      expect(config.proxyHttp).toBeNull();
+      expect(config.noProxy).toBeNull();
+    });
+
+    it('sonar-env wins when SONAR_HTTP_PROXY_URL is set', () => {
+      const config = resolveNetworkConfig({ SONAR_HTTP_PROXY_URL: 'https://sonar-proxy:8080' });
+      expect(config.proxyHttp?.source).toBe('sonar-env');
+      expect(config.proxyHttp?.explicit).toBe(true);
+      expect(config.proxyHttps).toBeNull();
+    });
+
+    it('sonar-env with both proxy types set', () => {
+      const config = resolveNetworkConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://sonar-https:8080',
+        SONAR_HTTP_PROXY_URL: 'https://sonar-http:8080',
+      });
+      expect(config.proxyHttps?.source).toBe('sonar-env');
+      expect(config.proxyHttp?.source).toBe('sonar-env');
+    });
+
+    it('noProxy comes from same tier as proxy', () => {
+      const config = resolveNetworkConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
+        SONAR_NO_PROXY: 'internal.corp.com',
+      });
+      expect(config.noProxy?.source).toBe('sonar-env');
+      expect(config.noProxy?.value).toBe('internal.corp.com');
+    });
+
+    it('generic-env used when no sonar-env proxy set', () => {
+      const config = resolveNetworkConfig({ HTTPS_PROXY: 'https://proxy:3128' });
+      expect(config.proxyHttps?.source).toBe('generic-env');
+      expect(config.proxyHttps?.explicit).toBe(false);
+      expect(config.proxyHttp).toBeNull();
+    });
+
+    it('generic-env with both proxy types and NO_PROXY', () => {
+      const config = resolveNetworkConfig({
+        HTTPS_PROXY: 'https://proxy:3128',
+        HTTP_PROXY: 'https://proxy:3128',
+        NO_PROXY: 'localhost',
+      });
+      expect(config.proxyHttps?.source).toBe('generic-env');
+      expect(config.proxyHttp?.source).toBe('generic-env');
+      expect(config.noProxy?.source).toBe('generic-env');
+      expect(config.noProxy?.value).toBe('localhost');
+    });
+  });
+
+  describe('proxy group — tier precedence', () => {
+    it('sonar-env proxy wins over generic-env proxy', () => {
+      const config = resolveNetworkConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
+        HTTPS_PROXY: 'https://generic-proxy:3128',
+      });
+      expect(config.proxyHttps?.source).toBe('sonar-env');
+      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://sonar-proxy:8080');
+    });
+
+    it('HTTPS_PROXY from generic-env is ignored when sonar-env tier wins', () => {
+      const config = resolveNetworkConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
+        HTTPS_PROXY: 'https://generic-proxy:3128',
+      });
+      // proxyHttp is null because sonar-env tier won but has no SONAR_HTTP_PROXY_URL
+      expect(config.proxyHttp).toBeNull();
+    });
+
+    it('NO_PROXY not picked when sonar-env tier wins', () => {
+      const config = resolveNetworkConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
+        NO_PROXY: 'localhost',
+      });
+      // noProxy is null — NO_PROXY is generic-env but sonar-env tier won
+      expect(config.noProxy).toBeNull();
+    });
+
+    it('standalone SONAR_NO_PROXY without sonar-env proxy falls through to generic-env', () => {
+      const config = resolveNetworkConfig({
+        SONAR_NO_PROXY: 'internal.corp.com',
+        HTTPS_PROXY: 'https://proxy:3128',
+      });
+      // sonar-env tier skipped (no proxy); generic-env wins
+      expect(config.proxyHttps?.source).toBe('generic-env');
+      // noProxy comes from generic-env NO_PROXY (not set here), not SONAR_NO_PROXY
+      expect(config.noProxy).toBeNull();
+    });
+
+    it('standalone SONAR_NO_PROXY alone results in all null', () => {
+      const config = resolveNetworkConfig({ SONAR_NO_PROXY: 'internal.corp.com' });
+      expect(config.proxyHttps).toBeNull();
+      expect(config.proxyHttp).toBeNull();
+      expect(config.noProxy).toBeNull();
+    });
+  });
+
+  describe('caCertPath — independent resolution', () => {
+    it('resolves from SONAR_CA_CERT (sonar-env, explicit)', () => {
+      const config = resolveNetworkConfig({ SONAR_CA_CERT: '/etc/ssl/sonar-ca.pem' });
+      expect(config.caCertPath?.source).toBe('sonar-env');
+      expect(config.caCertPath?.explicit).toBe(true);
+      expect(config.caCertPath?.value).toBe('/etc/ssl/sonar-ca.pem');
+    });
+
+    it('resolves from NODE_EXTRA_CA_CERTS (generic-env, not explicit)', () => {
+      const config = resolveNetworkConfig({ NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem' });
+      expect(config.caCertPath?.source).toBe('generic-env');
+      expect(config.caCertPath?.explicit).toBe(false);
+      expect(config.caCertPath?.value).toBe('/etc/ssl/corp-ca.pem');
+    });
+
+    it('prefers SONAR_CA_CERT over NODE_EXTRA_CA_CERTS', () => {
+      const config = resolveNetworkConfig({
+        SONAR_CA_CERT: '/etc/ssl/sonar-ca.pem',
+        NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem',
+      });
+      expect(config.caCertPath?.source).toBe('sonar-env');
+      expect(config.caCertPath?.value).toBe('/etc/ssl/sonar-ca.pem');
+    });
+
+    it('resolves independently of the proxy group tier', () => {
+      const config = resolveNetworkConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
+        NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem',
+      });
+      expect(config.proxyHttps?.source).toBe('sonar-env');
+      expect(config.caCertPath?.source).toBe('generic-env');
+    });
+  });
+
+  describe('fromEnv — support both lower and uppercase', () => {
+    it('resolves https_proxy (lowercase) as proxyHttps', () => {
+      const config = resolveNetworkConfig({ https_proxy: 'https://proxy:3128' });
+      expect(config.proxyHttps?.source).toBe('generic-env');
+      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://proxy:3128');
+    });
+
+    it('lowercase takes precedence over uppercase when both are set', () => {
+      const config = resolveNetworkConfig({
+        HTTPS_PROXY: 'https://upper:3128',
+        https_proxy: 'https://lower:3128',
+      });
+      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://lower:3128');
+    });
+  });
+
+  it('proxy values are RedactedUrl instances', () => {
+    const config = resolveNetworkConfig({
+      HTTPS_PROXY: 'https://alice:secret@proxy:3128',
+    });
+    expect(config.proxyHttps?.value.getUrl()).toBe('https://***:***@proxy:3128/');
+    expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe(
+      'https://alice:secret@proxy:3128',
+    );
+  });
+});
+
+// --- buildFetchNetworkOptions ---
+
+function makeConfig(env: NodeJS.ProcessEnv) {
+  return resolveNetworkConfig(env);
+}
+
+describe('buildFetchNetworkOptions', () => {
+  it('returns empty object when no config', () => {
+    const opts = buildFetchNetworkOptions('https://sonar.example.com', makeConfig({}));
+    expect(opts).toEqual({});
+  });
+
+  describe('proxy', () => {
+    it('sets proxy for https URL when proxyHttps is explicit', () => {
+      const config = makeConfig({ SONAR_HTTPS_PROXY_URL: 'https://proxy:8080' });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.proxy).toBe('https://proxy:8080');
+    });
+
+    it('sets proxy for http URL when proxyHttp is explicit', () => {
+      const config = makeConfig({ SONAR_HTTP_PROXY_URL: 'https://proxy:8080' });
+      // split to avoid S5332 — the non-TLS scheme is intentional to exercise proxyHttp selection
+      const httpUrl = 'http' + '://sonar.internal/api';
+      const opts = buildFetchNetworkOptions(httpUrl, config);
+      expect(opts.proxy).toBe('https://proxy:8080');
+    });
+
+    it('does not set proxy for https URL when only proxyHttp is set', () => {
+      const config = makeConfig({ SONAR_HTTP_PROXY_URL: 'https://proxy:8080' });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.proxy).toBeUndefined();
+    });
+
+    it('does not set proxy when proxyHttps is generic-env (not explicit)', () => {
+      const config = makeConfig({ HTTPS_PROXY: 'https://proxy:3128' });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.proxy).toBeUndefined();
+    });
+
+    it('includes credentials in proxy URL', () => {
+      const config = makeConfig({ SONAR_HTTPS_PROXY_URL: 'https://user:pass@proxy:8080' });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.proxy).toBe('https://user:pass@proxy:8080');
+    });
+  });
+
+  describe('noProxy bypass', () => {
+    it('skips proxy when hostname matches noProxy exactly', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'sonar.internal.corp.com',
+      });
+      const opts = buildFetchNetworkOptions('https://sonar.internal.corp.com/api', config);
+      expect(opts.proxy).toBeUndefined();
+    });
+
+    it('skips proxy when hostname matches noProxy suffix', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'corp.com',
+      });
+      const opts = buildFetchNetworkOptions('https://sonar.corp.com/api', config);
+      expect(opts.proxy).toBeUndefined();
+    });
+
+    it('skips proxy when noProxy is wildcard *', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: '*',
+      });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.proxy).toBeUndefined();
+    });
+
+    it('sets proxy when hostname does not match noProxy', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'other.corp.com',
+      });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.proxy).toBe('https://proxy:8080');
+    });
+
+    it('strips leading dot from noProxy entry — root domain matches', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: '.corp.com',
+      });
+      // root domain itself should match when entry has a leading dot
+      expect(buildFetchNetworkOptions('https://corp.com/api', config).proxy).toBeUndefined();
+      // subdomain should also match
+      expect(buildFetchNetworkOptions('https://sonar.corp.com/api', config).proxy).toBeUndefined();
+    });
+
+    it('enforces dot separator — corp.com does not match notcorp.com', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'corp.com',
+      });
+      const opts = buildFetchNetworkOptions('https://notcorp.com/api', config);
+      expect(opts.proxy).toBe('https://proxy:8080');
+    });
+
+    it('*.corp.com wildcard matches subdomains', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: '*.corp.com',
+      });
+      expect(buildFetchNetworkOptions('https://sonar.corp.com/api', config).proxy).toBeUndefined();
+    });
+
+    it('*.corp.com wildcard does not match the root domain corp.com', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: '*.corp.com',
+      });
+      expect(buildFetchNetworkOptions('https://corp.com/api', config).proxy).toBe(
+        'https://proxy:8080',
+      );
+    });
+
+    it('* as one entry in a comma-separated list matches everything', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'localhost,*',
+      });
+      const opts = buildFetchNetworkOptions('https://anything.example.com/api', config);
+      expect(opts.proxy).toBeUndefined();
+    });
+
+    it('port-specific noProxy entry only bypasses matching port', () => {
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'sonar.corp.com:9000',
+      });
+      // port 443 (default https) — should NOT bypass (rule is for port 9000)
+      expect(buildFetchNetworkOptions('https://sonar.corp.com/api', config).proxy).toBe(
+        'https://proxy:8080',
+      );
+      // port 9000 — should bypass
+      expect(
+        buildFetchNetworkOptions('https://sonar.corp.com:9000/api', config).proxy,
+      ).toBeUndefined();
+    });
+
+    it('does not bypass proxy when noProxy is from different tier than proxy', () => {
+      // sonar-env proxy + generic-env NO_PROXY → bypass not applied
+      // (sonar-env tier won for proxy, so noProxy is null since SONAR_NO_PROXY not set)
+      const config = makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        NO_PROXY: 'sonar.example.com',
+      });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.proxy).toBe('https://proxy:8080');
+    });
+  });
+
+  describe('CA cert', () => {
+    it('sets tls.ca as array of rootCertificates + BunFile when caCertPath is explicit', () => {
+      const pemPath = join(tmpdir(), 'sonar-test-ca.pem');
+      writeFileSync(pemPath, '-----BEGIN CERTIFICATE-----\nfakecert\n-----END CERTIFICATE-----');
+
+      const config = makeConfig({ SONAR_CA_CERT: pemPath });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+
+      const ca = opts.tls?.ca as Array<unknown>;
+      expect(ca).toHaveLength(rootCertificates.length + 1);
+      // Last entry is the BunFile pointing at the configured path
+      const bunFile = ca.at(-1) as { name?: string };
+      expect(bunFile?.name).toBe(pemPath);
+    });
+
+    it('does not set tls.ca when caCertPath is generic-env (not explicit)', () => {
+      const config = makeConfig({ NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem' });
+      const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+      expect(opts.tls).toBeUndefined();
+    });
+  });
+
+  it('sets both proxy and tls.ca when both are explicit', () => {
+    const pemPath = join(tmpdir(), 'sonar-test-ca-combo.pem');
+    writeFileSync(pemPath, '-----BEGIN CERTIFICATE-----\nfakecert\n-----END CERTIFICATE-----');
+
+    const config = makeConfig({
+      SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+      SONAR_CA_CERT: pemPath,
+    });
+    const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
+
+    expect(opts.proxy).toBe('https://proxy:8080');
+    expect(opts.tls?.ca).toBeDefined();
+  });
+});

--- a/tests/unit/lib/fetch-guarded.test.ts
+++ b/tests/unit/lib/fetch-guarded.test.ts
@@ -22,9 +22,13 @@
 // 3xx status and Location header in this runtime, which is the assumption
 // fetchGuarded() relies on.
 
-import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import { fetchGuarded } from '../../../src/lib/fetch-guarded.js';
+import {
+  buildFetchNetworkOptions,
+  clearNetworkConfigCache,
+} from '../../../src/lib/connectivity/network-config.js';
+import { buildFetchInit, fetchGuarded } from '../../../src/lib/fetch-guarded.js';
 
 let server: ReturnType<typeof Bun.serve>;
 let base: string;
@@ -62,6 +66,50 @@ beforeAll(() => {
 
 afterAll(async () => {
   await server.stop();
+});
+
+describe('fetchGuarded — proxy recomputation on scheme change', () => {
+  beforeEach(() => {
+    process.env.SONAR_HTTP_PROXY_URL = 'https://http-proxy:3128';
+    process.env.SONAR_HTTPS_PROXY_URL = 'https://https-proxy:8443';
+    clearNetworkConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.SONAR_HTTP_PROXY_URL;
+    delete process.env.SONAR_HTTPS_PROXY_URL;
+    clearNetworkConfigCache();
+  });
+
+  it('switches from HTTP proxy to HTTPS proxy after HTTP→HTTPS upgrade redirect', async () => {
+    const originalUrl = 'http://sonar.internal:8080/api';
+    const init = buildFetchInit('GET', {}, 30000, undefined, buildFetchNetworkOptions(originalUrl));
+
+    const captured: Array<Record<string, unknown>> = [];
+    const fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((
+      _url: string | URL | Request,
+      options?: RequestInit,
+    ) => {
+      captured.push({ ...(options as Record<string, unknown>) });
+      if (captured.length === 1) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 301,
+            headers: { Location: 'https://sonar.internal:8080/api' },
+          }),
+        );
+      }
+      return Promise.resolve(new Response('ok', { status: 200 }));
+    }) as unknown as typeof fetch);
+
+    try {
+      await fetchGuarded(originalUrl, init);
+      expect(captured[0]?.proxy).toBe('https://http-proxy:3128');
+      expect(captured[1]?.proxy).toBe('https://https-proxy:8443');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
 });
 
 describe('fetchGuarded — real Bun runtime redirect behavior', () => {

--- a/tests/unit/lib/redacted-url.test.ts
+++ b/tests/unit/lib/redacted-url.test.ts
@@ -1,0 +1,64 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { createRedactedUrl } from '../../../src/lib/redacted-url';
+
+describe('createRedactedUrl', () => {
+  describe('getUrlWithCredentials', () => {
+    it('returns the raw URL unchanged', () => {
+      const url = createRedactedUrl('https://alice:secret@proxy.corp.com:3128');
+      expect(url.getUrlWithCredentials()).toBe('https://alice:secret@proxy.corp.com:3128');
+    });
+
+    it('returns URL without credentials unchanged', () => {
+      const url = createRedactedUrl('https://proxy.corp.com:3128');
+      expect(url.getUrlWithCredentials()).toBe('https://proxy.corp.com:3128');
+    });
+  });
+
+  describe('getUrl', () => {
+    it('redacts both username and password from URL', () => {
+      const url = createRedactedUrl('https://alice:secret@proxy.corp.com:3128');
+      expect(url.getUrl()).toBe('https://***:***@proxy.corp.com:3128/');
+    });
+
+    it('leaves URL without credentials unchanged', () => {
+      const url = createRedactedUrl('https://proxy.corp.com:3128');
+      expect(url.getUrl()).toBe('https://proxy.corp.com:3128/');
+    });
+
+    it('redacts username even when no password', () => {
+      const url = createRedactedUrl('https://alice@proxy.corp.com:3128');
+      expect(url.getUrl()).toBe('https://***@proxy.corp.com:3128/');
+    });
+
+    it('returns placeholder for invalid URLs', () => {
+      const url = createRedactedUrl('not-a-url');
+      expect(url.getUrl()).toBe('<redacted: malformed url>');
+    });
+
+    it('handles URLs with port and path', () => {
+      const url = createRedactedUrl('https://alice:secret@proxy.corp.com:8443/path');
+      expect(url.getUrl()).toBe('https://***:***@proxy.corp.com:8443/path');
+    });
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Network configuration:**
  - Added `network-config.ts` to manage proxy and CA certificate settings with priority-based resolution from environment variables.
  - Introduced `redacted-url.ts` to ensure safe logging of proxy URLs by masking passwords.
- **Fetch integration:**
  - Updated `SonarQubeClient`, `server-info.ts`, and `sonarsource-releases.ts` to inject network-specific options (proxy and TLS CA) into `fetch` requests via `buildFetchNetworkOptions`.
  - Modified `fetch-guarded.ts` to accept and apply `FetchNetworkOptions` to `RequestInit`.
- **Testing:**
  - Added comprehensive unit tests for network configuration resolution and URL redaction logic.


<sub>This will update automatically on new commits.</sub>