### PR TITLE
CLI-732 Display network config in status, surface network errors

### DIFF
--- a/src/cli/commands/_common/token.ts
+++ b/src/cli/commands/_common/token.ts
@@ -39,29 +39,32 @@ const MAX_POST_BODY_BYTES = 4096;
 
 export type TokenStatus = 'valid' | 'invalid' | 'unreachable';
 
+export interface TokenCheckResult {
+  status: TokenStatus;
+  errorMessage?: string;
+}
+
 export interface BrowserAuthResult {
   token: string;
   tokenName?: string;
 }
 
-export async function checkTokenStatus(serverURL: string, token: string): Promise<TokenStatus> {
+export async function checkTokenStatus(
+  serverURL: string,
+  token: string,
+): Promise<TokenCheckResult> {
   try {
     const client = new SonarQubeClient(serverURL, token);
-    return await client.checkTokenValidity();
+    const status = await client.checkTokenValidity();
+    return { status };
   } catch (err) {
     // checkTokenValidity() lets HTTP errors propagate — any non-200 response or
     // network failure is treated as a connectivity issue rather than an auth failure,
     // because /api/authentication/validate always returns HTTP 200 per the SonarQube API contract.
-    logger.debug(`Token validation failed for ${serverURL}: ${(err as Error).message}`);
-    return 'unreachable';
+    const errorMessage = (err as Error).message;
+    logger.debug(`Token validation failed for ${serverURL}: ${errorMessage}`);
+    return { status: 'unreachable', errorMessage };
   }
-}
-
-/**
- * Validate token by calling SonarQube API
- */
-export async function validateToken(serverURL: string, token: string): Promise<boolean> {
-  return (await checkTokenStatus(serverURL, token)) === 'valid';
 }
 
 /**

--- a/src/cli/commands/auth/status.ts
+++ b/src/cli/commands/auth/status.ts
@@ -24,7 +24,7 @@ import { loadState } from '../../../lib/repository/state-repository';
 import { blank, note, print, withSpinner } from '../../../ui';
 import { NOTE_STYLES } from '../../../ui/colors';
 import { CommandFailedError } from '../_common/error';
-import type { TokenStatus } from '../_common/token';
+import type { TokenCheckResult } from '../_common/token';
 import { checkTokenStatus } from '../_common/token';
 
 function connectionLines(serverUrl: string, orgKey: string | undefined): string[] {
@@ -38,20 +38,19 @@ function displayTokenMissing(serverUrl: string, orgKey: string | undefined): voi
 function displayTokenStatus(
   serverUrl: string,
   orgKey: string | undefined,
-  status: TokenStatus,
+  result: TokenCheckResult,
 ): void {
   const lines = connectionLines(serverUrl, orgKey);
 
-  if (status === 'valid') {
+  if (result.status === 'valid') {
     printConnected(serverUrl, 'OS Keychain', orgKey);
-  } else if (status === 'invalid') {
+  } else if (result.status === 'invalid') {
     note(lines, '✗ Token invalid', NOTE_STYLES.error);
   } else {
-    note(
-      [...lines, '', 'Could not connect to the server to verify the token'],
-      '⚠ Cannot reach server',
-      NOTE_STYLES.warn,
-    );
+    const detail = result.errorMessage
+      ? `Could not connect to the server to verify the token: ${result.errorMessage}`
+      : 'Could not connect to the server to verify the token';
+    note([...lines, '', detail], '⚠ Cannot reach server', NOTE_STYLES.warn);
   }
 }
 
@@ -96,12 +95,15 @@ export async function authStatus(): Promise<void> {
 
   displayTokenStatus(conn.serverUrl, conn.orgKey, status);
 
-  if (status === 'unreachable') {
-    throw new CommandFailedError('Connection check failed.', {
+  if (status.status === 'unreachable') {
+    const message = status.errorMessage
+      ? `Connection check failed: ${status.errorMessage}`
+      : 'Connection check failed.';
+    throw new CommandFailedError(message, {
       remediationHint: 'Check the server URL and network connectivity, then retry.',
     });
   }
-  if (status !== 'valid') {
+  if (status.status !== 'valid') {
     throw new CommandFailedError('Authentication check failed.', {
       remediationHint: "Run 'sonar auth login' to reauthenticate.",
     });

--- a/src/cli/commands/integrate/_common/preflight-summary.ts
+++ b/src/cli/commands/integrate/_common/preflight-summary.ts
@@ -26,7 +26,7 @@ import type { PhaseItem, StepStatus } from '../../../../ui';
 import { info, outro, phase, phaseItem, text } from '../../../../ui';
 import { CommandFailedError } from '../../_common/error';
 import { GitRepo } from '../../_common/git-repo';
-import { checkTokenStatus, type TokenStatus } from '../../_common/token';
+import { checkTokenStatus, type TokenCheckResult, type TokenStatus } from '../../_common/token';
 
 export interface AgentPreflightSummaryOptions {
   serverUrl: string;
@@ -41,13 +41,17 @@ export interface AgentPreflightSummaryOptions {
 export async function printAgentPreflightSummary(
   options: AgentPreflightSummaryOptions,
 ): Promise<void> {
-  const tokenStatus = await checkTokenStatus(options.serverUrl, options.token);
+  const tokenResult: TokenCheckResult = await checkTokenStatus(options.serverUrl, options.token);
+  const tokenStatus: TokenStatus = tokenResult.status;
   phase('Connection', await buildConnectionItems(options, tokenStatus));
   phase('Project', await buildProjectItems(options, tokenStatus));
 
   if (tokenStatus === 'unreachable') {
     reportUnreachableServerFailure();
-    throw new CommandFailedError('Server is unreachable.');
+    const message = tokenResult.errorMessage
+      ? `Server is unreachable: ${tokenResult.errorMessage}`
+      : 'Server is unreachable.';
+    throw new CommandFailedError(message);
   }
   if (tokenStatus === 'invalid') {
     throw new CommandFailedError('Token is invalid.', {

--- a/src/cli/commands/system/status.ts
+++ b/src/cli/commands/system/status.ts
@@ -28,6 +28,8 @@ import { version as VERSION } from '../../../../package.json';
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import { resolveAuth } from '../../../lib/auth-resolver';
 import { CLI_DIR, GLOBAL_HOOKS_DIR, LOG_DIR } from '../../../lib/config-constants';
+import { getNetworkConfig } from '../../../lib/connectivity/network-config.js';
+import type { ConfigSource, ResolvedNetworkConfig } from '../../../lib/connectivity/types';
 import { IS_STANDALONE_DISTRIBUTION } from '../../../lib/distribution';
 import {
   CONTEXT_AUGMENTATION_BINARY_NAME,
@@ -44,7 +46,7 @@ import { isNewerVersion, stripBuildNumber } from '../../../lib/version';
 import { blank, print, success, text, warn } from '../../../ui';
 import { getBanner } from '../../root-help';
 import { SECRETS_SPEC } from '../_common/install/secrets';
-import type { TokenStatus } from '../_common/token';
+import type { TokenCheckResult } from '../_common/token';
 import { checkTokenStatus } from '../_common/token';
 import { supportedIntegrations } from '../integrate';
 import { checkAntigravitySecretsHookFile } from '../integrate/antigravity/health';
@@ -52,6 +54,18 @@ import { resolveAntigravityHooksJsonPathForScope } from '../integrate/antigravit
 import { checkForUpdate, type UpdateCheckResult } from '../self-update/update-check';
 
 const SCA_SCANNER_CACHE_DIR = join(CLI_DIR, 'sca-scanner-cache');
+
+const PROXY_SOURCE_LABELS: Record<ConfigSource, string> = {
+  'sonar-env': 'SONAR_HTTPS_PROXY_URL, SONAR_HTTP_PROXY_URL, SONAR_NO_PROXY environment variables',
+  'stored-config': 'sonar config',
+  'generic-env': 'HTTPS_PROXY, HTTP_PROXY, NO_PROXY environment variables',
+};
+
+const CA_CERT_SOURCE_LABELS: Record<ConfigSource, string> = {
+  'sonar-env': 'SONAR_CA_CERT environment variable',
+  'stored-config': 'sonar config',
+  'generic-env': 'NODE_EXTRA_CA_CERTS environment variable',
+};
 
 const PINNED_VERSIONS: Partial<Record<string, string>> = {
   [SECRETS_SPEC.name]: SECRETS_SPEC.version,
@@ -359,8 +373,8 @@ export async function systemStatus(options: SystemStatusOptions): Promise<void> 
     getCliUpdateInfo(),
   ]);
 
-  const tokenStatus: TokenStatus | null = auth
-    ? await checkTokenStatus(auth.serverUrl, auth.token).catch(() => 'unreachable' as const)
+  const tokenStatus: TokenCheckResult | null = auth
+    ? await checkTokenStatus(auth.serverUrl, auth.token)
     : null;
 
   const legacyBinaries = (state.tools?.installed ?? []).map((t) => {
@@ -409,8 +423,9 @@ export async function systemStatus(options: SystemStatusOptions): Promise<void> 
   const hasMcpIssues = integrations.some((i) => i.mcp?.config === 'invalid');
   const hasHooksIssues = integrations.some((i) => i.hooks?.config === 'invalid');
   const hasIssues =
-    tokenStatus === null || tokenStatus === 'invalid' || hasMcpIssues || hasHooksIssues;
+    tokenStatus === null || tokenStatus.status === 'invalid' || hasMcpIssues || hasHooksIssues;
   const recommendations = buildRecommendations(tokenStatus, updateResult, integrations);
+  const network = getNetworkConfig();
 
   const data: StatusData = {
     auth,
@@ -418,6 +433,7 @@ export async function systemStatus(options: SystemStatusOptions): Promise<void> 
     binaries,
     cache,
     integrations,
+    network,
     hasIssues,
     recommendations,
   };
@@ -441,22 +457,24 @@ type CacheInfo = { id: string; name: string; path: string; present: boolean };
 
 interface StatusData {
   auth: ResolvedAuth | null;
-  tokenStatus: TokenStatus | null;
+  tokenStatus: TokenCheckResult | null;
   binaries: BinaryInfo[];
   cache: CacheInfo[];
   integrations: IntegrationInfo[];
+  network: ResolvedNetworkConfig;
   hasIssues: boolean;
   recommendations: string[];
 }
 
 function buildRecommendations(
-  tokenStatus: TokenStatus | null,
+  tokenStatus: TokenCheckResult | null,
   updateResult: UpdateCheckResult | null,
   integrations: IntegrationInfo[],
 ): string[] {
   const recommendations: string[] = [];
   if (tokenStatus === null) recommendations.push("Run 'sonar auth login' to authenticate");
-  if (tokenStatus === 'invalid') recommendations.push("Run 'sonar auth login' to reauthenticate");
+  if (tokenStatus?.status === 'invalid')
+    recommendations.push("Run 'sonar auth login' to reauthenticate");
   if (updateResult && !updateResult.upToDate) {
     recommendations.push(
       `Run 'sonar self-update' to update to v${updateResult.latest.version.noBuild.text}`,
@@ -486,15 +504,16 @@ function buildRecommendations(
   return recommendations;
 }
 
-function tokenStatusLabel(tokenStatus: TokenStatus | null): string {
+function tokenStatusLabel(tokenStatus: TokenCheckResult | null): string {
   if (tokenStatus === null) return 'not_set';
-  if (tokenStatus === 'valid') return 'active';
-  if (tokenStatus === 'invalid') return 'invalid';
+  if (tokenStatus.status === 'valid') return 'active';
+  if (tokenStatus.status === 'invalid') return 'invalid';
   return 'set_unverified';
 }
 
 function printJsonStatus(version: string, data: StatusData): void {
-  const { auth, tokenStatus, binaries, cache, integrations, hasIssues, recommendations } = data;
+  const { auth, tokenStatus, binaries, cache, integrations, network, hasIssues, recommendations } =
+    data;
   print(
     JSON.stringify(
       {
@@ -505,6 +524,7 @@ function printJsonStatus(version: string, data: StatusData): void {
               server: auth.serverUrl,
               ...(auth.orgKey ? { org: auth.orgKey } : {}),
               token: tokenStatusLabel(tokenStatus),
+              ...(tokenStatus?.errorMessage ? { tokenError: tokenStatus.errorMessage } : {}),
             }
           : { status: 'unauthenticated', token: 'not_set' },
         binaries: binaries.map(({ name, version, path, updateAvailable, latestVersion }) => ({
@@ -537,6 +557,22 @@ function printJsonStatus(version: string, data: StatusData): void {
               }
             : {}),
         })),
+        network: {
+          proxy: network.proxy
+            ? {
+                source: PROXY_SOURCE_LABELS[network.proxy.source],
+                proxyHttps: network.proxy.proxyHttps?.getUrl() ?? null,
+                proxyHttp: network.proxy.proxyHttp?.getUrl() ?? null,
+                noProxy: network.proxy.noProxy,
+              }
+            : null,
+          caCert: network.caCert
+            ? {
+                source: CA_CERT_SOURCE_LABELS[network.caCert.source],
+                path: network.caCert.path,
+              }
+            : null,
+        },
         healthy: !hasIssues,
         recommendations,
       },
@@ -546,14 +582,20 @@ function printJsonStatus(version: string, data: StatusData): void {
   );
 }
 
-function renderTokenLine(tokenStatus: TokenStatus | null, serverUrl?: string): void {
-  if (tokenStatus === null) text('  • Token:   Not Set');
-  else if (tokenStatus === 'valid') text('  • Token:   Active');
-  else if (tokenStatus === 'invalid') text('  • Token:   Invalid');
-  else text(`  • Token:   Set, Unverified (${serverUrl} is unreachable)`);
+function renderTokenLine(tokenStatus: TokenCheckResult | null, serverUrl?: string): void {
+  if (tokenStatus === null) {
+    text('  • Token:   Not Set');
+  } else if (tokenStatus.status === 'valid') {
+    text('  • Token:   Active');
+  } else if (tokenStatus.status === 'invalid') {
+    text('  • Token:   Invalid');
+  } else {
+    const detail = tokenStatus.errorMessage ? `: ${tokenStatus.errorMessage}` : '';
+    text(`  • Token:   Set, Unverified (${serverUrl} is unreachable${detail})`);
+  }
 }
 
-function renderAuthSection(auth: ResolvedAuth | null, tokenStatus: TokenStatus | null): void {
+function renderAuthSection(auth: ResolvedAuth | null, tokenStatus: TokenCheckResult | null): void {
   text('AUTHENTICATION');
   if (auth) {
     text(`  • Server:  ${auth.serverUrl}`);
@@ -610,8 +652,40 @@ function renderRecommendationsSection(recommendations: string[]): void {
   }
 }
 
+function renderNetworkSection(network: ResolvedNetworkConfig): void {
+  blank();
+  text('NETWORK');
+  if (!network.proxy && !network.caCert) {
+    text('  No advanced network configuration detected.');
+    return;
+  }
+  text(
+    '  Note: Not all CLI features currently support proxy and certificate configuration. ' +
+      'Secrets hook, Context Augmentation and Software Composition Analysis might currently not pick up the network configuration.',
+  );
+  if (network.proxy) {
+    blank();
+    text(`  Proxy (${PROXY_SOURCE_LABELS[network.proxy.source]}):`);
+    if (network.proxy.proxyHttps) {
+      text(`    • HTTPS:     ${network.proxy.proxyHttps.getUrl()}`);
+    }
+    if (network.proxy.proxyHttp) {
+      text(`    • HTTP:      ${network.proxy.proxyHttp.getUrl()}`);
+    }
+    if (network.proxy.noProxy) {
+      text(`    • No Proxy:  ${network.proxy.noProxy}`);
+    }
+  }
+  if (network.caCert) {
+    blank();
+    text(`  CA Certificate (${CA_CERT_SOURCE_LABELS[network.caCert.source]}):`);
+    text(`    • ${network.caCert.path}`);
+  }
+}
+
 function renderTextStatus(version: string, data: StatusData): void {
-  const { auth, tokenStatus, binaries, cache, integrations, hasIssues, recommendations } = data;
+  const { auth, tokenStatus, binaries, cache, integrations, network, hasIssues, recommendations } =
+    data;
   print(getBanner(version));
   blank();
 
@@ -623,6 +697,7 @@ function renderTextStatus(version: string, data: StatusData): void {
   blank();
 
   renderAuthSection(auth, tokenStatus);
+  renderNetworkSection(network);
   renderBinariesSection(binaries);
   renderCacheSection(cache);
   renderIntegrationsSection(integrations);

--- a/src/lib/connectivity/network-config.ts
+++ b/src/lib/connectivity/network-config.ts
@@ -24,8 +24,10 @@ import type { BunFile } from 'bun';
 
 import { createRedactedUrl } from '../redacted-url';
 import type {
+  CaCertConfig,
   ConfigSource,
   FetchNetworkOptions,
+  ProxyGroup,
   ResolvedNetworkConfig,
   SourcedValue,
 } from './types';
@@ -73,9 +75,7 @@ const PROXY_CONFIGS: Array<SourcedValue<ProxyEnvVars>> = [
   },
 ];
 
-function resolveProxyGroup(
-  env: NodeJS.ProcessEnv,
-): Pick<ResolvedNetworkConfig, 'proxyHttps' | 'proxyHttp' | 'noProxy'> {
+function resolveProxyGroup(env: NodeJS.ProcessEnv): ProxyGroup | null {
   for (const {
     value: { httpsVar, httpVar, noProxyVar, lookup },
     source,
@@ -87,24 +87,32 @@ function resolveProxyGroup(
       continue;
     }
 
-    const noProxyVal = lookup(env, noProxyVar);
     return {
-      proxyHttps: httpsVal ? { value: createRedactedUrl(httpsVal), source, explicit } : null,
-      proxyHttp: httpVal ? { value: createRedactedUrl(httpVal), source, explicit } : null,
-      noProxy: noProxyVal ? { value: noProxyVal, source, explicit } : null,
+      source,
+      explicit,
+      proxyHttps: httpsVal ? createRedactedUrl(httpsVal) : null,
+      proxyHttp: httpVal ? createRedactedUrl(httpVal) : null,
+      noProxy: lookup(env, noProxyVar) ?? null,
     };
   }
-  return { proxyHttps: null, proxyHttp: null, noProxy: null };
+  return null;
 }
 
 // --- CA cert (resolves independently) ---
 
-function resolveCaCertPath(env: NodeJS.ProcessEnv): SourcedValue<string> | null {
-  return (
+function resolveCaCert(env: NodeJS.ProcessEnv): CaCertConfig | null {
+  const resolved =
     fromEnv(env, 'SONAR_CA_CERT', 'sonar-env') ??
     // stored-config slot added here when sonar config is wired
-    fromEnv(env, 'NODE_EXTRA_CA_CERTS', 'generic-env')
-  );
+    fromEnv(env, 'NODE_EXTRA_CA_CERTS', 'generic-env');
+  if (!resolved) {
+    return null;
+  }
+  return {
+    source: resolved.source,
+    explicit: resolved.explicit,
+    path: resolved.value,
+  };
 }
 
 function fromEnv(
@@ -120,8 +128,8 @@ function fromEnv(
 
 export function resolveNetworkConfig(env: NodeJS.ProcessEnv = process.env): ResolvedNetworkConfig {
   return {
-    ...resolveProxyGroup(env),
-    caCertPath: resolveCaCertPath(env),
+    proxy: resolveProxyGroup(env),
+    caCert: resolveCaCert(env),
   };
 }
 
@@ -158,28 +166,32 @@ function buildProxyOption(
   url: string,
   config: ResolvedNetworkConfig,
 ): { proxy: string } | Record<string, never> {
+  if (!config.proxy?.explicit) {
+    return {};
+  }
   const parsed = tryParseUrl(url);
   if (!parsed) {
     return {};
   }
-  const proxyCandidate = parsed.protocol === 'https:' ? config.proxyHttps : config.proxyHttp;
-  if (!proxyCandidate?.explicit) {
+  const proxyCandidate =
+    parsed.protocol === 'https:' ? config.proxy.proxyHttps : config.proxy.proxyHttp;
+  if (!proxyCandidate) {
     return {};
   }
   const defaultPort = parsed.protocol === 'https:' ? DEFAULT_PORT_HTTPS : DEFAULT_PORT_HTTP;
   const port = Number.parseInt(parsed.port) || defaultPort;
   const bypass =
-    config.noProxy !== null && matchesNoProxy(parsed.hostname, port, config.noProxy.value);
-  return bypass ? {} : { proxy: proxyCandidate.value.getUrlWithCredentials() };
+    config.proxy.noProxy !== null && matchesNoProxy(parsed.hostname, port, config.proxy.noProxy);
+  return bypass ? {} : { proxy: proxyCandidate.getUrlWithCredentials() };
 }
 
 function buildTlsOption(
   config: ResolvedNetworkConfig,
 ): { tls: { ca: Array<string | BunFile> } } | Record<string, never> {
-  if (!config.caCertPath?.explicit) {
+  if (!config.caCert?.explicit) {
     return {};
   }
-  return { tls: { ca: [...rootCertificates, Bun.file(config.caCertPath.value)] } };
+  return { tls: { ca: [...rootCertificates, Bun.file(config.caCert.path)] } };
 }
 
 function tryParseUrl(url: string): URL | null {

--- a/src/lib/connectivity/types.ts
+++ b/src/lib/connectivity/types.ts
@@ -35,9 +35,21 @@ export interface FetchNetworkOptions {
   tls?: { ca: Array<string | BunFile> };
 }
 
+export interface ProxyGroup {
+  readonly source: ConfigSource;
+  readonly explicit: boolean;
+  readonly proxyHttps: RedactedUrl | null;
+  readonly proxyHttp: RedactedUrl | null;
+  readonly noProxy: string | null;
+}
+
+export interface CaCertConfig {
+  readonly source: ConfigSource;
+  readonly explicit: boolean;
+  readonly path: string;
+}
+
 export interface ResolvedNetworkConfig {
-  readonly proxyHttps: SourcedValue<RedactedUrl> | null;
-  readonly proxyHttp: SourcedValue<RedactedUrl> | null;
-  readonly noProxy: SourcedValue<string> | null;
-  readonly caCertPath: SourcedValue<string> | null;
+  readonly proxy: ProxyGroup | null;
+  readonly caCert: CaCertConfig | null;
 }

--- a/tests/integration/specs/auth/auth.test.ts
+++ b/tests/integration/specs/auth/auth.test.ts
@@ -1191,7 +1191,7 @@ describe('auth status', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout).toContain('Cannot reach server');
-      expect(result.stderr).toContain('Connection check failed.');
+      expect(result.stderr).toContain('Connection check failed');
       expect(result.stderr).toContain(
         '  → Check the server URL and network connectivity, then retry.',
       );

--- a/tests/integration/specs/system/system-status.test.ts
+++ b/tests/integration/specs/system/system-status.test.ts
@@ -1224,4 +1224,30 @@ describe('system status', () => {
     },
     { timeout: 15000 },
   );
+
+  it('shows NETWORK section with proxy and note when HTTPS_PROXY is set', async () => {
+    const server = await harness.newFakeServer().withAuthToken('my-token').start();
+    harness.state().withAuth(server.baseUrl(), 'my-token');
+
+    const result = await harness.run('system status', {
+      extraEnv: { HTTPS_PROXY: 'https://user:pass@proxy.corp.com:3128' },
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('NETWORK');
+    expect(result.stdout).toContain('HTTPS_PROXY, HTTP_PROXY, NO_PROXY environment variables');
+    expect(result.stdout).toContain('***:***@proxy.corp.com');
+    expect(result.stdout).toContain('Not all CLI features currently support');
+  });
+
+  it('shows NETWORK section with no-config message when no network env vars are set', async () => {
+    const server = await harness.newFakeServer().withAuthToken('my-token').start();
+    harness.state().withAuth(server.baseUrl(), 'my-token');
+
+    const result = await harness.run('system status');
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('NETWORK');
+    expect(result.stdout).toContain('No advanced network configuration detected.');
+  });
 });

--- a/tests/unit/cli/commands/integrate/_common/preflight-summary.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/preflight-summary.test.ts
@@ -45,7 +45,7 @@ describe('printAgentPreflightSummary', () => {
 
   beforeEach(() => {
     setMockUi(true);
-    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue('valid');
+    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue({ status: 'valid' });
     checkComponentSpy = spyOn(SonarQubeClient.prototype, 'checkComponent').mockResolvedValue(true);
     checkOrganizationSpy = spyOn(SonarQubeClient.prototype, 'checkOrganization').mockResolvedValue(
       true,
@@ -79,7 +79,7 @@ describe('printAgentPreflightSummary', () => {
   });
 
   it('shows setup failed guidance when the server is unreachable', async () => {
-    checkTokenStatusSpy.mockResolvedValue('unreachable');
+    checkTokenStatusSpy.mockResolvedValue({ status: 'unreachable' });
 
     const error = await captureRejection(
       printAgentPreflightSummary({

--- a/tests/unit/cli/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/integrate.test.ts
@@ -110,7 +110,7 @@ describe('integrateCommand', () => {
     loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('test'));
     saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => {});
 
-    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue('valid');
+    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue({ status: 'valid' });
     checkComponentSpy = spyOn(SonarQubeClient.prototype, 'checkComponent').mockResolvedValue(true);
     checkOrganizationSpy = spyOn(SonarQubeClient.prototype, 'checkOrganization').mockResolvedValue(
       true,
@@ -266,14 +266,14 @@ describe('integrateCommand', () => {
   });
 
   it('aborts when token is invalid', () => {
-    checkTokenStatusSpy.mockResolvedValue('invalid');
+    checkTokenStatusSpy.mockResolvedValue({ status: 'invalid' });
 
     expect(integrateClaude({}, SERVER_AUTH)).rejects.toThrow('Token is invalid.');
     expect(installIntegrationSpy).not.toHaveBeenCalled();
   });
 
   it('aborts when server is unreachable', () => {
-    checkTokenStatusSpy.mockResolvedValue('unreachable');
+    checkTokenStatusSpy.mockResolvedValue({ status: 'unreachable' });
 
     expect(integrateClaude({}, SERVER_AUTH)).rejects.toThrow('Server is unreachable.');
     expect(installIntegrationSpy).not.toHaveBeenCalled();

--- a/tests/unit/cli/commands/integrate/codex/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/codex/integrate.test.ts
@@ -68,7 +68,7 @@ describe('integrateCodex', () => {
 
   beforeEach(() => {
     setMockUi(true);
-    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue('valid');
+    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue({ status: 'valid' });
     discoverProjectSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(BASE_PROJECT);
     installIntegrationSpy = spyOn(registry, 'installIntegration').mockResolvedValue([]);
     hasSqaaEntitlementSpy = spyOn(
@@ -94,14 +94,14 @@ describe('integrateCodex', () => {
   });
 
   it('aborts when token is invalid', () => {
-    checkTokenStatusSpy.mockResolvedValue('invalid');
+    checkTokenStatusSpy.mockResolvedValue({ status: 'invalid' });
 
     expect(integrateCodex({}, SERVER_AUTH)).rejects.toThrow('Token is invalid.');
     expect(installIntegrationSpy).not.toHaveBeenCalled();
   });
 
   it('aborts when server is unreachable', () => {
-    checkTokenStatusSpy.mockResolvedValue('unreachable');
+    checkTokenStatusSpy.mockResolvedValue({ status: 'unreachable' });
 
     expect(integrateCodex({}, SERVER_AUTH)).rejects.toThrow('Server is unreachable.');
     expect(installIntegrationSpy).not.toHaveBeenCalled();

--- a/tests/unit/cli/commands/integrate/copilot/integrate.test.ts
+++ b/tests/unit/cli/commands/integrate/copilot/integrate.test.ts
@@ -72,7 +72,7 @@ describe('integrateCopilot', () => {
 
   beforeEach(() => {
     setMockUi(true);
-    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue('valid');
+    checkTokenStatusSpy = spyOn(token, 'checkTokenStatus').mockResolvedValue({ status: 'valid' });
     discoverProjectSpy = spyOn(discovery, 'discoverProject').mockResolvedValue(BASE_PROJECT);
     installIntegrationSpy = spyOn(registry, 'installIntegration').mockResolvedValue([]);
     hasSqaaEntitlementSpy = spyOn(
@@ -102,14 +102,14 @@ describe('integrateCopilot', () => {
   });
 
   it('aborts when token is invalid', () => {
-    checkTokenStatusSpy.mockResolvedValue('invalid');
+    checkTokenStatusSpy.mockResolvedValue({ status: 'invalid' });
 
     expect(integrateCopilot(SERVER_AUTH, {})).rejects.toThrow('Token is invalid.');
     expect(installIntegrationSpy).not.toHaveBeenCalled();
   });
 
   it('aborts when server is unreachable', () => {
-    checkTokenStatusSpy.mockResolvedValue('unreachable');
+    checkTokenStatusSpy.mockResolvedValue({ status: 'unreachable' });
 
     expect(integrateCopilot(SERVER_AUTH, {})).rejects.toThrow('Server is unreachable.');
     expect(installIntegrationSpy).not.toHaveBeenCalled();

--- a/tests/unit/lib/connectivity/network-config.test.ts
+++ b/tests/unit/lib/connectivity/network-config.test.ts
@@ -36,29 +36,27 @@ afterEach(() => {
 });
 
 describe('resolveNetworkConfig', () => {
-  it('returns all null fields when env is empty', () => {
+  it('returns null proxy and caCert when env is empty', () => {
     const config = resolveNetworkConfig({});
-    expect(config.proxyHttps).toBeNull();
-    expect(config.proxyHttp).toBeNull();
-    expect(config.noProxy).toBeNull();
-    expect(config.caCertPath).toBeNull();
+    expect(config.proxy).toBeNull();
+    expect(config.caCert).toBeNull();
   });
 
   describe('proxy group — tier selection', () => {
     it('sonar-env wins when SONAR_HTTPS_PROXY_URL is set', () => {
       const config = resolveNetworkConfig({ SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080' });
-      expect(config.proxyHttps?.source).toBe('sonar-env');
-      expect(config.proxyHttps?.explicit).toBe(true);
-      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://sonar-proxy:8080');
-      expect(config.proxyHttp).toBeNull();
-      expect(config.noProxy).toBeNull();
+      expect(config.proxy?.source).toBe('sonar-env');
+      expect(config.proxy?.explicit).toBe(true);
+      expect(config.proxy?.proxyHttps?.getUrlWithCredentials()).toBe('https://sonar-proxy:8080');
+      expect(config.proxy?.proxyHttp).toBeNull();
+      expect(config.proxy?.noProxy).toBeNull();
     });
 
     it('sonar-env wins when SONAR_HTTP_PROXY_URL is set', () => {
       const config = resolveNetworkConfig({ SONAR_HTTP_PROXY_URL: 'https://sonar-proxy:8080' });
-      expect(config.proxyHttp?.source).toBe('sonar-env');
-      expect(config.proxyHttp?.explicit).toBe(true);
-      expect(config.proxyHttps).toBeNull();
+      expect(config.proxy?.source).toBe('sonar-env');
+      expect(config.proxy?.explicit).toBe(true);
+      expect(config.proxy?.proxyHttps).toBeNull();
     });
 
     it('sonar-env with both proxy types set', () => {
@@ -66,24 +64,25 @@ describe('resolveNetworkConfig', () => {
         SONAR_HTTPS_PROXY_URL: 'https://sonar-https:8080',
         SONAR_HTTP_PROXY_URL: 'https://sonar-http:8080',
       });
-      expect(config.proxyHttps?.source).toBe('sonar-env');
-      expect(config.proxyHttp?.source).toBe('sonar-env');
+      expect(config.proxy?.source).toBe('sonar-env');
+      expect(config.proxy?.proxyHttps?.getUrlWithCredentials()).toBe('https://sonar-https:8080');
+      expect(config.proxy?.proxyHttp?.getUrlWithCredentials()).toBe('https://sonar-http:8080');
     });
 
-    it('noProxy comes from same tier as proxy', () => {
+    it('noProxy comes from same group as proxy', () => {
       const config = resolveNetworkConfig({
         SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
         SONAR_NO_PROXY: 'internal.corp.com',
       });
-      expect(config.noProxy?.source).toBe('sonar-env');
-      expect(config.noProxy?.value).toBe('internal.corp.com');
+      expect(config.proxy?.source).toBe('sonar-env');
+      expect(config.proxy?.noProxy).toBe('internal.corp.com');
     });
 
     it('generic-env used when no sonar-env proxy set', () => {
       const config = resolveNetworkConfig({ HTTPS_PROXY: 'https://proxy:3128' });
-      expect(config.proxyHttps?.source).toBe('generic-env');
-      expect(config.proxyHttps?.explicit).toBe(false);
-      expect(config.proxyHttp).toBeNull();
+      expect(config.proxy?.source).toBe('generic-env');
+      expect(config.proxy?.explicit).toBe(false);
+      expect(config.proxy?.proxyHttp).toBeNull();
     });
 
     it('generic-env with both proxy types and NO_PROXY', () => {
@@ -92,10 +91,10 @@ describe('resolveNetworkConfig', () => {
         HTTP_PROXY: 'https://proxy:3128',
         NO_PROXY: 'localhost',
       });
-      expect(config.proxyHttps?.source).toBe('generic-env');
-      expect(config.proxyHttp?.source).toBe('generic-env');
-      expect(config.noProxy?.source).toBe('generic-env');
-      expect(config.noProxy?.value).toBe('localhost');
+      expect(config.proxy?.source).toBe('generic-env');
+      expect(config.proxy?.proxyHttps).not.toBeNull();
+      expect(config.proxy?.proxyHttp).not.toBeNull();
+      expect(config.proxy?.noProxy).toBe('localhost');
     });
   });
 
@@ -105,8 +104,8 @@ describe('resolveNetworkConfig', () => {
         SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
         HTTPS_PROXY: 'https://generic-proxy:3128',
       });
-      expect(config.proxyHttps?.source).toBe('sonar-env');
-      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://sonar-proxy:8080');
+      expect(config.proxy?.source).toBe('sonar-env');
+      expect(config.proxy?.proxyHttps?.getUrlWithCredentials()).toBe('https://sonar-proxy:8080');
     });
 
     it('HTTPS_PROXY from generic-env is ignored when sonar-env tier wins', () => {
@@ -115,7 +114,7 @@ describe('resolveNetworkConfig', () => {
         HTTPS_PROXY: 'https://generic-proxy:3128',
       });
       // proxyHttp is null because sonar-env tier won but has no SONAR_HTTP_PROXY_URL
-      expect(config.proxyHttp).toBeNull();
+      expect(config.proxy?.proxyHttp).toBeNull();
     });
 
     it('NO_PROXY not picked when sonar-env tier wins', () => {
@@ -124,7 +123,7 @@ describe('resolveNetworkConfig', () => {
         NO_PROXY: 'localhost',
       });
       // noProxy is null — NO_PROXY is generic-env but sonar-env tier won
-      expect(config.noProxy).toBeNull();
+      expect(config.proxy?.noProxy).toBeNull();
     });
 
     it('standalone SONAR_NO_PROXY without sonar-env proxy falls through to generic-env', () => {
@@ -133,32 +132,30 @@ describe('resolveNetworkConfig', () => {
         HTTPS_PROXY: 'https://proxy:3128',
       });
       // sonar-env tier skipped (no proxy); generic-env wins
-      expect(config.proxyHttps?.source).toBe('generic-env');
-      // noProxy comes from generic-env NO_PROXY (not set here), not SONAR_NO_PROXY
-      expect(config.noProxy).toBeNull();
+      expect(config.proxy?.source).toBe('generic-env');
+      // noProxy is null — NO_PROXY not set; SONAR_NO_PROXY not picked (wrong tier)
+      expect(config.proxy?.noProxy).toBeNull();
     });
 
-    it('standalone SONAR_NO_PROXY alone results in all null', () => {
+    it('standalone SONAR_NO_PROXY alone results in null proxy', () => {
       const config = resolveNetworkConfig({ SONAR_NO_PROXY: 'internal.corp.com' });
-      expect(config.proxyHttps).toBeNull();
-      expect(config.proxyHttp).toBeNull();
-      expect(config.noProxy).toBeNull();
+      expect(config.proxy).toBeNull();
     });
   });
 
-  describe('caCertPath — independent resolution', () => {
+  describe('caCert — independent resolution', () => {
     it('resolves from SONAR_CA_CERT (sonar-env, explicit)', () => {
       const config = resolveNetworkConfig({ SONAR_CA_CERT: '/etc/ssl/sonar-ca.pem' });
-      expect(config.caCertPath?.source).toBe('sonar-env');
-      expect(config.caCertPath?.explicit).toBe(true);
-      expect(config.caCertPath?.value).toBe('/etc/ssl/sonar-ca.pem');
+      expect(config.caCert?.source).toBe('sonar-env');
+      expect(config.caCert?.explicit).toBe(true);
+      expect(config.caCert?.path).toBe('/etc/ssl/sonar-ca.pem');
     });
 
     it('resolves from NODE_EXTRA_CA_CERTS (generic-env, not explicit)', () => {
       const config = resolveNetworkConfig({ NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem' });
-      expect(config.caCertPath?.source).toBe('generic-env');
-      expect(config.caCertPath?.explicit).toBe(false);
-      expect(config.caCertPath?.value).toBe('/etc/ssl/corp-ca.pem');
+      expect(config.caCert?.source).toBe('generic-env');
+      expect(config.caCert?.explicit).toBe(false);
+      expect(config.caCert?.path).toBe('/etc/ssl/corp-ca.pem');
     });
 
     it('prefers SONAR_CA_CERT over NODE_EXTRA_CA_CERTS', () => {
@@ -166,8 +163,8 @@ describe('resolveNetworkConfig', () => {
         SONAR_CA_CERT: '/etc/ssl/sonar-ca.pem',
         NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem',
       });
-      expect(config.caCertPath?.source).toBe('sonar-env');
-      expect(config.caCertPath?.value).toBe('/etc/ssl/sonar-ca.pem');
+      expect(config.caCert?.source).toBe('sonar-env');
+      expect(config.caCert?.path).toBe('/etc/ssl/sonar-ca.pem');
     });
 
     it('resolves independently of the proxy group tier', () => {
@@ -175,16 +172,16 @@ describe('resolveNetworkConfig', () => {
         SONAR_HTTPS_PROXY_URL: 'https://sonar-proxy:8080',
         NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem',
       });
-      expect(config.proxyHttps?.source).toBe('sonar-env');
-      expect(config.caCertPath?.source).toBe('generic-env');
+      expect(config.proxy?.source).toBe('sonar-env');
+      expect(config.caCert?.source).toBe('generic-env');
     });
   });
 
   describe('fromEnv — support both lower and uppercase', () => {
-    it('resolves https_proxy (lowercase) as proxyHttps', () => {
+    it('resolves https_proxy (lowercase) as proxy', () => {
       const config = resolveNetworkConfig({ https_proxy: 'https://proxy:3128' });
-      expect(config.proxyHttps?.source).toBe('generic-env');
-      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://proxy:3128');
+      expect(config.proxy?.source).toBe('generic-env');
+      expect(config.proxy?.proxyHttps?.getUrlWithCredentials()).toBe('https://proxy:3128');
     });
 
     it('lowercase takes precedence over uppercase when both are set', () => {
@@ -192,7 +189,7 @@ describe('resolveNetworkConfig', () => {
         HTTPS_PROXY: 'https://upper:3128',
         https_proxy: 'https://lower:3128',
       });
-      expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe('https://lower:3128');
+      expect(config.proxy?.proxyHttps?.getUrlWithCredentials()).toBe('https://lower:3128');
     });
   });
 
@@ -200,8 +197,8 @@ describe('resolveNetworkConfig', () => {
     const config = resolveNetworkConfig({
       HTTPS_PROXY: 'https://alice:secret@proxy:3128',
     });
-    expect(config.proxyHttps?.value.getUrl()).toBe('https://***:***@proxy:3128/');
-    expect(config.proxyHttps?.value.getUrlWithCredentials()).toBe(
+    expect(config.proxy?.proxyHttps?.getUrl()).toBe('https://***:***@proxy:3128/');
+    expect(config.proxy?.proxyHttps?.getUrlWithCredentials()).toBe(
       'https://alice:secret@proxy:3128',
     );
   });
@@ -365,7 +362,7 @@ describe('buildFetchNetworkOptions', () => {
   });
 
   describe('CA cert', () => {
-    it('sets tls.ca as array of rootCertificates + BunFile when caCertPath is explicit', () => {
+    it('sets tls.ca as array of rootCertificates + BunFile when caCert is explicit', () => {
       const pemPath = join(tmpdir(), 'sonar-test-ca.pem');
       writeFileSync(pemPath, '-----BEGIN CERTIFICATE-----\nfakecert\n-----END CERTIFICATE-----');
 
@@ -379,7 +376,7 @@ describe('buildFetchNetworkOptions', () => {
       expect(bunFile?.name).toBe(pemPath);
     });
 
-    it('does not set tls.ca when caCertPath is generic-env (not explicit)', () => {
+    it('does not set tls.ca when caCert is generic-env (not explicit)', () => {
       const config = makeConfig({ NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem' });
       const opts = buildFetchNetworkOptions('https://sonar.example.com/api', config);
       expect(opts.tls).toBeUndefined();


### PR DESCRIPTION
----
## Summary by Gitar

- **Network configuration:**
  - Added `network-config.ts` to resolve and cache proxy and CA certificate settings from environment variables.
  - Implemented `RedactedUrl` utility to safely display network configuration without leaking credentials.
- **CLI status reporting:**
  - Updated `sonar status` to display detected network proxy and CA certificate configurations.
  - Refactored `TokenStatus` to `TokenCheckResult` to surface specific network error messages in the status output.
- **Network connectivity:**
  - Integrated network configuration into `SonarQubeClient` and `fetchGuarded` to ensure API calls respect proxy settings and custom CA certs.
  - Updated `fetchGuarded` to automatically recompute proxy/TLS options when redirects involve a scheme change (HTTP to HTTPS).

<sub>This will update automatically on new commits.</sub>