### PR TITLE
CLI-730 Emit CliAnalysisCompleted and CliAnalysisFindingsDetected telemetry from all sonar-secrets call sites

### DIFF
--- a/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
@@ -23,6 +23,7 @@ import { isAbsolute, join } from 'node:path';
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import logger from '../../../../lib/logger';
+import { SECRETS_CALLER_COMMANDS } from '../../../../telemetry/secrets-analysis-telemetry.js';
 import { withSpinner } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 import { formatSpawnOutput } from '../../_common/install/install-utils';
@@ -85,12 +86,15 @@ async function scanManifestsForSecrets(
   // Spawn error propagate so the callers decide what it means
   // (the command aborts; the hook's wrapper turns it into a non-blocking warning).
   // scanAndEmitSecrets emits a failures_count:1 event before re-throwing on a failed run.
-  const { result, parsed } = await scanAndEmitSecrets('analyze dependency-risks', auth, () =>
-    withSpinner(
-      'Scanning manifests for secrets',
-      () => runSecretsBinary(binaryPath, files, auth),
-      'stderr',
-    ),
+  const { result, parsed } = await scanAndEmitSecrets(
+    SECRETS_CALLER_COMMANDS.analyzeDependencyRisks,
+    auth,
+    () =>
+      withSpinner(
+        'Scanning manifests for secrets',
+        () => runSecretsBinary(binaryPath, files, auth),
+        'stderr',
+      ),
   );
   const { issues, errors } = parsed;
   const exitCode = result.exitCode ?? 1;

--- a/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/manifest-secrets-guard.ts
@@ -31,8 +31,8 @@ import type { SecretsInstaller } from '../../_common/install/secrets';
 import type { SecretsJsonIssue } from '../secrets';
 import {
   EXIT_CODE_SECRETS_FOUND,
-  parseSecretsJson,
   runSecretsBinary,
+  scanAndEmitSecrets,
   warnScanErrors,
 } from '../secrets';
 import { ScaDiscoverManifestsRunner } from './sca-discover-manifests';
@@ -84,13 +84,16 @@ async function scanManifestsForSecrets(
 
   // Spawn error propagate so the callers decide what it means
   // (the command aborts; the hook's wrapper turns it into a non-blocking warning).
-  const result = await withSpinner(
-    'Scanning manifests for secrets',
-    () => runSecretsBinary(binaryPath, files, auth),
-    'stderr',
+  // scanAndEmitSecrets emits a failures_count:1 event before re-throwing on a failed run.
+  const { result, parsed } = await scanAndEmitSecrets('analyze dependency-risks', auth, () =>
+    withSpinner(
+      'Scanning manifests for secrets',
+      () => runSecretsBinary(binaryPath, files, auth),
+      'stderr',
+    ),
   );
+  const { issues, errors } = parsed;
   const exitCode = result.exitCode ?? 1;
-  const { issues, errors } = parseSecretsJson(result.stdout);
 
   if (exitCode === EXIT_CODE_SECRETS_FOUND) {
     const findings = formatSecretFindings(issues);

--- a/src/cli/commands/analyze/secrets.ts
+++ b/src/cli/commands/analyze/secrets.ts
@@ -17,6 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
+import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
@@ -24,6 +25,11 @@ import { buildSubprocessNetworkEnv } from '../../../lib/connectivity/network-con
 import logger from '../../../lib/logger';
 import type { SpawnResult, StdioMode } from '../../../lib/process';
 import { spawnProcessWithTimeout } from '../../../lib/process';
+import {
+  buildAnalysisIdentityBase,
+  emitAnalysisCompleted,
+  emitAnalysisFindingsDetected,
+} from '../../../telemetry/findings.js';
 import { blank, print, success, warn } from '../../../ui';
 import { green, yellow } from '../../../ui/colors.js';
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
@@ -85,6 +91,98 @@ export function parseSecretsJson(stdout: string): SecretsJsonOutput {
   } catch (err) {
     logger.debug(`parseSecretsJson: failed to parse stdout: ${(err as Error).message}`);
     return { issues: [] };
+  }
+}
+
+/**
+ * Emits CliAnalysisCompleted (always) and CliAnalysisFindingsDetected (when findings > 0)
+ * for one sonar-secrets run. Fire-and-forget — telemetry failures are swallowed.
+ *
+ * Pass `result: null` for a run that failed to execute (spawn error or timeout): the completed
+ * event is emitted with `exit_code: null` and `failures_count: 1` so failed-to-run scans are
+ * still counted. Prefer {@link scanAndEmitSecrets}, which handles both outcomes for callers.
+ */
+export function emitSecretsRunTelemetry(
+  callerCommand: string,
+  auth: ResolvedAuth,
+  result: { exitCode: number | null; stdout: string } | null,
+  durationMs: number,
+): SecretsJsonOutput {
+  const parsed = result ? parseSecretsJson(result.stdout) : { issues: [] };
+
+  const base = buildAnalysisIdentityBase(auth);
+  if (!base) return parsed;
+
+  const { issues, errors } = parsed;
+  const exitCode = result?.exitCode ?? null;
+  // Per-invocation failure flag (0/1): 1 when the scan did not produce a valid result — it
+  // failed to run (null exit code) or exited with a non-clean, non-findings code.
+  const failuresCount = exitCode === 0 || exitCode === EXIT_CODE_SECRETS_FOUND ? 0 : 1;
+  const analysisId = randomUUID();
+
+  emitAnalysisCompleted(auth, {
+    caller_command: callerCommand,
+    analyzer: 'sonar-secrets',
+    analysis_id: analysisId,
+    findings_count: issues.length,
+    exit_code: exitCode,
+    errors_count: errors?.length ?? 0,
+    failures_count: failuresCount,
+    scan_duration_ms: durationMs,
+  });
+
+  if (issues.length > 0) {
+    const countsByRule: Record<string, number> = {};
+    const filesWithFindings = new Set<string>();
+    for (const issue of issues) {
+      countsByRule[issue.ruleKey] = (countsByRule[issue.ruleKey] ?? 0) + 1;
+      if (issue.file) filesWithFindings.add(issue.file);
+    }
+    const source: 'files' | 'stdin' = filesWithFindings.size > 0 ? 'files' : 'stdin';
+    emitAnalysisFindingsDetected(auth, {
+      caller_command: callerCommand,
+      analyzer: 'sonar-secrets',
+      analysis_id: analysisId,
+      details_schema_version: 1,
+      details: JSON.stringify({
+        counts_by_rule: countsByRule,
+        files_with_findings_count: filesWithFindings.size,
+        source,
+      }),
+    });
+  }
+
+  return parsed;
+}
+
+/**
+ * Runs one sonar-secrets spawn and emits CliAnalysisCompleted for either outcome:
+ *  - the process ran (any exit code) → telemetry via {@link emitSecretsRunTelemetry};
+ *  - the process failed to run (spawn error or timeout, i.e. the promise rejected) →
+ *    a failures_count:1 event with exit_code null, then the error is re-thrown.
+ *
+ * Re-throwing preserves each caller's own fail-open / fail-closed / block handling; because the
+ * emit happens first, failed runs are recorded even when the caller then throws (e.g. git hooks
+ * failing closed under environment-based auth).
+ */
+export async function scanAndEmitSecrets(
+  callerCommand: string,
+  auth: ResolvedAuth,
+  run: () => Promise<SpawnResult>,
+): Promise<{ result: SpawnResult; parsed: SecretsJsonOutput }> {
+  const start = performance.now();
+  try {
+    const result = await run();
+    const parsed = emitSecretsRunTelemetry(
+      callerCommand,
+      auth,
+      result,
+      Math.round(performance.now() - start),
+    );
+    return { result, parsed };
+  } catch (err) {
+    emitSecretsRunTelemetry(callerCommand, auth, null, Math.round(performance.now() - start));
+    throw err;
   }
 }
 
@@ -171,11 +269,10 @@ async function handleCheckCommand(
   const scanStartTime = Date.now();
 
   if (options.stdin) {
-    reportScanResult(
-      await runSecretsBinary(binaryPath, ['--input'], auth, 'inherit'),
-      scanStartTime,
-      { paths: [] },
+    const { result, parsed } = await scanAndEmitSecrets('analyze secrets', auth, () =>
+      runSecretsBinary(binaryPath, ['--input'], auth, 'inherit'),
     );
+    reportScanResult(result, parsed, scanStartTime, { paths: [] });
   } else {
     await performPathsScan(binaryPath, options.paths ?? [], auth, scanStartTime);
   }
@@ -208,31 +305,34 @@ async function performPathsScan(
     }
   }
 
-  const result = await runSecretsBinary(binaryPath, paths, auth);
-  reportScanResult(result, scanStartTime, { paths });
+  const { result, parsed } = await scanAndEmitSecrets('analyze secrets', auth, () =>
+    runSecretsBinary(binaryPath, paths, auth),
+  );
+  reportScanResult(result, parsed, scanStartTime, { paths });
 }
 
 function reportScanResult(
   result: SpawnResult,
+  parsed: SecretsJsonOutput,
   scanStartTime: number,
   context: ScanDisplayContext,
 ): void {
   const scanDurationMs = Date.now() - scanStartTime;
   const exitCode = result.exitCode ?? 1;
   if (exitCode === 0) {
-    handleScanSuccess(result, scanDurationMs, context);
+    handleScanSuccess(parsed, scanDurationMs, context);
   } else {
-    handleScanFailure(result, scanDurationMs, exitCode);
+    handleScanFailure(result, parsed, scanDurationMs, exitCode);
   }
 }
 
 function handleScanSuccess(
-  result: { stdout: string },
+  parsed: SecretsJsonOutput,
   scanDurationMs: number,
   context: ScanDisplayContext,
 ): void {
   blank();
-  const { errors } = parseSecretsJson(result.stdout);
+  const { errors } = parsed;
   const displayPaths = context.paths.length > 0 ? context.paths : ['(stdin)'];
   for (const p of displayPaths) {
     print(`  ${green('✓')}  ${p}`);
@@ -285,14 +385,15 @@ export function warnScanErrors(errors?: string[]): void {
 }
 
 function handleScanFailure(
-  result: { exitCode: number | null; stderr: string; stdout: string },
+  result: { stderr: string; stdout: string },
+  parsed: SecretsJsonOutput,
   scanDurationMs: number,
   exitCode: number,
 ): void {
   blank();
 
   if (exitCode === EXIT_CODE_SECRETS_FOUND) {
-    const { issues, errors } = parseSecretsJson(result.stdout);
+    const { issues, errors } = parsed;
     if (issues.length > 0) {
       displaySecretsFindings(issues);
       blank();

--- a/src/cli/commands/analyze/secrets.ts
+++ b/src/cli/commands/analyze/secrets.ts
@@ -30,6 +30,11 @@ import {
   emitAnalysisCompleted,
   emitAnalysisFindingsDetected,
 } from '../../../telemetry/findings.js';
+import {
+  SECRETS_CALLER_COMMANDS,
+  SECRETS_DETAILS_SCHEMA_VERSION,
+  type SecretsCallerCommand,
+} from '../../../telemetry/secrets-analysis-telemetry.js';
 import { blank, print, success, warn } from '../../../ui';
 import { green, yellow } from '../../../ui/colors.js';
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
@@ -102,8 +107,8 @@ export function parseSecretsJson(stdout: string): SecretsJsonOutput {
  * event is emitted with `exit_code: null` and `failures_count: 1` so failed-to-run scans are
  * still counted. Prefer {@link scanAndEmitSecrets}, which handles both outcomes for callers.
  */
-export function emitSecretsRunTelemetry(
-  callerCommand: string,
+function emitSecretsRunTelemetry(
+  callerCommand: SecretsCallerCommand,
   auth: ResolvedAuth,
   result: { exitCode: number | null; stdout: string } | null,
   durationMs: number,
@@ -143,7 +148,7 @@ export function emitSecretsRunTelemetry(
       caller_command: callerCommand,
       analyzer: 'sonar-secrets',
       analysis_id: analysisId,
-      details_schema_version: 1,
+      details_schema_version: SECRETS_DETAILS_SCHEMA_VERSION,
       details: JSON.stringify({
         counts_by_rule: countsByRule,
         files_with_findings_count: filesWithFindings.size,
@@ -166,7 +171,7 @@ export function emitSecretsRunTelemetry(
  * failing closed under environment-based auth).
  */
 export async function scanAndEmitSecrets(
-  callerCommand: string,
+  callerCommand: SecretsCallerCommand,
   auth: ResolvedAuth,
   run: () => Promise<SpawnResult>,
 ): Promise<{ result: SpawnResult; parsed: SecretsJsonOutput }> {
@@ -269,8 +274,10 @@ async function handleCheckCommand(
   const scanStartTime = Date.now();
 
   if (options.stdin) {
-    const { result, parsed } = await scanAndEmitSecrets('analyze secrets', auth, () =>
-      runSecretsBinary(binaryPath, ['--input'], auth, 'inherit'),
+    const { result, parsed } = await scanAndEmitSecrets(
+      SECRETS_CALLER_COMMANDS.analyzeSecrets,
+      auth,
+      () => runSecretsBinary(binaryPath, ['--input'], auth, 'inherit'),
     );
     reportScanResult(result, parsed, scanStartTime, { paths: [] });
   } else {
@@ -305,8 +312,10 @@ async function performPathsScan(
     }
   }
 
-  const { result, parsed } = await scanAndEmitSecrets('analyze secrets', auth, () =>
-    runSecretsBinary(binaryPath, paths, auth),
+  const { result, parsed } = await scanAndEmitSecrets(
+    SECRETS_CALLER_COMMANDS.analyzeSecrets,
+    auth,
+    () => runSecretsBinary(binaryPath, paths, auth),
   );
   reportScanResult(result, parsed, scanStartTime, { paths });
 }

--- a/src/cli/commands/hook/agent-prompt-submit.ts
+++ b/src/cli/commands/hook/agent-prompt-submit.ts
@@ -22,6 +22,7 @@
 // Replaces the bash/PowerShell logic that was previously embedded in the hook script.
 
 import logger from '../../../lib/logger';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
 import { resolveAuthAndSecrets, runAndEmitTextSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
@@ -46,7 +47,11 @@ export async function agentPromptSubmit(): Promise<void> {
   if (!deps) return;
 
   try {
-    const exitCode = await runAndEmitTextSecretsScan('agent-prompt-submit', deps, prompt);
+    const exitCode = await runAndEmitTextSecretsScan(
+      SECRETS_CALLER_COMMANDS.agentPromptSubmit,
+      deps,
+      prompt,
+    );
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({ decision: 'block', reason: 'Sonar detected secrets in prompt' }) + '\n',

--- a/src/cli/commands/hook/agent-prompt-submit.ts
+++ b/src/cli/commands/hook/agent-prompt-submit.ts
@@ -22,8 +22,8 @@
 // Replaces the bash/PowerShell logic that was previously embedded in the hook script.
 
 import logger from '../../../lib/logger';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinaryOnText } from '../analyze/secrets';
-import { resolveAuthAndSecrets } from './hook-dependencies';
+import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
+import { resolveAuthAndSecrets, runAndEmitTextSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
 
 interface PromptSubmitPayload {
@@ -46,8 +46,7 @@ export async function agentPromptSubmit(): Promise<void> {
   if (!deps) return;
 
   try {
-    const result = await runSecretsBinaryOnText(deps.binaryPath, prompt, deps.auth);
-    const exitCode = result.exitCode ?? 1;
+    const exitCode = await runAndEmitTextSecretsScan('agent-prompt-submit', deps, prompt);
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({ decision: 'block', reason: 'Sonar detected secrets in prompt' }) + '\n',

--- a/src/cli/commands/hook/antigravity-pre-tool-use.ts
+++ b/src/cli/commands/hook/antigravity-pre-tool-use.ts
@@ -31,6 +31,7 @@
 import { existsSync } from 'node:fs';
 
 import logger from '../../../lib/logger';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
 import { resolveAuthAndSecrets, runAndEmitFileSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
@@ -61,7 +62,11 @@ export async function antigravityPreToolUse(): Promise<void> {
   if (!deps) return;
 
   try {
-    const exitCode = await runAndEmitFileSecretsScan('antigravity-pre-tool-use', deps, filePath);
+    const exitCode = await runAndEmitFileSecretsScan(
+      SECRETS_CALLER_COMMANDS.antigravityPreToolUse,
+      deps,
+      filePath,
+    );
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({

--- a/src/cli/commands/hook/antigravity-pre-tool-use.ts
+++ b/src/cli/commands/hook/antigravity-pre-tool-use.ts
@@ -31,8 +31,8 @@
 import { existsSync } from 'node:fs';
 
 import logger from '../../../lib/logger';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
-import { resolveAuthAndSecrets } from './hook-dependencies';
+import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
+import { resolveAuthAndSecrets, runAndEmitFileSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
 
 interface AntigravityPreToolUsePayload {
@@ -61,8 +61,7 @@ export async function antigravityPreToolUse(): Promise<void> {
   if (!deps) return;
 
   try {
-    const result = await runSecretsBinary(deps.binaryPath, [filePath], deps.auth);
-    const exitCode = result.exitCode ?? 1;
+    const exitCode = await runAndEmitFileSecretsScan('antigravity-pre-tool-use', deps, filePath);
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({

--- a/src/cli/commands/hook/claude-pre-tool-use.ts
+++ b/src/cli/commands/hook/claude-pre-tool-use.ts
@@ -24,6 +24,7 @@
 import { existsSync } from 'node:fs';
 
 import logger from '../../../lib/logger';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
 import { resolveAuthAndSecrets, runAndEmitFileSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
@@ -50,7 +51,11 @@ export async function claudePreToolUse(): Promise<void> {
   if (!deps) return;
 
   try {
-    const exitCode = await runAndEmitFileSecretsScan('claude-pre-tool-use', deps, filePath);
+    const exitCode = await runAndEmitFileSecretsScan(
+      SECRETS_CALLER_COMMANDS.claudePreToolUse,
+      deps,
+      filePath,
+    );
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({

--- a/src/cli/commands/hook/claude-pre-tool-use.ts
+++ b/src/cli/commands/hook/claude-pre-tool-use.ts
@@ -24,8 +24,8 @@
 import { existsSync } from 'node:fs';
 
 import logger from '../../../lib/logger';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
-import { resolveAuthAndSecrets } from './hook-dependencies';
+import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
+import { resolveAuthAndSecrets, runAndEmitFileSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
 
 interface PreToolUsePayload {
@@ -50,8 +50,7 @@ export async function claudePreToolUse(): Promise<void> {
   if (!deps) return;
 
   try {
-    const result = await runSecretsBinary(deps.binaryPath, [filePath], deps.auth);
-    const exitCode = result.exitCode ?? 1;
+    const exitCode = await runAndEmitFileSecretsScan('claude-pre-tool-use', deps, filePath);
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({

--- a/src/cli/commands/hook/copilot-pre-tool-use.ts
+++ b/src/cli/commands/hook/copilot-pre-tool-use.ts
@@ -34,8 +34,8 @@
 import { existsSync } from 'node:fs';
 
 import logger from '../../../lib/logger';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
-import { resolveAuthAndSecrets } from './hook-dependencies';
+import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
+import { resolveAuthAndSecrets, runAndEmitFileSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
 
 interface CopilotPreToolUsePayload {
@@ -66,8 +66,7 @@ export async function copilotPreToolUse(): Promise<void> {
   if (!deps) return;
 
   try {
-    const result = await runSecretsBinary(deps.binaryPath, [filePath], deps.auth);
-    const exitCode = result.exitCode ?? 1;
+    const exitCode = await runAndEmitFileSecretsScan('copilot-pre-tool-use', deps, filePath);
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({

--- a/src/cli/commands/hook/copilot-pre-tool-use.ts
+++ b/src/cli/commands/hook/copilot-pre-tool-use.ts
@@ -34,6 +34,7 @@
 import { existsSync } from 'node:fs';
 
 import logger from '../../../lib/logger';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
 import { resolveAuthAndSecrets, runAndEmitFileSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
@@ -66,7 +67,11 @@ export async function copilotPreToolUse(): Promise<void> {
   if (!deps) return;
 
   try {
-    const exitCode = await runAndEmitFileSecretsScan('copilot-pre-tool-use', deps, filePath);
+    const exitCode = await runAndEmitFileSecretsScan(
+      SECRETS_CALLER_COMMANDS.copilotPreToolUse,
+      deps,
+      filePath,
+    );
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({

--- a/src/cli/commands/hook/cursor-pre-file-read.ts
+++ b/src/cli/commands/hook/cursor-pre-file-read.ts
@@ -27,8 +27,8 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
 import logger from '../../../lib/logger';
-import { timed } from '../../../lib/timed.js';
-import { emitSecretsRunTelemetry } from '../analyze/secrets';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
+import { scanAndEmitSecrets } from '../analyze/secrets';
 import {
   denyCursorFileAccess,
   scanTextForSecrets,
@@ -57,14 +57,18 @@ export async function cursorPreFileRead(): Promise<void> {
   const deps = await resolveAuthAndSecrets();
   if (!deps) return;
 
+  let scan: Awaited<ReturnType<typeof scanAndEmitSecrets>>;
   try {
-    const { result, durationMs } = await timed(() => scanTextForSecrets(deps, content));
-    emitSecretsRunTelemetry('cursor-pre-file-read', deps.auth, result, durationMs);
-    if (secretsFoundInScan(result)) {
-      await denyCursorFileAccess(filePath);
-    }
+    scan = await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.cursorPreFileRead, deps.auth, () =>
+      scanTextForSecrets(deps, content),
+    );
   } catch (err) {
     logger.debug(`cursorPreFileRead secrets scan failed: ${(err as Error).message}`);
+    return;
+  }
+
+  if (secretsFoundInScan(scan.result)) {
+    await denyCursorFileAccess(filePath);
   }
 }
 

--- a/src/cli/commands/hook/cursor-pre-file-read.ts
+++ b/src/cli/commands/hook/cursor-pre-file-read.ts
@@ -27,6 +27,8 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
 import logger from '../../../lib/logger';
+import { timed } from '../../../lib/timed.js';
+import { emitSecretsRunTelemetry } from '../analyze/secrets';
 import {
   denyCursorFileAccess,
   scanTextForSecrets,
@@ -56,7 +58,8 @@ export async function cursorPreFileRead(): Promise<void> {
   if (!deps) return;
 
   try {
-    const result = await scanTextForSecrets(deps, content);
+    const { result, durationMs } = await timed(() => scanTextForSecrets(deps, content));
+    emitSecretsRunTelemetry('cursor-pre-file-read', deps.auth, result, durationMs);
     if (secretsFoundInScan(result)) {
       await denyCursorFileAccess(filePath);
     }

--- a/src/cli/commands/hook/cursor-pre-tool-use.ts
+++ b/src/cli/commands/hook/cursor-pre-tool-use.ts
@@ -27,8 +27,8 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
 import logger from '../../../lib/logger';
-import { timed } from '../../../lib/timed.js';
-import { emitSecretsRunTelemetry } from '../analyze/secrets';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
+import { scanAndEmitSecrets } from '../analyze/secrets';
 import {
   denyCursorFileAccess,
   scanTextForSecrets,
@@ -58,14 +58,18 @@ export async function cursorPreToolUse(): Promise<void> {
   const deps = await resolveAuthAndSecrets();
   if (!deps) return;
 
+  let scan: Awaited<ReturnType<typeof scanAndEmitSecrets>>;
   try {
     const content = await readFile(filePath, 'utf-8');
-    const { result, durationMs } = await timed(() => scanTextForSecrets(deps, content));
-    emitSecretsRunTelemetry('cursor-pre-tool-use', deps.auth, result, durationMs);
-    if (secretsFoundInScan(result)) {
-      await denyCursorFileAccess(filePath);
-    }
+    scan = await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.cursorPreToolUse, deps.auth, () =>
+      scanTextForSecrets(deps, content),
+    );
   } catch (err) {
     logger.debug(`cursorPreToolUse secrets scan failed: ${(err as Error).message}`);
+    return;
+  }
+
+  if (secretsFoundInScan(scan.result)) {
+    await denyCursorFileAccess(filePath);
   }
 }

--- a/src/cli/commands/hook/cursor-pre-tool-use.ts
+++ b/src/cli/commands/hook/cursor-pre-tool-use.ts
@@ -27,6 +27,8 @@ import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
 import logger from '../../../lib/logger';
+import { timed } from '../../../lib/timed.js';
+import { emitSecretsRunTelemetry } from '../analyze/secrets';
 import {
   denyCursorFileAccess,
   scanTextForSecrets,
@@ -58,7 +60,8 @@ export async function cursorPreToolUse(): Promise<void> {
 
   try {
     const content = await readFile(filePath, 'utf-8');
-    const result = await scanTextForSecrets(deps, content);
+    const { result, durationMs } = await timed(() => scanTextForSecrets(deps, content));
+    emitSecretsRunTelemetry('cursor-pre-tool-use', deps.auth, result, durationMs);
     if (secretsFoundInScan(result)) {
       await denyCursorFileAccess(filePath);
     }

--- a/src/cli/commands/hook/cursor-prompt-submit.ts
+++ b/src/cli/commands/hook/cursor-prompt-submit.ts
@@ -27,8 +27,8 @@
 // `agentPromptSubmit`.
 
 import logger from '../../../lib/logger';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinaryOnText } from '../analyze/secrets';
-import { resolveAuthAndSecrets } from './hook-dependencies';
+import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
+import { resolveAuthAndSecrets, runAndEmitTextSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
 
 interface CursorPromptSubmitPayload {
@@ -51,8 +51,7 @@ export async function cursorPromptSubmit(): Promise<void> {
   if (!deps) return;
 
   try {
-    const result = await runSecretsBinaryOnText(deps.binaryPath, prompt, deps.auth);
-    const exitCode = result.exitCode ?? 1;
+    const exitCode = await runAndEmitTextSecretsScan('cursor-prompt-submit', deps, prompt);
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({ continue: false, user_message: 'Sonar detected secrets in prompt' }) +

--- a/src/cli/commands/hook/cursor-prompt-submit.ts
+++ b/src/cli/commands/hook/cursor-prompt-submit.ts
@@ -27,6 +27,7 @@
 // `agentPromptSubmit`.
 
 import logger from '../../../lib/logger';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { EXIT_CODE_SECRETS_FOUND } from '../analyze/secrets';
 import { resolveAuthAndSecrets, runAndEmitTextSecretsScan } from './hook-dependencies';
 import { readStdinJson } from './stdin';
@@ -51,7 +52,11 @@ export async function cursorPromptSubmit(): Promise<void> {
   if (!deps) return;
 
   try {
-    const exitCode = await runAndEmitTextSecretsScan('cursor-prompt-submit', deps, prompt);
+    const exitCode = await runAndEmitTextSecretsScan(
+      SECRETS_CALLER_COMMANDS.cursorPromptSubmit,
+      deps,
+      prompt,
+    );
     if (exitCode === EXIT_CODE_SECRETS_FOUND) {
       process.stdout.write(
         JSON.stringify({ continue: false, user_message: 'Sonar detected secrets in prompt' }) +

--- a/src/cli/commands/hook/git-pre-commit-secrets.ts
+++ b/src/cli/commands/hook/git-pre-commit-secrets.ts
@@ -19,6 +19,7 @@
  */
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { print } from '../../../ui';
 import { CommandFailedError } from '../_common/error';
 import { resolveSecretsBinaryPath } from '../_common/install/secrets';
@@ -36,7 +37,7 @@ export async function runCommitSecretsStage(files: string[], auth: ResolvedAuth)
 
   let scan: Awaited<ReturnType<typeof scanAndEmitSecrets>>;
   try {
-    scan = await scanAndEmitSecrets('git-pre-commit', auth, () =>
+    scan = await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.gitPreCommit, auth, () =>
       runSecretsBinary(binaryPath, files, auth),
     );
   } catch (err) {

--- a/src/cli/commands/hook/git-pre-commit-secrets.ts
+++ b/src/cli/commands/hook/git-pre-commit-secrets.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SonarQube CLI
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com
@@ -24,8 +24,8 @@ import { CommandFailedError } from '../_common/error';
 import { resolveSecretsBinaryPath } from '../_common/install/secrets';
 import {
   EXIT_CODE_SECRETS_FOUND,
-  parseSecretsJson,
   runSecretsBinary,
+  scanAndEmitSecrets,
   warnScanErrors,
 } from '../analyze/secrets';
 import { handleScanError } from './hook-dependencies';
@@ -34,15 +34,18 @@ export async function runCommitSecretsStage(files: string[], auth: ResolvedAuth)
   const binaryPath = resolveSecretsBinaryPath();
   if (!binaryPath) return;
 
-  let result;
+  let scan: Awaited<ReturnType<typeof scanAndEmitSecrets>>;
   try {
-    result = await runSecretsBinary(binaryPath, files, auth);
+    scan = await scanAndEmitSecrets('git-pre-commit', auth, () =>
+      runSecretsBinary(binaryPath, files, auth),
+    );
   } catch (err) {
     handleScanError('Commit', err as Error);
     return;
   }
 
-  const { issues, errors } = parseSecretsJson(result.stdout);
+  const { result, parsed } = scan;
+  const { issues, errors } = parsed;
   warnScanErrors(errors);
 
   if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {

--- a/src/cli/commands/hook/git-pre-push-secrets.ts
+++ b/src/cli/commands/hook/git-pre-push-secrets.ts
@@ -19,6 +19,7 @@
  */
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { SECRETS_CALLER_COMMANDS } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { CommandFailedError } from '../_common/error';
 import { resolveSecretsBinaryPath } from '../_common/install/secrets';
 import {
@@ -36,7 +37,7 @@ export async function runSecretsStage(files: string[], auth: ResolvedAuth): Prom
 
   let scan: Awaited<ReturnType<typeof scanAndEmitSecrets>>;
   try {
-    scan = await scanAndEmitSecrets('git-pre-push', auth, () =>
+    scan = await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.gitPrePush, auth, () =>
       runSecretsBinary(binaryPath, files, auth),
     );
   } catch (err) {

--- a/src/cli/commands/hook/git-pre-push-secrets.ts
+++ b/src/cli/commands/hook/git-pre-push-secrets.ts
@@ -21,7 +21,12 @@
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import { CommandFailedError } from '../_common/error';
 import { resolveSecretsBinaryPath } from '../_common/install/secrets';
-import { EXIT_CODE_SECRETS_FOUND, runSecretsBinary } from '../analyze/secrets';
+import {
+  EXIT_CODE_SECRETS_FOUND,
+  runSecretsBinary,
+  scanAndEmitSecrets,
+  warnScanErrors,
+} from '../analyze/secrets';
 import { handleScanError } from './hook-dependencies';
 
 export async function runSecretsStage(files: string[], auth: ResolvedAuth): Promise<void> {
@@ -29,13 +34,18 @@ export async function runSecretsStage(files: string[], auth: ResolvedAuth): Prom
   if (!binaryPath) return;
   if (files.length === 0) return;
 
-  let result;
+  let scan: Awaited<ReturnType<typeof scanAndEmitSecrets>>;
   try {
-    result = await runSecretsBinary(binaryPath, files, auth);
+    scan = await scanAndEmitSecrets('git-pre-push', auth, () =>
+      runSecretsBinary(binaryPath, files, auth),
+    );
   } catch (err) {
     handleScanError('Push', err as Error);
     return;
   }
+
+  const { result, parsed } = scan;
+  warnScanErrors(parsed.errors);
 
   if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
     throw new CommandFailedError('Secrets detected in pushed commits.', {

--- a/src/cli/commands/hook/hook-dependencies.ts
+++ b/src/cli/commands/hook/hook-dependencies.ts
@@ -23,6 +23,7 @@
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import { isEnvBasedAuth, resolveAuth } from '../../../lib/auth-resolver';
+import type { SecretsCallerCommand } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { warn } from '../../../ui';
 import { CommandFailedError } from '../_common/error';
 import { resolveSecretsBinaryPath } from '../_common/install/secrets';
@@ -60,7 +61,7 @@ export async function resolveAuthAndSecrets(): Promise<HookDependencies | null> 
 }
 
 export async function runAndEmitFileSecretsScan(
-  callerCommand: string,
+  callerCommand: SecretsCallerCommand,
   deps: HookDependencies,
   filePath: string,
 ): Promise<number> {
@@ -71,7 +72,7 @@ export async function runAndEmitFileSecretsScan(
 }
 
 export async function runAndEmitTextSecretsScan(
-  callerCommand: string,
+  callerCommand: SecretsCallerCommand,
   deps: HookDependencies,
   text: string,
 ): Promise<number> {

--- a/src/cli/commands/hook/hook-dependencies.ts
+++ b/src/cli/commands/hook/hook-dependencies.ts
@@ -26,6 +26,11 @@ import { isEnvBasedAuth, resolveAuth } from '../../../lib/auth-resolver';
 import { warn } from '../../../ui';
 import { CommandFailedError } from '../_common/error';
 import { resolveSecretsBinaryPath } from '../_common/install/secrets';
+import {
+  runSecretsBinary,
+  runSecretsBinaryOnText,
+  scanAndEmitSecrets,
+} from '../analyze/secrets.js';
 
 export interface HookDependencies {
   auth: ResolvedAuth;
@@ -52,4 +57,26 @@ export async function resolveAuthAndSecrets(): Promise<HookDependencies | null> 
   if (!binaryPath) return null; // binary not installed — allow gracefully
 
   return { auth, binaryPath };
+}
+
+export async function runAndEmitFileSecretsScan(
+  callerCommand: string,
+  deps: HookDependencies,
+  filePath: string,
+): Promise<number> {
+  const { result } = await scanAndEmitSecrets(callerCommand, deps.auth, () =>
+    runSecretsBinary(deps.binaryPath, [filePath], deps.auth),
+  );
+  return result.exitCode ?? 1;
+}
+
+export async function runAndEmitTextSecretsScan(
+  callerCommand: string,
+  deps: HookDependencies,
+  text: string,
+): Promise<number> {
+  const { result } = await scanAndEmitSecrets(callerCommand, deps.auth, () =>
+    runSecretsBinaryOnText(deps.binaryPath, text, deps.auth),
+  );
+  return result.exitCode ?? 1;
 }

--- a/src/telemetry/secrets-analysis-telemetry.ts
+++ b/src/telemetry/secrets-analysis-telemetry.ts
@@ -1,0 +1,53 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Telemetry constants for the sonar-secrets analyzer's CliAnalysisCompleted /
+// CliAnalysisFindingsDetected events. Versioned independently of other analyzers
+// (e.g. SQAA) because each analyzer owns the shape of its own `details` blob.
+
+/**
+ * Schema version of the sonar-secrets CliAnalysisFindingsDetected `details` blob
+ * ({ counts_by_rule, files_with_findings_count, source }). Bump when that shape changes;
+ * independent of SQAA_DETAILS_SCHEMA_VERSION.
+ */
+export const SECRETS_DETAILS_SCHEMA_VERSION = 1;
+
+/**
+ * The `caller_command` value recorded on every sonar-secrets analysis event, one per
+ * call site. `agentPromptSubmit` is shared by the Claude and Codex prompt-submit hooks
+ * (they are distinguished by `caller_agent`, not `caller_command`).
+ */
+export const SECRETS_CALLER_COMMANDS = {
+  analyzeSecrets: 'analyze secrets',
+  analyzeDependencyRisks: 'analyze dependency-risks',
+  gitPreCommit: 'git-pre-commit',
+  gitPrePush: 'git-pre-push',
+  agentPromptSubmit: 'agent-prompt-submit',
+  cursorPromptSubmit: 'cursor-prompt-submit',
+  claudePreToolUse: 'claude-pre-tool-use',
+  copilotPreToolUse: 'copilot-pre-tool-use',
+  antigravityPreToolUse: 'antigravity-pre-tool-use',
+  cursorPreFileRead: 'cursor-pre-file-read',
+  cursorPreToolUse: 'cursor-pre-tool-use',
+} as const;
+
+/** Union of the valid sonar-secrets `caller_command` values. */
+export type SecretsCallerCommand =
+  (typeof SECRETS_CALLER_COMMANDS)[keyof typeof SECRETS_CALLER_COMMANDS];

--- a/tests/integration/harness/cli-runner.ts
+++ b/tests/integration/harness/cli-runner.ts
@@ -23,6 +23,7 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { ENV_DO_NOT_TRACK } from '../../../src/lib/config-constants.js';
 import { ISOLATED_CLI_SPAWN_ENV } from '../../_common/isolated-cli-env.js';
 import { COVERAGE_BINARY, COVERAGE_RAW_DIR } from '../../coverage/paths.js';
 import { IS_WINDOWS } from './platform';
@@ -74,6 +75,11 @@ export async function runCli(
   mkdirSync(options.cwd, { recursive: true });
 
   const spawnEnv: Record<string, string> = { ...env, ...ISOLATED_CLI_SPAWN_ENV };
+  // ISOLATED_CLI_SPAWN_ENV force-disables telemetry (DO_NOT_TRACK=1). Let an explicit
+  // DO_NOT_TRACK from the caller's env win, so telemetry-opted tests can exercise the sink.
+  if (ENV_DO_NOT_TRACK in env) {
+    spawnEnv[ENV_DO_NOT_TRACK] = env[ENV_DO_NOT_TRACK];
+  }
   if (coverageMode) {
     mkdirSync(COVERAGE_RAW_DIR, { recursive: true });
     const unique = `${Date.now()}-${crypto.randomUUID()}`;

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -144,6 +144,7 @@ export class EnvironmentBuilder {
   private _cagStderrLine?: string;
   private _installScaScannerBinary = false;
   private _rawStateJson?: string;
+  private _telemetryEnabled = false;
   private _dockerMockRunning?: boolean;
   private _dockerMockBinDir?: string;
   private readonly keychainTokens: Array<{ serverURL: string; token: string; org?: string }> = [];
@@ -282,6 +283,10 @@ export class EnvironmentBuilder {
     return this._dockerMockBinDir;
   }
 
+  get telemetryEnabled(): boolean {
+    return this._telemetryEnabled;
+  }
+
   /**
    * Stores a token in the file-based keychain when writeTo() is called.
    */
@@ -296,6 +301,17 @@ export class EnvironmentBuilder {
    */
   withRawState(json: string): this {
     this._rawStateJson = json;
+    return this;
+  }
+
+  /**
+   * Enables telemetry in the generated state (off by default for integration tests).
+   * Use when a test needs to assert telemetry side effects such as findings.ndjson.
+   * Pair with extraEnv `__SQ_CLI_TELEMETRY_FLUSH__=1` so the sink is written but the
+   * detached flush worker never spawns, and nothing is POSTed to the telemetry endpoint.
+   */
+  withTelemetryEnabled(): this {
+    this._telemetryEnabled = true;
     return this;
   }
 
@@ -378,8 +394,8 @@ export class EnvironmentBuilder {
     // withRawState().
     const state = getDefaultState(CURRENT_CLI_VERSION);
 
-    // disable telemetry for integration tests
-    state.telemetry.enabled = false;
+    // Telemetry is off by default for integration tests; opt in via withTelemetryEnabled().
+    state.telemetry.enabled = this._telemetryEnabled;
 
     if (this.activeConnectionUrl) {
       const connectionId = 'test-connection-id';

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -25,7 +25,10 @@ import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { ENV_SQAA_RETRY_BASE_DELAY_MS } from '../../../src/lib/config-constants.js';
+import {
+  ENV_DO_NOT_TRACK,
+  ENV_SQAA_RETRY_BASE_DELAY_MS,
+} from '../../../src/lib/config-constants.js';
 import { ISOLATED_CLI_SPAWN_ENV } from '../../_common/isolated-cli-env.js';
 import { getCliBinaryPath, runCli } from './cli-runner.js';
 import { Dir } from './dir';
@@ -253,7 +256,14 @@ export class TestHarness {
       composed.PATH = `${dockerBin}:${composed.PATH ?? process.env.PATH ?? ''}`;
     }
 
-    return { ...composed, ...ISOLATED_CLI_SPAWN_ENV };
+    const spawnEnv = { ...composed, ...ISOLATED_CLI_SPAWN_ENV };
+    // ISOLATED_CLI_SPAWN_ENV force-disables telemetry (DO_NOT_TRACK=1) for every spawn.
+    // Tests that opted into telemetry via withTelemetryEnabled() need it re-enabled so the
+    // findings.ndjson sink is written; pair with __SQ_CLI_TELEMETRY_FLUSH__=1 to avoid posting.
+    if (this._envBuilder?.telemetryEnabled) {
+      spawnEnv[ENV_DO_NOT_TRACK] = '0';
+    }
+    return spawnEnv;
   }
 
   /**

--- a/tests/integration/specs/analyze/analyze-secrets.test.ts
+++ b/tests/integration/specs/analyze/analyze-secrets.test.ts
@@ -260,4 +260,58 @@ describe('analyze secrets', () => {
     },
     { timeout: 30000 },
   );
+
+  it(
+    'writes CliAnalysisCompleted + CliAnalysisFindingsDetected to findings.ndjson from a real scan',
+    async () => {
+      harness.state().withSecretsBinaryInstalled().withTelemetryEnabled();
+      harness.withAuth(FAKE_SERVER, 'fake-token');
+      // Run in flush-worker mode so storeEvent() never spawns the detached flush worker:
+      // findings.ndjson is written but nothing is POSTed to the telemetry endpoint.
+      harness.withExtraEnv({ __SQ_CLI_TELEMETRY_FLUSH__: '1' });
+      harness.cwd.writeFile('secrets.js', `const token = "${GITHUB_TEST_TOKEN}";`);
+
+      const result = await harness.run('analyze secrets secrets.js');
+      expect(result.exitCode).toBe(EXIT_CODE_SECRETS_FOUND);
+
+      const findingsFile = harness.cliHome.file('telemetry', 'findings.ndjson');
+      expect(findingsFile.exists()).toBe(true);
+
+      interface AnalysisEvent {
+        metadata: { event_type: string };
+        event_payload: Record<string, unknown>;
+      }
+      const events = findingsFile
+        .asText()
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as AnalysisEvent);
+
+      // One completed event (always) + one findings-detected event (findings present).
+      expect(events).toHaveLength(2);
+      const completed = events[0];
+      const detected = events[1];
+      expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+      expect(detected.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingsDetected');
+
+      expect(completed.event_payload.analyzer).toBe('sonar-secrets');
+      expect(completed.event_payload.caller_command).toBe('analyze secrets');
+      expect(completed.event_payload.failures_count).toBe(0);
+      expect(completed.event_payload.exit_code).toBe(EXIT_CODE_SECRETS_FOUND);
+      expect(completed.event_payload.findings_count as number).toBeGreaterThanOrEqual(1);
+
+      const details = JSON.parse(detected.event_payload.details as string) as {
+        counts_by_rule: Record<string, number>;
+        files_with_findings_count: number;
+        source: string;
+      };
+      expect(Object.keys(details.counts_by_rule).length).toBeGreaterThanOrEqual(1);
+      expect(details.source).toBe('files');
+
+      // The two events are joinable on a shared analysis_id.
+      expect(completed.event_payload.analysis_id).toBe(detected.event_payload.analysis_id);
+    },
+    { timeout: 30000 },
+  );
 });

--- a/tests/integration/specs/analyze/analyze-secrets.test.ts
+++ b/tests/integration/specs/analyze/analyze-secrets.test.ts
@@ -289,11 +289,17 @@ describe('analyze secrets', () => {
         .map((line) => JSON.parse(line) as AnalysisEvent);
 
       // One completed event (always) + one findings-detected event (findings present).
+      // Select by event_type rather than position so the assertions don't depend on emit order.
       expect(events).toHaveLength(2);
-      const completed = events[0];
-      const detected = events[1];
-      expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-      expect(detected.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingsDetected');
+      const completed = events.find(
+        (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
+      );
+      const detected = events.find(
+        (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
+      );
+      expect(completed).toBeDefined();
+      expect(detected).toBeDefined();
+      if (!completed || !detected) throw new Error('expected both analysis events');
 
       expect(completed.event_payload.analyzer).toBe('sonar-secrets');
       expect(completed.event_payload.caller_command).toBe('analyze secrets');

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -32,9 +32,14 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
+import {
+  emitSecretsRunTelemetry,
+  scanAndEmitSecrets,
+} from '../../../src/cli/commands/analyze/secrets.js';
 import * as agentDetector from '../../../src/lib/agent-detector.js';
 import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
 import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
+import type { SpawnResult } from '../../../src/lib/process.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
 import type { CliState } from '../../../src/lib/state.js';
 import type {
@@ -619,5 +624,171 @@ describe('flushFindings()', () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+});
+
+// ─── emitSecretsRunTelemetry ───────────────────────────────────────────────────
+
+describe('emitSecretsRunTelemetry()', () => {
+  it('does nothing when telemetry is disabled', () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+    emitSecretsRunTelemetry('analyze secrets', AUTH, { exitCode: 0, stdout: '{}' }, 100);
+    expect(readLines(testSonarUserHome)).toHaveLength(0);
+  });
+
+  it('emits only CliAnalysisCompleted on a clean scan (exit 0, no issues)', () => {
+    emitSecretsRunTelemetry(
+      'analyze secrets',
+      AUTH,
+      { exitCode: 0, stdout: JSON.stringify({ issues: [] }) },
+      200,
+    );
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.failures_count).toBe(0);
+    expect(completed.event_payload.exit_code).toBe(0);
+    expect(completed.event_payload.findings_count).toBe(0);
+    expect(completed.event_payload.scan_duration_ms).toBe(200);
+    expect(completed.event_payload.caller_command).toBe('analyze secrets');
+    expect(completed.event_payload.analyzer).toBe('sonar-secrets');
+  });
+
+  it('emits CliAnalysisCompleted + CliAnalysisFindingsDetected when secrets found (exit 51)', () => {
+    const stdout = JSON.stringify({
+      issues: [
+        { ruleKey: 'secrets:S6290', description: 'AWS key', file: 'src/config.ts' },
+        { ruleKey: 'secrets:S6290', description: 'AWS key (2)', file: 'src/config.ts' },
+        { ruleKey: 'secrets:S1234', description: 'Other', file: 'src/other.ts' },
+      ],
+    });
+    emitSecretsRunTelemetry('git-pre-commit', AUTH, { exitCode: 51, stdout }, 300);
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(2);
+
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    expect(completed.event_payload.failures_count).toBe(0);
+    expect(completed.event_payload.exit_code).toBe(51);
+    expect(completed.event_payload.findings_count).toBe(3);
+    expect(completed.event_payload.caller_command).toBe('git-pre-commit');
+
+    const detected = lines[1] as StoredAnalysisFindingsDetectedEvent;
+    expect(detected.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingsDetected');
+    const details = JSON.parse(detected.event_payload.details) as {
+      counts_by_rule: Record<string, number>;
+      files_with_findings_count: number;
+      source: string;
+    };
+    expect(details.counts_by_rule['secrets:S6290']).toBe(2);
+    expect(details.counts_by_rule['secrets:S1234']).toBe(1);
+    expect(details.files_with_findings_count).toBe(2);
+    expect(details.source).toBe('files');
+
+    expect(completed.event_payload.analysis_id).toBe(detected.event_payload.analysis_id);
+  });
+
+  it('sets source to stdin and files_with_findings_count to 0 when no file paths in issues', () => {
+    const stdout = JSON.stringify({
+      issues: [{ ruleKey: 'secrets:S6290', description: 'AWS key in prompt' }],
+    });
+    emitSecretsRunTelemetry('agent-prompt-submit', AUTH, { exitCode: 51, stdout }, 100);
+
+    const lines = readLines(testSonarUserHome);
+    const detected = lines[1] as StoredAnalysisFindingsDetectedEvent;
+    const details = JSON.parse(detected.event_payload.details) as {
+      files_with_findings_count: number;
+      source: string;
+    };
+    expect(details.files_with_findings_count).toBe(0);
+    expect(details.source).toBe('stdin');
+  });
+
+  it('emits only CliAnalysisCompleted with failures_count 1 for a non-clean, non-findings exit code', () => {
+    emitSecretsRunTelemetry('copilot-pre-tool-use', AUTH, { exitCode: 2, stdout: '{}' }, 50);
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(1);
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.failures_count).toBe(1);
+    expect(completed.event_payload.findings_count).toBe(0);
+    expect(completed.event_payload.exit_code).toBe(2);
+  });
+
+  it('reports a null exitCode as exit_code null with failures_count 1 (no coercion)', () => {
+    emitSecretsRunTelemetry('agent-prompt-submit', AUTH, { exitCode: null, stdout: '{}' }, 50);
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(1);
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.failures_count).toBe(1);
+    expect(completed.event_payload.exit_code).toBeNull();
+  });
+
+  it('emits a failed-to-run event (failures_count 1, exit_code null) when result is null', () => {
+    emitSecretsRunTelemetry('git-pre-commit', AUTH, null, 30000);
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(1);
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    expect(completed.event_payload.failures_count).toBe(1);
+    expect(completed.event_payload.exit_code).toBeNull();
+    expect(completed.event_payload.findings_count).toBe(0);
+    expect(completed.event_payload.errors_count).toBe(0);
+    expect(completed.event_payload.scan_duration_ms).toBe(30000);
+  });
+
+  it('records errors_count from the errors field in stdout, independent of failures_count', () => {
+    const stdout = JSON.stringify({ issues: [], errors: ['auth failed', 'partial scan'] });
+    // exit 2: run failed (failures_count 1) AND reported errors[] (errors_count 2) — not mutually exclusive
+    emitSecretsRunTelemetry('analyze secrets', AUTH, { exitCode: 2, stdout }, 100);
+
+    const lines = readLines(testSonarUserHome);
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.errors_count).toBe(2);
+    expect(completed.event_payload.failures_count).toBe(1);
+  });
+});
+
+describe('scanAndEmitSecrets()', () => {
+  it('emits a completed event and returns the spawn result + parsed output on success', async () => {
+    const result: SpawnResult = {
+      exitCode: 51,
+      stdout: JSON.stringify({ issues: [{ ruleKey: 'secrets:S6290', description: 'AWS key' }] }),
+      stderr: '',
+    };
+    const out = await scanAndEmitSecrets('git-pre-commit', AUTH, () => Promise.resolve(result));
+
+    expect(out.result).toBe(result);
+    expect(out.parsed.issues).toHaveLength(1);
+
+    const lines = readLines(testSonarUserHome);
+    // one Completed + one FindingsDetected (findings present)
+    expect(lines).toHaveLength(2);
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.failures_count).toBe(0);
+    expect(completed.event_payload.exit_code).toBe(51);
+  });
+
+  it('emits a failures_count:1 event and re-throws when the scan fails to run', async () => {
+    const boom = new Error('Scan timed out after 30000ms');
+
+    let thrown: unknown;
+    await scanAndEmitSecrets('git-pre-commit', AUTH, () => Promise.reject(boom)).catch((err) => {
+      thrown = err;
+    });
+    expect(thrown).toBe(boom);
+
+    const lines = readLines(testSonarUserHome);
+    expect(lines).toHaveLength(1);
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    expect(completed.event_payload.failures_count).toBe(1);
+    expect(completed.event_payload.exit_code).toBeNull();
+    expect(completed.event_payload.findings_count).toBe(0);
   });
 });

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -32,10 +32,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
-import {
-  emitSecretsRunTelemetry,
-  scanAndEmitSecrets,
-} from '../../../src/cli/commands/analyze/secrets.js';
+import { scanAndEmitSecrets } from '../../../src/cli/commands/analyze/secrets.js';
 import * as agentDetector from '../../../src/lib/agent-detector.js';
 import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
 import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
@@ -629,19 +626,23 @@ describe('flushFindings()', () => {
 
 // ─── emitSecretsRunTelemetry ───────────────────────────────────────────────────
 
-describe('emitSecretsRunTelemetry()', () => {
-  it('does nothing when telemetry is disabled', () => {
+// Resolves a spawn as if sonar-secrets ran to completion with the given exit code / stdout.
+function resolvedRun(exitCode: number | null, stdout: string): () => Promise<SpawnResult> {
+  return () => Promise.resolve({ exitCode, stdout, stderr: '' });
+}
+
+describe('scanAndEmitSecrets() — emitted event fields', () => {
+  it('does nothing when telemetry is disabled', async () => {
     loadStateSpy.mockReturnValue(makeTelemetryState(false));
-    emitSecretsRunTelemetry('analyze secrets', AUTH, { exitCode: 0, stdout: '{}' }, 100);
+    await scanAndEmitSecrets('analyze secrets', AUTH, resolvedRun(0, '{}'));
     expect(readLines(testSonarUserHome)).toHaveLength(0);
   });
 
-  it('emits only CliAnalysisCompleted on a clean scan (exit 0, no issues)', () => {
-    emitSecretsRunTelemetry(
+  it('emits only CliAnalysisCompleted on a clean scan (exit 0, no issues)', async () => {
+    await scanAndEmitSecrets(
       'analyze secrets',
       AUTH,
-      { exitCode: 0, stdout: JSON.stringify({ issues: [] }) },
-      200,
+      resolvedRun(0, JSON.stringify({ issues: [] })),
     );
 
     const lines = readLines(testSonarUserHome);
@@ -651,12 +652,13 @@ describe('emitSecretsRunTelemetry()', () => {
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(0);
     expect(completed.event_payload.findings_count).toBe(0);
-    expect(completed.event_payload.scan_duration_ms).toBe(200);
+    expect(typeof completed.event_payload.scan_duration_ms).toBe('number');
+    expect(completed.event_payload.scan_duration_ms).toBeGreaterThanOrEqual(0);
     expect(completed.event_payload.caller_command).toBe('analyze secrets');
     expect(completed.event_payload.analyzer).toBe('sonar-secrets');
   });
 
-  it('emits CliAnalysisCompleted + CliAnalysisFindingsDetected when secrets found (exit 51)', () => {
+  it('emits CliAnalysisCompleted + CliAnalysisFindingsDetected when secrets found (exit 51)', async () => {
     const stdout = JSON.stringify({
       issues: [
         { ruleKey: 'secrets:S6290', description: 'AWS key', file: 'src/config.ts' },
@@ -664,7 +666,7 @@ describe('emitSecretsRunTelemetry()', () => {
         { ruleKey: 'secrets:S1234', description: 'Other', file: 'src/other.ts' },
       ],
     });
-    emitSecretsRunTelemetry('git-pre-commit', AUTH, { exitCode: 51, stdout }, 300);
+    await scanAndEmitSecrets('git-pre-commit', AUTH, resolvedRun(51, stdout));
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(2);
@@ -691,11 +693,11 @@ describe('emitSecretsRunTelemetry()', () => {
     expect(completed.event_payload.analysis_id).toBe(detected.event_payload.analysis_id);
   });
 
-  it('sets source to stdin and files_with_findings_count to 0 when no file paths in issues', () => {
+  it('sets source to stdin and files_with_findings_count to 0 when no file paths in issues', async () => {
     const stdout = JSON.stringify({
       issues: [{ ruleKey: 'secrets:S6290', description: 'AWS key in prompt' }],
     });
-    emitSecretsRunTelemetry('agent-prompt-submit', AUTH, { exitCode: 51, stdout }, 100);
+    await scanAndEmitSecrets('agent-prompt-submit', AUTH, resolvedRun(51, stdout));
 
     const lines = readLines(testSonarUserHome);
     const detected = lines[1] as StoredAnalysisFindingsDetectedEvent;
@@ -707,8 +709,8 @@ describe('emitSecretsRunTelemetry()', () => {
     expect(details.source).toBe('stdin');
   });
 
-  it('emits only CliAnalysisCompleted with failures_count 1 for a non-clean, non-findings exit code', () => {
-    emitSecretsRunTelemetry('copilot-pre-tool-use', AUTH, { exitCode: 2, stdout: '{}' }, 50);
+  it('emits only CliAnalysisCompleted with failures_count 1 for a non-clean, non-findings exit code', async () => {
+    await scanAndEmitSecrets('copilot-pre-tool-use', AUTH, resolvedRun(2, '{}'));
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
@@ -718,8 +720,8 @@ describe('emitSecretsRunTelemetry()', () => {
     expect(completed.event_payload.exit_code).toBe(2);
   });
 
-  it('reports a null exitCode as exit_code null with failures_count 1 (no coercion)', () => {
-    emitSecretsRunTelemetry('agent-prompt-submit', AUTH, { exitCode: null, stdout: '{}' }, 50);
+  it('reports a resolved null exitCode as exit_code null with failures_count 1 (no coercion)', async () => {
+    await scanAndEmitSecrets('agent-prompt-submit', AUTH, resolvedRun(null, '{}'));
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
@@ -728,24 +730,10 @@ describe('emitSecretsRunTelemetry()', () => {
     expect(completed.event_payload.exit_code).toBeNull();
   });
 
-  it('emits a failed-to-run event (failures_count 1, exit_code null) when result is null', () => {
-    emitSecretsRunTelemetry('git-pre-commit', AUTH, null, 30000);
-
-    const lines = readLines(testSonarUserHome);
-    expect(lines).toHaveLength(1);
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
-    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-    expect(completed.event_payload.failures_count).toBe(1);
-    expect(completed.event_payload.exit_code).toBeNull();
-    expect(completed.event_payload.findings_count).toBe(0);
-    expect(completed.event_payload.errors_count).toBe(0);
-    expect(completed.event_payload.scan_duration_ms).toBe(30000);
-  });
-
-  it('records errors_count from the errors field in stdout, independent of failures_count', () => {
+  it('records errors_count from the errors field in stdout, independent of failures_count', async () => {
     const stdout = JSON.stringify({ issues: [], errors: ['auth failed', 'partial scan'] });
     // exit 2: run failed (failures_count 1) AND reported errors[] (errors_count 2) — not mutually exclusive
-    emitSecretsRunTelemetry('analyze secrets', AUTH, { exitCode: 2, stdout }, 100);
+    await scanAndEmitSecrets('analyze secrets', AUTH, resolvedRun(2, stdout));
 
     const lines = readLines(testSonarUserHome);
     const completed = lines[0] as StoredAnalysisCompletedEvent;
@@ -754,7 +742,7 @@ describe('emitSecretsRunTelemetry()', () => {
   });
 });
 
-describe('scanAndEmitSecrets()', () => {
+describe('scanAndEmitSecrets() — wrapper behavior', () => {
   it('emits a completed event and returns the spawn result + parsed output on success', async () => {
     const result: SpawnResult = {
       exitCode: 51,

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -55,6 +55,7 @@ import {
   emitAnalysisFindingsDetected,
   flushFindings,
 } from '../../../src/telemetry/findings.js';
+import { SECRETS_CALLER_COMMANDS } from '../../../src/telemetry/secrets-analysis-telemetry.js';
 import { SQAA_ANALYZE_AGENTIC_CALLER_COMMAND } from '../../../src/telemetry/sqaa-analysis-telemetry.js';
 import * as userModule from '../../../src/telemetry/user.js';
 
@@ -624,7 +625,7 @@ describe('flushFindings()', () => {
   });
 });
 
-// ─── emitSecretsRunTelemetry ───────────────────────────────────────────────────
+// ─── scanAndEmitSecrets ────────────────────────────────────────────────────────
 
 // Resolves a spawn as if sonar-secrets ran to completion with the given exit code / stdout.
 function resolvedRun(exitCode: number | null, stdout: string): () => Promise<SpawnResult> {
@@ -634,13 +635,13 @@ function resolvedRun(exitCode: number | null, stdout: string): () => Promise<Spa
 describe('scanAndEmitSecrets() — emitted event fields', () => {
   it('does nothing when telemetry is disabled', async () => {
     loadStateSpy.mockReturnValue(makeTelemetryState(false));
-    await scanAndEmitSecrets('analyze secrets', AUTH, resolvedRun(0, '{}'));
+    await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.analyzeSecrets, AUTH, resolvedRun(0, '{}'));
     expect(readLines(testSonarUserHome)).toHaveLength(0);
   });
 
   it('emits only CliAnalysisCompleted on a clean scan (exit 0, no issues)', async () => {
     await scanAndEmitSecrets(
-      'analyze secrets',
+      SECRETS_CALLER_COMMANDS.analyzeSecrets,
       AUTH,
       resolvedRun(0, JSON.stringify({ issues: [] })),
     );
@@ -654,7 +655,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     expect(completed.event_payload.findings_count).toBe(0);
     expect(typeof completed.event_payload.scan_duration_ms).toBe('number');
     expect(completed.event_payload.scan_duration_ms).toBeGreaterThanOrEqual(0);
-    expect(completed.event_payload.caller_command).toBe('analyze secrets');
+    expect(completed.event_payload.caller_command).toBe(SECRETS_CALLER_COMMANDS.analyzeSecrets);
     expect(completed.event_payload.analyzer).toBe('sonar-secrets');
   });
 
@@ -666,7 +667,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
         { ruleKey: 'secrets:S1234', description: 'Other', file: 'src/other.ts' },
       ],
     });
-    await scanAndEmitSecrets('git-pre-commit', AUTH, resolvedRun(51, stdout));
+    await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.gitPreCommit, AUTH, resolvedRun(51, stdout));
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(2);
@@ -676,7 +677,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(51);
     expect(completed.event_payload.findings_count).toBe(3);
-    expect(completed.event_payload.caller_command).toBe('git-pre-commit');
+    expect(completed.event_payload.caller_command).toBe(SECRETS_CALLER_COMMANDS.gitPreCommit);
 
     const detected = lines[1] as StoredAnalysisFindingsDetectedEvent;
     expect(detected.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingsDetected');
@@ -697,7 +698,11 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     const stdout = JSON.stringify({
       issues: [{ ruleKey: 'secrets:S6290', description: 'AWS key in prompt' }],
     });
-    await scanAndEmitSecrets('agent-prompt-submit', AUTH, resolvedRun(51, stdout));
+    await scanAndEmitSecrets(
+      SECRETS_CALLER_COMMANDS.agentPromptSubmit,
+      AUTH,
+      resolvedRun(51, stdout),
+    );
 
     const lines = readLines(testSonarUserHome);
     const detected = lines[1] as StoredAnalysisFindingsDetectedEvent;
@@ -710,7 +715,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
   });
 
   it('emits only CliAnalysisCompleted with failures_count 1 for a non-clean, non-findings exit code', async () => {
-    await scanAndEmitSecrets('copilot-pre-tool-use', AUTH, resolvedRun(2, '{}'));
+    await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.copilotPreToolUse, AUTH, resolvedRun(2, '{}'));
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
@@ -721,7 +726,11 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
   });
 
   it('reports a resolved null exitCode as exit_code null with failures_count 1 (no coercion)', async () => {
-    await scanAndEmitSecrets('agent-prompt-submit', AUTH, resolvedRun(null, '{}'));
+    await scanAndEmitSecrets(
+      SECRETS_CALLER_COMMANDS.agentPromptSubmit,
+      AUTH,
+      resolvedRun(null, '{}'),
+    );
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
@@ -733,7 +742,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
   it('records errors_count from the errors field in stdout, independent of failures_count', async () => {
     const stdout = JSON.stringify({ issues: [], errors: ['auth failed', 'partial scan'] });
     // exit 2: run failed (failures_count 1) AND reported errors[] (errors_count 2) — not mutually exclusive
-    await scanAndEmitSecrets('analyze secrets', AUTH, resolvedRun(2, stdout));
+    await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.analyzeSecrets, AUTH, resolvedRun(2, stdout));
 
     const lines = readLines(testSonarUserHome);
     const completed = lines[0] as StoredAnalysisCompletedEvent;
@@ -749,7 +758,9 @@ describe('scanAndEmitSecrets() — wrapper behavior', () => {
       stdout: JSON.stringify({ issues: [{ ruleKey: 'secrets:S6290', description: 'AWS key' }] }),
       stderr: '',
     };
-    const out = await scanAndEmitSecrets('git-pre-commit', AUTH, () => Promise.resolve(result));
+    const out = await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.gitPreCommit, AUTH, () =>
+      Promise.resolve(result),
+    );
 
     expect(out.result).toBe(result);
     expect(out.parsed.issues).toHaveLength(1);
@@ -766,7 +777,9 @@ describe('scanAndEmitSecrets() — wrapper behavior', () => {
     const boom = new Error('Scan timed out after 30000ms');
 
     let thrown: unknown;
-    await scanAndEmitSecrets('git-pre-commit', AUTH, () => Promise.reject(boom)).catch((err) => {
+    await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.gitPreCommit, AUTH, () =>
+      Promise.reject(boom),
+    ).catch((err) => {
       thrown = err;
     });
     expect(thrown).toBe(boom);


### PR DESCRIPTION
## Summary

Wires the **sonar-secrets** analyzer into the shared analysis-telemetry schema (from #528 / CLI-782 and #531 / CLI-783), so every sonar-secrets run emits telemetry appended to `findings.ndjson` and flushed by the detached telemetry worker.

**Events emitted per run:**
- `CliAnalysisCompleted` — always, for every invocation (clean / findings / errored / **failed to run**)
- `CliAnalysisFindingsDetected` — only when `findings_count > 0`, carrying a versioned `details` blob

Both events share an `analysis_id` UUID so they can be joined on a single column.

## `CliAnalysisCompleted` counts (no `status` field)

- **`failures_count`** — per-invocation `0`/`1`: `1` when the scan did not produce a valid result — it either **failed to run** (spawn error or timeout → `exit_code: null`) or exited with a non-clean, non-findings code — otherwise `0`.
- **`errors_count`** — parsed `errors[]` from the analyzer's `--json` output (renamed from `error_count` in CLI-783). Independent of `failures_count`; both can be non-zero (e.g. a non-51 exit that also reported `errors[]`).
- **`exit_code`** — raw subprocess exit code, or `null` when the scan failed to run.

`status` was dropped in CLI-783 and is fully reconstructable: `clean` = `findings_count == 0 && failures_count == 0`, `findings` = `findings_count > 0`, `error` = `failures_count > 0`. "Failed to run" vs "ran but errored" stays distinguishable via `exit_code` (`null` vs the actual code).

## `CliAnalysisFindingsDetected` details blob

```json
{
  "counts_by_rule": { "secrets:S6290": 2, "secrets:S1234": 1 },
  "files_with_findings_count": 2,
  "source": "files"
}
```
`source` is `"files"` when findings carry file paths (file scans), `"stdin"` for `--input` / prompt / text scans. `rule_keys` is omitted — fully derivable from `Object.keys(counts_by_rule)`.

## Call sites covered

| `caller_command` | File |
|---|---|
| `analyze secrets` (file + stdin) | `secrets.ts` |
| `analyze dependency-risks` | `manifest-secrets-guard.ts` |
| `git-pre-commit` | `git-pre-commit-secrets.ts` |
| `git-pre-push` | `git-pre-push-secrets.ts` |
| `agent-prompt-submit` | `agent-prompt-submit.ts` (Claude + Codex) |
| `cursor-prompt-submit` | `cursor-prompt-submit.ts` |
| `claude-pre-tool-use` | `claude-pre-tool-use.ts` |
| `copilot-pre-tool-use` | `copilot-pre-tool-use.ts` |
| `antigravity-pre-tool-use` | `antigravity-pre-tool-use.ts` |
| `cursor-pre-file-read` | `cursor-pre-file-read.ts` |
| `cursor-pre-tool-use` | `cursor-pre-tool-use.ts` |

`codex-prompt-submit` shares the `agent-prompt-submit` caller_command (shared core); the two are distinguished by `caller_agent`, not `caller_command`.

## Implementation notes

- Every call site routes through a single **`scanAndEmitSecrets`** wrapper that times the spawn and emits `CliAnalysisCompleted` for **both** outcomes — a completed run (via `emitSecretsRunTelemetry`) and a **failed-to-run** scan (`failures_count: 1`, `exit_code: null`) — then re-throws. This closes the previous gap where spawn errors / timeouts emitted no telemetry at all.
- The emit happens **before** the caller's error handling, so failed runs are recorded even when a caller then throws — e.g. git hooks failing closed under environment-based auth still record `failures_count: 1`.
- Callers keep their existing fail-open / fail-closed / block behaviour. Cursor's `denyCursorFileAccess()` still exits 2 after telemetry is emitted.
- No display changes. The only behavioural change is that failed-to-run scans now emit a `CliAnalysisCompleted` event (previously silent).

Rebased on top of #531 (CLI-783); depends on that schema being on `master`.
