### PR TITLE
CLI-780 `sonar integrate`: Add "What will be installed" box before installation

### DIFF
--- a/src/cli/commands/integrate/_common/feature-constants.ts
+++ b/src/cli/commands/integrate/_common/feature-constants.ts
@@ -23,24 +23,27 @@
  * prompts for `sonar integrate` features (see `FeatureDeclaration.benefitDescription`).
  */
 
-/** Secrets protection via prompt scanning, and the combined hook covering prompt + file reads. */
-export const SECRETS_FEATURE_DESCRIPTION = 'prevents leaked secrets in AI prompts';
+/** Combined prompt + pre-tool-use secrets scanning. */
+export const SECRETS_COMBINED_FEATURE_BENEFIT =
+  'prevents leaked secrets in AI prompts and file reads';
 
-/** Secrets protection via file-read scanning (pre-tool-use). */
-export const SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION =
+/** Prompt-only secrets scanning. */
+export const SECRETS_PROMPT_FEATURE_BENEFIT = 'prevents leaked secrets in AI prompts';
+
+/** pre-tool-use secrets scanning. */
+export const SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT =
   'prevents the agent from reading files with secrets';
 
 /** post-tool-use SQAA hook. */
-export const AGENTIC_ANALYSIS_FEATURE_DESCRIPTION = 'automatic analysis of edits';
+export const AGENTIC_ANALYSIS_FEATURE_BENEFIT = 'automatic analysis of edits';
 
 /** End-of-turn SQAA delivered via instructions/rules. */
-export const AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION =
+export const AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT =
   'deep analysis of all changes at end of turn';
 
-export const CONTEXT_AUGMENTATION_FEATURE_DESCRIPTION =
-  'enriches AI prompts with SonarQube context';
+export const CONTEXT_AUGMENTATION_FEATURE_BENEFIT = 'enriches AI prompts with SonarQube context';
 
-export const MCP_SERVER_FEATURE_DESCRIPTION = 'gives your AI agent access to SonarQube data';
+export const MCP_SERVER_FEATURE_BENEFIT = 'gives your AI agent access to SonarQube data';
 
 /**
  * Longer, full-sentence copy for the pre-install "What will be installed"
@@ -59,9 +62,11 @@ export const SECRETS_PROMPT_FEATURE_PREVIEW =
 export const SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW =
   'Scans files for hardcoded secrets before the agent can read them.';
 
+/** post-tool-use SQAA hook. */
 export const AGENTIC_ANALYSIS_FEATURE_PREVIEW =
   'Analyzes every file the agent edits, on demand. Catches issues before they reach your main branch.';
 
+/** End-of-turn SQAA delivered via instructions/rules. */
 export const AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW =
   'Runs a deep analysis of all your changes at the end of each turn. Catches issues before they reach your main branch.';
 

--- a/src/cli/commands/integrate/_common/feature-constants.ts
+++ b/src/cli/commands/integrate/_common/feature-constants.ts
@@ -41,3 +41,32 @@ export const CONTEXT_AUGMENTATION_FEATURE_DESCRIPTION =
   'enriches AI prompts with SonarQube context';
 
 export const MCP_SERVER_FEATURE_DESCRIPTION = 'gives your AI agent access to SonarQube data';
+
+/**
+ * Longer, full-sentence copy for the pre-install "What will be installed"
+ * preview box (see `FeatureDeclaration.previewDescription`).
+ */
+
+/** Combined prompt + pre-tool-use secrets scanning. */
+export const SECRETS_COMBINED_FEATURE_PREVIEW =
+  'Scans files and prompts for hardcoded secrets before the agent can read or act on them.';
+
+/** Prompt-only secrets scanning. */
+export const SECRETS_PROMPT_FEATURE_PREVIEW =
+  'Scans your prompts for hardcoded secrets before the agent can act on them.';
+
+/** pre-tool-use secrets scanning. */
+export const SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW =
+  'Scans files for hardcoded secrets before the agent can read them.';
+
+export const AGENTIC_ANALYSIS_FEATURE_PREVIEW =
+  'Analyzes every file the agent edits, on demand. Catches issues before they reach your main branch.';
+
+export const AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW =
+  'Runs a deep analysis of all your changes at the end of each turn. Catches issues before they reach your main branch.';
+
+export const CONTEXT_AUGMENTATION_FEATURE_PREVIEW =
+  'Enriches AI prompts with SonarQube context: issues, hotspots, and rules for the file at hand.';
+
+export const MCP_SERVER_FEATURE_PREVIEW =
+  'Gives the agent direct access to your SonarQube project: issues, quality profiles, and rules.';

--- a/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
+++ b/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
@@ -24,7 +24,7 @@ import { CommandFailedError } from '../../../_common/error';
 import { getOptionalStringAttr } from '../attrs';
 import { printContextAugmentationSkill, runToolIntegrateCommand } from '../context-augmentation';
 import {
-  CONTEXT_AUGMENTATION_FEATURE_DESCRIPTION,
+  CONTEXT_AUGMENTATION_FEATURE_BENEFIT,
   CONTEXT_AUGMENTATION_FEATURE_PREVIEW,
 } from '../feature-constants';
 import { contextAugmentationBinaryDependency } from '../registry/dependencies';
