### PR TITLE
CLI-781 Enforce network config for self-update.

### DIFF
--- a/src/cli/commands/self-update/update-check.ts
+++ b/src/cli/commands/self-update/update-check.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 
 import { version as CURRENT_VERSION } from '../../../../package.json';
 import { SONARSOURCE_BINARIES_URL, UPDATE_SCRIPT_BASE_URL } from '../../../lib/config-constants';
+import { buildFetchNetworkOptions } from '../../../lib/connectivity/network-config';
 import { isWindows } from '../../../lib/platform-detector';
 import { CommandFailedError } from '../_common/error';
 import { Version } from '../_common/version';
@@ -161,7 +162,10 @@ export interface UpdateCheckResult {
 }
 
 async function fetchText(url: string, description: string): Promise<string> {
-  const response = await fetch(url, { signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS) });
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS),
+    ...buildFetchNetworkOptions(url),
+  });
   if (!response.ok) {
     throw new CommandFailedError(`Failed to fetch ${description}: HTTP ${response.status}`, {
       remediationHint: 'Check network access and retry.',

--- a/tests/unit/cli/commands/self-update/self-update.test.ts
+++ b/tests/unit/cli/commands/self-update/self-update.test.ts
@@ -22,6 +22,7 @@ import { EventEmitter } from 'node:events';
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
+import { clearNetworkConfigCache } from '../../../../../src/lib/connectivity/network-config';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../src/ui';
 
 // Mock node:child_process before importing self-update so that the named
@@ -128,6 +129,36 @@ describe('checkForUpdate', () => {
     });
 
     expect(checkForUpdate()).rejects.toThrow('Could not determine the latest version');
+  });
+
+  describe('with SONAR_HTTPS_PROXY_URL set', () => {
+    let originalProxyUrl: string | undefined;
+
+    beforeEach(() => {
+      originalProxyUrl = process.env.SONAR_HTTPS_PROXY_URL;
+      process.env.SONAR_HTTPS_PROXY_URL = 'http://proxy.corp.com:3128';
+      clearNetworkConfigCache();
+    });
+
+    afterEach(() => {
+      if (originalProxyUrl === undefined) {
+        delete process.env.SONAR_HTTPS_PROXY_URL;
+      } else {
+        process.env.SONAR_HTTPS_PROXY_URL = originalProxyUrl;
+      }
+      clearNetworkConfigCache();
+    });
+
+    it('passes proxy option to fetch', async () => {
+      fetchSpy.mockResolvedValue({ ok: true, text: async () => Promise.resolve('1.0.0\n') });
+
+      await checkForUpdate();
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ proxy: 'http://proxy.corp.com:3128' }),
+      );
+    });
   });
 });
 


### PR DESCRIPTION
During the implementation the self-update command was changed in parallel with Proxy/SSL addition, so it’s missing the config enforcement.