### PR TITLE
CLI-740 Pass standardized env vars to binaries

### DIFF
--- a/src/cli/commands/_common/context-augmentation-env.ts
+++ b/src/cli/commands/_common/context-augmentation-env.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { buildSubprocessNetworkEnv } from '../../../lib/connectivity/network-config.js';
 import { INVOCATION_ID } from '../../../lib/invocation-id';
 
 export interface ContextAugmentationEnvContext {
@@ -48,7 +49,7 @@ type ContextAugmentationEnvKey =
 export function buildContextAugmentationEnv(
   context?: ContextAugmentationEnvContext,
 ): NodeJS.ProcessEnv {
-  const env = { ...process.env };
+  const env = { ...process.env, ...buildSubprocessNetworkEnv() };
   env.SONAR_CONTEXT_INVOCATION_ID = INVOCATION_ID;
   if (context === undefined) {
     return env;

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-runner-base.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-runner-base.ts
@@ -21,6 +21,7 @@
 import { rmSync } from 'node:fs';
 
 import { LOG_FILE } from '../../../../lib/config-constants.ts';
+import { buildSubprocessNetworkEnv } from '../../../../lib/connectivity/network-config.js';
 import logger from '../../../../lib/logger.ts';
 import type { SpawnResult } from '../../../../lib/process.ts';
 import { warn, withSpinner } from '../../../../ui';
@@ -64,7 +65,7 @@ export abstract class ScaScannerRunnerBase<T> {
   async run(invocation: ScaScannerInvocation): Promise<T> {
     const args = this.buildArgs(invocation);
     logger.debug(`sca-scanner args: ${JSON.stringify(args)}`);
-    const env = { [SONAR_TOKEN_ENV]: invocation.sonarToken };
+    const env = { ...buildSubprocessNetworkEnv(), [SONAR_TOKEN_ENV]: invocation.sonarToken };
     const binaryPath = await this.installer.install();
     try {
       const result = await withSpinner(

--- a/src/cli/commands/analyze/secrets.ts
+++ b/src/cli/commands/analyze/secrets.ts
@@ -20,6 +20,7 @@
 import { existsSync } from 'node:fs';
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { buildSubprocessNetworkEnv } from '../../../lib/connectivity/network-config.js';
 import logger from '../../../lib/logger';
 import type { SpawnResult, StdioMode } from '../../../lib/process';
 import { spawnProcessWithTimeout } from '../../../lib/process';
@@ -95,7 +96,11 @@ export async function runSecretsBinaryOnText(
 }
 
 function buildAuthEnv(auth: ResolvedAuth): Record<string, string> {
-  return { [BINARY_AUTH_URL_ENV]: auth.serverUrl, [BINARY_AUTH_TOKEN_ENV]: auth.token };
+  return {
+    ...buildSubprocessNetworkEnv(),
+    [BINARY_AUTH_URL_ENV]: auth.serverUrl,
+    [BINARY_AUTH_TOKEN_ENV]: auth.token,
+  };
 }
 
 async function handleCheckCommand(

--- a/src/lib/connectivity/network-config.ts
+++ b/src/lib/connectivity/network-config.ts
@@ -150,6 +150,36 @@ export function clearNetworkConfigCache(): void {
 const DEFAULT_PORT_HTTPS = 443;
 const DEFAULT_PORT_HTTP = 80;
 
+// --- Subprocess env builder ---
+
+/**
+ * Builds env vars to inject into subprocess invocations (sonar-secrets, sca-scanner-cli, CAG).
+ * Translates the resolved network config into all known env var names each binary may read,
+ * regardless of which source (sonar-env, stored-config, generic-env) the config came from.
+ */
+export function buildSubprocessNetworkEnv(
+  config: ResolvedNetworkConfig = getNetworkConfig(),
+): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  if (config.proxy?.proxyHttps) {
+    env.SONAR_HTTPS_PROXY_URL = config.proxy.proxyHttps.getUrlWithCredentials();
+  }
+  if (config.proxy?.proxyHttp) {
+    env.SONAR_HTTP_PROXY_URL = config.proxy.proxyHttp.getUrlWithCredentials();
+  }
+  if (config.proxy?.noProxy) {
+    env.SONAR_NO_PROXY = config.proxy.noProxy;
+  }
+
+  if (config.caCert) {
+    env.SONAR_CA_CERT = config.caCert.path;
+    env.SONAR_SECRETS_AUTH_CERT_FILE = config.caCert.path; // sonar-secrets
+  }
+
+  return env;
+}
+
 // --- Fetch options builder ---
 
 export function buildFetchNetworkOptions(

--- a/tests/unit/cli/commands/_common/context-augmentation-env.test.ts
+++ b/tests/unit/cli/commands/_common/context-augmentation-env.test.ts
@@ -21,6 +21,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { buildContextAugmentationEnv } from '../../../../../src/cli/commands/_common/context-augmentation-env';
+import { clearNetworkConfigCache } from '../../../../../src/lib/connectivity/network-config';
 import { INVOCATION_ID } from '../../../../../src/lib/invocation-id';
 
 const KEYS = [
@@ -136,5 +137,30 @@ describe('buildContextAugmentationEnv', () => {
     const second = buildContextAugmentationEnv({ organization: 'my-org' });
 
     expect(first.SONAR_CONTEXT_INVOCATION_ID).toBe(second.SONAR_CONTEXT_INVOCATION_ID);
+  });
+});
+
+describe('buildContextAugmentationEnv — network env propagation', () => {
+  const CERT_PATH = '/etc/ssl/corp-ca.pem';
+  const PROXY_URL = 'https://proxy.corp.com:3128';
+
+  beforeEach(() => {
+    process.env.SONAR_CA_CERT = CERT_PATH;
+    process.env.SONAR_HTTPS_PROXY_URL = PROXY_URL;
+    clearNetworkConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.SONAR_CA_CERT;
+    delete process.env.SONAR_HTTPS_PROXY_URL;
+    clearNetworkConfigCache();
+  });
+
+  it('injects all cert and proxy env vars into the returned env', () => {
+    const env = buildContextAugmentationEnv();
+
+    expect(env.SONAR_CA_CERT).toBe(CERT_PATH);
+    expect(env.SONAR_SECRETS_AUTH_CERT_FILE).toBe(CERT_PATH);
+    expect(env.SONAR_HTTPS_PROXY_URL).toBe(PROXY_URL);
   });
 });

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-discover-manifests.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-discover-manifests.test.ts
@@ -154,7 +154,7 @@ describe('ScaDiscoverManifestsRunner.run', () => {
     expect(spawn).toHaveBeenCalledWith(
       '/bin/sca-from-installer',
       discoverManifestsArgs(invocation),
-      { SONAR_TOKEN: invocation.sonarToken },
+      expect.objectContaining({ SONAR_TOKEN: invocation.sonarToken }),
     );
   });
 

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
@@ -104,7 +104,7 @@ describe('ScaScanOrchestrator', () => {
     const [, args, env] = analyzeCall!;
     expect(args).toContain('--project-key=my-project');
     expect(args.some((arg) => arg.includes('--sonar-token'))).toBe(false);
-    expect(env).toEqual({ SONAR_TOKEN: 'test-token' });
+    expect(env).toMatchObject({ SONAR_TOKEN: 'test-token' });
   });
 
   it('skips the analyze-project scan when the manifest pre-scan throws', async () => {

--- a/tests/unit/cli/commands/analyze/sca-scanner.test.ts
+++ b/tests/unit/cli/commands/analyze/sca-scanner.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { describe, expect, it, mock } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
 import { CommandFailedError } from '../../../../../src/cli/commands/_common/error.ts';
 import { ScaScannerInstaller } from '../../../../../src/cli/commands/_common/install/sca-scanner.ts';
@@ -29,6 +29,7 @@ import {
 import { ScaScannerInvocation } from '../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-runner-base.ts';
 import { ScaScannerSpawner } from '../../../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner-spawner.ts';
 import { LOG_FILE } from '../../../../../src/lib/config-constants.ts';
+import { clearNetworkConfigCache } from '../../../../../src/lib/connectivity/network-config.ts';
 import type { SpawnResult } from '../../../../../src/lib/process.ts';
 
 const okInstaller: ScaScannerInstaller = { install: () => Promise.resolve('/bin/sca') };
@@ -202,9 +203,11 @@ describe('ScaScannerRunner.run', () => {
     await runner.run(invocation);
 
     expect(spawn).toHaveBeenCalledTimes(1);
-    expect(spawn).toHaveBeenCalledWith('/bin/sca-from-installer', analyzeProjectArgs(invocation), {
-      SONAR_TOKEN: invocation.sonarToken,
-    });
+    expect(spawn).toHaveBeenCalledWith(
+      '/bin/sca-from-installer',
+      analyzeProjectArgs(invocation),
+      expect.objectContaining({ SONAR_TOKEN: invocation.sonarToken }),
+    );
   });
 
   it('passes the sonar token via the SONAR_TOKEN env and never in argv', async () => {
@@ -219,7 +222,7 @@ describe('ScaScannerRunner.run', () => {
     expect(args.some((arg) => arg.includes('super-secret') || arg.includes('--sonar-token'))).toBe(
       false,
     );
-    expect(env).toEqual({ SONAR_TOKEN: 'super-secret' });
+    expect(env).toMatchObject({ SONAR_TOKEN: 'super-secret' });
   });
 });
 
@@ -270,5 +273,45 @@ describe('ScaScannerRunner.buildArgs', () => {
   it('emits --debug only when the flag is true', () => {
     expect(analyzeProjectArgs(makeInvocation({ debug: false }))).not.toContain('--debug');
     expect(analyzeProjectArgs(makeInvocation({ debug: true }))).toContain('--debug');
+  });
+});
+
+describe('ScaScannerRunner — network env propagation', () => {
+  const CERT_PATH = '/etc/ssl/corp-ca.pem';
+
+  beforeEach(() => {
+    process.env.SONAR_CA_CERT = CERT_PATH;
+    clearNetworkConfigCache();
+  });
+
+  afterEach(() => {
+    delete process.env.SONAR_CA_CERT;
+    clearNetworkConfigCache();
+  });
+
+  it('injects all cert env vars into the spawn call', async () => {
+    const spawn = mock((_path: string, _args: string[], _env?: Record<string, string>) =>
+      Promise.resolve({ exitCode: 0, stdout: '{}', stderr: '' }),
+    );
+    const runner = new ScaScannerRunner({ install: () => Promise.resolve('/bin/sca') }, { spawn });
+    await runner.run(makeInvocation());
+
+    const [, , env] = spawn.mock.calls[0];
+    expect(env).toMatchObject({
+      SONAR_CA_CERT: CERT_PATH,
+      SONAR_SECRETS_AUTH_CERT_FILE: CERT_PATH,
+    });
+  });
+
+  it('does not override SONAR_TOKEN with network env vars', async () => {
+    const spawn = mock((_path: string, _args: string[], _env?: Record<string, string>) =>
+      Promise.resolve({ exitCode: 0, stdout: '{}', stderr: '' }),
+    );
+    const invocation = makeInvocation({ sonarToken: 'my-token' });
+    const runner = new ScaScannerRunner({ install: () => Promise.resolve('/bin/sca') }, { spawn });
+    await runner.run(invocation);
+
+    const [, , env] = spawn.mock.calls[0];
+    expect(env).toMatchObject({ SONAR_TOKEN: 'my-token' });
   });
 });

--- a/tests/unit/lib/connectivity/network-config.test.ts
+++ b/tests/unit/lib/connectivity/network-config.test.ts
@@ -27,6 +27,7 @@ import { afterEach, describe, expect, it } from 'bun:test';
 
 import {
   buildFetchNetworkOptions,
+  buildSubprocessNetworkEnv,
   clearNetworkConfigCache,
   resolveNetworkConfig,
 } from '../../../../src/lib/connectivity/network-config';
@@ -395,5 +396,96 @@ describe('buildFetchNetworkOptions', () => {
 
     expect(opts.proxy).toBe('https://proxy:8080');
     expect(opts.tls?.ca).toBeDefined();
+  });
+});
+
+// --- buildSubprocessNetworkEnv ---
+
+describe('buildSubprocessNetworkEnv', () => {
+  it('returns empty object when no config', () => {
+    expect(buildSubprocessNetworkEnv(makeConfig({}))).toEqual({});
+  });
+
+  it('sets SONAR_HTTPS_PROXY_URL when HTTPS proxy is configured', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({ SONAR_HTTPS_PROXY_URL: 'https://proxy:8080' }),
+    );
+    expect(env.SONAR_HTTPS_PROXY_URL).toBe('https://proxy:8080');
+    expect(env.SONAR_HTTP_PROXY_URL).toBeUndefined();
+  });
+
+  it('sets SONAR_HTTP_PROXY_URL when HTTP proxy is configured', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({ SONAR_HTTP_PROXY_URL: 'https://proxy:8080' }),
+    );
+    expect(env.SONAR_HTTP_PROXY_URL).toBe('https://proxy:8080');
+    expect(env.SONAR_HTTPS_PROXY_URL).toBeUndefined();
+  });
+
+  it('sets both proxy vars when both are configured', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://https-proxy:8080',
+        SONAR_HTTP_PROXY_URL: 'https://http-proxy:8080',
+      }),
+    );
+    expect(env.SONAR_HTTPS_PROXY_URL).toBe('https://https-proxy:8080');
+    expect(env.SONAR_HTTP_PROXY_URL).toBe('https://http-proxy:8080');
+  });
+
+  it('sets SONAR_NO_PROXY when noProxy is configured', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'internal.corp.com',
+      }),
+    );
+    expect(env.SONAR_NO_PROXY).toBe('internal.corp.com');
+  });
+
+  it('omits SONAR_NO_PROXY when noProxy is absent', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({ SONAR_HTTPS_PROXY_URL: 'https://proxy:8080' }),
+    );
+    expect(env.SONAR_NO_PROXY).toBeUndefined();
+  });
+
+  it('propagates proxy from generic-env source (HTTPS_PROXY)', () => {
+    const env = buildSubprocessNetworkEnv(makeConfig({ HTTPS_PROXY: 'https://proxy:3128' }));
+    expect(env.SONAR_HTTPS_PROXY_URL).toBe('https://proxy:3128');
+  });
+
+  it('uses getUrlWithCredentials — credentials are not redacted', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({ SONAR_HTTPS_PROXY_URL: 'https://user:pass@proxy:8080' }),
+    );
+    expect(env.SONAR_HTTPS_PROXY_URL).toBe('https://user:pass@proxy:8080');
+  });
+
+  it('sets all three cert vars to the same path when CA cert is configured', () => {
+    const env = buildSubprocessNetworkEnv(makeConfig({ SONAR_CA_CERT: '/etc/ssl/corp-ca.pem' }));
+    expect(env.SONAR_CA_CERT).toBe('/etc/ssl/corp-ca.pem');
+    expect(env.SONAR_SECRETS_AUTH_CERT_FILE).toBe('/etc/ssl/corp-ca.pem');
+  });
+
+  it('propagates cert vars from generic-env source (NODE_EXTRA_CA_CERTS)', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({ NODE_EXTRA_CA_CERTS: '/etc/ssl/corp-ca.pem' }),
+    );
+    expect(env.SONAR_CA_CERT).toBe('/etc/ssl/corp-ca.pem');
+    expect(env.SONAR_SECRETS_AUTH_CERT_FILE).toBe('/etc/ssl/corp-ca.pem');
+  });
+
+  it('returns all proxy and cert vars combined', () => {
+    const env = buildSubprocessNetworkEnv(
+      makeConfig({
+        SONAR_HTTPS_PROXY_URL: 'https://proxy:8080',
+        SONAR_NO_PROXY: 'localhost',
+        SONAR_CA_CERT: '/etc/ssl/corp-ca.pem',
+      }),
+    );
+    expect(env.SONAR_HTTPS_PROXY_URL).toBe('https://proxy:8080');
+    expect(env.SONAR_NO_PROXY).toBe('localhost');
+    expect(env.SONAR_CA_CERT).toBe('/etc/ssl/corp-ca.pem');
   });
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **Subprocess environment management:**
  - Added `buildSubprocessNetworkEnv` to centralize propagation of network settings (proxy and CA certs) to sub-binaries.
  - Updated `sca-scanner` and `secrets` binaries to inject these standardized network environment variables during execution.
- **Context augmentation:**
  - Modified `buildContextAugmentationEnv` to include standardized network environment variables for broader CLI operations.
- **Testing enhancements:**
  - Added comprehensive unit tests for network environment variable resolution and propagation.
  - Updated existing integration tests to ensure network variables do not conflict with required authentication tokens.


<sub>This will update automatically on new commits.</sub>