@@ -47,7 +47,7 @@ export function createContextAugmentationFeature<
   return {
     id: CONTEXT_AUGMENTATION_FEATURE_ID,
     displayName: 'Context Augmentation',
-    benefitDescription: CONTEXT_AUGMENTATION_FEATURE_DESCRIPTION,
+    benefitDescription: CONTEXT_AUGMENTATION_FEATURE_BENEFIT,
     previewDescription: CONTEXT_AUGMENTATION_FEATURE_PREVIEW,
     shouldInstall: ({ options: integrationOptions }) =>
       integrationOptions.installContextAugmentation === true ? askUser() : skip(),

--- a/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
+++ b/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
@@ -23,7 +23,10 @@ import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '../../../../../lib/signature
 import { CommandFailedError } from '../../../_common/error';
 import { getOptionalStringAttr } from '../attrs';
 import { printContextAugmentationSkill, runToolIntegrateCommand } from '../context-augmentation';
-import { CONTEXT_AUGMENTATION_FEATURE_DESCRIPTION } from '../feature-constants';
+import {
+  CONTEXT_AUGMENTATION_FEATURE_DESCRIPTION,
+  CONTEXT_AUGMENTATION_FEATURE_PREVIEW,
+} from '../feature-constants';
 import { contextAugmentationBinaryDependency } from '../registry/dependencies';
 import { wholeFile } from '../registry/resources';
 import { askUser, skip } from '../registry/selection';
@@ -45,6 +48,7 @@ export function createContextAugmentationFeature<
     id: CONTEXT_AUGMENTATION_FEATURE_ID,
     displayName: 'Context Augmentation',
     benefitDescription: CONTEXT_AUGMENTATION_FEATURE_DESCRIPTION,
+    previewDescription: CONTEXT_AUGMENTATION_FEATURE_PREVIEW,
     shouldInstall: ({ options: integrationOptions }) =>
       integrationOptions.installContextAugmentation === true ? askUser() : skip(),
     dependencies: [contextAugmentationBinaryDependency],

--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -32,7 +32,12 @@ import { sonarSecretsBinaryDependency } from '../registry/dependencies';
 import { isFeatureInstalledGloballyForProject } from '../registry/installation-recorder';
 import { jsonPatch, type PlatformSpecificContent, wholeFile } from '../registry/resources';
 import { askUser, skip } from '../registry/selection';
-import type { FeatureDeclaration, IntegrationContext, PostInstallExample } from '../registry/types';
+import type {
+  FeatureDeclaration,
+  FeaturePreview,
+  IntegrationContext,
+  PostInstallExample,
+} from '../registry/types';
 
 const SONAR_SECRETS_HOOKS_FEATURE_ID = 'sonar-secrets-hooks';
 
@@ -126,6 +131,7 @@ export interface SonarSecretsHooksFeatureConfig {
   featureId?: string;
   /** Feature display name shown during install. Defaults to `secret scanning hooks`. */
   displayName?: string;
+  previewDescription?: FeaturePreview;
   /** Hook-config serializer. Defaults to the Claude/Codex schema; agents like Cursor inject their own. */
   hookWriter?: SonarSecretsHooksWriter;
 }
@@ -150,6 +156,7 @@ export function createSonarSecretsHooksFeature<TOptions extends SonarSecretsHook
     id: featureId,
     displayName: config.displayName ?? 'secret scanning hooks',
     benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+    previewDescription: config.previewDescription,
     shouldInstall: ({ options, scope, state }) =>
       globalSecretsHookAlreadyConfigured(config.integrationId, featureId, options, scope, state)
         ? skip(

--- a/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
+++ b/src/cli/commands/integrate/_common/features/sonar-secrets-hooks-feature.ts
@@ -21,7 +21,6 @@
 import { join } from 'node:path';
 
 import type { CliState, IntegrationScope } from '../../../../../lib/state';
-import { SECRETS_FEATURE_DESCRIPTION } from '../feature-constants';
 import {
   createAgentHookEntry,
   removeAgentHooks,
@@ -131,6 +130,7 @@ export interface SonarSecretsHooksFeatureConfig {
   featureId?: string;
   /** Feature display name shown during install. Defaults to `secret scanning hooks`. */
   displayName?: string;
+  benefitDescription?: string;
   previewDescription?: FeaturePreview;
   /** Hook-config serializer. Defaults to the Claude/Codex schema; agents like Cursor inject their own. */
   hookWriter?: SonarSecretsHooksWriter;
@@ -155,7 +155,7 @@ export function createSonarSecretsHooksFeature<TOptions extends SonarSecretsHook
   return {
     id: featureId,
     displayName: config.displayName ?? 'secret scanning hooks',
-    benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+    benefitDescription: config.benefitDescription,
     previewDescription: config.previewDescription,
     shouldInstall: ({ options, scope, state }) =>
       globalSecretsHookAlreadyConfigured(config.integrationId, featureId, options, scope, state)

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -34,6 +34,7 @@ import { CommandFailedError } from '../../../_common/error';
 import { renderCompletionSummary } from './completion-summary';
 import type { IntegrationRegistry } from './core';
 import { buildApplications } from './feature-target';
+import { renderInstallPreviewAndConfirm } from './install-preview';
 import { integrationInstaller } from './installer';
 import { isFeatureContainer, selectFeaturesForInvocation } from './selection';
 import type {
@@ -88,6 +89,8 @@ export async function installIntegration<TOptions>({
     throw new CommandFailedError(`No feature selected for ${integration.displayName}`);
   }
 
+  text('');
+  await renderInstallPreviewAndConfirm(toInstall, nonInteractive);
   text('');
 
   try {

--- a/src/cli/commands/integrate/_common/registry/install-preview.ts
+++ b/src/cli/commands/integrate/_common/registry/install-preview.ts
@@ -1,0 +1,78 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Framework-rendered "What will be installed" preview shared by every
+// `sonar integrate` command.
+
+import { bold, dim, note, pressEnterKeyPrompt, wrapText } from '../../../../../ui';
+import { isFeatureContainer } from './selection';
+import type { FeatureApplication, FeatureDeclaration } from './types';
+
+const PREVIEW_BOX_TITLE = 'What will be installed';
+const INSTALL_PROMPT = 'Press Enter to install…';
+const DESCRIPTION_INDENT = '  ';
+const DESCRIPTION_WRAP_WIDTH = 72;
+
+export function buildInstallPreviewLines<TOptions>(
+  toInstall: FeatureApplication<TOptions>[],
+): string[] {
+  const blocks = toInstall.map(({ feature }) => {
+    const block = [bold(feature.displayName)];
+    const description = resolvePreviewDescription(feature);
+    if (description) {
+      for (const line of wrapText(description, DESCRIPTION_WRAP_WIDTH)) {
+        block.push(dim(`${DESCRIPTION_INDENT}${line}`));
+      }
+    }
+    return block;
+  });
+  // Separate feature blocks with a blank line.
+  return blocks.flatMap((block, index) => (index === 0 ? block : ['', ...block]));
+}
+
+function resolvePreviewDescription<TOptions>(
+  feature: FeatureDeclaration<TOptions>,
+): string | undefined {
+  const { previewDescription } = feature;
+  if (typeof previewDescription !== 'function') {
+    return previewDescription;
+  }
+  const activeSubfeatureIds = isFeatureContainer(feature)
+    ? feature.subfeatures.map((subfeature) => subfeature.id)
+    : [];
+  return previewDescription(activeSubfeatureIds);
+}
+
+/**
+ * Render the install preview box, then — unless non-interactive — wait for the
+ * user to press Enter before installation proceeds.
+ */
+export async function renderInstallPreviewAndConfirm<TOptions>(
+  toInstall: FeatureApplication<TOptions>[],
+  nonInteractive: boolean | undefined,
+): Promise<void> {
+  if (toInstall.length === 0) {
+    return;
+  }
+  note(buildInstallPreviewLines(toInstall), PREVIEW_BOX_TITLE);
+  if (!nonInteractive) {
+    await pressEnterKeyPrompt(INSTALL_PROMPT);
+  }
+}

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -108,10 +108,13 @@ export interface FeatureSelectionResult<TOptions = Record<string, unknown>> {
   toRemove: FeatureApplication<TOptions>[];
 }
 
+export type FeaturePreview = string | ((activeSubfeatureIds: readonly string[]) => string);
+
 export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
   id: string;
   displayName: string;
   benefitDescription?: string;
+  previewDescription?: FeaturePreview;
   shouldInstall?: (
     invocation: IntegrationInvocation<TOptions>,
   ) => MaybePromise<boolean | InstallDecision>;

--- a/src/cli/commands/integrate/antigravity/declaration.ts
+++ b/src/cli/commands/integrate/antigravity/declaration.ts
@@ -34,9 +34,13 @@ import { getMcpConfig } from '../../../../lib/mcp/mcp-helper';
 import { getRequiredStringAttr } from '../_common/attrs';
 import {
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
   MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_PREVIEW,
   SECRETS_FEATURE_DESCRIPTION,
   SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+  SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
+  SECRETS_PROMPT_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { secretsScanningExample } from '../_common/features/sonar-secrets-hooks-feature';
@@ -92,6 +96,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
       id: 'sonar-secrets-hooks',
       displayName: 'Secret scanning hooks',
       benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+      previewDescription: SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.globalSecretsHookExists === true
           ? skip(
@@ -125,6 +130,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis rules',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
@@ -156,6 +162,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
       id: 'mcp-server',
       displayName: 'MCP server',
       benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({
           id: 'antigravity-mcp-config',
@@ -172,6 +179,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
       id: 'prompt-secrets-project-rules',
       displayName: 'Prompt-secrets workspace rules',
       benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) => {
         if (scope !== 'project') {
           return skip();
@@ -204,6 +212,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
       id: 'prompt-secrets-global-rules',
       displayName: 'Prompt-secrets global rules',
       benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) => (scope === 'global' ? askUser() : skip()),
       resources: [
         textSnippet({

--- a/src/cli/commands/integrate/antigravity/declaration.ts
+++ b/src/cli/commands/integrate/antigravity/declaration.ts
@@ -33,13 +33,13 @@ import {
 import { getMcpConfig } from '../../../../lib/mcp/mcp-helper';
 import { getRequiredStringAttr } from '../_common/attrs';
 import {
-  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
-  MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_BENEFIT,
   MCP_SERVER_FEATURE_PREVIEW,
-  SECRETS_FEATURE_DESCRIPTION,
-  SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+  SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT,
   SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
+  SECRETS_PROMPT_FEATURE_BENEFIT,
   SECRETS_PROMPT_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
@@ -95,7 +95,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     {
       id: 'sonar-secrets-hooks',
       displayName: 'Secret scanning hooks',
-      benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+      benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT,
       previewDescription: SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.globalSecretsHookExists === true
@@ -129,7 +129,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis rules',
-      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
@@ -161,7 +161,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      benefitDescription: MCP_SERVER_FEATURE_BENEFIT,
       previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({
@@ -178,7 +178,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     {
       id: 'prompt-secrets-project-rules',
       displayName: 'Prompt-secrets workspace rules',
-      benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      benefitDescription: SECRETS_PROMPT_FEATURE_BENEFIT,
       previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) => {
         if (scope !== 'project') {
@@ -211,7 +211,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     {
       id: 'prompt-secrets-global-rules',
       displayName: 'Prompt-secrets global rules',
-      benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      benefitDescription: SECRETS_PROMPT_FEATURE_BENEFIT,
       previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) => (scope === 'global' ? askUser() : skip()),
       resources: [

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -24,12 +24,13 @@ import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
-  AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_FEATURE_BENEFIT,
   AGENTIC_ANALYSIS_FEATURE_PREVIEW,
-  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
-  MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_BENEFIT,
   MCP_SERVER_FEATURE_PREVIEW,
+  SECRETS_COMBINED_FEATURE_BENEFIT,
   SECRETS_COMBINED_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
@@ -85,6 +86,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
       configDir: CLAUDE_CONFIG_DIR,
       hooksConfigFileName: SETTINGS_FILE,
       hooksPatchId: 'claude-settings-secrets-hooks',
+      benefitDescription: SECRETS_COMBINED_FEATURE_BENEFIT,
       previewDescription: SECRETS_COMBINED_FEATURE_PREVIEW,
       scripts: [
         {
@@ -124,7 +126,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     {
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
-      benefitDescription: AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+      benefitDescription: AGENTIC_ANALYSIS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) => {
         if (options.installSqaaHook === true) {
@@ -179,7 +181,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
@@ -202,7 +204,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      benefitDescription: MCP_SERVER_FEATURE_BENEFIT,
       previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -25,8 +25,12 @@ import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-help
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
   AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_FEATURE_PREVIEW,
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
   MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_PREVIEW,
+  SECRETS_COMBINED_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
@@ -75,53 +79,53 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
   id: CLAUDE_INTEGRATION_ID,
   displayName: 'Claude Code',
   features: [
-    {
-      ...createSonarSecretsHooksFeature({
-        agentDisplayName: 'Claude',
-        integrationId: CLAUDE_INTEGRATION_ID,
-        configDir: CLAUDE_CONFIG_DIR,
-        hooksConfigFileName: SETTINGS_FILE,
-        hooksPatchId: 'claude-settings-secrets-hooks',
-        scripts: [
-          {
-            id: 'pretool-secrets-script',
-            displayName: 'Claude PreToolUse hook script',
-            scriptPath: PRETOOL_SCRIPT_REL,
-            content: {
-              unix: getSecretPreToolTemplateUnix(),
-              windows: getSecretPreToolTemplateWindows(),
-            },
+    createSonarSecretsHooksFeature({
+      agentDisplayName: 'Claude',
+      integrationId: CLAUDE_INTEGRATION_ID,
+      configDir: CLAUDE_CONFIG_DIR,
+      hooksConfigFileName: SETTINGS_FILE,
+      hooksPatchId: 'claude-settings-secrets-hooks',
+      previewDescription: SECRETS_COMBINED_FEATURE_PREVIEW,
+      scripts: [
+        {
+          id: 'pretool-secrets-script',
+          displayName: 'Claude PreToolUse hook script',
+          scriptPath: PRETOOL_SCRIPT_REL,
+          content: {
+            unix: getSecretPreToolTemplateUnix(),
+            windows: getSecretPreToolTemplateWindows(),
           },
-          {
-            id: 'prompt-secrets-script',
-            displayName: 'Claude UserPromptSubmit hook script',
-            scriptPath: PROMPT_SCRIPT_REL,
-            content: {
-              unix: getSecretPromptTemplateUnix(),
-              windows: getSecretPromptTemplateWindows(),
-            },
+        },
+        {
+          id: 'prompt-secrets-script',
+          displayName: 'Claude UserPromptSubmit hook script',
+          scriptPath: PROMPT_SCRIPT_REL,
+          content: {
+            unix: getSecretPromptTemplateUnix(),
+            windows: getSecretPromptTemplateWindows(),
           },
-        ],
-        hookEntries: [
-          {
-            eventType: 'PreToolUse',
-            matcher: 'Read',
-            marker: 'sonar-secrets',
-            scriptPath: PRETOOL_SCRIPT_REL,
-          },
-          {
-            eventType: 'UserPromptSubmit',
-            matcher: '*',
-            marker: 'sonar-secrets',
-            scriptPath: PROMPT_SCRIPT_REL,
-          },
-        ],
-      }),
-    },
+        },
+      ],
+      hookEntries: [
+        {
+          eventType: 'PreToolUse',
+          matcher: 'Read',
+          marker: 'sonar-secrets',
+          scriptPath: PRETOOL_SCRIPT_REL,
+        },
+        {
+          eventType: 'UserPromptSubmit',
+          matcher: '*',
+          marker: 'sonar-secrets',
+          scriptPath: PROMPT_SCRIPT_REL,
+        },
+      ],
+    }),
     {
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
       benefitDescription: AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+      previewDescription: AGENTIC_ANALYSIS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) => {
         if (options.installSqaaHook === true) {
           return askUser();
@@ -176,6 +180,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
@@ -198,6 +203,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
       id: 'mcp-server',
       displayName: 'MCP server',
       benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({
           id: 'claude-mcp-config',

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -25,8 +25,12 @@ import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-help
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
   AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_FEATURE_PREVIEW,
   MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_PREVIEW,
   SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+  SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
+  SECRETS_PROMPT_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { createSonarSecretsHooksFeature } from '../_common/features/sonar-secrets-hooks-feature';
@@ -82,6 +86,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       configDir: CODEX_CONFIG_DIR,
       hooksConfigFileName: HOOKS_FILE,
       hooksPatchId: 'codex-hooks-secrets-hook',
+      previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       scripts: [
         {
           id: 'prompt-secrets-script',
@@ -106,6 +111,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
       benefitDescription: AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+      previewDescription: AGENTIC_ANALYSIS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) => {
         if (options.installSqaaHook === true) {
           return askUser();
@@ -155,6 +161,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       id: 'secrets-instructions',
       displayName: 'secrets-on-read instructions',
       benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+      previewDescription: SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
       shouldInstall: ({ scope, state }) =>
         isFeatureInstalledGloballyForProject(
           state,
@@ -181,6 +188,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       id: 'mcp-server',
       displayName: 'MCP server',
       benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         tomlPatch({
           id: 'codex-mcp-config',

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -24,12 +24,13 @@ import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
-  AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_FEATURE_BENEFIT,
   AGENTIC_ANALYSIS_FEATURE_PREVIEW,
-  MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_BENEFIT,
   MCP_SERVER_FEATURE_PREVIEW,
-  SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+  SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT,
   SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
+  SECRETS_PROMPT_FEATURE_BENEFIT,
   SECRETS_PROMPT_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
@@ -86,6 +87,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
       configDir: CODEX_CONFIG_DIR,
       hooksConfigFileName: HOOKS_FILE,
       hooksPatchId: 'codex-hooks-secrets-hook',
+      benefitDescription: SECRETS_PROMPT_FEATURE_BENEFIT,
       previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       scripts: [
         {
@@ -110,7 +112,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     {
       id: 'sonar-sqaa-hook',
       displayName: 'SonarQube Agentic Analysis hook',
-      benefitDescription: AGENTIC_ANALYSIS_FEATURE_DESCRIPTION,
+      benefitDescription: AGENTIC_ANALYSIS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) => {
         if (options.installSqaaHook === true) {
@@ -160,7 +162,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     {
       id: 'secrets-instructions',
       displayName: 'secrets-on-read instructions',
-      benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+      benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT,
       previewDescription: SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
       shouldInstall: ({ scope, state }) =>
         isFeatureInstalledGloballyForProject(
@@ -187,7 +189,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      benefitDescription: MCP_SERVER_FEATURE_BENEFIT,
       previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         tomlPatch({

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -25,9 +25,13 @@ import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-help
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
   MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_PREVIEW,
   SECRETS_FEATURE_DESCRIPTION,
   SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+  SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
+  SECRETS_PROMPT_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import { secretsScanningExample } from '../_common/features/sonar-secrets-hooks-feature';
@@ -83,6 +87,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       id: 'pre-tool-use-hook',
       displayName: 'pre-tool-use hook',
       benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+      previewDescription: SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.globalSecretsHookExists === true
           ? skip(
@@ -116,6 +121,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       id: 'prompt-secrets-instructions',
       displayName: 'prompt-secrets instructions',
       benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) =>
         scope === 'project' && globalCopilotInstructionsExist()
           ? askUser(
@@ -137,6 +143,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
       targetRoot: ({ options, targetRoot }) => options.projectRoot ?? targetRoot,
@@ -159,6 +166,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       id: 'mcp-server',
       displayName: 'MCP server',
       benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({
           id: 'copilot-mcp-config',

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -24,13 +24,13 @@ import { CLI_COMMAND } from '../../../../lib/config-constants';
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
-  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
-  MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_BENEFIT,
   MCP_SERVER_FEATURE_PREVIEW,
-  SECRETS_FEATURE_DESCRIPTION,
-  SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+  SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT,
   SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
+  SECRETS_PROMPT_FEATURE_BENEFIT,
   SECRETS_PROMPT_FEATURE_PREVIEW,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
@@ -86,7 +86,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'pre-tool-use-hook',
       displayName: 'pre-tool-use hook',
-      benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_DESCRIPTION,
+      benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT,
       previewDescription: SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.globalSecretsHookExists === true
@@ -120,7 +120,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'prompt-secrets-instructions',
       displayName: 'prompt-secrets instructions',
-      benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      benefitDescription: SECRETS_PROMPT_FEATURE_BENEFIT,
       previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) =>
         scope === 'project' && globalCopilotInstructionsExist()
@@ -142,7 +142,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
@@ -165,7 +165,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      benefitDescription: MCP_SERVER_FEATURE_BENEFIT,
       previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({

--- a/src/cli/commands/integrate/cursor/declaration.ts
+++ b/src/cli/commands/integrate/cursor/declaration.ts
@@ -24,12 +24,12 @@ import { CLI_COMMAND, CURSOR_CONFIG_DIR } from '../../../../lib/config-constants
 import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-helper';
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
-  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
-  MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_BENEFIT,
   MCP_SERVER_FEATURE_PREVIEW,
+  SECRETS_COMBINED_FEATURE_BENEFIT,
   SECRETS_COMBINED_FEATURE_PREVIEW,
-  SECRETS_FEATURE_DESCRIPTION,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
 import {
@@ -140,7 +140,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
     {
       id: 'sonar-secrets-hooks',
       displayName: 'secret scanning hooks',
-      benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      benefitDescription: SECRETS_COMBINED_FEATURE_BENEFIT,
       previewDescription: SECRETS_COMBINED_FEATURE_PREVIEW,
       shouldInstall: ({ options, scope, state }) => {
         const globalHookExists =
@@ -221,7 +221,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
     {
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
-      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
@@ -239,7 +239,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
     {
       id: 'mcp-server',
       displayName: 'MCP server',
-      benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      benefitDescription: MCP_SERVER_FEATURE_BENEFIT,
       previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({

--- a/src/cli/commands/integrate/cursor/declaration.ts
+++ b/src/cli/commands/integrate/cursor/declaration.ts
@@ -25,7 +25,10 @@ import { getMcpConfig, getMcpConfigFilePath } from '../../../../lib/mcp/mcp-help
 import { getOptionalStringAttr, getRequiredStringAttr } from '../_common/attrs';
 import {
   AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+  AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
   MCP_SERVER_FEATURE_DESCRIPTION,
+  MCP_SERVER_FEATURE_PREVIEW,
+  SECRETS_COMBINED_FEATURE_PREVIEW,
   SECRETS_FEATURE_DESCRIPTION,
 } from '../_common/feature-constants';
 import { createContextAugmentationFeature } from '../_common/features/context-augmentation-feature';
@@ -138,6 +141,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
       id: 'sonar-secrets-hooks',
       displayName: 'secret scanning hooks',
       benefitDescription: SECRETS_FEATURE_DESCRIPTION,
+      previewDescription: SECRETS_COMBINED_FEATURE_PREVIEW,
       shouldInstall: ({ options, scope, state }) => {
         const globalHookExists =
           options.globalSecretsHookExists ??
@@ -218,6 +222,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
       id: 'sqaa-instructions',
       displayName: 'SonarQube Agentic Analysis instructions',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_DESCRIPTION,
+      previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
         options.installSqaaInstructions === true ? askUser() : skip(),
       scope: 'project',
@@ -235,6 +240,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
       id: 'mcp-server',
       displayName: 'MCP server',
       benefitDescription: MCP_SERVER_FEATURE_DESCRIPTION,
+      previewDescription: MCP_SERVER_FEATURE_PREVIEW,
       resources: [
         jsonPatch({
           id: 'cursor-mcp-config',

--- a/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
+++ b/src/cli/commands/integrate/git/tools/git-integration-subfeatures.ts
@@ -27,10 +27,21 @@ import {
   sonarSecretsBinaryDependency,
 } from '../../_common/registry/dependencies';
 import { askUser, install, skip } from '../../_common/registry/selection';
-import type { SubfeatureDeclaration } from '../../_common/registry/types';
-import type { IntegrateGitOptions } from '../options';
+import type { FeaturePreview, SubfeatureDeclaration } from '../../_common/registry/types';
+import type { GitHookType, IntegrateGitOptions } from '../options';
 
 export const PRE_COMMIT_DEP_RISKS_SUBFEATURE_ID = 'pre-commit-dependency-risks';
+
+export function gitHookPreview(hook: GitHookType): FeaturePreview {
+  return (activeSubfeatureIds) => {
+    const event = hook === 'pre-push' ? 'push' : 'commit';
+    const scansDependencies = activeSubfeatureIds.includes(PRE_COMMIT_DEP_RISKS_SUBFEATURE_ID);
+    const target = scansDependencies
+      ? 'files for secrets and checks dependencies for known vulnerabilities (SCA)'
+      : 'files for secrets';
+    return `Scans ${target} before each ${event}. Works independently of any AI agent.`;
+  };
+}
 
 async function scaSkipReason(auth: ResolvedAuth) {
   const client = new SonarQubeClient(auth.serverUrl, auth.token);

--- a/src/cli/commands/integrate/git/tools/husky/index.ts
+++ b/src/cli/commands/integrate/git/tools/husky/index.ts
@@ -28,7 +28,11 @@ import type {
   IntegrationDeclaration,
 } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { createDepRisksSubfeature, createSecretsSubfeature } from '../git-integration-subfeatures';
+import {
+  createDepRisksSubfeature,
+  createSecretsSubfeature,
+  gitHookPreview,
+} from '../git-integration-subfeatures';
 import {
   gitCombinedHookExample,
   gitHookExample,
@@ -61,6 +65,7 @@ function createHuskyFeature(
   const base: FeatureDeclaration<IntegrateGitOptions> = {
     id: `${hook}-hook`,
     displayName: `${hook} code scanning hook`,
+    previewDescription: gitHookPreview(hook),
     shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     resources: [

--- a/src/cli/commands/integrate/git/tools/native/index.ts
+++ b/src/cli/commands/integrate/git/tools/native/index.ts
@@ -33,7 +33,11 @@ import type {
   IntegrationDeclaration,
 } from '../../../_common/registry/types';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { createDepRisksSubfeature, createSecretsSubfeature } from '../git-integration-subfeatures';
+import {
+  createDepRisksSubfeature,
+  createSecretsSubfeature,
+  gitHookPreview,
+} from '../git-integration-subfeatures';
 import {
   gitCombinedHookExample,
   gitHookExample,
@@ -61,6 +65,7 @@ function createNativeGitFeature(
   const base: FeatureDeclaration<IntegrateGitOptions> = {
     id: `${hook}-hook`,
     displayName: `${hook} code scanning hook`,
+    previewDescription: gitHookPreview(hook),
     shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     resources: [

--- a/src/cli/commands/integrate/git/tools/pre-commit/index.ts
+++ b/src/cli/commands/integrate/git/tools/pre-commit/index.ts
@@ -31,7 +31,11 @@ import {
   yamlPatchRemover,
 } from '../../../_common/registry';
 import type { GitHookType, IntegrateGitOptions } from '../../options';
-import { createDepRisksSubfeature, createSecretsSubfeature } from '../git-integration-subfeatures';
+import {
+  createDepRisksSubfeature,
+  createSecretsSubfeature,
+  gitHookPreview,
+} from '../git-integration-subfeatures';
 import { gitCombinedHookExample, gitHookExample, shouldInstallHook } from '../shared';
 import {
   activatePreCommitFramework,
@@ -59,6 +63,7 @@ function createPreCommitFeature(
   const base: FeatureDeclaration<IntegrateGitOptions> = {
     id: `${hook}-hook`,
     displayName: `${hook} code scanning hook`,
+    previewDescription: gitHookPreview(hook),
     shouldInstall: ({ options }) => shouldInstallHook(hook, options),
     postInstallExample: gitHookExample(hook),
     resources: [

--- a/src/ui/colors.ts
+++ b/src/ui/colors.ts
@@ -27,6 +27,18 @@ import type { ColorFn, NoteOptions, StepStatus } from './types.js';
 // When stdout is not a TTY (piped), all color functions become identity
 export const isTTY = process.stdout.isTTY;
 
+// Matches SGR (color/style) escape sequences emitted by picocolors so callers
+// can measure the visible width of a styled string.
+const ANSI_SGR_PATTERN = /\x1b\[[0-9;]*m/g;
+
+export function stripAnsi(s: string): string {
+  return s.replace(ANSI_SGR_PATTERN, '');
+}
+
+export function visibleLength(s: string): number {
+  return stripAnsi(s).length;
+}
+
 function c(fn: (s: string) => string): ColorFn {
   return (s: string) => (isTTY ? fn(s) : s);
 }

--- a/src/ui/components/note.ts
+++ b/src/ui/components/note.ts
@@ -22,7 +22,7 @@
 
 import { getColumns } from '@clack/core';
 
-import { bold, dim, isTTY, visibleLength } from '../colors.js';
+import { bold, dim, isTTY, stripAnsi, visibleLength } from '../colors.js';
 import { isMockActive, recordCall } from '../mock.js';
 import type { ColorFn, NoteOptions } from '../types.js';
 
@@ -53,7 +53,10 @@ function renderTTY(lines: string[], title: string | undefined, opts: NoteOptions
   const bottom = borderColor('└' + '─'.repeat(width) + '┘');
 
   const contentLines = lines.map((line) => {
-    const truncated = visibleLength(line) > width - 1 ? line.slice(0, width - 4) + '...' : line;
+    // Truncate on visible text so a cut never leaves a dangling "style on"
+    // escape that bleeds into the border. Styling is dropped on cut lines.
+    const truncated =
+      visibleLength(line) > width - 1 ? stripAnsi(line).slice(0, width - 4) + '...' : line;
     const padded = truncated + ' '.repeat(Math.max(0, width - 1 - visibleLength(truncated)));
     return borderColor('│') + ' ' + contentColor(padded) + borderColor('│');
   });

--- a/src/ui/components/note.ts
+++ b/src/ui/components/note.ts
@@ -22,7 +22,7 @@
 
 import { getColumns } from '@clack/core';
 
-import { bold, dim, isTTY } from '../colors.js';
+import { bold, dim, isTTY, visibleLength } from '../colors.js';
 import { isMockActive, recordCall } from '../mock.js';
 import type { ColorFn, NoteOptions } from '../types.js';
 
@@ -53,8 +53,8 @@ function renderTTY(lines: string[], title: string | undefined, opts: NoteOptions
   const bottom = borderColor('└' + '─'.repeat(width) + '┘');
 
   const contentLines = lines.map((line) => {
-    const truncated = line.length > width - 1 ? line.slice(0, width - 4) + '...' : line;
-    const padded = truncated + ' '.repeat(Math.max(0, width - 1 - truncated.length));
+    const truncated = visibleLength(line) > width - 1 ? line.slice(0, width - 4) + '...' : line;
+    const padded = truncated + ' '.repeat(Math.max(0, width - 1 - visibleLength(truncated)));
     return borderColor('│') + ' ' + contentColor(padded) + borderColor('│');
   });
 

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -20,6 +20,7 @@
 
 // Public API for the UI module
 
+export { bold, dim, stripAnsi, visibleLength } from './colors.js';
 export { note } from './components/note.js';
 export type { PhaseItem, StepStatus } from './components/phase.js';
 export { phase, phaseItem } from './components/phase.js';
@@ -45,6 +46,7 @@ export {
   success,
   text,
   warn,
+  wrapText,
 } from './messages.js';
 export type { UiCall, UiMethod } from './mock.js';
 export {

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -141,3 +141,27 @@ export function blank(): void {
   if (_formattedOutputMode) return;
   if (isTTY) process.stdout.write('\n');
 }
+
+/**
+ * Greedy word wrap: packs whitespace-separated words into lines no longer than
+ * `width`. A single word longer than `width` is left on its own over-long line
+ * rather than split mid-word.
+ */
+export function wrapText(content: string, width: number): string[] {
+  const lines: string[] = [];
+  let current = '';
+  for (const word of content.split(/\s+/)) {
+    if (current === '') {
+      current = word;
+    } else if (`${current} ${word}`.length <= width) {
+      current = `${current} ${word}`;
+    } else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current !== '') {
+    lines.push(current);
+  }
+  return lines;
+}

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -85,6 +85,9 @@ describe('integrate claude', () => {
         ),
       ).toBe(true);
 
+      // Pre-install "What will be installed" summary box
+      expect(result.stdout).toContain('What will be installed');
+
       // Completion summary
       expect(result.stdout).toContain('Installed');
       expect(result.stdout).toContain('Setup complete!');

--- a/tests/unit/cli/commands/integrate/_common/registry/install-preview.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry/install-preview.test.ts
@@ -1,0 +1,162 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Force color functions to identity so preview-line assertions are independent
+// of whether the test process is attached to a TTY.
+void mock.module('../../../../../../../src/ui/colors.js', () => ({
+  isTTY: false,
+  bold: (s: string) => s,
+  dim: (s: string) => s,
+  green: (s: string) => s,
+  red: (s: string) => s,
+  yellow: (s: string) => s,
+  cyan: (s: string) => s,
+  gray: (s: string) => s,
+  white: (s: string) => s,
+  stripAnsi: (s: string) => s,
+  visibleLength: (s: string) => s.length,
+}));
+
+import {
+  buildInstallPreviewLines,
+  renderInstallPreviewAndConfirm,
+} from '../../../../../../../src/cli/commands/integrate/_common/registry/install-preview';
+import type {
+  FeatureApplication,
+  FeatureContainer,
+  FeatureDeclaration,
+} from '../../../../../../../src/cli/commands/integrate/_common/registry/types';
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../../../src/ui';
+
+function application(feature: FeatureDeclaration): FeatureApplication {
+  return { feature, targetRoot: '/repo', scope: 'project' };
+}
+
+describe('install preview', () => {
+  describe('buildInstallPreviewLines', () => {
+    it('renders name lines with indented descriptions, separates features with a blank line, and omits missing descriptions', () => {
+      const lines = buildInstallPreviewLines([
+        application({ id: 'a', displayName: 'Feature A' }),
+        application({
+          id: 'mcp-server',
+          displayName: 'MCP server',
+          previewDescription: 'Gives the agent direct access to your SonarQube project.',
+        }),
+      ]);
+
+      expect(lines).toEqual([
+        'Feature A',
+        '',
+        'MCP server',
+        '  Gives the agent direct access to your SonarQube project.',
+      ]);
+    });
+
+    it('resolves a handler previewDescription from the active subfeature ids', () => {
+      const container: FeatureContainer = {
+        id: 'pre-commit-hook',
+        displayName: 'pre-commit code scanning hook',
+        previewDescription: (activeSubfeatureIds) =>
+          activeSubfeatureIds.includes('pre-commit-dependency-risks')
+            ? 'Scans files for secrets and checks dependencies before each commit.'
+            : 'Scans files for secrets before each commit.',
+        subfeatures: [
+          { id: 'pre-commit-secrets', displayName: 'pre-commit secrets scan' },
+          { id: 'pre-commit-dependency-risks', displayName: 'pre-commit dependency-risks scan' },
+        ],
+        defaultInstallSubfeatureIds: ['pre-commit-secrets'],
+      };
+
+      const withDeps = buildInstallPreviewLines([application(container)]);
+      expect(withDeps).toEqual([
+        'pre-commit code scanning hook',
+        '  Scans files for secrets and checks dependencies before each commit.',
+      ]);
+
+      // Secrets-only: the handler omits the dependency clause.
+      const secretsOnlyContainer: FeatureContainer = {
+        ...container,
+        subfeatures: [container.subfeatures[0]],
+      };
+      const secretsOnly = buildInstallPreviewLines([application(secretsOnlyContainer)]);
+      expect(secretsOnly).toEqual([
+        'pre-commit code scanning hook',
+        '  Scans files for secrets before each commit.',
+      ]);
+    });
+
+    it('wraps long descriptions across indented continuation lines', () => {
+      const long =
+        'Scans files and prompts for hardcoded secrets before the agent can read or act on them, ' +
+        'blocking the dangerous operation entirely.';
+      const lines = buildInstallPreviewLines([
+        application({ id: 'x', displayName: 'X', previewDescription: long }),
+      ]);
+
+      expect(lines[0]).toBe('X');
+      const descriptionLines = lines.slice(1);
+      expect(descriptionLines.length).toBeGreaterThan(1); // wrapped across rows
+      expect(descriptionLines.every((line) => line.startsWith('  '))).toBe(true);
+      expect(descriptionLines.every((line) => line.length <= 76)).toBe(true);
+      // No content is dropped — the wrapped lines reconstruct the original text.
+      expect(descriptionLines.map((line) => line.trim()).join(' ')).toBe(long);
+    });
+  });
+
+  describe('renderInstallPreviewAndConfirm', () => {
+    beforeEach(() => {
+      setMockUi(true);
+      clearMockUiCalls();
+    });
+
+    afterEach(() => {
+      setMockUi(false);
+    });
+
+    it('prints the box and waits for Enter in interactive mode', async () => {
+      await renderInstallPreviewAndConfirm(
+        [application({ id: 'a', displayName: 'Feature A', previewDescription: 'Does A.' })],
+        false,
+      );
+
+      const methods = getMockUiCalls().map((call) => call.method);
+      expect(methods).toContain('note');
+      expect(methods).toContain('pressAnyKeyPrompt');
+    });
+
+    it('prints the box but does not wait in non-interactive mode', async () => {
+      await renderInstallPreviewAndConfirm(
+        [application({ id: 'a', displayName: 'Feature A', previewDescription: 'Does A.' })],
+        true,
+      );
+
+      const methods = getMockUiCalls().map((call) => call.method);
+      expect(methods).toContain('note');
+      expect(methods).not.toContain('pressAnyKeyPrompt');
+    });
+
+    it('renders nothing when there is nothing to install', async () => {
+      await renderInstallPreviewAndConfirm([], false);
+      expect(getMockUiCalls()).toHaveLength(0);
+    });
+  });
+});

--- a/tests/unit/ui/note.test.ts
+++ b/tests/unit/ui/note.test.ts
@@ -37,10 +37,11 @@ void mock.module('../../../src/ui/colors.js', () => ({
   cyan: (s: string) => s,
   gray: (s: string) => s,
   white: (s: string) => s,
+  stripAnsi: (s: string) => s.replace(/\x1b\[[0-9;]*m/g, ''),
+  visibleLength: (s: string) => s.replace(/\x1b\[[0-9;]*m/g, '').length,
 }));
 
-import { note } from '../../../src/ui';
-import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../src/ui';
+import { clearMockUiCalls, getMockUiCalls, note, setMockUi, stripAnsi } from '../../../src/ui';
 
 // ─── Mock mode ────────────────────────────────────────────────────────────────
 
@@ -152,6 +153,29 @@ describe('note(): TTY box rendering (renderTTY)', () => {
     } finally {
       writeSpy.mockRestore();
     }
+  });
+
+  it('aligns the right border when content contains ANSI escape codes', () => {
+    const render = (content: string[]): string => {
+      const output: string[] = [];
+      const writeSpy = spyOn(process.stdout, 'write').mockImplementation((s) => {
+        output.push(String(s));
+        return true;
+      });
+      try {
+        note(content);
+        return output.join('');
+      } finally {
+        writeSpy.mockRestore();
+      }
+    };
+
+    const plain = render(['hello world']);
+    const styled = render([`\x1b[31mhello world\x1b[39m`]);
+
+    // Once the escape codes are stripped, the styled box must be byte-identical
+    // to the plain box — i.e. padding was computed from visible width.
+    expect(stripAnsi(styled)).toBe(plain);
   });
 
   it('appends newline at the end', () => {

--- a/tests/unit/ui/note.test.ts
+++ b/tests/unit/ui/note.test.ts
@@ -178,6 +178,26 @@ describe('note(): TTY box rendering (renderTTY)', () => {
     expect(stripAnsi(styled)).toBe(plain);
   });
 
+  it('truncates a styled overflow line without leaving a dangling escape', () => {
+    const output: string[] = [];
+    const writeSpy = spyOn(process.stdout, 'write').mockImplementation((s) => {
+      output.push(String(s));
+      return true;
+    });
+    try {
+      // A dim-styled line far wider than the box.
+      const styled = `\x1b[2m${'x'.repeat(200)}\x1b[22m`;
+      note([styled]);
+      const rendered = output.join('');
+      // The overflow cut strips styling entirely.
+      expect(rendered).not.toContain('\x1b[2m');
+      expect(rendered).not.toContain('\x1b[22m');
+      expect(rendered).toContain('...');
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
   it('appends newline at the end', () => {
     const output: string[] = [];
     const writeSpy = spyOn(process.stdout, 'write').mockImplementation((s) => {


### PR DESCRIPTION
----
## Summary by Gitar

- **New interactive UI:**
  - Added `renderInstallPreviewAndConfirm` to display a "What will be installed" box before integration.
  - Added `wrapText` utility and `visibleLength` helper to handle terminal word wrapping and ANSI character calculation.
- **Feature configuration:**
  - Added `previewDescription` to all integration features to populate the new install preview box.
  - Updated existing `feature-constants.ts` to include descriptive preview text alongside benefit summaries.

<sub>This will update automatically on new commits.</sub>