### PR TITLE
CLI-783 SQAA analysis telemetry emit helper

### DIFF
--- a/src/cli/commands/analyze/sqaa-analysis.ts
+++ b/src/cli/commands/analyze/sqaa-analysis.ts
@@ -60,7 +60,9 @@ export interface RunContext {
 export interface RunTally {
   allResults: FileResult[];
   totalIssues: number;
+  /** API `errors[]` warnings on successfully analyzed files (not HTTP failures). */
   totalErrors: number;
+  /** Files that could not be analyzed (HTTP 4xx/5xx, fetch errors, etc.). */
   totalFailures: number;
 }
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -468,13 +468,10 @@ export interface AnalysisEventIdentityPayload {
   caller_agent: CallerAgent | null;
 }
 
-export type AnalysisRunStatus = 'clean' | 'findings' | 'error';
-
 export type AnalysisTelemetryAnalyzer = 'sonar-secrets' | 'sqaa' | 'sca-scanner-cli';
 
 /**
- * Payload for a CliAnalysisCompleted event — one event per analyzer run
- * (clean, findings, or error).
+ * Payload for a CliAnalysisCompleted event — one event per analyzer run.
  */
 export interface AnalysisCompletedEventPayload extends AnalysisEventIdentityPayload {
   /** Literal CLI subcommand path (e.g. "analyze agentic", "hook git-pre-commit") */
@@ -483,10 +480,23 @@ export interface AnalysisCompletedEventPayload extends AnalysisEventIdentityPayl
   /** UUID minted once per run; join key with CliAnalysisFindingsDetected */
   analysis_id: string;
   findings_count: number;
-  status: AnalysisRunStatus;
-  /** Subprocess exit code for binary analyzers; null for API-based analyzers */
+  /**
+   * Command exit code when the handler sets one (SQAA: 0/51/1/2 via `applyExitCode` or
+   * `CliError`). Null when the run has no command exit semantics or the code is unknown.
+   */
   exit_code: number | null;
-  error_count: number;
+  /**
+   * Analyzer-reported errors during the run (not transport failures). SQAA:
+   * {@link RunTally.totalErrors} — API `errors[]` on successfully analyzed files.
+   * sonar-secrets: parsed `errors[]` from `--json` output.
+   */
+  errors_count: number;
+  /**
+   * Files that could not be analyzed (SQAA: {@link RunTally.totalFailures} — HTTP errors,
+   * read failures, validation rejections; counted per file, so one batch error may increment
+   * multiple times). Other analyzers: 0 unless applicable.
+   */
+  failures_count: number;
   scan_duration_ms: number;
 }
 

--- a/src/telemetry/sqaa-analysis-telemetry.ts
+++ b/src/telemetry/sqaa-analysis-telemetry.ts
@@ -1,0 +1,159 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import type { FileResult, RunTally } from '../cli/commands/analyze/sqaa-analysis.js';
+import type { SqaaJsonReport } from '../cli/commands/analyze/sqaa-display-json.js';
+import type { ResolvedAuth } from '../lib/auth-resolver.js';
+import type { SqaaIssue } from '../sonarqube/client.js';
+import { emitAnalysisCompleted, emitAnalysisFindingsDetected } from './findings.js';
+
+export const SQAA_DETAILS_SCHEMA_VERSION = 1;
+
+export const SQAA_ANALYZE_AGENTIC_CALLER_COMMAND = 'analyze agentic';
+
+export const SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND = 'claude-post-tool-use';
+
+export const SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND = 'codex-post-tool-use';
+
+export interface SqaaRuleCountsDetails {
+  rule_keys: string[];
+  counts_by_rule: Record<string, number>;
+}
+
+export function collectRuleCounts(
+  issues: ReadonlyArray<Pick<SqaaIssue, 'rule'>>,
+): SqaaRuleCountsDetails {
+  const countsByRule: Record<string, number> = {};
+  for (const issue of issues) {
+    countsByRule[issue.rule] = (countsByRule[issue.rule] ?? 0) + 1;
+  }
+  return {
+    rule_keys: Object.keys(countsByRule).sort((a, b) => a.localeCompare(b)),
+    counts_by_rule: countsByRule,
+  };
+}
+
+function collectIssuesFromTally(tally: RunTally): SqaaIssue[] {
+  const issues: SqaaIssue[] = [];
+  for (const result of tally.allResults) {
+    if ('failure' in result) continue;
+    issues.push(...result.issues);
+  }
+  return issues;
+}
+
+/** Builds a RunTally from a single-file SQAA API response (PostToolUse hook path). */
+export function tallyFromSqaaResponse(
+  filePath: string,
+  issues: SqaaIssue[],
+  errors?: Array<{ code: string; message: string }> | null,
+): RunTally {
+  const allResults: FileResult[] = [
+    {
+      file: filePath,
+      filePath,
+      issues,
+      errors,
+    },
+  ];
+  return {
+    allResults,
+    totalIssues: issues.length,
+    totalErrors: errors?.length ?? 0,
+    totalFailures: 0,
+  };
+}
+
+/** Builds a RunTally from a SQAA JSON report (change-set / Codex hook path). */
+export function tallyFromSqaaJsonReport(report: SqaaJsonReport): RunTally {
+  const allResults: FileResult[] = [];
+
+  for (const file of report.files) {
+    allResults.push({
+      file: file.path,
+      filePath: file.path,
+      issues: file.issues,
+      errors: file.errors,
+    });
+  }
+
+  for (const failure of report.failures) {
+    allResults.push({
+      file: failure.path,
+      filePath: failure.path,
+      failure: new Error(failure.message),
+    });
+  }
+
+  const totalErrors = report.files.reduce((count, file) => count + (file.errors?.length ?? 0), 0);
+
+  return {
+    allResults,
+    totalIssues: report.summary.totalIssues,
+    totalErrors,
+    totalFailures: report.summary.totalFailures,
+  };
+}
+
+/**
+ * Emits CliAnalysisCompleted (always) and CliAnalysisFindingsDetected (when issues exist)
+ * for one SQAA run. No-ops when telemetry is disabled.
+ *
+ * Pass `exitCode` from the command handler. Omit or pass `null` when the invocation has no exit.
+ *
+ * `errors_count` is {@link RunTally.totalErrors} only (API `errors[]` on successful analyses).
+ * `failures_count` is {@link RunTally.totalFailures} (per-file analysis failures).
+ */
+export function emitSqaaAnalysisTelemetry(
+  callerCommand:
+    | typeof SQAA_ANALYZE_AGENTIC_CALLER_COMMAND
+    | typeof SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND
+    | typeof SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
+  auth: ResolvedAuth,
+  tally: RunTally,
+  durationMs: number,
+  exitCode?: number | null,
+): void {
+  const analysisId = randomUUID();
+  const findingsCount = tally.totalIssues;
+
+  emitAnalysisCompleted(auth, {
+    caller_command: callerCommand,
+    analyzer: 'sqaa',
+    analysis_id: analysisId,
+    findings_count: findingsCount,
+    exit_code: exitCode ?? null,
+    errors_count: tally.totalErrors,
+    failures_count: tally.totalFailures,
+    scan_duration_ms: durationMs,
+  });
+
+  if (findingsCount === 0) return;
+
+  emitAnalysisFindingsDetected(auth, {
+    caller_command: callerCommand,
+    analyzer: 'sqaa',
+    analysis_id: analysisId,
+    details_schema_version: SQAA_DETAILS_SCHEMA_VERSION,
+    details: JSON.stringify(collectRuleCounts(collectIssuesFromTally(tally))),
+  });
+}

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -53,6 +53,7 @@ import {
   emitAnalysisFindingsDetected,
   flushFindings,
 } from '../../../src/telemetry/findings.js';
+import { SQAA_ANALYZE_AGENTIC_CALLER_COMMAND } from '../../../src/telemetry/sqaa-analysis-telemetry.js';
 import * as userModule from '../../../src/telemetry/user.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -76,13 +77,13 @@ function makeCompletedFields(
   overrides: Partial<AnalysisCompletedFields> = {},
 ): AnalysisCompletedFields {
   return {
-    caller_command: 'analyze agentic',
+    caller_command: SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
     analyzer: 'sqaa',
     analysis_id: 'analysis-id-123',
     findings_count: 0,
-    status: 'clean',
     exit_code: null,
-    error_count: 0,
+    errors_count: 0,
+    failures_count: 0,
     scan_duration_ms: 456,
     ...overrides,
   };
@@ -102,7 +103,7 @@ function makeFindingsDetectedFields(
   overrides: Partial<AnalysisFindingsDetectedFields> = {},
 ): AnalysisFindingsDetectedFields {
   return {
-    caller_command: 'analyze agentic',
+    caller_command: SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
     analyzer: 'sqaa',
     analysis_id: 'analysis-id-123',
     details_schema_version: 1,
@@ -243,16 +244,15 @@ afterEach(async () => {
 
 describe('emitAnalysisCompleted()', () => {
   it('writes a valid CliAnalysisCompleted envelope', () => {
-    emitAnalysisCompleted(AUTH, makeCompletedFields({ findings_count: 2, status: 'findings' }));
+    emitAnalysisCompleted(AUTH, makeCompletedFields({ findings_count: 2, exit_code: 51 }));
 
     const [event] = readLines(testSonarUserHome);
     expect(event.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
     const completedEvent = event as StoredAnalysisCompletedEvent;
     expect(completedEvent.event_payload.analyzer).toBe('sqaa');
     expect(completedEvent.event_payload.findings_count).toBe(2);
-    expect(completedEvent.event_payload.status).toBe('findings');
-    expect(completedEvent.event_payload.exit_code).toBeNull();
-    expect(completedEvent.event_payload.caller_command).toBe('analyze agentic');
+    expect(completedEvent.event_payload.exit_code).toBe(51);
+    expect(completedEvent.event_payload.caller_command).toBe(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND);
   });
 
   it('does not append when telemetry is disabled', () => {
@@ -426,7 +426,7 @@ describe('flushFindings()', () => {
   });
 
   it('serialises the analysis event in the request body', async () => {
-    writeStoredEvent(makeStoredCompletedEvent({ findings_count: 3, status: 'findings' }));
+    writeStoredEvent(makeStoredCompletedEvent({ findings_count: 3, exit_code: 51 }));
 
     const fetchSpy = mockFetch();
     try {

--- a/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
@@ -1,0 +1,374 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import type { RunTally } from '../../../src/cli/commands/analyze/sqaa-analysis.js';
+import type { SqaaJsonReport } from '../../../src/cli/commands/analyze/sqaa-display-json.js';
+import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
+import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
+import * as stateRepository from '../../../src/lib/repository/state-repository.js';
+import type {
+  StoredAnalysisCompletedEvent,
+  StoredAnalysisEvent,
+  StoredAnalysisFindingsDetectedEvent,
+} from '../../../src/lib/state.js';
+import { getDefaultState } from '../../../src/lib/state.js';
+import * as stateManager from '../../../src/lib/state-manager.js';
+import type { SqaaIssue } from '../../../src/sonarqube/client.js';
+import {
+  collectRuleCounts,
+  emitSqaaAnalysisTelemetry,
+  SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
+  SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
+  SQAA_DETAILS_SCHEMA_VERSION,
+  tallyFromSqaaJsonReport,
+  tallyFromSqaaResponse,
+} from '../../../src/telemetry/sqaa-analysis-telemetry.js';
+import * as userModule from '../../../src/telemetry/user.js';
+
+const AUTH: ResolvedAuth = {
+  connectionType: 'cloud',
+  serverUrl: 'https://sonarcloud.io',
+  token: 'test-token',
+  orgKey: 'my-org',
+};
+
+function makeIssue(rule: string, message = 'issue'): SqaaIssue {
+  return {
+    id: `id-${rule}-${message}`,
+    message,
+    rule,
+  };
+}
+
+function makeTally(overrides: Partial<RunTally> = {}): RunTally {
+  return {
+    allResults: [],
+    totalIssues: 0,
+    totalErrors: 0,
+    totalFailures: 0,
+    ...overrides,
+  };
+}
+
+function findingsPath(sonarUserHome: string): string {
+  return join(sonarUserHome, 'sonarqube-cli', 'telemetry', 'findings.ndjson');
+}
+
+function readEvents(sonarUserHome: string): StoredAnalysisEvent[] {
+  const path = findingsPath(sonarUserHome);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as StoredAnalysisEvent);
+}
+
+function makeTelemetryState(enabled = true) {
+  const state = getDefaultState('1.0.0');
+  state.telemetry.enabled = enabled;
+  state.telemetry.installationId = 'install-id';
+  return state;
+}
+
+let testSonarUserHome: string;
+const previousSonarUserHome = process.env[ENV_SONAR_USER_HOME];
+let loadStateSpy: ReturnType<typeof spyOn>;
+let getConnectionSpy: ReturnType<typeof spyOn>;
+let getUserIdSpy: ReturnType<typeof spyOn>;
+let savedDoNotTrack: string | undefined;
+
+beforeEach(async () => {
+  testSonarUserHome = await mkdtemp(join(tmpdir(), 'cli-sqaa-telemetry-test-'));
+  process.env[ENV_SONAR_USER_HOME] = testSonarUserHome;
+
+  savedDoNotTrack = process.env.DO_NOT_TRACK;
+  delete process.env.DO_NOT_TRACK;
+
+  loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeTelemetryState());
+  getConnectionSpy = spyOn(stateManager, 'getActiveConnection').mockReturnValue(undefined);
+  getUserIdSpy = spyOn(userModule, 'getOrCreateUserId').mockReturnValue('machine-id');
+});
+
+afterEach(async () => {
+  if (savedDoNotTrack !== undefined) {
+    process.env.DO_NOT_TRACK = savedDoNotTrack;
+  } else {
+    delete process.env.DO_NOT_TRACK;
+  }
+
+  loadStateSpy.mockRestore();
+  getConnectionSpy.mockRestore();
+  getUserIdSpy.mockRestore();
+
+  await rm(testSonarUserHome, { recursive: true, force: true });
+  if (previousSonarUserHome === undefined) {
+    delete process.env[ENV_SONAR_USER_HOME];
+  } else {
+    process.env[ENV_SONAR_USER_HOME] = previousSonarUserHome;
+  }
+});
+
+describe('collectRuleCounts()', () => {
+  it('aggregates counts by rule key', () => {
+    expect(
+      collectRuleCounts([
+        makeIssue('sqaa:S1234', 'a'),
+        makeIssue('sqaa:S1234', 'b'),
+        makeIssue('sqaa:S5678'),
+      ]),
+    ).toEqual({
+      rule_keys: ['sqaa:S1234', 'sqaa:S5678'],
+      counts_by_rule: { 'sqaa:S1234': 2, 'sqaa:S5678': 1 },
+    });
+  });
+});
+
+describe('tallyFromSqaaResponse()', () => {
+  it('builds a RunTally from a single-file API response', () => {
+    const tally = tallyFromSqaaResponse(
+      'src/a.ts',
+      [makeIssue('sqaa:S1234')],
+      [{ code: 'E1', message: 'API warning' }],
+    );
+
+    expect(tally.totalIssues).toBe(1);
+    expect(tally.totalErrors).toBe(1);
+    expect(tally.totalFailures).toBe(0);
+    expect(tally.allResults).toHaveLength(1);
+    if ('issues' in tally.allResults[0]) {
+      expect(tally.allResults[0].filePath).toBe('src/a.ts');
+      expect(tally.allResults[0].issues).toHaveLength(1);
+    }
+  });
+});
+
+describe('tallyFromSqaaJsonReport()', () => {
+  it('builds a RunTally from a JSON report', () => {
+    const report: SqaaJsonReport = {
+      files: [
+        {
+          path: 'src/a.ts',
+          issues: [makeIssue('sqaa:S1234', 'a'), makeIssue('sqaa:S1234', 'b')],
+          errors: [{ code: 'E1', message: 'warn' }],
+        },
+      ],
+      ignored: [],
+      failures: [{ path: 'src/b.ts', message: 'HTTP 500' }],
+      skipped: [],
+      summary: { totalIssues: 2, totalFailures: 1, totalSkipped: 0 },
+      analysisDepth: 'STANDARD',
+    };
+
+    const tally = tallyFromSqaaJsonReport(report);
+    expect(tally.totalIssues).toBe(2);
+    expect(tally.totalErrors).toBe(1);
+    expect(tally.totalFailures).toBe(1);
+    expect(tally.allResults).toHaveLength(2);
+  });
+});
+
+describe('emitSqaaAnalysisTelemetry()', () => {
+  it('writes CliAnalysisCompleted only on a clean run', () => {
+    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, makeTally(), 123, 0);
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(1);
+    expect(events[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    const completed = events[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.caller_command).toBe(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND);
+    expect(completed.event_payload.analyzer).toBe('sqaa');
+    expect(completed.event_payload.findings_count).toBe(0);
+    expect(completed.event_payload.exit_code).toBe(0);
+    expect(completed.event_payload.errors_count).toBe(0);
+    expect(completed.event_payload.failures_count).toBe(0);
+    expect(completed.event_payload.scan_duration_ms).toBe(123);
+    expect(completed.event_payload.analysis_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('emits null exit_code when the handler does not pass one', () => {
+    emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, makeTally(), 123);
+
+    const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.exit_code).toBeNull();
+    expect(completed.event_payload.failures_count).toBe(0);
+  });
+
+  it('emits failures_count when files fail even without exit_code', () => {
+    const tally = makeTally({
+      totalFailures: 1,
+      allResults: [
+        {
+          file: 'src/a.ts',
+          filePath: 'src/a.ts',
+          failure: new Error('HTTP 500'),
+        },
+      ],
+    });
+
+    emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, tally, 123);
+
+    const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.exit_code).toBeNull();
+    expect(completed.event_payload.failures_count).toBe(1);
+  });
+
+  it('writes Completed and FindingsDetected with matching analysis_id when issues exist', () => {
+    const tally = makeTally({
+      totalIssues: 2,
+      allResults: [
+        {
+          file: 'src/a.ts',
+          filePath: 'src/a.ts',
+          issues: [makeIssue('sqaa:S1234', 'a'), makeIssue('sqaa:S1234', 'b')],
+          errors: null,
+        },
+      ],
+    });
+
+    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 456, 51);
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(2);
+    const completed = events.find(
+      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
+    ) as StoredAnalysisCompletedEvent | undefined;
+    const findings = events.find(
+      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
+    ) as StoredAnalysisFindingsDetectedEvent | undefined;
+    expect(completed).toBeDefined();
+    expect(findings).toBeDefined();
+    expect(completed!.event_payload.analysis_id).toBe(findings!.event_payload.analysis_id);
+    expect(completed!.event_payload.findings_count).toBe(2);
+    expect(completed!.event_payload.exit_code).toBe(51);
+    expect(findings!.event_payload.details_schema_version).toBe(SQAA_DETAILS_SCHEMA_VERSION);
+    expect(JSON.parse(findings!.event_payload.details)).toEqual({
+      rule_keys: ['sqaa:S1234'],
+      counts_by_rule: { 'sqaa:S1234': 2 },
+    });
+  });
+
+  it('writes exit code 1 when failures exist without issues', () => {
+    const tally = makeTally({
+      totalFailures: 1,
+      allResults: [
+        {
+          file: 'src/a.ts',
+          filePath: 'src/a.ts',
+          failure: new Error('HTTP 500'),
+        },
+      ],
+    });
+
+    emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, tally, 789, 1);
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(1);
+    const completed = events[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.caller_command).toBe(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND);
+    expect(completed.event_payload.exit_code).toBe(1);
+    expect(completed.event_payload.errors_count).toBe(0);
+    expect(completed.event_payload.failures_count).toBe(1);
+    expect(completed.event_payload.findings_count).toBe(0);
+  });
+
+  it('counts API errors from successful analyses in errors_count', () => {
+    const tally = makeTally({
+      totalIssues: 1,
+      totalErrors: 2,
+      allResults: [
+        {
+          file: 'src/a.ts',
+          filePath: 'src/a.ts',
+          issues: [makeIssue('sqaa:S1234')],
+          errors: [
+            { code: 'E1', message: 'warn 1' },
+            { code: 'E2', message: 'warn 2' },
+          ],
+        },
+      ],
+    });
+
+    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 51);
+
+    const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.exit_code).toBe(51);
+    expect(completed.event_payload.errors_count).toBe(2);
+  });
+
+  it('uses exit code 1 when failures coexist with findings', () => {
+    const tally = makeTally({
+      totalIssues: 2,
+      totalFailures: 1,
+      allResults: [
+        {
+          file: 'src/a.ts',
+          filePath: 'src/a.ts',
+          issues: [makeIssue('sqaa:S1234', 'a'), makeIssue('sqaa:S1234', 'b')],
+          errors: null,
+        },
+        {
+          file: 'src/b.ts',
+          filePath: 'src/b.ts',
+          failure: new Error('HTTP 500'),
+        },
+      ],
+    });
+
+    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 1);
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(2);
+    const completed = events[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.exit_code).toBe(1);
+    expect(completed.event_payload.findings_count).toBe(2);
+    expect(completed.event_payload.errors_count).toBe(0);
+    expect(completed.event_payload.failures_count).toBe(1);
+  });
+
+  it('does not write when telemetry is disabled', () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+
+    emitSqaaAnalysisTelemetry(
+      SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
+      AUTH,
+      makeTally({ totalIssues: 1, allResults: [] }),
+      100,
+    );
+
+    expect(readEvents(testSonarUserHome)).toHaveLength(0);
+  });
+
+  it('does not write when installationId is absent', () => {
+    const stateWithoutId = makeTelemetryState();
+    stateWithoutId.telemetry.installationId = undefined;
+    loadStateSpy.mockReturnValue(stateWithoutId);
+
+    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, makeTally(), 100);
+
+    expect(readEvents(testSonarUserHome)).toHaveLength(0);
+  });
+});

--- a/tests/unit/telemetry/telemetry.test.ts
+++ b/tests/unit/telemetry/telemetry.test.ts
@@ -595,9 +595,9 @@ describe('flushTelemetry', () => {
           analyzer: 'sonar-secrets',
           analysis_id: 'analysis-id',
           findings_count: 1,
-          status: 'findings',
           exit_code: 51,
-          error_count: 0,
+          errors_count: 0,
+          failures_count: 0,
           scan_duration_ms: 123,
         },
       };


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry infrastructure:**
  - Introduced `emitSqaaAnalysisTelemetry` to track analysis status, duration, and error counts.
  - Added utility functions `tallyFromSqaaResponse` and `tallyFromSqaaJsonReport` to standardize analysis results for telemetry.
- **Data processing:**
  - Added `collectRuleCounts` to aggregate and export rule-specific findings data.
- **Safety enhancements:**
  - Implemented `SQAA_ANALYZE_AGENTIC_CALLER_COMMAND` and related constants to enforce type-safe command identification across telemetry events.

<sub>This will update automatically on new commits.</sub>