### PR TITLE
CLI-741 Add capability to uninstall features from integrations

### DIFF
--- a/src/cli/commands/_common/install/binary.ts
+++ b/src/cli/commands/_common/install/binary.ts
@@ -75,6 +75,19 @@ export function resolveBinaryPath(spec: BinarySpec, binDir?: string): string | n
 }
 
 /**
+ * Delete the local cached binary from disk if present.
+ * No-op when absent. Returns true when a file was removed.
+ */
+export function removeBinary(spec: BinarySpec, binDir?: string): boolean {
+  const path = resolveBinaryPath(spec, binDir);
+  if (path === null) {
+    return false;
+  }
+  rmSync(path, { force: true });
+  return true;
+}
+
+/**
  * Download, verify, and install a binary into BIN_DIR (or a custom binDir).
  * No-op when the same version is already present unless `force` is set.
  */

--- a/src/cli/commands/integrate/_common/registry/completion-summary.ts
+++ b/src/cli/commands/integrate/_common/registry/completion-summary.ts
@@ -34,14 +34,25 @@ import type { FeatureDeclaration, IntegrationDeclaration, PostInstallExample } f
 export function renderCompletionSummary<TOptions>(
   integration: IntegrationDeclaration<TOptions>,
   installedFeatures: InstalledIntegrationFeature[],
+  removedFeatures: FeatureDeclaration<TOptions>[],
 ): void {
-  if (installedFeatures.length === 0) {
+  if (installedFeatures.length === 0 && removedFeatures.length === 0) {
     return;
   }
 
-  renderInstalledList(integration, installedFeatures);
+  if (installedFeatures.length > 0) {
+    renderInstalledList(integration, installedFeatures);
+  }
+  if (removedFeatures.length > 0) {
+    renderRemovedList(removedFeatures);
+  }
   outro('Setup complete!', 'success');
   renderPostInstallExamples(integration, installedFeatures);
+}
+
+function renderRemovedList<TOptions>(removedFeatures: FeatureDeclaration<TOptions>[]): void {
+  const items = removedFeatures.map((feature) => phaseItem(feature.displayName, 'done'));
+  phase('Removed', items);
 }
 
 function renderInstalledList<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/dependencies/common.ts
+++ b/src/cli/commands/integrate/_common/registry/dependencies/common.ts
@@ -38,4 +38,5 @@ export interface DependencyDeclaration {
   version?: string;
   installOrUpdate: (context: DependencyInstallContext) => MaybePromise<InstalledDependency>;
   isInstalled: (context: IntegrationContext) => MaybePromise<boolean>;
+  remove: (context: IntegrationContext) => MaybePromise<void>;
 }

--- a/src/cli/commands/integrate/_common/registry/dependencies/context-augmentation.ts
+++ b/src/cli/commands/integrate/_common/registry/dependencies/context-augmentation.ts
@@ -18,6 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { rmSync } from 'node:fs';
+
 import { CONTEXT_AUGMENTATION_BINARY_NAME } from '../../../../../../lib/install-types';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../../../../lib/signatures';
 import {
@@ -60,6 +62,15 @@ export class ContextAugmentationBinaryDependency implements DependencyDeclaratio
 
   isInstalled(_context: IntegrationContext): boolean {
     return resolveContextAugmentationBinaryPath() !== null;
+  }
+
+  async remove(_context: IntegrationContext): Promise<void> {
+    const binaryPath = resolveContextAugmentationBinaryPath();
+    if (binaryPath === null) {
+      return;
+    }
+    await stopAllContextAugmentationTools(binaryPath);
+    rmSync(binaryPath, { force: true });
   }
 }
 

--- a/src/cli/commands/integrate/_common/registry/dependencies/sonarsource-binary.ts
+++ b/src/cli/commands/integrate/_common/registry/dependencies/sonarsource-binary.ts
@@ -33,6 +33,7 @@ import {
 import {
   type BinarySpec,
   installBinary,
+  removeBinary,
   resolveBinaryPath,
 } from '../../../../_common/install/binary';
 import type { DependencyInstallContext, InstalledDependency, IntegrationContext } from '../types';
@@ -100,6 +101,10 @@ export class SonarSourceBinaryDependency implements DependencyDeclaration {
 
   isInstalled(_context: IntegrationContext): boolean {
     return resolveBinaryPath(this.options.binary.spec) !== null;
+  }
+
+  remove(_context: IntegrationContext): void {
+    removeBinary(this.options.binary.spec);
   }
 }
 

--- a/src/cli/commands/integrate/_common/registry/feature-target.ts
+++ b/src/cli/commands/integrate/_common/registry/feature-target.ts
@@ -1,0 +1,77 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { IntegrationScope } from '../../../../../lib/state';
+import type { FeatureApplication, FeatureDeclaration, IntegrationInvocation } from './types';
+
+/**
+ * Resolve every feature into a {@link FeatureApplication} for the invocation,
+ * pairing the declaration with its resolved target root and scope plus the
+ * invocation's auth/force/attrs.
+ */
+export async function buildApplications<TOptions>(
+  invocation: IntegrationInvocation<TOptions>,
+  features: FeatureDeclaration<TOptions>[],
+): Promise<FeatureApplication<TOptions>[]> {
+  const applications: FeatureApplication<TOptions>[] = [];
+  for (const feature of features) {
+    applications.push({
+      feature,
+      targetRoot: await resolveFeatureTargetRoot(invocation, feature),
+      scope: await resolveFeatureScope(invocation, feature),
+      auth: invocation.auth,
+      force: invocation.force,
+      attrs: invocation.attrs,
+    });
+  }
+  return applications;
+}
+
+/**
+ * Resolve the target root a feature applies to for the given invocation. A
+ * feature may pin a fixed root, derive one from the invocation, or fall back to
+ * the invocation's default root.
+ */
+export async function resolveFeatureTargetRoot<TOptions>(
+  invocation: IntegrationInvocation<TOptions>,
+  feature: FeatureDeclaration<TOptions>,
+): Promise<string> {
+  const { targetRoot } = feature;
+  if (typeof targetRoot === 'function') {
+    return targetRoot(invocation);
+  }
+  return targetRoot ?? invocation.targetRoot;
+}
+
+/**
+ * Resolve the scope a feature installs at for the given invocation. A feature
+ * may pin a fixed scope, derive one from the invocation, or fall back to the
+ * invocation's default scope.
+ */
+export async function resolveFeatureScope<TOptions>(
+  invocation: IntegrationInvocation<TOptions>,
+  feature: FeatureDeclaration<TOptions>,
+): Promise<IntegrationScope> {
+  const { scope } = feature;
+  if (typeof scope === 'function') {
+    return scope(invocation);
+  }
+  return scope ?? invocation.scope;
+}

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -35,12 +35,17 @@ export {
   type SonarSourceBinaryDependencyOptions,
   type SonarSourceBinaryDescriptor,
 } from './dependencies';
+export { buildApplications } from './feature-target';
 export {
   installIntegration,
   type InstallIntegrationOptions,
   makeContext,
 } from './install-integration';
-export { isFeatureInstalledGloballyForProject } from './installation-recorder';
+export {
+  findInstalledFeature,
+  findInstalledIntegration,
+  isFeatureInstalledGloballyForProject,
+} from './installation-recorder';
 export {
   IntegrationInstaller,
   integrationInstaller,
@@ -72,7 +77,15 @@ export {
   yamlPatchRemover,
   type YamlPatchRemoverOptions,
 } from './resources';
-export { askUser, install, type InstallDecision, isFeatureContainer, skip } from './selection';
+export {
+  askUser,
+  install,
+  type InstallDecision,
+  isFeatureContainer,
+  selectFeatures,
+  selectFeaturesForInvocation,
+  skip,
+} from './selection';
 export type {
   AppliedFeature,
   AppliedOperation,
@@ -82,6 +95,7 @@ export type {
   FeatureContainer,
   FeatureDeclaration,
   FeatureOperation,
+  FeatureSelectionResult,
   InstalledDependency,
   IntegrationContext,
   IntegrationDeclaration,

--- a/src/cli/commands/integrate/_common/registry/index.ts
+++ b/src/cli/commands/integrate/_common/registry/index.ts
@@ -82,7 +82,6 @@ export {
   install,
   type InstallDecision,
   isFeatureContainer,
-  selectFeatures,
   selectFeaturesForInvocation,
   skip,
 } from './selection';

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -92,22 +92,6 @@ export async function installIntegration<TOptions>({
   text('');
 
   try {
-    const removedFeatures = await integrationInstaller.removeAndRecordFeatures(
-      state,
-      integration,
-      toRemove,
-      {
-        callbacks: {
-          onFeatureRemoveStart: (feature) => {
-            text(`     Removing ${feature.displayName}...`);
-          },
-          onDependencyRemoved: (dependency) => {
-            text(`     ${dependency.displayName ?? dependency.id} removed`);
-          },
-        },
-      },
-    );
-
     const installedFeatures = await integrationInstaller.applyAndRecordFeatures(
       state,
       integration,
@@ -130,6 +114,22 @@ export async function installIntegration<TOptions>({
           },
         },
         executionMode: 'install',
+      },
+    );
+
+    const removedFeatures = await integrationInstaller.removeAndRecordFeatures(
+      state,
+      integration,
+      toRemove,
+      {
+        callbacks: {
+          onFeatureRemoveStart: (feature) => {
+            text(`     Removing ${feature.displayName}...`);
+          },
+          onDependencyRemoved: (dependency) => {
+            text(`     ${dependency.displayName ?? dependency.id} removed`);
+          },
+        },
       },
     );
 

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -35,7 +35,7 @@ import { renderCompletionSummary } from './completion-summary';
 import type { IntegrationRegistry } from './core';
 import { buildApplications } from './feature-target';
 import { integrationInstaller } from './installer';
-import { isFeatureContainer, selectFeatures, selectFeaturesForInvocation } from './selection';
+import { isFeatureContainer, selectFeaturesForInvocation } from './selection';
 import type {
   IntegrationContext,
   IntegrationDeclaration,
@@ -52,7 +52,6 @@ export interface InstallIntegrationOptions<TOptions> {
   auth?: ResolvedAuth;
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
-  featureIds?: string[];
   nonInteractive?: boolean;
 }
 
@@ -65,7 +64,6 @@ export async function installIntegration<TOptions>({
   auth,
   force,
   attrs,
-  featureIds,
   nonInteractive,
 }: InstallIntegrationOptions<TOptions>): Promise<InstalledIntegrationFeature[]> {
   const integration = getIntegrationDeclaration<TOptions>(registry, integrationId);
@@ -81,10 +79,11 @@ export async function installIntegration<TOptions>({
     state,
   };
   const applications = await buildApplications(invocation, integration.features);
-  const { toInstall, toRemove } =
-    featureIds === undefined
-      ? await selectFeaturesForInvocation(integration, invocation, applications)
-      : selectFeatures(integration, applications, featureIds);
+  const { toInstall, toRemove } = await selectFeaturesForInvocation(
+    integration,
+    invocation,
+    applications,
+  );
   if (toInstall.length === 0 && toRemove.length === 0) {
     throw new CommandFailedError(`No feature selected for ${integration.displayName}`);
   }

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -33,11 +33,10 @@ import { text, warn } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
 import { renderCompletionSummary } from './completion-summary';
 import type { IntegrationRegistry } from './core';
-import type { FeatureApplication } from './installer';
+import { buildApplications } from './feature-target';
 import { integrationInstaller } from './installer';
-import { isFeatureContainer } from './selection';
+import { isFeatureContainer, selectFeatures, selectFeaturesForInvocation } from './selection';
 import type {
-  FeatureDeclaration,
   IntegrationContext,
   IntegrationDeclaration,
   IntegrationExecutionMode,
@@ -81,33 +80,38 @@ export async function installIntegration<TOptions>({
     nonInteractive,
     state,
   };
-  const features =
+  const applications = await buildApplications(invocation, integration.features);
+  const { toInstall, toRemove } =
     featureIds === undefined
-      ? await integrationInstaller.selectFeaturesForInvocation(integration, invocation)
-      : integrationInstaller.selectFeatures(integration, featureIds);
-  if (features.length === 0) {
+      ? await selectFeaturesForInvocation(integration, invocation, applications)
+      : selectFeatures(integration, applications, featureIds);
+  if (toInstall.length === 0 && toRemove.length === 0) {
     throw new CommandFailedError(`No feature selected for ${integration.displayName}`);
   }
 
-  const applications: FeatureApplication<TOptions>[] = [];
   text('');
-  for (const feature of features) {
-    const context = await resolveFeatureContext(state, invocation, feature, 'install');
-    applications.push({
-      feature,
-      targetRoot: context.targetRoot,
-      scope: context.scope,
-      auth: context.auth,
-      force: context.force,
-      attrs: context.attrs,
-    });
-  }
 
   try {
+    const removedFeatures = await integrationInstaller.removeAndRecordFeatures(
+      state,
+      integration,
+      toRemove,
+      {
+        callbacks: {
+          onFeatureRemoveStart: (feature) => {
+            text(`     Removing ${feature.displayName}...`);
+          },
+          onDependencyRemoved: (dependency) => {
+            text(`     ${dependency.displayName ?? dependency.id} removed`);
+          },
+        },
+      },
+    );
+
     const installedFeatures = await integrationInstaller.applyAndRecordFeatures(
       state,
       integration,
-      applications,
+      toInstall,
       {
         callbacks: {
           onFeatureApplyStart: (feature) => {
@@ -129,7 +133,7 @@ export async function installIntegration<TOptions>({
       },
     );
 
-    renderCompletionSummary(integration, installedFeatures);
+    renderCompletionSummary(integration, installedFeatures, removedFeatures);
 
     return saveInstalledFeatures(state) ? installedFeatures : [];
   } catch (error) {
@@ -196,43 +200,4 @@ function loadStateForInstallation(): CliState {
     logger.warn(`Failed to read configuration state: ${msg}`);
     return getDefaultState(VERSION);
   }
-}
-
-async function resolveFeatureContext<TOptions>(
-  state: CliState,
-  invocation: IntegrationInvocation<TOptions>,
-  feature: FeatureDeclaration<TOptions>,
-  executionMode: IntegrationExecutionMode,
-): Promise<IntegrationContext> {
-  return makeContext(
-    state,
-    await resolveFeatureTargetRoot(invocation, feature),
-    await resolveFeatureScope(invocation, feature),
-    executionMode,
-    invocation.auth,
-    invocation.force,
-    invocation.attrs,
-  );
-}
-
-async function resolveFeatureTargetRoot<TOptions>(
-  invocation: IntegrationInvocation<TOptions>,
-  feature: FeatureDeclaration<TOptions>,
-): Promise<string> {
-  const { targetRoot } = feature;
-  if (typeof targetRoot === 'function') {
-    return targetRoot(invocation);
-  }
-  return targetRoot ?? invocation.targetRoot;
-}
-
-async function resolveFeatureScope<TOptions>(
-  invocation: IntegrationInvocation<TOptions>,
-  feature: FeatureDeclaration<TOptions>,
-): Promise<IntegrationScope> {
-  const { scope } = feature;
-  if (typeof scope === 'function') {
-    return scope(invocation);
-  }
-  return scope ?? invocation.scope;
 }

--- a/src/cli/commands/integrate/_common/registry/installation-recorder.ts
+++ b/src/cli/commands/integrate/_common/registry/installation-recorder.ts
@@ -43,6 +43,19 @@ import type {
   SubfeatureDeclaration,
 } from './types';
 
+/** Match a recorded feature entry by its id + scope + targetRoot key. */
+function matchesFeatureKey<TOptions>(
+  entry: InstalledIntegrationFeature,
+  context: Pick<IntegrationContext, 'scope' | 'targetRoot'>,
+  feature: FeatureDeclaration<TOptions>,
+): boolean {
+  return (
+    entry.featureId === feature.id &&
+    entry.scope === context.scope &&
+    entry.targetRoot === context.targetRoot
+  );
+}
+
 export function recordInstalledFeature<TOptions>(
   state: CliState,
   context: Omit<IntegrationContext, 'state'>,
@@ -53,11 +66,8 @@ export function recordInstalledFeature<TOptions>(
 ): InstalledIntegrationFeature {
   const now = new Date().toISOString();
   const installedIntegration = upsertInstalledIntegration(state, integration, now);
-  const existing = installedIntegration.features.find(
-    (entry) =>
-      entry.featureId === feature.id &&
-      entry.scope === context.scope &&
-      entry.targetRoot === context.targetRoot,
+  const existing = installedIntegration.features.find((entry) =>
+    matchesFeatureKey(entry, context, feature),
   );
   const next: InstalledIntegrationFeature = {
     featureId: feature.id,
@@ -113,6 +123,56 @@ export function recordInstalledFeature<TOptions>(
   return existing ?? next;
 }
 
+/**
+ * Remove a recorded feature from state, matching by id + scope + targetRoot
+ * (same key as {@link recordInstalledFeature}), and drop the owning integration
+ * entry when no features remain. Prunes dependencies of the removed feature from
+ * state and returns the orphaned ones so the caller can delete their binaries.
+ */
+export function removeInstalledFeature<TOptions>(
+  state: CliState,
+  context: Pick<IntegrationContext, 'scope' | 'targetRoot'>,
+  integration: IntegrationDeclaration<TOptions>,
+  feature: FeatureDeclaration<TOptions>,
+): InstalledIntegrationDependency[] {
+  const installedIntegration = state.integrations.installed.find(
+    (entry) => entry.integrationId === integration.id,
+  );
+  if (!installedIntegration) {
+    return [];
+  }
+
+  const featureIndex = installedIntegration.features.findIndex((entry) =>
+    matchesFeatureKey(entry, context, feature),
+  );
+  if (featureIndex < 0) {
+    return [];
+  }
+
+  const [removedFeature] = installedIntegration.features.splice(featureIndex, 1);
+  const removedDependencyIds = new Set(featureDependencyIds(removedFeature));
+
+  if (installedIntegration.features.length === 0) {
+    state.integrations.installed = state.integrations.installed.filter(
+      (entry) => entry !== installedIntegration,
+    );
+  }
+
+  const stillReferenced = collectReferencedDependencyIds(state);
+  const orphanedIds = new Set([...removedDependencyIds].filter((id) => !stillReferenced.has(id)));
+  if (orphanedIds.size === 0) {
+    return [];
+  }
+
+  const orphanedDependencies = state.dependencies.installed.filter((dependency) =>
+    orphanedIds.has(dependency.id),
+  );
+  state.dependencies.installed = state.dependencies.installed.filter(
+    (dependency) => !orphanedIds.has(dependency.id),
+  );
+  return orphanedDependencies;
+}
+
 function featureDependencyIds(feature: InstalledIntegrationFeature): string[] {
   return [
     ...feature.dependencies.map((d) => d.id),
@@ -125,6 +185,26 @@ export function collectReferencedDependencyIds(state: CliState): Set<string> {
     state.integrations.installed.flatMap((integration) =>
       integration.features.flatMap(featureDependencyIds),
     ),
+  );
+}
+
+/** Find the recorded integration entry, or `undefined` if the integration has none. */
+export function findInstalledIntegration<TOptions>(
+  state: CliState,
+  integration: IntegrationDeclaration<TOptions>,
+): InstalledIntegration | undefined {
+  return state.integrations.installed.find((entry) => entry.integrationId === integration.id);
+}
+
+/** Find a recorded feature by id + scope + targetRoot, or `undefined` if not installed. */
+export function findInstalledFeature<TOptions>(
+  state: CliState,
+  context: Pick<IntegrationContext, 'scope' | 'targetRoot'>,
+  integration: IntegrationDeclaration<TOptions>,
+  feature: FeatureDeclaration<TOptions>,
+): InstalledIntegrationFeature | undefined {
+  return findInstalledIntegration(state, integration)?.features.find((entry) =>
+    matchesFeatureKey(entry, context, feature),
   );
 }
 

--- a/src/cli/commands/integrate/_common/registry/installer.ts
+++ b/src/cli/commands/integrate/_common/registry/installer.ts
@@ -18,35 +18,31 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { ResolvedAuth } from '../../../../../lib/auth-resolver';
 import type {
   CliState,
-  InstalledIntegration,
   InstalledIntegrationDependency,
   InstalledIntegrationFeature,
-  IntegrationScope,
-  IntegrationStateAttribute,
 } from '../../../../../lib/state';
-import { confirmPrompt, discreetSuccess, info } from '../../../../../ui';
-import { CommandFailedError } from '../../../_common/error';
 import type { DependencyDeclaration } from './dependencies';
-import { recordInstalledFeature } from './installation-recorder';
+import {
+  findInstalledFeature,
+  recordInstalledFeature,
+  removeInstalledFeature,
+} from './installation-recorder';
 import type { ResourceDeclaration } from './resources';
-import { isFeatureContainer, normalizeDecision } from './selection';
+import { isFeatureContainer } from './selection';
 import type {
   AppliedFeature,
   AppliedOperation,
   AppliedResource,
   ContainerIntegrationContext,
-  FeatureContainer,
+  FeatureApplication,
   FeatureDeclaration,
   FeatureOperation,
   InstalledDependency,
   IntegrationContext,
   IntegrationDeclaration,
   IntegrationExecutionMode,
-  IntegrationInvocation,
-  SubfeatureDeclaration,
 } from './types';
 
 function resolveVersion(version: string | undefined): string {
@@ -69,15 +65,6 @@ interface ApplyFeatureCallbacks<TOptions = Record<string, unknown>> {
   onResourceInstalled?: (resource: ResourceDeclaration) => void;
   onResourceSkipped?: (resource: ResourceDeclaration) => void;
   onOperationApplied?: (operation: FeatureOperation) => void;
-}
-
-export interface FeatureApplication<TOptions = Record<string, unknown>> {
-  feature: FeatureDeclaration<TOptions>;
-  targetRoot: string;
-  scope: IntegrationScope;
-  auth?: ResolvedAuth;
-  force?: boolean;
-  attrs?: Record<string, IntegrationStateAttribute>;
 }
 
 interface ApplyAndRecordFeaturesOptions<TOptions = Record<string, unknown>> {
@@ -104,132 +91,15 @@ interface UniqueDependencyExecution<TOptions = Record<string, unknown>> {
   execution: PreparedFeatureExecution<TOptions>;
 }
 
-export interface RemoveFeatureCallbacks {
+export interface RemoveFeatureCallbacks<TOptions = Record<string, unknown>> {
+  onFeatureRemoveStart?: (feature: FeatureDeclaration<TOptions>) => void;
   onResourceRemoved?: (resource: ResourceDeclaration) => void;
   onResourceSkipped?: (resource: ResourceDeclaration) => void;
   onOperationUndone?: (operation: FeatureOperation) => void;
+  onDependencyRemoved?: (dependency: DependencyDeclaration) => void;
 }
 
 export class IntegrationInstaller {
-  selectFeatures<TOptions>(
-    integration: IntegrationDeclaration<TOptions>,
-    featureIds: (string | { featureId: string; subfeatureIds: string[] })[],
-  ): FeatureDeclaration<TOptions>[] {
-    const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
-
-    return featureIds.map((entry) => {
-      const featureId = typeof entry === 'string' ? entry : entry.featureId;
-      const subfeatureIds = typeof entry === 'string' ? undefined : entry.subfeatureIds;
-
-      const feature = featuresById.get(featureId);
-      if (!feature) {
-        throw new Error(`Unknown feature ${integration.id}.${featureId}`);
-      }
-
-      if (subfeatureIds !== undefined) {
-        if (!isFeatureContainer(feature)) {
-          throw new Error(
-            `Feature ${integration.id}.${featureId} is not a container and does not support subfeature selection`,
-          );
-        }
-        const validIds = new Set(feature.subfeatures.map((s) => s.id));
-        const unknown = subfeatureIds.filter((id) => !validIds.has(id));
-        if (unknown.length > 0) {
-          const prefix = `${integration.id}.${featureId}.`;
-          throw new Error(`Unknown subfeature(s) ${unknown.map((id) => prefix + id).join(', ')}`);
-        }
-        return {
-          ...feature,
-          subfeatures: feature.subfeatures.filter((s) => subfeatureIds.includes(s.id)),
-        };
-      }
-
-      return feature;
-    });
-  }
-
-  async selectFeaturesForInvocation<TOptions>(
-    integration: IntegrationDeclaration<TOptions>,
-    invocation: IntegrationInvocation<TOptions>,
-  ): Promise<FeatureDeclaration<TOptions>[]> {
-    const selected: FeatureDeclaration<TOptions>[] = [];
-    for (let feature of integration.features) {
-      if (await this.shouldInstallFeature(feature, invocation)) {
-        if (isFeatureContainer(feature)) {
-          feature = await this.selectActiveSubfeatures(feature, invocation);
-        }
-        selected.push(feature);
-      }
-    }
-    return selected;
-  }
-
-  private async selectActiveSubfeatures<TOptions>(
-    container: FeatureContainer<TOptions>,
-    invocation: IntegrationInvocation<TOptions>,
-  ): Promise<FeatureContainer<TOptions>> {
-    const active: SubfeatureDeclaration<TOptions>[] = [];
-    for (const subfeature of container.subfeatures) {
-      if (await this.shouldInstallFeature(subfeature, invocation)) {
-        active.push(subfeature);
-      }
-    }
-    return { ...container, subfeatures: active };
-  }
-
-  private async shouldInstallFeature<TOptions>(
-    feature: FeatureDeclaration<TOptions>,
-    invocation: IntegrationInvocation<TOptions>,
-  ): Promise<boolean> {
-    const decision = normalizeDecision(await feature.shouldInstall?.(invocation));
-    switch (decision.action) {
-      case 'install':
-        if (decision.message) {
-          discreetSuccess(decision.message);
-        }
-        return true;
-      case 'skip':
-        if (decision.message) {
-          info(decision.message);
-        }
-        return false;
-      case 'ask': {
-        if (invocation.nonInteractive) {
-          return true;
-        }
-        const confirmed = await confirmPrompt(
-          decision.question ?? `Install ${feature.displayName}?`,
-          true,
-        );
-        if (confirmed === null) {
-          throw new CommandFailedError('Installation cancelled');
-        }
-        return confirmed;
-      }
-    }
-  }
-
-  findInstalledFeature<TOptions>(
-    state: CliState,
-    context: Omit<IntegrationContext, 'state'>,
-    integration: IntegrationDeclaration<TOptions>,
-    feature: FeatureDeclaration<TOptions>,
-  ): InstalledIntegrationFeature | undefined {
-    return this.findInstalledIntegration(state, integration)?.features.find(
-      (entry) =>
-        entry.featureId === feature.id &&
-        entry.scope === context.scope &&
-        entry.targetRoot === context.targetRoot,
-    );
-  }
-
-  findInstalledIntegration<TOptions>(
-    state: CliState,
-    integration: IntegrationDeclaration<TOptions>,
-  ): InstalledIntegration | undefined {
-    return state.integrations.installed.find((entry) => entry.integrationId === integration.id);
-  }
-
   findInstalledDependency(
     state: CliState,
     dependency: DependencyDeclaration,
@@ -368,7 +238,7 @@ export class IntegrationInstaller {
   async removeFeature<TOptions>(
     context: IntegrationContext,
     feature: FeatureDeclaration<TOptions>,
-    callbacks: RemoveFeatureCallbacks = {},
+    callbacks: RemoveFeatureCallbacks<TOptions> = {},
   ): Promise<void> {
     for (const resource of feature.resources ?? []) {
       await resource.remove(context);
@@ -385,6 +255,43 @@ export class IntegrationInstaller {
         callbacks.onOperationUndone?.(operation);
       }
     }
+  }
+
+  /**
+   * Remove the given features and update state: tear down each feature's
+   * resources/operations, prune the recorded state entries, and uninstall any
+   * binary dependency that becomes orphaned. Returns the removed feature
+   * declarations.
+   */
+  async removeAndRecordFeatures<TOptions>(
+    state: CliState,
+    integration: IntegrationDeclaration<TOptions>,
+    applications: FeatureApplication<TOptions>[],
+    options: { callbacks?: RemoveFeatureCallbacks<TOptions> } = {},
+  ): Promise<FeatureDeclaration<TOptions>[]> {
+    const removed: FeatureDeclaration<TOptions>[] = [];
+
+    for (const application of applications) {
+      const feature = application.feature;
+      const context = this.contextForApplication(state, application, 'install');
+
+      options.callbacks?.onFeatureRemoveStart?.(feature);
+      await this.removeFeature(context, feature, options.callbacks ?? {});
+
+      const orphanedDependencies = removeInstalledFeature(state, context, integration, feature);
+      const declaredDependencies = resolveAllDeps(feature);
+      for (const orphaned of orphanedDependencies) {
+        const declaration = declaredDependencies.find((dep) => dep.id === orphaned.id);
+        if (declaration) {
+          await declaration.remove(context);
+          options.callbacks?.onDependencyRemoved?.(declaration);
+        }
+      }
+
+      removed.push(feature);
+    }
+
+    return removed;
   }
 
   private async prepareUniqueDependencies<TOptions>(
@@ -519,27 +426,30 @@ export class IntegrationInstaller {
     executionMode: IntegrationExecutionMode,
   ): PreparedFeatureExecution<TOptions>[] {
     return applications.map((application) => {
-      const context: IntegrationContext = {
-        state,
-        targetRoot: application.targetRoot,
-        scope: application.scope,
-        executionMode,
-        auth: application.auth,
-        force: application.force,
-        attrs: application.attrs,
-        resolvedDependencies: new Map(),
-      };
+      const context = this.contextForApplication(state, application, executionMode);
       return {
         application,
         context,
-        installedFeature: this.findInstalledFeature(
-          state,
-          context,
-          integration,
-          application.feature,
-        ),
+        installedFeature: findInstalledFeature(state, context, integration, application.feature),
       };
     });
+  }
+
+  private contextForApplication<TOptions>(
+    state: CliState,
+    application: FeatureApplication<TOptions>,
+    executionMode: IntegrationExecutionMode,
+  ): IntegrationContext {
+    return {
+      state,
+      targetRoot: application.targetRoot,
+      scope: application.scope,
+      executionMode,
+      auth: application.auth,
+      force: application.force,
+      attrs: application.attrs,
+      resolvedDependencies: new Map(),
+    };
   }
 
   private collectUniqueDependencies<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -84,56 +84,6 @@ export function isFeatureContainer<TOptions>(
 }
 
 /**
- * Explicit feature selection by id (non-interactive path), picking from the
- * pre-resolved `applications`.
- *
- * This path is currently unused.
- */
-export function selectFeatures<TOptions>(
-  integration: IntegrationDeclaration<TOptions>,
-  applications: FeatureApplication<TOptions>[],
-  featureIds: (string | { featureId: string; subfeatureIds: string[] })[],
-): FeatureSelectionResult<TOptions> {
-  const applicationsById = new Map(applications.map((app) => [app.feature.id, app]));
-
-  const toInstall = featureIds.map((entry) => {
-    const featureId = typeof entry === 'string' ? entry : entry.featureId;
-    const subfeatureIds = typeof entry === 'string' ? undefined : entry.subfeatureIds;
-
-    const application = applicationsById.get(featureId);
-    if (!application) {
-      throw new Error(`Unknown feature ${integration.id}.${featureId}`);
-    }
-
-    if (subfeatureIds !== undefined) {
-      const feature = application.feature;
-      if (!isFeatureContainer(feature)) {
-        throw new Error(
-          `Feature ${integration.id}.${featureId} is not a container and does not support subfeature selection`,
-        );
-      }
-      const validIds = new Set(feature.subfeatures.map((s) => s.id));
-      const unknown = subfeatureIds.filter((id) => !validIds.has(id));
-      if (unknown.length > 0) {
-        const prefix = `${integration.id}.${featureId}.`;
-        throw new Error(`Unknown subfeature(s) ${unknown.map((id) => prefix + id).join(', ')}`);
-      }
-      return {
-        ...application,
-        feature: {
-          ...feature,
-          subfeatures: feature.subfeatures.filter((s) => subfeatureIds.includes(s.id)),
-        },
-      };
-    }
-
-    return application;
-  });
-
-  return { toInstall, toRemove: [] };
-}
-
-/**
  * Interactive feature selection over the pre-resolved `applications`.
  */
 export async function selectFeaturesForInvocation<TOptions>(

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -18,7 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { confirmPrompt, discreetSuccess, info, warn } from '../../../../../ui';
+import { confirmPrompt, discreetSuccess, info, text } from '../../../../../ui';
+import { yellow } from '../../../../../ui/colors.js';
 import { CommandFailedError } from '../../../_common/error';
 import { findInstalledFeature } from './installation-recorder';
 import type {
@@ -191,12 +192,24 @@ async function shouldRemoveInstalledFeature<TOptions>(
     return false;
   }
 
-  warn(`${feature.displayName} will be removed.`);
+  warnFeatureRemoval(`${feature.displayName} will be removed.`);
   const proceed = await confirmPrompt('Proceed with removal?', true);
   if (proceed === null) {
     throw new CommandFailedError('Installation cancelled');
   }
   return proceed;
+}
+
+/**
+ * One-off, local to the keep/remove flow — not a shared `prompts.ts` primitive.
+ * The generic `warn()` writes `⚠️ <msg>` to stderr at column 0 with a
+ * double-width emoji, so it juts left of the clack prompts that bracket it
+ * (`Keep?` / `Proceed with removal?`). We instead reproduce the prompt gutter:
+ * `  <glyph>  <message>` on stdout, with a single-width `⚠` (U+26A0, no VS16 —
+ * the emoji is double-width and shifts the text a column).
+ */
+function warnFeatureRemoval(message: string): void {
+  text(`  ${yellow('⚠')}  ${message}`);
 }
 
 /**

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -18,7 +18,18 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { FeatureContainer, FeatureDeclaration } from './types';
+import { confirmPrompt, discreetSuccess, info, warn } from '../../../../../ui';
+import { CommandFailedError } from '../../../_common/error';
+import { findInstalledFeature } from './installation-recorder';
+import type {
+  FeatureApplication,
+  FeatureContainer,
+  FeatureDeclaration,
+  FeatureSelectionResult,
+  IntegrationDeclaration,
+  IntegrationInvocation,
+  SubfeatureDeclaration,
+} from './types';
 
 /**
  * Outcome of a feature's `shouldInstall` evaluation. Integrations declare the
@@ -69,4 +80,181 @@ export function isFeatureContainer<TOptions>(
   feature: FeatureDeclaration<TOptions>,
 ): feature is FeatureContainer<TOptions> {
   return 'subfeatures' in feature;
+}
+
+/**
+ * Explicit feature selection by id (non-interactive path), picking from the
+ * pre-resolved `applications`.
+ *
+ * This path is currently unused.
+ */
+export function selectFeatures<TOptions>(
+  integration: IntegrationDeclaration<TOptions>,
+  applications: FeatureApplication<TOptions>[],
+  featureIds: (string | { featureId: string; subfeatureIds: string[] })[],
+): FeatureSelectionResult<TOptions> {
+  const applicationsById = new Map(applications.map((app) => [app.feature.id, app]));
+
+  const toInstall = featureIds.map((entry) => {
+    const featureId = typeof entry === 'string' ? entry : entry.featureId;
+    const subfeatureIds = typeof entry === 'string' ? undefined : entry.subfeatureIds;
+
+    const application = applicationsById.get(featureId);
+    if (!application) {
+      throw new Error(`Unknown feature ${integration.id}.${featureId}`);
+    }
+
+    if (subfeatureIds !== undefined) {
+      const feature = application.feature;
+      if (!isFeatureContainer(feature)) {
+        throw new Error(
+          `Feature ${integration.id}.${featureId} is not a container and does not support subfeature selection`,
+        );
+      }
+      const validIds = new Set(feature.subfeatures.map((s) => s.id));
+      const unknown = subfeatureIds.filter((id) => !validIds.has(id));
+      if (unknown.length > 0) {
+        const prefix = `${integration.id}.${featureId}.`;
+        throw new Error(`Unknown subfeature(s) ${unknown.map((id) => prefix + id).join(', ')}`);
+      }
+      return {
+        ...application,
+        feature: {
+          ...feature,
+          subfeatures: feature.subfeatures.filter((s) => subfeatureIds.includes(s.id)),
+        },
+      };
+    }
+
+    return application;
+  });
+
+  return { toInstall, toRemove: [] };
+}
+
+/**
+ * Interactive feature selection over the pre-resolved `applications`.
+ */
+export async function selectFeaturesForInvocation<TOptions>(
+  integration: IntegrationDeclaration<TOptions>,
+  invocation: IntegrationInvocation<TOptions>,
+  applications: FeatureApplication<TOptions>[],
+): Promise<FeatureSelectionResult<TOptions>> {
+  const toInstall: FeatureApplication<TOptions>[] = [];
+  const toRemove: FeatureApplication<TOptions>[] = [];
+
+  for (const application of applications) {
+    const feature = application.feature;
+    if (isFeatureInstalled(integration, invocation, application)) {
+      if (await shouldRemoveInstalledFeature(feature, invocation)) {
+        toRemove.push(application);
+      } else {
+        toInstall.push(await materializeApplication(application, invocation));
+      }
+    } else if (await shouldInstallFeature(feature, invocation)) {
+      toInstall.push(await materializeApplication(application, invocation));
+    }
+  }
+
+  return { toInstall, toRemove };
+}
+
+function isFeatureInstalled<TOptions>(
+  integration: IntegrationDeclaration<TOptions>,
+  invocation: IntegrationInvocation<TOptions>,
+  application: FeatureApplication<TOptions>,
+): boolean {
+  return (
+    findInstalledFeature(invocation.state, application, integration, application.feature) !==
+    undefined
+  );
+}
+
+/**
+ * Decide whether to uninstall an already-installed feature. Prompts `Keep?`
+ * (default Yes); declining asks for a removal confirmation (default Yes).
+ * Returns true only when the user confirms removal.
+ */
+async function shouldRemoveInstalledFeature<TOptions>(
+  feature: FeatureDeclaration<TOptions>,
+  invocation: IntegrationInvocation<TOptions>,
+): Promise<boolean> {
+  if (invocation.nonInteractive) {
+    return false;
+  }
+
+  const keep = await confirmPrompt(`${feature.displayName} (currently installed)  Keep?`, true);
+  if (keep === null) {
+    throw new CommandFailedError('Installation cancelled');
+  }
+  if (keep) {
+    return false;
+  }
+
+  warn(`${feature.displayName} will be removed.`);
+  const proceed = await confirmPrompt('Proceed with removal?', true);
+  if (proceed === null) {
+    throw new CommandFailedError('Installation cancelled');
+  }
+  return proceed;
+}
+
+/**
+ * For a container application, narrow its subfeatures to those whose
+ * `shouldInstall` is active; non-container applications are returned unchanged.
+ */
+async function materializeApplication<TOptions>(
+  application: FeatureApplication<TOptions>,
+  invocation: IntegrationInvocation<TOptions>,
+): Promise<FeatureApplication<TOptions>> {
+  const feature = application.feature;
+  if (!isFeatureContainer(feature)) {
+    return application;
+  }
+  return { ...application, feature: await selectActiveSubfeatures(feature, invocation) };
+}
+
+async function selectActiveSubfeatures<TOptions>(
+  container: FeatureContainer<TOptions>,
+  invocation: IntegrationInvocation<TOptions>,
+): Promise<FeatureContainer<TOptions>> {
+  const active: SubfeatureDeclaration<TOptions>[] = [];
+  for (const subfeature of container.subfeatures) {
+    if (await shouldInstallFeature(subfeature, invocation)) {
+      active.push(subfeature);
+    }
+  }
+  return { ...container, subfeatures: active };
+}
+
+async function shouldInstallFeature<TOptions>(
+  feature: FeatureDeclaration<TOptions>,
+  invocation: IntegrationInvocation<TOptions>,
+): Promise<boolean> {
+  const decision = normalizeDecision(await feature.shouldInstall?.(invocation));
+  switch (decision.action) {
+    case 'install':
+      if (decision.message) {
+        discreetSuccess(decision.message);
+      }
+      return true;
+    case 'skip':
+      if (decision.message) {
+        info(decision.message);
+      }
+      return false;
+    case 'ask': {
+      if (invocation.nonInteractive) {
+        return true;
+      }
+      const confirmed = await confirmPrompt(
+        decision.question ?? `Install ${feature.displayName}?`,
+        true,
+      );
+      if (confirmed === null) {
+        throw new CommandFailedError('Installation cancelled');
+      }
+      return confirmed;
+    }
+  }
 }

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -90,6 +90,24 @@ export interface PostInstallExample {
   footer?: string;
 }
 
+/**
+ * A feature paired with its resolved per-invocation execution context (target
+ * root, scope, auth, …).
+ */
+export interface FeatureApplication<TOptions = Record<string, unknown>> {
+  feature: FeatureDeclaration<TOptions>;
+  targetRoot: string;
+  scope: IntegrationScope;
+  auth?: ResolvedAuth;
+  force?: boolean;
+  attrs?: Record<string, IntegrationStateAttribute>;
+}
+
+export interface FeatureSelectionResult<TOptions = Record<string, unknown>> {
+  toInstall: FeatureApplication<TOptions>[];
+  toRemove: FeatureApplication<TOptions>[];
+}
+
 export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
   id: string;
   displayName: string;

--- a/src/lib/post-update.ts
+++ b/src/lib/post-update.ts
@@ -28,6 +28,7 @@ import { installSecretsBinary } from '../cli/commands/_common/install/secrets';
 import { supportedIntegrations } from '../cli/commands/integrate';
 import {
   type FeatureDeclaration,
+  findInstalledIntegration,
   integrationInstaller,
   type IntegrationRegistry,
   isFeatureContainer,
@@ -96,7 +97,7 @@ export async function migrateDeclarativeIntegrations(
   let stateChanged = false;
 
   for (const integration of registry.list()) {
-    const installedIntegration = integrationInstaller.findInstalledIntegration(state, integration);
+    const installedIntegration = findInstalledIntegration(state, integration);
     if (!installedIntegration) {
       continue;
     }

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -28,6 +28,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { version as CURRENT_VERSION } from '../../../../package.json';
 import { buildLocalBinaryName } from '../../../../src/cli/commands/_common/install/secrets.js';
+import { claudeIntegration } from '../../../../src/cli/commands/integrate/claude/declaration.js';
 import { detectPlatform } from '../../../../src/lib/platform-detector.js';
 import {
   hookScriptName,
@@ -36,7 +37,7 @@ import {
   normalizePath,
   TestHarness,
 } from '../../harness';
-import { findInstalledFeature } from './state-helpers';
+import { findInstalledFeature, getInstalledIntegration } from './state-helpers';
 
 function findClaudeFeature(harness: TestHarness, featureId: string, scope?: string) {
   return findInstalledFeature(harness, 'claude-code', featureId, scope);
@@ -2142,6 +2143,238 @@ describe('integrate claude — interactive feature selection', () => {
       expect(output).toContain('Could not determine SonarQube Agentic Analysis entitlement');
       expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
       expect(findClaudeFeature(harness, 'sonar-sqaa-hook')).toBeUndefined();
+    },
+    { timeout: 30000 },
+  );
+});
+
+// ─── Keep / remove already-installed features on re-run ───────────────────────
+
+describe('integrate claude — keep/remove already-installed features', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+    harness.state().withSecretsBinaryInstalled();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  function seedInstalledFeatures(): void {
+    harness
+      .state()
+      .withInstalledIntegrationFeature(
+        claudeIntegration,
+        'sonar-secrets-hooks',
+        'project',
+        harness.cwd.path,
+      )
+      .withInstalledIntegrationFeature(
+        claudeIntegration,
+        'mcp-server',
+        'project',
+        harness.cwd.path,
+      );
+  }
+
+  it(
+    'offers "Keep?" for installed features and uninstalls the one the user declines',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
+      harness.withAuth(server.baseUrl(), 'tok');
+      seedInstalledFeatures();
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+      );
+
+      // Project scope, keep the hooks (default Yes), decline the MCP server ('n')
+      // then confirm removal (default Yes).
+      const result = await harness.run('integrate claude', {
+        stdinChunks: ['\r', '\r', 'n', '\r'],
+      });
+
+      expect(result.exitCode).toBe(0);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(output).toContain('MCP server (currently installed)  Keep?');
+      expect(output).toContain('Proceed with removal?');
+      expect(output).toContain('Removing MCP server');
+      expect(output).toContain('Removed');
+
+      // MCP server is gone from state; the kept secret scanning hooks remain.
+      expect(findClaudeFeature(harness, 'mcp-server')).toBeUndefined();
+      expect(findClaudeFeature(harness, 'sonar-secrets-hooks')).toBeDefined();
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'keeps an installed feature untouched when the user declines removal',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
+      harness.withAuth(server.baseUrl(), 'tok');
+      seedInstalledFeatures();
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+      );
+
+      // Project scope, keep the hooks, decline MCP keep ('n') then decline removal ('n').
+      const result = await harness.run('integrate claude', {
+        stdinChunks: ['\r', '\r', 'n', 'n'],
+      });
+
+      expect(result.exitCode).toBe(0);
+      // Declining removal leaves the MCP server installed.
+      expect(findClaudeFeature(harness, 'mcp-server')).toBeDefined();
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'uninstalls the sonar-secrets binary when the removed feature was its last referrer',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
+      harness.withAuth(server.baseUrl(), 'tok');
+      seedInstalledFeatures();
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+      );
+
+      // Project scope, decline keeping the secrets hooks ('n') then confirm removal
+      // (default Yes); keep the MCP server (default Yes). No other feature references
+      // sonar-secrets, so the binary is orphaned and uninstalled.
+      const result = await harness.run('integrate claude', {
+        stdinChunks: ['\r', 'n', '\r', '\r'],
+      });
+
+      expect(result.exitCode).toBe(0);
+      const output = `${result.stdout}\n${result.stderr}`;
+      expect(output).toContain('secret scanning hooks (currently installed)  Keep?');
+      expect(output).toContain('secret scanning hooks will be removed.');
+
+      // The feature is gone and, being the last referrer, so is the binary.
+      expect(findClaudeFeature(harness, 'sonar-secrets-hooks')).toBeUndefined();
+      const state = harness.stateJsonFile.asJson();
+      expect(
+        state.dependencies.installed.find((dep: { id: string }) => dep.id === 'sonar-secrets'),
+      ).toBeUndefined();
+      expect(harness.cliHome.file('bin', buildLocalBinaryName(detectPlatform())).exists()).toBe(
+        false,
+      );
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'keeps the sonar-secrets binary when another project still references it',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
+      harness.withAuth(server.baseUrl(), 'tok');
+      seedInstalledFeatures();
+      // A second project on this machine also has the secrets hooks installed, so it
+      // shares the same sonar-secrets binary.
+      harness
+        .state()
+        .withInstalledIntegrationFeature(
+          claudeIntegration,
+          'sonar-secrets-hooks',
+          'project',
+          `${harness.cwd.path}-other-project`,
+        );
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+      );
+
+      // Project scope, decline keeping this project's secrets hooks ('n') then confirm
+      // removal (default Yes); keep the MCP server (default Yes).
+      const result = await harness.run('integrate claude', {
+        stdinChunks: ['\r', 'n', '\r', '\r'],
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // This project's feature is removed, but the other project's entry survives, so
+      // the binary is neither pruned from state nor deleted from disk.
+      const state = harness.stateJsonFile.asJson();
+      const claude = state.integrations.installed.find(
+        (integration: { integrationId: string }) => integration.integrationId === 'claude-code',
+      );
+      const remainingSecretsHooks = claude.features.filter(
+        (feature: { featureId: string }) => feature.featureId === 'sonar-secrets-hooks',
+      );
+      expect(remainingSecretsHooks).toHaveLength(1);
+      expect(remainingSecretsHooks[0].targetRoot).toBe(`${harness.cwd.path}-other-project`);
+      expect(
+        state.dependencies.installed.find((dep: { id: string }) => dep.id === 'sonar-secrets'),
+      ).toBeDefined();
+      expect(harness.cliHome.file('bin', buildLocalBinaryName(detectPlatform())).exists()).toBe(
+        true,
+      );
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'keeps installed features without prompting or removing in non-interactive mode',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
+      harness.withAuth(server.baseUrl(), 'tok');
+      seedInstalledFeatures();
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+      );
+
+      const result = await harness.run('integrate claude --non-interactive');
+
+      expect(result.exitCode).toBe(0);
+      const output = `${result.stdout}\n${result.stderr}`;
+      // Non-interactive runs never offer keep/remove and never uninstall.
+      expect(output).not.toContain('Keep?');
+      expect(output).not.toContain('will be removed.');
+      expect(output).not.toContain('Removing');
+
+      // Both installed features survive untouched.
+      expect(findClaudeFeature(harness, 'sonar-secrets-hooks')).toBeDefined();
+      expect(findClaudeFeature(harness, 'mcp-server')).toBeDefined();
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'drops the integration entry from state when its last feature is removed',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
+      harness.withAuth(server.baseUrl(), 'tok');
+      seedInstalledFeatures();
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+      );
+
+      // Project scope, then decline + confirm removal for both installed features
+      // (secret scanning hooks, then MCP server). No feature remains afterwards.
+      const result = await harness.run('integrate claude', {
+        stdinChunks: ['\r', 'n', '\r', 'n', '\r'],
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // With no features left, the whole claude-code integration entry is pruned,
+      // and the orphaned sonar-secrets binary is uninstalled with it.
+      expect(getInstalledIntegration(harness, 'claude-code')).toBeUndefined();
+      const state = harness.stateJsonFile.asJson();
+      expect(
+        state.dependencies.installed.find((dep: { id: string }) => dep.id === 'sonar-secrets'),
+      ).toBeUndefined();
+      expect(harness.cliHome.file('bin', buildLocalBinaryName(detectPlatform())).exists()).toBe(
+        false,
+      );
     },
     { timeout: 30000 },
   );

--- a/tests/unit/cli/commands/_common/install/binary.test.ts
+++ b/tests/unit/cli/commands/_common/install/binary.test.ts
@@ -18,12 +18,18 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import {
   type BinarySpec,
   buildLocalBinaryName,
+  removeBinary,
 } from '../../../../../../src/cli/commands/_common/install/binary.js';
+import { detectPlatform } from '../../../../../../src/lib/platform-detector.js';
 
 const baseSpec: Omit<BinarySpec, 'name' | 'version'> = {
   distPrefix: 'CommercialDistribution/whatever',
@@ -46,5 +52,30 @@ describe('buildLocalBinaryName', () => {
       { os: 'windows', arch: 'x86-64', extension: '.exe' },
     );
     expect(name).toBe('sonar-secrets-1.2.3-windows-x86-64.exe');
+  });
+});
+
+describe('removeBinary', () => {
+  const spec: BinarySpec = { ...baseSpec, name: 'sonar-secrets', version: '1.2.3' };
+  let binDir: string;
+
+  beforeEach(() => {
+    binDir = mkdtempSync(join(tmpdir(), 'sonar-cli-bin-'));
+  });
+
+  afterEach(() => {
+    rmSync(binDir, { recursive: true, force: true });
+  });
+
+  it('deletes the cached binary and reports it removed', () => {
+    const binaryPath = join(binDir, buildLocalBinaryName(spec, detectPlatform()));
+    writeFileSync(binaryPath, 'binary');
+
+    expect(removeBinary(spec, binDir)).toBe(true);
+    expect(existsSync(binaryPath)).toBe(false);
+  });
+
+  it('is a no-op when the binary is absent', () => {
+    expect(removeBinary(spec, binDir)).toBe(false);
   });
 });

--- a/tests/unit/cli/commands/integrate/_common/completion-summary.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/completion-summary.test.ts
@@ -58,19 +58,23 @@ function renderWithResourcePath(path: string): string[] {
     features: [{ id: 'a', displayName: 'Feature A' }],
   };
 
-  renderCompletionSummary(integration, [
-    installedFeature('a', {
-      resources: [
-        {
-          id: 'r1',
-          resourceType: 'whole-file',
-          path,
-          updatedByCliVersion: 'test',
-          updatedAt: '2026-01-01T00:00:00.000Z',
-        },
-      ],
-    }),
-  ]);
+  renderCompletionSummary(
+    integration,
+    [
+      installedFeature('a', {
+        resources: [
+          {
+            id: 'r1',
+            resourceType: 'whole-file',
+            path,
+            updatedByCliVersion: 'test',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      }),
+    ],
+    [],
+  );
 
   const phaseCall = getMockUiCalls().find((c) => c.method === 'phase' && c.args[0] === 'Installed');
   const items = (phaseCall?.args[1] ?? []) as PhaseItem[];
@@ -94,7 +98,7 @@ describe('renderCompletionSummary', () => {
       features: [{ id: 'a', displayName: 'Feature A' }],
     };
 
-    renderCompletionSummary(integration, []);
+    renderCompletionSummary(integration, [], []);
 
     expect(getMockUiCalls()).toHaveLength(0);
   });
@@ -109,20 +113,24 @@ describe('renderCompletionSummary', () => {
       ],
     };
 
-    renderCompletionSummary(integration, [
-      installedFeature('a', {
-        resources: [
-          {
-            id: 'r1',
-            resourceType: 'whole-file',
-            path: '/tmp/project/.sonar/hook.sh',
-            updatedByCliVersion: 'test',
-            updatedAt: '2026-01-01T00:00:00.000Z',
-          },
-        ],
-      }),
-      installedFeature('b'),
-    ]);
+    renderCompletionSummary(
+      integration,
+      [
+        installedFeature('a', {
+          resources: [
+            {
+              id: 'r1',
+              resourceType: 'whole-file',
+              path: '/tmp/project/.sonar/hook.sh',
+              updatedByCliVersion: 'test',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+        installedFeature('b'),
+      ],
+      [],
+    );
 
     const phaseCall = getMockUiCalls().find(
       (c) => c.method === 'phase' && c.args[0] === 'Installed',
@@ -135,6 +143,26 @@ describe('renderCompletionSummary', () => {
     const outroCall = getMockUiCalls().find((c) => c.method === 'outro');
     expect(outroCall?.args[0]).toBe('Setup complete!');
     expect(outroCall?.args[1]).toBe('success');
+  });
+
+  it('renders a Removed list for uninstalled features', () => {
+    const integration: IntegrationDeclaration = {
+      id: 'test',
+      displayName: 'Test',
+      features: [
+        { id: 'a', displayName: 'Feature A' },
+        { id: 'b', displayName: 'Feature B' },
+      ],
+    };
+
+    renderCompletionSummary(integration, [installedFeature('a')], [integration.features[1]]);
+
+    const removedPhase = getMockUiCalls().find(
+      (c) => c.method === 'phase' && c.args[0] === 'Removed',
+    );
+    const items = (removedPhase?.args[1] ?? []) as PhaseItem[];
+    expect(items.map((item) => item.text)).toEqual(['Feature B']);
+    expect(getMockUiCalls().find((c) => c.method === 'outro')?.args[0]).toBe('Setup complete!');
   });
 
   it('abbreviates the home directory with ~ only on a path boundary', () => {
@@ -159,7 +187,7 @@ describe('renderCompletionSummary', () => {
       features: [],
     };
 
-    expect(() => renderCompletionSummary(integration, [installedFeature('orphan')])).toThrow(
+    expect(() => renderCompletionSummary(integration, [installedFeature('orphan')], [])).toThrow(
       'No declaration found for installed feature test.orphan',
     );
   });
@@ -182,7 +210,7 @@ describe('renderCompletionSummary', () => {
       ],
     };
 
-    renderCompletionSummary(integration, [installedFeature('a')]);
+    renderCompletionSummary(integration, [installedFeature('a')], []);
 
     const calls = getMockUiCalls();
     expect(
@@ -207,7 +235,7 @@ describe('renderCompletionSummary', () => {
           : undefined,
     };
 
-    renderCompletionSummary(integration, [installedFeature('a'), installedFeature('b')]);
+    renderCompletionSummary(integration, [installedFeature('a'), installedFeature('b')], []);
 
     const notes = getMockUiCalls().filter((c) => c.method === 'note');
     expect(notes).toHaveLength(1);
@@ -226,7 +254,7 @@ describe('renderCompletionSummary', () => {
       combinedPostInstallExample: () => undefined,
     };
 
-    renderCompletionSummary(integration, [installedFeature('a'), installedFeature('b')]);
+    renderCompletionSummary(integration, [installedFeature('a'), installedFeature('b')], []);
 
     const noteBodies = getMockUiCalls()
       .filter((c) => c.method === 'note')

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -170,54 +170,6 @@ describe('generic integration installer', () => {
     expect(await readFile(join(projectRoot, 'project.txt'), 'utf-8')).toBe('project\n');
   });
 
-  it('supports explicit feature selection independently of the feature predicates', async () => {
-    const integration = registerIntegration<{ installMain?: boolean }>(
-      registry,
-      'installer-feature-selection',
-      [
-        {
-          id: 'main',
-          displayName: 'Main feature',
-          shouldInstall: ({ options }) => options.installMain === true,
-          resources: [
-            wholeFile({
-              id: 'main-file',
-              displayName: 'Main file',
-              targetPath: join(tempDir, 'main.txt'),
-              content: 'main\n',
-            }),
-          ],
-        },
-        {
-          id: 'context-skill',
-          displayName: 'Context skill',
-          shouldInstall: () => false,
-          resources: [
-            wholeFile({
-              id: 'skill-file',
-              displayName: 'Skill file',
-              targetPath: join(tempDir, 'skill.txt'),
-              content: 'skill\n',
-            }),
-          ],
-        },
-      ],
-    );
-
-    const installed = await installIntegration({
-      registry,
-      integrationId: integration.id,
-      options: {},
-      targetRoot: tempDir,
-      scope: 'project',
-      featureIds: ['context-skill'],
-    });
-
-    expect(installed).toMatchObject([{ featureId: 'context-skill' }]);
-    expect(await readFile(join(tempDir, 'skill.txt'), 'utf-8')).toBe('skill\n');
-    expect(await Bun.file(join(tempDir, 'main.txt')).exists()).toBe(false);
-  });
-
   it('passes resolved dependency metadata to feature resources after dependency installation', async () => {
     const state = getDefaultState('test');
     loadStateSpy.mockReturnValue(state);

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -232,6 +232,7 @@ describe('generic integration installer', () => {
         path: '/opt/sonar/shared-binary',
       }),
       isInstalled: () => false,
+      remove: () => {},
     };
     const integration = registerIntegration(registry, 'installer-resolved-dependency', [
       {
@@ -358,6 +359,7 @@ describe('generic integration installer', () => {
         path: '/opt/sonar/unnamed-binary',
       }),
       isInstalled: () => true,
+      remove: () => {},
     };
     const integration = registerIntegration(registry, 'installer-skip-unnamed-dependency', [
       {

--- a/tests/unit/cli/commands/integrate/_common/registry-resources.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry-resources.test.ts
@@ -47,6 +47,8 @@ const {
   textSnippet,
   wholeFile,
 } = await import('../../../../../../src/cli/commands/integrate/_common/registry');
+const { removeInstalledFeature } =
+  await import('../../../../../../src/cli/commands/integrate/_common/registry/installation-recorder');
 
 type Installer = InstanceType<typeof IntegrationInstaller>;
 
@@ -516,6 +518,34 @@ describe('declarative integration framework - resources and state recording', ()
     expect(
       installer.operationNeedsApply(installed, { ...feature.operations![0], version: '2' }),
     ).toBe(true);
+  });
+
+  it('removeInstalledFeature returns [] without mutation when the integration is not recorded', () => {
+    const integration = makeIntegration();
+    const state = getDefaultState('test');
+
+    const removed = removeInstalledFeature(
+      state,
+      { scope: 'project', targetRoot: tempDir },
+      integration,
+      integration.features[0],
+    );
+
+    expect(removed).toEqual([]);
+    expect(state.integrations.installed).toEqual([]);
+  });
+
+  it('removeInstalledFeature returns [] and leaves other features intact when the target feature is not recorded', async () => {
+    const integration = makeIntegration();
+    const state = getDefaultState('test');
+    const context = makeContext(state, tempDir);
+    // Record a different feature; the one we ask to remove was never installed.
+    await applyAndRecord(installer, context, integration, { id: 'other', displayName: 'Other' });
+
+    const removed = removeInstalledFeature(state, context, integration, integration.features[0]);
+
+    expect(removed).toEqual([]);
+    expect(state.integrations.installed[0]?.features.map((f) => f.featureId)).toEqual(['other']);
   });
 });
 

--- a/tests/unit/cli/commands/integrate/_common/registry-resources.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry-resources.test.ts
@@ -38,6 +38,7 @@ await mock.module('../../../../../../src/cli/commands/_common/install/binary', (
 }));
 
 const {
+  findInstalledFeature,
   IntegrationInstaller,
   jsonPatch,
   textSnippetRemover,
@@ -469,7 +470,7 @@ describe('declarative integration framework - resources and state recording', ()
     ).toBe(true);
 
     const installed = await applyAndRecord(installer, context, integration, feature);
-    const found = installer.findInstalledFeature(state, context, integration, feature);
+    const found = findInstalledFeature(state, context, integration, feature);
     resolveBinaryPathSpy.mockReturnValue(join(tempDir, 'bin', 'sonar-secrets'));
 
     expect(found?.featureId).toBe(installed.featureId);

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -50,7 +50,6 @@ const {
   IntegrationRegistry,
   isFeatureContainer,
   jsonPatch,
-  selectFeatures,
   selectFeaturesForInvocation,
   skip,
   SonarSourceBinary,
@@ -71,14 +70,6 @@ async function selectForInvocation<TOptions>(
 ) {
   const applications = await buildApplications(invocation, integration.features);
   return selectFeaturesForInvocation(integration, invocation, applications);
-}
-
-/** Resolve an integration's features into applications for the by-id selectFeatures tests. */
-function applicationsFor<TOptions>(integration: IntegrationDeclaration<TOptions>) {
-  return buildApplications(
-    { options: {} as TOptions, targetRoot: '', scope: 'project', state: getDefaultState('test') },
-    integration.features,
-  );
 }
 
 const { findMockUiCall, getMockUiCalls, queueMockResponse, setMockUi } =
@@ -598,76 +589,6 @@ describe('declarative integration framework', () => {
     expect(registry.get('first')).toBe(first);
     expect(registry.get('missing')).toBeUndefined();
     expect(registry.list()).toEqual([first, second]);
-  });
-
-  it('selects declared features and rejects unknown feature ids', async () => {
-    const integration = makeIntegration({
-      features: [
-        { id: 'one', displayName: 'One' },
-        { id: 'two', displayName: 'Two' },
-      ],
-    });
-    const applications = await applicationsFor(integration);
-
-    expect(
-      selectFeatures(integration, applications, ['two', 'one']).toInstall.map(
-        (application) => application.feature.id,
-      ),
-    ).toEqual(['two', 'one']);
-    expect(() => selectFeatures(integration, applications, ['missing'])).toThrow(
-      'Unknown feature test-integration.missing',
-    );
-  });
-
-  it('selectFeatures filters container subfeatures to the requested ids', async () => {
-    const container: FeatureContainer = {
-      id: 'container',
-      displayName: 'Container',
-      subfeatures: [
-        { id: 'sub-a', displayName: 'Sub A' },
-        { id: 'sub-b', displayName: 'Sub B' },
-        { id: 'sub-c', displayName: 'Sub C' },
-      ],
-      defaultInstallSubfeatureIds: [],
-    };
-    const integration = makeIntegration({ features: [container] });
-    const applications = await applicationsFor(integration);
-
-    const [selected] = selectFeatures(integration, applications, [
-      { featureId: 'container', subfeatureIds: ['sub-c', 'sub-a'] },
-    ]).toInstall;
-    expect((selected.feature as FeatureContainer).subfeatures.map((s) => s.id)).toEqual([
-      'sub-a',
-      'sub-c',
-    ]);
-  });
-
-  it('selectFeatures rejects subfeatureIds for a non-container feature', async () => {
-    const integration = makeIntegration({
-      features: [{ id: 'plain', displayName: 'Plain' }],
-    });
-    const applications = await applicationsFor(integration);
-
-    expect(() =>
-      selectFeatures(integration, applications, [{ featureId: 'plain', subfeatureIds: ['sub'] }]),
-    ).toThrow('Feature test-integration.plain is not a container');
-  });
-
-  it('selectFeatures rejects unknown subfeature ids on a container', async () => {
-    const container: FeatureContainer = {
-      id: 'container',
-      displayName: 'Container',
-      subfeatures: [{ id: 'valid', displayName: 'Valid' }],
-      defaultInstallSubfeatureIds: [],
-    };
-    const integration = makeIntegration({ features: [container] });
-    const applications = await applicationsFor(integration);
-
-    expect(() =>
-      selectFeatures(integration, applications, [
-        { featureId: 'container', subfeatureIds: ['valid', 'typo'] },
-      ]),
-    ).toThrow('Unknown subfeature(s) test-integration.container.typo');
   });
 
   it('selects features matching an invocation, honoring boolean and decision results', async () => {

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -474,6 +474,58 @@ describe('declarative integration framework', () => {
     expect((caughtError as Error).message).toContain('Installation cancelled');
   });
 
+  it('selectFeaturesForInvocation throws CommandFailedError on Ctrl+C at the Keep? prompt', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({ features: [{ id: 'feature', displayName: 'Feature' }] });
+    const state = getDefaultState('test');
+    // Seed the feature as already installed so the keep/remove flow kicks in.
+    await installer.applyAndRecordFeatures(state, integration, [
+      { feature: integration.features[0], targetRoot: tempDir, scope: 'project' },
+    ]);
+    queueMockResponse(null); // Ctrl+C at "Keep?"
+
+    let caughtError: unknown;
+    try {
+      await selectForInvocation(integration, {
+        options: {},
+        targetRoot: tempDir,
+        scope: 'project',
+        nonInteractive: false,
+        state,
+      });
+    } catch (err) {
+      caughtError = err;
+    }
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toContain('Installation cancelled');
+  });
+
+  it('selectFeaturesForInvocation throws CommandFailedError on Ctrl+C at the removal confirmation', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({ features: [{ id: 'feature', displayName: 'Feature' }] });
+    const state = getDefaultState('test');
+    await installer.applyAndRecordFeatures(state, integration, [
+      { feature: integration.features[0], targetRoot: tempDir, scope: 'project' },
+    ]);
+    queueMockResponse(false); // decline "Keep?"
+    queueMockResponse(null); // Ctrl+C at "Proceed with removal?"
+
+    let caughtError: unknown;
+    try {
+      await selectForInvocation(integration, {
+        options: {},
+        targetRoot: tempDir,
+        scope: 'project',
+        nonInteractive: false,
+        state,
+      });
+    } catch (err) {
+      caughtError = err;
+    }
+    expect(caughtError).toBeInstanceOf(Error);
+    expect((caughtError as Error).message).toContain('Installation cancelled');
+  });
+
   it('records active subfeatures nested under the container feature in state', async () => {
     const dep = sonarSourceBinary({ id: 'sub-dep', binary: SonarSourceBinary.SonarSecrets });
     const container: FeatureContainer = {

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -31,6 +31,7 @@ import type {
   FeatureDeclaration,
   IntegrationContext,
   IntegrationDeclaration,
+  IntegrationInvocation,
 } from '../../../../../../src/cli/commands/integrate/_common/registry';
 import { isContainerIntegrationContext } from '../../../../../../src/cli/commands/integrate/_common/registry/types.ts';
 import { getDefaultState, type InstalledIntegrationFeature } from '../../../../../../src/lib/state';
@@ -42,12 +43,15 @@ void mock.module('../../../../../../src/cli/commands/_common/install/binary', ()
 
 const {
   askUser,
+  buildApplications,
   createIntegrationRegistry,
   install,
   IntegrationInstaller,
   IntegrationRegistry,
   isFeatureContainer,
   jsonPatch,
+  selectFeatures,
+  selectFeaturesForInvocation,
   skip,
   SonarSourceBinary,
   sonarSourceBinary,
@@ -59,6 +63,23 @@ const {
 } = await import('../../../../../../src/cli/commands/integrate/_common/registry');
 
 type Installer = InstanceType<typeof IntegrationInstaller>;
+
+/** Build applications for the invocation, then run interactive selection (mirrors install-integration). */
+async function selectForInvocation<TOptions>(
+  integration: IntegrationDeclaration<TOptions>,
+  invocation: IntegrationInvocation<TOptions>,
+) {
+  const applications = await buildApplications(invocation, integration.features);
+  return selectFeaturesForInvocation(integration, invocation, applications);
+}
+
+/** Resolve an integration's features into applications for the by-id selectFeatures tests. */
+function applicationsFor<TOptions>(integration: IntegrationDeclaration<TOptions>) {
+  return buildApplications(
+    { options: {} as TOptions, targetRoot: '', scope: 'project', state: getDefaultState('test') },
+    integration.features,
+  );
+}
 
 const { findMockUiCall, getMockUiCalls, queueMockResponse, setMockUi } =
   await import('../../../../../../src/ui');
@@ -313,7 +334,7 @@ describe('declarative integration framework', () => {
     };
     const integration = makeIntegration<{ enableSca?: boolean }>({ features: [container] });
 
-    const withoutSca = await installer.selectFeaturesForInvocation(integration, {
+    const withoutSca = await selectForInvocation(integration, {
       options: {},
       targetRoot: '/tmp',
       scope: 'project',
@@ -321,10 +342,12 @@ describe('declarative integration framework', () => {
       state: getDefaultState('test'),
     });
     expect(
-      (withoutSca[0] as FeatureContainer<{ enableSca?: boolean }>).subfeatures.map((s) => s.id),
+      (
+        withoutSca.toInstall[0].feature as FeatureContainer<{ enableSca?: boolean }>
+      ).subfeatures.map((s) => s.id),
     ).toEqual(['mandatory']);
 
-    const withSca = await installer.selectFeaturesForInvocation(integration, {
+    const withSca = await selectForInvocation(integration, {
       options: { enableSca: true },
       targetRoot: '/tmp',
       scope: 'project',
@@ -332,7 +355,9 @@ describe('declarative integration framework', () => {
       state: getDefaultState('test'),
     });
     expect(
-      (withSca[0] as FeatureContainer<{ enableSca?: boolean }>).subfeatures.map((s) => s.id),
+      (withSca.toInstall[0].feature as FeatureContainer<{ enableSca?: boolean }>).subfeatures.map(
+        (s) => s.id,
+      ),
     ).toEqual(['mandatory', 'optional']);
   });
 
@@ -398,7 +423,7 @@ describe('declarative integration framework', () => {
     queueMockResponse(true); // accept 'opted-in'
     queueMockResponse(false); // decline 'declined'
 
-    const result = await installer.selectFeaturesForInvocation(integration, {
+    const result = await selectForInvocation(integration, {
       options: {},
       targetRoot: '/tmp',
       scope: 'project',
@@ -406,7 +431,8 @@ describe('declarative integration framework', () => {
       state: getDefaultState('test'),
     });
 
-    const selected = (result[0] as FeatureContainer<Record<string, unknown>>).subfeatures;
+    const selected = (result.toInstall[0].feature as FeatureContainer<Record<string, unknown>>)
+      .subfeatures;
     expect(selected).toHaveLength(1);
     expect(selected[0]?.id).toBe('opted-in');
     const confirmCalls = getMockUiCalls().filter((c) => c.method === 'confirmPrompt');
@@ -434,7 +460,7 @@ describe('declarative integration framework', () => {
 
     let caughtError: unknown;
     try {
-      await installer.selectFeaturesForInvocation(integration, {
+      await selectForInvocation(integration, {
         options: {},
         targetRoot: '/tmp',
         scope: 'project',
@@ -522,23 +548,26 @@ describe('declarative integration framework', () => {
     expect(registry.list()).toEqual([first, second]);
   });
 
-  it('selects declared features and rejects unknown feature ids', () => {
+  it('selects declared features and rejects unknown feature ids', async () => {
     const integration = makeIntegration({
       features: [
         { id: 'one', displayName: 'One' },
         { id: 'two', displayName: 'Two' },
       ],
     });
+    const applications = await applicationsFor(integration);
 
     expect(
-      installer.selectFeatures(integration, ['two', 'one']).map((feature) => feature.id),
+      selectFeatures(integration, applications, ['two', 'one']).toInstall.map(
+        (application) => application.feature.id,
+      ),
     ).toEqual(['two', 'one']);
-    expect(() => installer.selectFeatures(integration, ['missing'])).toThrow(
+    expect(() => selectFeatures(integration, applications, ['missing'])).toThrow(
       'Unknown feature test-integration.missing',
     );
   });
 
-  it('selectFeatures filters container subfeatures to the requested ids', () => {
+  it('selectFeatures filters container subfeatures to the requested ids', async () => {
     const container: FeatureContainer = {
       id: 'container',
       displayName: 'Container',
@@ -550,24 +579,29 @@ describe('declarative integration framework', () => {
       defaultInstallSubfeatureIds: [],
     };
     const integration = makeIntegration({ features: [container] });
+    const applications = await applicationsFor(integration);
 
-    const [selected] = installer.selectFeatures(integration, [
+    const [selected] = selectFeatures(integration, applications, [
       { featureId: 'container', subfeatureIds: ['sub-c', 'sub-a'] },
+    ]).toInstall;
+    expect((selected.feature as FeatureContainer).subfeatures.map((s) => s.id)).toEqual([
+      'sub-a',
+      'sub-c',
     ]);
-    expect((selected as FeatureContainer).subfeatures.map((s) => s.id)).toEqual(['sub-a', 'sub-c']);
   });
 
-  it('selectFeatures rejects subfeatureIds for a non-container feature', () => {
+  it('selectFeatures rejects subfeatureIds for a non-container feature', async () => {
     const integration = makeIntegration({
       features: [{ id: 'plain', displayName: 'Plain' }],
     });
+    const applications = await applicationsFor(integration);
 
     expect(() =>
-      installer.selectFeatures(integration, [{ featureId: 'plain', subfeatureIds: ['sub'] }]),
+      selectFeatures(integration, applications, [{ featureId: 'plain', subfeatureIds: ['sub'] }]),
     ).toThrow('Feature test-integration.plain is not a container');
   });
 
-  it('selectFeatures rejects unknown subfeature ids on a container', () => {
+  it('selectFeatures rejects unknown subfeature ids on a container', async () => {
     const container: FeatureContainer = {
       id: 'container',
       displayName: 'Container',
@@ -575,9 +609,10 @@ describe('declarative integration framework', () => {
       defaultInstallSubfeatureIds: [],
     };
     const integration = makeIntegration({ features: [container] });
+    const applications = await applicationsFor(integration);
 
     expect(() =>
-      installer.selectFeatures(integration, [
+      selectFeatures(integration, applications, [
         { featureId: 'container', subfeatureIds: ['valid', 'typo'] },
       ]),
     ).toThrow('Unknown subfeature(s) test-integration.container.typo');
@@ -614,23 +649,23 @@ describe('declarative integration framework', () => {
 
     expect(
       (
-        await installer.selectFeaturesForInvocation(integration, {
+        await selectForInvocation(integration, {
           options: {},
           targetRoot: tempDir,
           scope: 'project',
           state: getDefaultState('test'),
         })
-      ).map((feature) => feature.id),
+      ).toInstall.map((application) => application.feature.id),
     ).toEqual(['pre-commit', 'always']);
     expect(
       (
-        await installer.selectFeaturesForInvocation(integration, {
+        await selectForInvocation(integration, {
           options: { hook: 'pre-push' },
           targetRoot: tempDir,
           scope: 'project',
           state: getDefaultState('test'),
         })
-      ).map((feature) => feature.id),
+      ).toInstall.map((application) => application.feature.id),
     ).toEqual(['pre-push', 'always']);
   });
 
@@ -643,14 +678,14 @@ describe('declarative integration framework', () => {
       ],
     });
 
-    const selected = await installer.selectFeaturesForInvocation(integration, {
+    const selected = await selectForInvocation(integration, {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
       state: getDefaultState('test'),
     });
 
-    expect(selected).toEqual([]);
+    expect(selected.toInstall).toEqual([]);
     expect(findMockUiCall('info', 'covered')).toBeDefined();
     expect(getMockUiCalls().filter((call) => call.method === 'info')).toHaveLength(1);
   });
@@ -668,14 +703,17 @@ describe('declarative integration framework', () => {
       ],
     });
 
-    const selected = await installer.selectFeaturesForInvocation(integration, {
+    const selected = await selectForInvocation(integration, {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
       state: getDefaultState('test'),
     });
 
-    expect(selected.map((feature) => feature.id)).toEqual(['with-message', 'silent']);
+    expect(selected.toInstall.map((application) => application.feature.id)).toEqual([
+      'with-message',
+      'silent',
+    ]);
     expect(findMockUiCall('discreetSuccess', 'auto-configured')).toBeDefined();
     expect(getMockUiCalls().filter((call) => call.method === 'discreetSuccess')).toHaveLength(1);
   });
@@ -695,14 +733,14 @@ describe('declarative integration framework', () => {
     queueMockResponse(true);
     queueMockResponse(false);
 
-    const selected = await installer.selectFeaturesForInvocation(integration, {
+    const selected = await selectForInvocation(integration, {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
       state: getDefaultState('test'),
     });
 
-    expect(selected.map((feature) => feature.id)).toEqual(['accepted']);
+    expect(selected.toInstall.map((application) => application.feature.id)).toEqual(['accepted']);
     const confirmCalls = getMockUiCalls().filter((call) => call.method === 'confirmPrompt');
     expect(confirmCalls).toHaveLength(2);
     expect(confirmCalls[1]?.args[0]).toBe('Install the thing?');
@@ -715,14 +753,14 @@ describe('declarative integration framework', () => {
     });
     queueMockResponse(false);
 
-    const selected = await installer.selectFeaturesForInvocation(integration, {
+    const selected = await selectForInvocation(integration, {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
       state: getDefaultState('test'),
     });
 
-    expect(selected).toEqual([]);
+    expect(selected.toInstall).toEqual([]);
     expect(getMockUiCalls().filter((call) => call.method === 'confirmPrompt')).toHaveLength(1);
   });
 
@@ -735,7 +773,7 @@ describe('declarative integration framework', () => {
       ],
     });
 
-    const selected = await installer.selectFeaturesForInvocation(integration, {
+    const selected = await selectForInvocation(integration, {
       options: {},
       targetRoot: tempDir,
       scope: 'project',
@@ -743,7 +781,10 @@ describe('declarative integration framework', () => {
       state: getDefaultState('test'),
     });
 
-    expect(selected.map((feature) => feature.id)).toEqual(['asked', 'defaulted']);
+    expect(selected.toInstall.map((application) => application.feature.id)).toEqual([
+      'asked',
+      'defaulted',
+    ]);
     expect(getMockUiCalls().filter((call) => call.method === 'confirmPrompt')).toHaveLength(0);
   });
 

--- a/tests/unit/cli/commands/integrate/_common/registry/dependencies/context-augmentation.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry/dependencies/context-augmentation.test.ts
@@ -1,0 +1,95 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import type { IntegrationContext } from '../../../../../../../../src/cli/commands/integrate/_common/registry';
+
+let binaryPath: string | null = null;
+const stopCalls: { path: string; existedAtCall: boolean }[] = [];
+
+const installModule =
+  await import('../../../../../../../../src/cli/commands/_common/install/context-augmentation');
+await mock.module(
+  '../../../../../../../../src/cli/commands/_common/install/context-augmentation',
+  () => ({
+    ...installModule,
+    resolveContextAugmentationBinaryPath: () => binaryPath,
+  }),
+);
+
+const integrateCagModule =
+  await import('../../../../../../../../src/cli/commands/integrate/_common/context-augmentation');
+await mock.module(
+  '../../../../../../../../src/cli/commands/integrate/_common/context-augmentation',
+  () => ({
+    ...integrateCagModule,
+    stopAllContextAugmentationTools: (path: string) => {
+      stopCalls.push({ path, existedAtCall: existsSync(path) });
+      return Promise.resolve(true);
+    },
+  }),
+);
+
+const { contextAugmentationBinaryDependency } =
+  await import('../../../../../../../../src/cli/commands/integrate/_common/registry/dependencies/context-augmentation');
+
+const context = {} as IntegrationContext;
+
+describe('ContextAugmentationBinaryDependency.remove', () => {
+  let binDir: string;
+
+  beforeEach(() => {
+    binDir = mkdtempSync(join(tmpdir(), 'sonar-cli-cag-'));
+    binaryPath = null;
+    stopCalls.length = 0;
+  });
+
+  afterEach(() => {
+    rmSync(binDir, { recursive: true, force: true });
+  });
+
+  it('stops the running tools and then deletes the binary', async () => {
+    const path = join(binDir, 'sonar-context-augmentation');
+    writeFileSync(path, 'binary');
+    binaryPath = path;
+
+    await contextAugmentationBinaryDependency.remove(context);
+
+    // The daemon must be stopped before the file is removed, otherwise we would
+    // delete a binary that is still running.
+    expect(stopCalls).toHaveLength(1);
+    expect(stopCalls[0]?.path).toBe(path);
+    expect(stopCalls[0]?.existedAtCall).toBe(true);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it('is a no-op when the binary is not installed', async () => {
+    binaryPath = null;
+
+    await contextAugmentationBinaryDependency.remove(context);
+
+    expect(stopCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/cli/commands/self-update/post-update.test.ts
+++ b/tests/unit/cli/commands/self-update/post-update.test.ts
@@ -382,6 +382,7 @@ describe('migrateDeclarativeIntegrations', () => {
         };
       },
       isInstalled: () => true,
+      remove: () => {},
     };
 
     const state = makeState();


### PR DESCRIPTION
----
## Summary by Gitar

- **Feature uninstall:**
  - Added `removeAndRecordFeatures` to handle feature uninstallation, including dependency cleanup and state updates.
  - Implemented an interactive "Keep/Remove" flow in `selectFeaturesForInvocation` for installed features.
- **Dependency management:**
  - Added `remove` to `DependencyDeclaration` interface and implemented it for binary dependencies.
  - Added `removeBinary` utility to safely clean up cached files from the local environment.
- **State and Registry:**
  - Introduced `removeInstalledFeature` to prune features and orphan dependencies from `CliState`.
  - Updated `renderCompletionSummary` to explicitly display uninstalled features.
- **Testing:**
  - Added comprehensive integration tests covering interactive uninstallation, binary pruning, and multi-project shared dependency scenarios.


<sub>This will update automatically on new commits.</sub>