### PR TITLE
CLI-695 use lowercase feature names

### DIFF
--- a/src/cli/commands/integrate/antigravity/declaration.ts
+++ b/src/cli/commands/integrate/antigravity/declaration.ts
@@ -94,7 +94,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
   features: [
     {
       id: 'sonar-secrets-hooks',
-      displayName: 'Secret scanning hooks',
+      displayName: 'secret scanning hooks',
       benefitDescription: SECRETS_PRE_TOOL_USE_FEATURE_BENEFIT,
       previewDescription: SECRETS_PRE_TOOL_USE_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
@@ -177,7 +177,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     },
     {
       id: 'prompt-secrets-project-rules',
-      displayName: 'Prompt-secrets workspace rules',
+      displayName: 'prompt-secrets workspace rules',
       benefitDescription: SECRETS_PROMPT_FEATURE_BENEFIT,
       previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) => {
@@ -210,7 +210,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     },
     {
       id: 'prompt-secrets-global-rules',
-      displayName: 'Prompt-secrets global rules',
+      displayName: 'prompt-secrets global rules',
       benefitDescription: SECRETS_PROMPT_FEATURE_BENEFIT,
       previewDescription: SECRETS_PROMPT_FEATURE_PREVIEW,
       shouldInstall: ({ scope }) => (scope === 'global' ? askUser() : skip()),

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -293,7 +293,7 @@ describe('integrate antigravity', () => {
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;
         expect(output).toContain('global secrets scanning hook');
-        expect(output).not.toContain('Install Secret scanning hooks?');
+        expect(output).not.toContain('Install secret scanning hooks?');
         expect(harness.cwd.exists(...PROJECT_HOOK_SCRIPT_PATH)).toBe(false);
         expect(findAntigravityFeature(harness, 'sonar-secrets-hooks')).toBeUndefined();
         expect(output).toContain(


### PR DESCRIPTION
----
## Summary by Gitar

- **UI enhancements:**
  - Update `displayName` fields in `antigravityIntegration` to use lowercase naming consistently.
  - Adjust integration test assertions in `antigravity.test.ts` to match the new lowercase `displayName` format.

<sub>This will update automatically on new commits.</sub>