### PR TITLE
CLI-539 set org_uuid telemetry fields with env-based auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,30 @@ The CAG installer (`src/cli/commands/_common/install/context-augmentation.ts`) h
 
 `sonar system reset` returns the CLI to a factory-like state in one shot. Registered as `anonymousAction` so it works when auth is broken. Implementation is split across `src/cli/commands/system/reset.ts` (orchestration), `reset-auth.ts`, `reset-binaries.ts`, `reset-integrations.ts`, `reset-filesystem.ts`, and `safe-path.ts`. Integration teardown is declarative-only: `integrations.installed` features are removed via `removeFeature()`; legacy `agentExtensions` entries are cleared from state in `clearLegacyState()` but are not used for on-disk cleanup (1.0 does not guarantee removal of pre-declarative artifacts). Binary cleanup removes paths from both `dependencies.installed` and legacy `tools.installed` under `BIN_DIR`. Partial reset (step warnings) exits `0`.
 
+### Telemetry
+
+Command telemetry (`storeEvent` in `src/telemetry/index.ts`) and analysis telemetry (`emitAnalysisCompleted` / `emitAnalysisFindingsDetected` in `src/telemetry/findings.ts`) share a tiered identity resolver in `src/telemetry/identity.ts`. It fills `connection_type`, `user_uuid`, `organization_uuid_v4`, and `sqs_installation_id` on every event — including env-var auth (`SONARQUBE_CLI_TOKEN` + `SONARQUBE_CLI_ORG` or `SONARQUBE_CLI_SERVER`) where those fields were previously always null.
+
+**Resolution order** (per auth token, keyed by connection type + server URL + org key + token fingerprint):
+
+1. **Connection seed** — `identityFromConnection()` maps `AuthConnection.userUuid`, `organizationUuidV4`, and `sqsInstallationId` (populated at `sonar auth login` via `getCurrentUser()`, `getOrganizationId()`, and `getSystemStatus()`).
+2. **Disk cache** — `{SONAR_USER_HOME}/sonarqube-cli/telemetry/identity-cache.json`, one entry per auth fingerprint. Avoids repeat API calls across CLI invocations.
+3. **API enrichment** — `SonarQubeClient.getSafe()` fetches only missing fields: `/api/users/current` (cloud and server), `/organizations/organizations` (cloud only, when `orgKey` is set), `/api/system/status` (server only).
+
+**Fast paths** (skip keychain / `resolveFromState()`):
+
+- Env-var auth when `isEnvBasedAuth()` is true — uses `resolveFromEnv()` directly; partial env (token only) does not warn during silent `storeEvent`.
+- Logged-in user when the active connection already satisfies `needsIdentityEnrichment()` — complete required fields plus `user_uuid` resolved (present, or login persisted `userUuid: null`).
+
+**Field completeness** (`isIdentityCompleteForConnection`):
+
+- **Cloud** — requires `user_uuid` and `organization_uuid_v4`.
+- **Server** — requires `sqs_installation_id` only; `user_uuid` is optional on older SonarQube Server versions that do not return it (see `TelemetryEventPayload`).
+
+**`user_uuid` policy** — always attempted for cloud and server (login and env-var auth) whenever not already known. Login stores `userUuid` on the connection (`string` or explicit `null` after a successful login-time fetch). Telemetry skips re-fetch when `conn.userUuid !== undefined`. Legacy connections without that field, and all env-var sessions, resolve via the API path. A successful API response with no user id is cached as confirmed-absent (`userUuid: null` in the disk entry) so old servers do not cause infinite re-fetch; transient API failures are not cached and retry on the next command.
+
+**Caching rules** — disk entries are written only when the API call succeeded (`response.ok`). Non-null values and confirmed-absent nulls are persisted; failed/transient responses are omitted so the next run retries. The `'fieldName' in entry` check in `planFieldsToFetch()` distinguishes “not yet tried” from “confirmed absent”.
+
 ## Error handling
 
 Please use the exception types defined in `src/cli/commands/_common/error.ts` for production code. If you need to throw an error from a mock in test code, it's fine to use the generic `Error` type.

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -406,6 +406,12 @@ export interface IntegrationsState {
 }
 
 /**
+ * Product code sent on telemetry events: SonarQube Cloud or SonarQube Server.
+ * Distinct from {@link ServerType} (`cloud` / `on-premise`), which the CLI uses for auth routing.
+ */
+export type TelemetryConnectionType = 'sqc' | 'sqs' | null;
+
+/**
  * Metadata envelope for a telemetry event.
  */
 export interface TelemetryEventMetadata {
@@ -432,8 +438,8 @@ export interface TelemetryEventPayload {
   invocation_id: string;
   result: 'success' | 'failure';
   os: string;
-  /** "sqc" for SonarQube Cloud, "sqs" for SonarQube Server, null when not authenticated */
-  connection_type: 'sqc' | 'sqs' | null;
+  /** {@link TelemetryConnectionType} — null when not authenticated */
+  connection_type: TelemetryConnectionType;
   /** UUID of the user on SonarQube Cloud or Server, null when not authenticated or on older SQS versions */
   user_uuid: string | null;
   /** UUID of the SonarQube Cloud organization, null when not authenticated or SQS */
@@ -461,7 +467,7 @@ export interface AnalysisEventIdentityPayload {
   cli_version: string;
   invocation_id: string;
   os: string;
-  connection_type: 'sqc' | 'sqs' | null;
+  connection_type: TelemetryConnectionType;
   user_uuid: string | null;
   organization_uuid_v4: string | null;
   sqs_installation_id: string | null;

--- a/src/telemetry/findings.ts
+++ b/src/telemetry/findings.ts
@@ -36,6 +36,7 @@ import type {
 } from '../lib/state.js';
 import { getActiveConnection, loadState } from '../lib/state-manager.js';
 import { isTelemetryEnabled } from './enabled.js';
+import { resolveCommandTelemetryIdentity } from './identity.js';
 import { getOrCreateUserId } from './user.js';
 
 const FINDINGS_FILENAME = 'findings.ndjson';
@@ -59,23 +60,27 @@ function appendAnalysisEvent(event: StoredAnalysisEvent): void {
  * Resolves shared identity fields for analysis telemetry events.
  * Returns null when telemetry is disabled or installationId is absent.
  */
-export function buildAnalysisIdentityBase(auth: ResolvedAuth): AnalysisEventIdentityPayload | null {
+export async function buildAnalysisIdentityBase(
+  auth: ResolvedAuth,
+): Promise<AnalysisEventIdentityPayload | null> {
   const state = loadState();
   if (!isTelemetryEnabled(state)) return null;
   const installationId = state.telemetry.installationId;
   if (!installationId) return null;
 
   const conn = getActiveConnection(state);
+  const { connectionType, identity } = await resolveCommandTelemetryIdentity(conn, auth);
+
   return {
     cli_installation_id: installationId,
     machine_id: getOrCreateUserId(),
     cli_version: VERSION,
     invocation_id: INVOCATION_ID,
     os: process.platform,
-    connection_type: auth.connectionType === 'cloud' ? 'sqc' : 'sqs',
-    user_uuid: conn?.userUuid ?? null,
-    organization_uuid_v4: conn?.organizationUuidV4 ?? null,
-    sqs_installation_id: conn?.sqsInstallationId ?? null,
+    connection_type: connectionType,
+    user_uuid: identity.user_uuid,
+    organization_uuid_v4: identity.organization_uuid_v4,
+    sqs_installation_id: identity.sqs_installation_id,
     caller_agent: detectCallerAgent(),
   };
 }
@@ -94,8 +99,11 @@ export type AnalysisFindingsDetectedFields = Omit<
  * Emits one CliAnalysisCompleted event when telemetry is enabled.
  * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
  */
-export function emitAnalysisCompleted(auth: ResolvedAuth, fields: AnalysisCompletedFields): void {
-  const base = buildAnalysisIdentityBase(auth);
+export async function emitAnalysisCompleted(
+  auth: ResolvedAuth,
+  fields: AnalysisCompletedFields,
+): Promise<void> {
+  const base = await buildAnalysisIdentityBase(auth);
   if (!base) return;
   appendAnalysisEvent({
     metadata: {
@@ -114,11 +122,11 @@ export function emitAnalysisCompleted(auth: ResolvedAuth, fields: AnalysisComple
  * findings; this helper does not enforce findings_count > 0.
  * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
  */
-export function emitAnalysisFindingsDetected(
+export async function emitAnalysisFindingsDetected(
   auth: ResolvedAuth,
   fields: AnalysisFindingsDetectedFields,
-): void {
-  const base = buildAnalysisIdentityBase(auth);
+): Promise<void> {
+  const base = await buildAnalysisIdentityBase(auth);
   if (!base) return;
   appendAnalysisEvent({
     metadata: {

--- a/src/telemetry/identity.ts
+++ b/src/telemetry/identity.ts
@@ -1,0 +1,385 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  isEnvBasedAuth,
+  type ResolvedAuth,
+  resolveFromEndpoint,
+  resolveFromEnv,
+  resolveFromState,
+} from '../lib/auth-resolver.js';
+import { getTelemetryDir } from '../lib/config-constants.js';
+import type { AuthConnection, ServerType, TelemetryConnectionType } from '../lib/state.js';
+import { SonarQubeClient } from '../sonarqube/client.js';
+
+export interface TelemetryIdentity {
+  user_uuid: string | null;
+  organization_uuid_v4: string | null;
+  sqs_installation_id: string | null;
+}
+
+interface CacheEntry {
+  userUuid?: string | null;
+  organizationUuidV4?: string | null;
+  sqsInstallationId?: string | null;
+}
+
+interface IdentityCacheFile {
+  entries: Record<string, CacheEntry>;
+}
+
+interface IdentityFetchPlan {
+  user: boolean;
+  org: boolean;
+  sqs: boolean;
+}
+
+const CACHE_FILENAME = 'identity-cache.json';
+const TOKEN_FINGERPRINT_HEX_LENGTH = 16;
+
+const EMPTY_IDENTITY: TelemetryIdentity = {
+  user_uuid: null,
+  organization_uuid_v4: null,
+  sqs_installation_id: null,
+};
+
+export function identityFromConnection(conn: AuthConnection | undefined): TelemetryIdentity {
+  return {
+    user_uuid: conn?.userUuid ?? null,
+    organization_uuid_v4: conn?.organizationUuidV4 ?? null,
+    sqs_installation_id: conn?.sqsInstallationId ?? null,
+  };
+}
+
+export function authMatchesConnection(auth: ResolvedAuth, conn: AuthConnection): boolean {
+  if (auth.serverUrl !== conn.serverUrl) return false;
+  if (auth.connectionType === 'cloud' && auth.orgKey !== conn.orgKey) return false;
+  return true;
+}
+
+export function isIdentityCompleteForConnection(
+  identity: TelemetryIdentity,
+  connectionType: ServerType,
+): boolean {
+  if (connectionType === 'cloud') {
+    return !!identity.user_uuid && !!identity.organization_uuid_v4;
+  }
+  // user_uuid may be absent on older SonarQube Server versions (see TelemetryEventPayload).
+  return !!identity.sqs_installation_id;
+}
+
+function toTelemetryConnectionType(type: ServerType): Exclude<TelemetryConnectionType, null> {
+  return type === 'cloud' ? 'sqc' : 'sqs';
+}
+
+function matchingConnection(
+  conn: AuthConnection | undefined,
+  auth: ResolvedAuth | null,
+): AuthConnection | undefined {
+  if (conn === undefined) return undefined;
+  if (auth && !authMatchesConnection(auth, conn)) return undefined;
+  return conn;
+}
+
+/** Login persists `userUuid` (string or null); undefined means we have not tried yet. */
+function connectionUserUuidResolved(conn: AuthConnection | undefined): boolean {
+  return conn?.userUuid !== undefined;
+}
+
+function needsIdentityEnrichment(
+  identity: TelemetryIdentity,
+  connectionType: ServerType,
+  conn: AuthConnection | undefined,
+): boolean {
+  if (!isIdentityCompleteForConnection(identity, connectionType)) {
+    return true;
+  }
+  return !identity.user_uuid && !connectionUserUuidResolved(conn);
+}
+
+/**
+ * Resolves telemetry identity for command events (`storeEvent` postAction).
+ * Skips keychain/state auth lookup when the active connection already carries
+ * complete UUIDs and env-var auth is not in use.
+ */
+async function resolveStoreEventTelemetryIdentity(
+  conn: AuthConnection | undefined,
+): Promise<{ connectionType: TelemetryConnectionType; identity: TelemetryIdentity }> {
+  const envAuth = isEnvBasedAuth() ? resolveFromEnv() : null;
+  if (envAuth) {
+    return resolveCommandTelemetryIdentity(conn, envAuth);
+  }
+
+  if (conn) {
+    const identity = identityFromConnection(conn);
+    if (!needsIdentityEnrichment(identity, conn.type, conn)) {
+      return { connectionType: toTelemetryConnectionType(conn.type), identity };
+    }
+  }
+
+  const auth = await resolveFromState();
+  return resolveCommandTelemetryIdentity(conn, auth);
+}
+
+/**
+ * Like {@link resolveStoreEventTelemetryIdentity}, but never throws — telemetry
+ * must not fail an otherwise-successful command.
+ */
+export async function resolveStoreEventTelemetryIdentitySafely(
+  conn: AuthConnection | undefined,
+): Promise<{ connectionType: TelemetryConnectionType; identity: TelemetryIdentity }> {
+  try {
+    return await resolveStoreEventTelemetryIdentity(conn);
+  } catch {
+    return {
+      connectionType: conn ? toTelemetryConnectionType(conn.type) : null,
+      identity: identityFromConnection(conn),
+    };
+  }
+}
+
+export async function resolveCommandTelemetryIdentity(
+  conn: AuthConnection | undefined,
+  auth: ResolvedAuth | null,
+): Promise<{ connectionType: TelemetryConnectionType; identity: TelemetryIdentity }> {
+  const seedConn = matchingConnection(conn, auth);
+  let identity = identityFromConnection(seedConn);
+  let connectionType: TelemetryConnectionType = seedConn
+    ? toTelemetryConnectionType(seedConn.type)
+    : null;
+
+  if (auth) {
+    connectionType = toTelemetryConnectionType(auth.connectionType);
+    if (needsIdentityEnrichment(identity, auth.connectionType, seedConn)) {
+      identity = await resolveTelemetryIdentity(auth, identity);
+    }
+  }
+
+  return { connectionType, identity };
+}
+
+export async function resolveTelemetryIdentity(
+  auth: ResolvedAuth,
+  seed: TelemetryIdentity = EMPTY_IDENTITY,
+): Promise<TelemetryIdentity> {
+  const entryKey = cacheKey(auth);
+  const diskCache = readDiskCache();
+  const diskEntry = entryKey in diskCache.entries ? diskCache.entries[entryKey] : undefined;
+
+  let identity = mergeIdentity(EMPTY_IDENTITY, seed);
+  if (diskEntry !== undefined) {
+    identity = mergeIdentity(identity, cacheEntryToIdentity(diskEntry));
+  }
+
+  const fetchPlan = planFieldsToFetch(auth, identity, diskEntry);
+  if (fetchPlanIsComplete(fetchPlan)) {
+    return identity;
+  }
+
+  const fetchResult = await fetchMissingFromApi(auth, identity, fetchPlan);
+  identity = fetchResult.identity;
+
+  const updatedEntry: CacheEntry = diskEntry === undefined ? {} : { ...diskEntry };
+  if (fetchPlan.user && fetchResult.resolved.user) {
+    updatedEntry.userUuid = identity.user_uuid;
+  }
+  if (fetchPlan.org && fetchResult.resolved.org) {
+    updatedEntry.organizationUuidV4 = identity.organization_uuid_v4;
+  }
+  if (fetchPlan.sqs && fetchResult.resolved.sqs) {
+    updatedEntry.sqsInstallationId = identity.sqs_installation_id;
+  }
+  if (Object.keys(updatedEntry).length > 0) {
+    diskCache.entries[entryKey] = updatedEntry;
+    writeDiskCache(diskCache);
+  }
+
+  return identity;
+}
+
+function cacheKey(auth: ResolvedAuth): string {
+  const fingerprint = createHash('sha256')
+    .update(auth.token)
+    .digest('hex')
+    .slice(0, TOKEN_FINGERPRINT_HEX_LENGTH);
+  return [auth.connectionType, auth.serverUrl, auth.orgKey ?? '', fingerprint].join('|');
+}
+
+function cacheEntryToIdentity(entry: CacheEntry): TelemetryIdentity {
+  return {
+    user_uuid: entry.userUuid ?? null,
+    organization_uuid_v4: entry.organizationUuidV4 ?? null,
+    sqs_installation_id: entry.sqsInstallationId ?? null,
+  };
+}
+
+function fetchPlanIsComplete(plan: IdentityFetchPlan): boolean {
+  return !plan.user && !plan.org && !plan.sqs;
+}
+
+function planFieldsToFetch(
+  auth: ResolvedAuth,
+  identity: TelemetryIdentity,
+  entry?: CacheEntry,
+): IdentityFetchPlan {
+  return {
+    user: !identity.user_uuid && !(entry && 'userUuid' in entry),
+    org:
+      auth.connectionType === 'cloud' &&
+      !!auth.orgKey &&
+      !identity.organization_uuid_v4 &&
+      !(entry && 'organizationUuidV4' in entry),
+    sqs:
+      auth.connectionType === 'on-premise' &&
+      !identity.sqs_installation_id &&
+      !(entry && 'sqsInstallationId' in entry),
+  };
+}
+
+function mergeIdentity(
+  base: TelemetryIdentity,
+  partial: Partial<TelemetryIdentity>,
+): TelemetryIdentity {
+  return {
+    user_uuid: partial.user_uuid ?? base.user_uuid,
+    organization_uuid_v4: partial.organization_uuid_v4 ?? base.organization_uuid_v4,
+    sqs_installation_id: partial.sqs_installation_id ?? base.sqs_installation_id,
+  };
+}
+
+function readDiskCache(): IdentityCacheFile {
+  const path = join(getTelemetryDir(), CACHE_FILENAME);
+  if (!existsSync(path)) {
+    return { entries: {} };
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'entries' in parsed &&
+      typeof (parsed as IdentityCacheFile).entries === 'object'
+    ) {
+      return parsed as IdentityCacheFile;
+    }
+  } catch {
+    return { entries: {} };
+  }
+  return { entries: {} };
+}
+
+function writeDiskCache(cache: IdentityCacheFile): void {
+  try {
+    mkdirSync(getTelemetryDir(), { recursive: true });
+    writeFileSync(join(getTelemetryDir(), CACHE_FILENAME), JSON.stringify(cache));
+  } catch {
+    // Best-effort — read-only or ephemeral filesystems skip persistence.
+  }
+}
+
+interface IdentityFetchResult {
+  identity: TelemetryIdentity;
+  resolved: IdentityFetchPlan;
+}
+
+async function fetchMissingFromApi(
+  auth: ResolvedAuth,
+  identity: TelemetryIdentity,
+  fetchPlan: IdentityFetchPlan,
+): Promise<IdentityFetchResult> {
+  const client = new SonarQubeClient(auth.serverUrl, auth.token);
+  let { user_uuid, organization_uuid_v4, sqs_installation_id } = identity;
+  const resolved: IdentityFetchPlan = { user: false, org: false, sqs: false };
+
+  if (fetchPlan.user) {
+    const user = await fetchUserUuid(client);
+    user_uuid = user.value;
+    resolved.user = user.resolved;
+  }
+  if (fetchPlan.org && auth.orgKey) {
+    const org = await fetchOrganizationUuid(client, auth.serverUrl, auth.orgKey);
+    organization_uuid_v4 = org.value;
+    resolved.org = org.resolved;
+  }
+  if (fetchPlan.sqs) {
+    const sqs = await fetchSqsInstallationId(client);
+    sqs_installation_id = sqs.value;
+    resolved.sqs = sqs.resolved;
+  }
+
+  return {
+    identity: { user_uuid, organization_uuid_v4, sqs_installation_id },
+    resolved,
+  };
+}
+
+interface FieldFetchResult {
+  value: string | null;
+  resolved: boolean;
+}
+
+async function fetchUserUuid(client: SonarQubeClient): Promise<FieldFetchResult> {
+  try {
+    const { response, value } = await client.getSafe<{ id: string }>('/api/users/current');
+    if (!response.ok) {
+      return { value: null, resolved: false };
+    }
+    return { value: value?.id ?? null, resolved: true };
+  } catch {
+    return { value: null, resolved: false };
+  }
+}
+
+async function fetchOrganizationUuid(
+  client: SonarQubeClient,
+  serverUrl: string,
+  orgKey: string,
+): Promise<FieldFetchResult> {
+  try {
+    const endpoint = '/organizations/organizations';
+    const { response, value } = await client.getSafe<Array<{ uuidV4: string }>>(
+      endpoint,
+      { organizationKey: orgKey, excludeEligibility: 'true' },
+      resolveFromEndpoint(serverUrl, endpoint),
+    );
+    if (!response.ok) {
+      return { value: null, resolved: false };
+    }
+    return { value: value?.[0]?.uuidV4 ?? null, resolved: true };
+  } catch {
+    return { value: null, resolved: false };
+  }
+}
+
+async function fetchSqsInstallationId(client: SonarQubeClient): Promise<FieldFetchResult> {
+  try {
+    const { response, value } = await client.getSafe<{ id?: string }>('/api/system/status');
+    if (!response.ok) {
+      return { value: null, resolved: false };
+    }
+    return { value: value?.id ?? null, resolved: true };
+  } catch {
+    return { value: null, resolved: false };
+  }
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -32,6 +32,7 @@ import type { StoredTelemetryEvent, TelemetryEventPayload } from '../lib/state.j
 import { getActiveConnection, loadState, saveState } from '../lib/state-manager.js';
 import { isTelemetryEnabled } from './enabled.js';
 import { flushFindings } from './findings.js';
+import { resolveStoreEventTelemetryIdentitySafely } from './identity.js';
 import { getOrCreateUserId } from './user.js';
 
 export const TELEMETRY_FLUSH_MODE_ENV = '__SQ_CLI_TELEMETRY_FLUSH__';
@@ -49,13 +50,13 @@ export function setPassthroughSubcommand(command: Command, subcommand: string | 
  * Append one event to the pending batch and spawn a detached flush worker.
  * No-ops when called from within a flush worker to prevent infinite recursion.
  */
-export function storeEvent(command: Command, success: boolean): Promise<void> {
-  if (process.env[TELEMETRY_FLUSH_MODE_ENV]) return Promise.resolve();
+export async function storeEvent(command: Command, success: boolean): Promise<void> {
+  if (process.env[TELEMETRY_FLUSH_MODE_ENV]) return;
 
   const state = loadState();
 
   if (!isTelemetryEnabled(state)) {
-    return Promise.resolve();
+    return;
   }
   const commandNames: string[] = [];
   let current: Command = command;
@@ -74,8 +75,7 @@ export function storeEvent(command: Command, success: boolean): Promise<void> {
   }
 
   const conn = getActiveConnection(state);
-  const connectionType: 'sqc' | 'sqs' | null =
-    conn?.type === 'cloud' ? 'sqc' : conn?.type === 'on-premise' ? 'sqs' : null;
+  const { connectionType, identity } = await resolveStoreEventTelemetryIdentitySafely(conn);
 
   const eventPayload: TelemetryEventPayload = {
     cli_installation_id: state.telemetry.installationId!,
@@ -87,9 +87,9 @@ export function storeEvent(command: Command, success: boolean): Promise<void> {
     result: success ? 'success' : 'failure',
     os: process.platform,
     connection_type: connectionType,
-    user_uuid: conn?.userUuid ?? null,
-    organization_uuid_v4: conn?.organizationUuidV4 ?? null,
-    sqs_installation_id: conn?.sqsInstallationId ?? null,
+    user_uuid: identity.user_uuid,
+    organization_uuid_v4: identity.organization_uuid_v4,
+    sqs_installation_id: identity.sqs_installation_id,
     distribution: DISTRIBUTION,
     caller_agent: detectCallerAgent(),
   };
@@ -110,7 +110,6 @@ export function storeEvent(command: Command, success: boolean): Promise<void> {
   saveState(state);
 
   spawnFlushWorker();
-  return Promise.resolve();
 }
 
 /**

--- a/src/telemetry/sqaa-analysis-telemetry.ts
+++ b/src/telemetry/sqaa-analysis-telemetry.ts
@@ -123,7 +123,7 @@ export function tallyFromSqaaJsonReport(report: SqaaJsonReport): RunTally {
  * `errors_count` is {@link RunTally.totalErrors} only (API `errors[]` on successful analyses).
  * `failures_count` is {@link RunTally.totalFailures} (per-file analysis failures).
  */
-export function emitSqaaAnalysisTelemetry(
+export async function emitSqaaAnalysisTelemetry(
   callerCommand:
     | typeof SQAA_ANALYZE_AGENTIC_CALLER_COMMAND
     | typeof SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND
@@ -132,11 +132,11 @@ export function emitSqaaAnalysisTelemetry(
   tally: RunTally,
   durationMs: number,
   exitCode?: number | null,
-): void {
+): Promise<void> {
   const analysisId = randomUUID();
   const findingsCount = tally.totalIssues;
 
-  emitAnalysisCompleted(auth, {
+  await emitAnalysisCompleted(auth, {
     caller_command: callerCommand,
     analyzer: 'sqaa',
     analysis_id: analysisId,
@@ -149,7 +149,7 @@ export function emitSqaaAnalysisTelemetry(
 
   if (findingsCount === 0) return;
 
-  emitAnalysisFindingsDetected(auth, {
+  await emitAnalysisFindingsDetected(auth, {
     caller_command: callerCommand,
     analyzer: 'sqaa',
     analysis_id: analysisId,

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -243,8 +243,8 @@ afterEach(async () => {
 // ─── emitAnalysisCompleted ─────────────────────────────────────────────────────
 
 describe('emitAnalysisCompleted()', () => {
-  it('writes a valid CliAnalysisCompleted envelope', () => {
-    emitAnalysisCompleted(AUTH, makeCompletedFields({ findings_count: 2, exit_code: 51 }));
+  it('writes a valid CliAnalysisCompleted envelope', async () => {
+    await emitAnalysisCompleted(AUTH, makeCompletedFields({ findings_count: 2, exit_code: 51 }));
 
     const [event] = readLines(testSonarUserHome);
     expect(event.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
@@ -255,48 +255,51 @@ describe('emitAnalysisCompleted()', () => {
     expect(completedEvent.event_payload.caller_command).toBe(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND);
   });
 
-  it('does not append when telemetry is disabled', () => {
+  it('does not append when telemetry is disabled', async () => {
     loadStateSpy.mockReturnValue(makeTelemetryState(false));
 
-    emitAnalysisCompleted(AUTH, makeCompletedFields());
+    await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     expect(readLines(testSonarUserHome)).toHaveLength(0);
   });
 
-  it('does not append when installationId is absent', () => {
+  it('does not append when installationId is absent', async () => {
     const stateWithoutId = makeTelemetryState();
     stateWithoutId.telemetry.installationId = undefined;
     loadStateSpy.mockReturnValue(stateWithoutId);
 
-    emitAnalysisCompleted(AUTH, makeCompletedFields());
+    await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     expect(readLines(testSonarUserHome)).toHaveLength(0);
   });
 
-  it('sets connection_type to sqc for cloud connections', () => {
-    emitAnalysisCompleted({ ...AUTH, connectionType: 'cloud' }, makeCompletedFields());
+  it('sets connection_type to sqc for cloud connections', async () => {
+    await emitAnalysisCompleted({ ...AUTH, connectionType: 'cloud' }, makeCompletedFields());
 
     const [event] = readLines(testSonarUserHome);
     expect((event as StoredAnalysisCompletedEvent).event_payload.connection_type).toBe('sqc');
   });
 
-  it('sets connection_type to sqs for server connections', () => {
-    emitAnalysisCompleted({ ...AUTH, connectionType: 'on-premise' }, makeCompletedFields());
+  it('sets connection_type to sqs for server connections', async () => {
+    await emitAnalysisCompleted({ ...AUTH, connectionType: 'on-premise' }, makeCompletedFields());
 
     const [event] = readLines(testSonarUserHome);
     expect((event as StoredAnalysisCompletedEvent).event_payload.connection_type).toBe('sqs');
   });
 
-  it('includes connection identity fields from the active connection', () => {
+  it('includes connection identity fields from the active connection', async () => {
     getConnectionSpy.mockReturnValue({
+      id: 'conn-id',
+      type: 'cloud',
       serverUrl: 'https://sonarcloud.io',
+      orgKey: 'my-org',
       authenticatedAt: '2026-01-01T00:00:00.000Z',
       userUuid: 'user-uuid-abc',
       organizationUuidV4: 'org-uuid-xyz',
       sqsInstallationId: 'sqs-install-id-123',
     });
 
-    emitAnalysisCompleted(AUTH, makeCompletedFields());
+    await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     const payload = (readLines(testSonarUserHome)[0] as StoredAnalysisCompletedEvent).event_payload;
     expect(payload.user_uuid).toBe('user-uuid-abc');
@@ -304,20 +307,20 @@ describe('emitAnalysisCompleted()', () => {
     expect(payload.sqs_installation_id).toBe('sqs-install-id-123');
   });
 
-  it('sets caller_agent from detectCallerAgent', () => {
+  it('sets caller_agent from detectCallerAgent', async () => {
     detectAgentSpy.mockReturnValue('cursor');
 
-    emitAnalysisCompleted(AUTH, makeCompletedFields());
+    await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     const payload = (readLines(testSonarUserHome)[0] as StoredAnalysisCompletedEvent).event_payload;
     expect(payload.caller_agent).toBe('cursor');
   });
 
-  it('creates the telemetry directory if it does not exist', () => {
+  it('creates the telemetry directory if it does not exist', async () => {
     const telemetryDir = join(testSonarUserHome, 'sonarqube-cli', 'telemetry');
     expect(existsSync(telemetryDir)).toBe(false);
 
-    emitAnalysisCompleted(AUTH, makeCompletedFields());
+    await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     expect(existsSync(telemetryDir)).toBe(true);
   });
@@ -326,8 +329,8 @@ describe('emitAnalysisCompleted()', () => {
 // ─── emitAnalysisFindingsDetected ──────────────────────────────────────────────
 
 describe('emitAnalysisFindingsDetected()', () => {
-  it('writes a valid CliAnalysisFindingsDetected envelope', () => {
-    emitAnalysisFindingsDetected(
+  it('writes a valid CliAnalysisFindingsDetected envelope', async () => {
+    await emitAnalysisFindingsDetected(
       AUTH,
       makeFindingsDetectedFields({ analysis_id: 'abc-123', details_schema_version: 1 }),
     );
@@ -343,10 +346,10 @@ describe('emitAnalysisFindingsDetected()', () => {
     });
   });
 
-  it('does not append when telemetry is disabled', () => {
+  it('does not append when telemetry is disabled', async () => {
     loadStateSpy.mockReturnValue(makeTelemetryState(false));
 
-    emitAnalysisFindingsDetected(AUTH, makeFindingsDetectedFields());
+    await emitAnalysisFindingsDetected(AUTH, makeFindingsDetectedFields());
 
     expect(readLines(testSonarUserHome)).toHaveLength(0);
   });

--- a/tests/unit/telemetry/identity-api-mock.ts
+++ b/tests/unit/telemetry/identity-api-mock.ts
@@ -1,0 +1,88 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { spyOn } from 'bun:test';
+
+import { SonarQubeClient } from '../../../src/sonarqube/client.js';
+
+interface ApiStep {
+  ok: boolean;
+  id?: string;
+  uuidV4?: string;
+}
+
+interface IdentityApiMockOptions {
+  user?: ApiStep[];
+  org?: ApiStep[];
+  status?: ApiStep[];
+}
+
+function shiftStep(queue: ApiStep[] | undefined, fallback: ApiStep): ApiStep {
+  return queue?.shift() ?? fallback;
+}
+
+/** Mock SonarQubeClient.getSafe for telemetry identity resolver tests. */
+export function mockIdentityGetSafe(
+  options: IdentityApiMockOptions = {},
+): ReturnType<typeof spyOn> {
+  const prototype = SonarQubeClient.prototype as {
+    getSafe?: ReturnType<typeof spyOn>;
+  };
+  prototype.getSafe?.mockRestore?.();
+
+  const userSteps = options.user ? [...options.user] : undefined;
+  const orgSteps = options.org ? [...options.org] : undefined;
+  const statusSteps = options.status ? [...options.status] : undefined;
+
+  return spyOn(SonarQubeClient.prototype, 'getSafe').mockImplementation(
+    <TValue>(
+      endpoint: string,
+      _params?: Record<string, string | number | boolean>,
+      _baseUrl?: string,
+    ): Promise<{ response: Response; value: TValue | undefined }> => {
+      if (endpoint === '/api/users/current') {
+        const step = shiftStep(userSteps, { ok: true });
+        return Promise.resolve({
+          response: { ok: step.ok } as Response,
+          value: (step.id ? { id: step.id } : {}) as TValue,
+        });
+      }
+      if (endpoint === '/organizations/organizations') {
+        const step = shiftStep(orgSteps, { ok: true });
+        return Promise.resolve({
+          response: { ok: step.ok } as Response,
+          value: (step.uuidV4 ? [{ uuidV4: step.uuidV4 }] : []) as TValue,
+        });
+      }
+      if (endpoint === '/api/system/status') {
+        const step = shiftStep(statusSteps, { ok: true });
+        return Promise.resolve({
+          response: { ok: step.ok } as Response,
+          value: {
+            status: 'UP',
+            version: '1',
+            ...(step.id ? { id: step.id } : {}),
+          } as TValue,
+        });
+      }
+      return Promise.reject(new Error(`Unexpected getSafe endpoint in identity test: ${endpoint}`));
+    },
+  );
+}

--- a/tests/unit/telemetry/identity.test.ts
+++ b/tests/unit/telemetry/identity.test.ts
@@ -1,0 +1,465 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * Unit tests for telemetry/identity.ts pure helpers and the disk/env/API
+ * enrichment layering in resolveTelemetryIdentity / resolveCommandTelemetryIdentity.
+ * Every test uses a unique token and isolated SONAR_USER_HOME to avoid cross-test
+ * disk-cache hits.
+ */
+
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
+import * as authResolver from '../../../src/lib/auth-resolver.js';
+import { ENV_SONAR_USER_HOME, getTelemetryDir } from '../../../src/lib/config-constants.js';
+import type { AuthConnection } from '../../../src/lib/state.js';
+import {
+  authMatchesConnection,
+  identityFromConnection,
+  isIdentityCompleteForConnection,
+  resolveCommandTelemetryIdentity,
+  resolveStoreEventTelemetryIdentitySafely,
+  resolveTelemetryIdentity,
+} from '../../../src/telemetry/identity.js';
+import { mockIdentityGetSafe } from './identity-api-mock.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function cloudAuth(token: string, orgKey = 'my-org'): ResolvedAuth {
+  return { token, serverUrl: 'https://sonarcloud.io', orgKey, connectionType: 'cloud' };
+}
+
+function serverAuth(token: string): ResolvedAuth {
+  return { token, serverUrl: 'https://sq.example.com', connectionType: 'on-premise' };
+}
+
+function cloudConn(overrides: Partial<AuthConnection> = {}): AuthConnection {
+  return {
+    id: 'conn-cloud',
+    type: 'cloud',
+    serverUrl: 'https://sonarcloud.io',
+    orgKey: 'my-org',
+    authenticatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Replicates identity.ts#cacheKey so tests can seed the disk cache directly. */
+function cacheKey(auth: ResolvedAuth): string {
+  const fingerprint = createHash('sha256').update(auth.token).digest('hex').slice(0, 16);
+  return [auth.connectionType, auth.serverUrl, auth.orgKey ?? '', fingerprint].join('|');
+}
+
+function seedDiskCache(auth: ResolvedAuth, entry: Record<string, unknown>): void {
+  mkdirSync(getTelemetryDir(), { recursive: true });
+  writeFileSync(
+    join(getTelemetryDir(), 'identity-cache.json'),
+    JSON.stringify({ entries: { [cacheKey(auth)]: entry } }),
+  );
+}
+
+function writeRawCache(contents: string): void {
+  mkdirSync(getTelemetryDir(), { recursive: true });
+  writeFileSync(join(getTelemetryDir(), 'identity-cache.json'), contents);
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'identity-test-'));
+  process.env[ENV_SONAR_USER_HOME] = testDir;
+});
+
+afterEach(() => {
+  delete process.env[ENV_SONAR_USER_HOME];
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+describe('identityFromConnection()', () => {
+  it('returns all-null identity when the connection is undefined', () => {
+    expect(identityFromConnection(undefined)).toEqual({
+      user_uuid: null,
+      organization_uuid_v4: null,
+      sqs_installation_id: null,
+    });
+  });
+
+  it('maps connection UUID fields into the identity payload', () => {
+    const identity = identityFromConnection(
+      cloudConn({ userUuid: 'u', organizationUuidV4: 'o', sqsInstallationId: 's' }),
+    );
+    expect(identity).toEqual({
+      user_uuid: 'u',
+      organization_uuid_v4: 'o',
+      sqs_installation_id: 's',
+    });
+  });
+});
+
+describe('authMatchesConnection()', () => {
+  it('matches when server URL and org key align (cloud)', () => {
+    expect(authMatchesConnection(cloudAuth('t'), cloudConn())).toBe(true);
+  });
+
+  it('does not match on a different server URL', () => {
+    expect(
+      authMatchesConnection(cloudAuth('t'), cloudConn({ serverUrl: 'https://other.io' })),
+    ).toBe(false);
+  });
+
+  it('does not match on a different org key (cloud)', () => {
+    expect(authMatchesConnection(cloudAuth('t'), cloudConn({ orgKey: 'different' }))).toBe(false);
+  });
+
+  it('ignores org key for on-premise connections', () => {
+    const conn: AuthConnection = {
+      id: 'c',
+      type: 'on-premise',
+      serverUrl: 'https://sq.example.com',
+      authenticatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    expect(authMatchesConnection(serverAuth('t'), conn)).toBe(true);
+  });
+});
+
+describe('isIdentityCompleteForConnection()', () => {
+  it('requires user_uuid for cloud', () => {
+    expect(
+      isIdentityCompleteForConnection(
+        { user_uuid: null, organization_uuid_v4: 'o', sqs_installation_id: null },
+        'cloud',
+      ),
+    ).toBe(false);
+  });
+
+  it('requires organization_uuid_v4 for cloud', () => {
+    expect(
+      isIdentityCompleteForConnection(
+        { user_uuid: 'u', organization_uuid_v4: null, sqs_installation_id: null },
+        'cloud',
+      ),
+    ).toBe(false);
+    expect(
+      isIdentityCompleteForConnection(
+        { user_uuid: 'u', organization_uuid_v4: 'o', sqs_installation_id: null },
+        'cloud',
+      ),
+    ).toBe(true);
+  });
+
+  it('requires sqs_installation_id for on-premise', () => {
+    expect(
+      isIdentityCompleteForConnection(
+        { user_uuid: null, organization_uuid_v4: null, sqs_installation_id: null },
+        'on-premise',
+      ),
+    ).toBe(false);
+    expect(
+      isIdentityCompleteForConnection(
+        { user_uuid: null, organization_uuid_v4: null, sqs_installation_id: 's' },
+        'on-premise',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('resolveStoreEventTelemetryIdentitySafely()', () => {
+  it('falls back to the connection identity when enrichment throws', async () => {
+    const conn = cloudConn({ userUuid: 'u' });
+    const resolveFromStateSpy = spyOn(authResolver, 'resolveFromState').mockRejectedValue(
+      new Error('keychain locked'),
+    );
+
+    const result = await resolveStoreEventTelemetryIdentitySafely(conn);
+
+    expect(result.connectionType).toBe('sqc');
+    expect(result.identity.user_uuid).toBe('u');
+    resolveFromStateSpy.mockRestore();
+  });
+});
+
+// ─── resolveCommandTelemetryIdentity ───────────────────────────────────────────
+
+describe('resolveCommandTelemetryIdentity()', () => {
+  it('uses the connection identity without enrichment when auth is null', async () => {
+    const conn = cloudConn({ userUuid: 'u', organizationUuidV4: 'o' });
+    const getSafeSpy = mockIdentityGetSafe();
+
+    const { connectionType, identity } = await resolveCommandTelemetryIdentity(conn, null);
+
+    expect(connectionType).toBe('sqc');
+    expect(identity.user_uuid).toBe('u');
+    expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('maps on-premise auth to sqs and skips enrichment when the connection is complete', async () => {
+    const conn: AuthConnection = {
+      id: 'c',
+      type: 'on-premise',
+      serverUrl: 'https://sq.example.com',
+      authenticatedAt: '2026-01-01T00:00:00.000Z',
+      sqsInstallationId: 's',
+      userUuid: 'server-user',
+    };
+    const getSafeSpy = mockIdentityGetSafe();
+
+    const { connectionType, identity } = await resolveCommandTelemetryIdentity(
+      conn,
+      serverAuth('sqs-complete-token'),
+    );
+
+    expect(connectionType).toBe('sqs');
+    expect(identity.sqs_installation_id).toBe('s');
+    expect(identity.user_uuid).toBe('server-user');
+    expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('ignores a connection that does not match the resolved auth', async () => {
+    const conn = cloudConn({ userUuid: 'stale-user', serverUrl: 'https://other.io' });
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'fresh-user' }],
+      org: [{ ok: true, uuidV4: 'fresh-org' }],
+    });
+
+    const { identity } = await resolveCommandTelemetryIdentity(
+      conn,
+      cloudAuth('cmd-mismatch-token'),
+    );
+
+    expect(identity.user_uuid).toBe('fresh-user');
+    getSafeSpy.mockRestore();
+  });
+});
+
+// ─── resolveTelemetryIdentity ──────────────────────────────────────────────────
+
+describe('resolveTelemetryIdentity()', () => {
+  it('resolves the SQS installation id from system status for on-premise auth', async () => {
+    const getSafeSpy = mockIdentityGetSafe({
+      status: [{ ok: true, id: 'sqs-abc' }],
+      user: [{ ok: true, id: 'sqs-user' }],
+    });
+
+    const identity = await resolveTelemetryIdentity(serverAuth('sqs-token-1'));
+
+    expect(identity.user_uuid).toBe('sqs-user');
+    expect(identity.sqs_installation_id).toBe('sqs-abc');
+    getSafeSpy.mockRestore();
+  });
+
+  it('fetches user_uuid for on-premise auth when available', async () => {
+    const getSafeSpy = mockIdentityGetSafe({
+      status: [{ ok: true, id: 'sqs-only' }],
+      user: [{ ok: true, id: 'sqs-user-id' }],
+    });
+
+    const identity = await resolveTelemetryIdentity(serverAuth('sqs-token-with-user'));
+
+    expect(identity.user_uuid).toBe('sqs-user-id');
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+    ).toHaveLength(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('leaves sqs_installation_id null when system status fails', async () => {
+    const getSafeSpy = mockIdentityGetSafe({
+      status: [{ ok: false }],
+    });
+
+    const identity = await resolveTelemetryIdentity(serverAuth('sqs-token-2'));
+
+    expect(identity.sqs_installation_id).toBeNull();
+    getSafeSpy.mockRestore();
+  });
+
+  it('serves a complete identity from the disk cache without hitting the API', async () => {
+    const auth = cloudAuth('disk-complete-token');
+    seedDiskCache(auth, { userUuid: 'disk-user', organizationUuidV4: 'disk-org' });
+
+    const getSafeSpy = mockIdentityGetSafe();
+
+    const identity = await resolveTelemetryIdentity(auth);
+
+    expect(identity.user_uuid).toBe('disk-user');
+    expect(identity.organization_uuid_v4).toBe('disk-org');
+    expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('caches confirmed-absent organization_uuid and stops re-fetching', async () => {
+    const auth = cloudAuth('org-absent-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'cloud-user' }],
+      org: [{ ok: true }],
+    });
+
+    await resolveTelemetryIdentity(auth);
+    await resolveTelemetryIdentity(cloudAuth('org-absent-token'));
+
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/organizations/organizations'),
+    ).toHaveLength(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('treats a malformed disk cache as empty and falls back to the API', async () => {
+    writeRawCache('{ not valid json');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'api-user' }],
+      org: [{ ok: true, uuidV4: 'api-org' }],
+    });
+
+    const identity = await resolveTelemetryIdentity(cloudAuth('malformed-cache-token'));
+
+    expect(identity.user_uuid).toBe('api-user');
+    expect(getSafeSpy).toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('treats a cache file without an entries object as empty', async () => {
+    writeRawCache(JSON.stringify({ unexpected: true }));
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'api-user' }],
+      org: [{ ok: true, uuidV4: 'api-org' }],
+    });
+
+    const identity = await resolveTelemetryIdentity(cloudAuth('no-entries-token'));
+
+    expect(identity.user_uuid).toBe('api-user');
+    expect(identity.organization_uuid_v4).toBe('api-org');
+    getSafeSpy.mockRestore();
+  });
+
+  it('caches confirmed-absent user_uuid for cloud and stops re-fetching', async () => {
+    const auth = cloudAuth('user-absent-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true }],
+      org: [{ ok: true, uuidV4: 'cloud-org' }],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(cloudAuth('user-absent-token'));
+
+    expect(first.user_uuid).toBeNull();
+    expect(first.organization_uuid_v4).toBe('cloud-org');
+    expect(second.user_uuid).toBeNull();
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+    ).toHaveLength(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('retries user_uuid fetch after a transient API failure', async () => {
+    const auth = cloudAuth('transient-user-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: false }, { ok: true, id: 'user-after-retry' }],
+      org: [{ ok: true, uuidV4: 'cached-org' }],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(cloudAuth('transient-user-token'));
+
+    expect(first.user_uuid).toBeNull();
+    expect(second.user_uuid).toBe('user-after-retry');
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+    ).toHaveLength(2);
+    getSafeSpy.mockRestore();
+  });
+
+  it('treats on-premise identity as complete with only sqs_installation_id when login confirmed user absence', async () => {
+    const conn: AuthConnection = {
+      id: 'c',
+      type: 'on-premise',
+      serverUrl: 'https://sq.example.com',
+      authenticatedAt: '2026-01-01T00:00:00.000Z',
+      sqsInstallationId: 'sqs-old-server',
+      userUuid: null,
+    };
+    const getSafeSpy = mockIdentityGetSafe();
+
+    const { connectionType, identity } = await resolveCommandTelemetryIdentity(
+      conn,
+      serverAuth('sqs-old-token'),
+    );
+
+    expect(connectionType).toBe('sqs');
+    expect(identity.user_uuid).toBeNull();
+    expect(identity.sqs_installation_id).toBe('sqs-old-server');
+    expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('fetches user_uuid for on-premise when the connection has sqs but login never resolved user', async () => {
+    const conn: AuthConnection = {
+      id: 'c',
+      type: 'on-premise',
+      serverUrl: 'https://sq.example.com',
+      authenticatedAt: '2026-01-01T00:00:00.000Z',
+      sqsInstallationId: 'sqs-old-server',
+    };
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'legacy-conn-user' }],
+    });
+
+    const { identity } = await resolveCommandTelemetryIdentity(
+      conn,
+      serverAuth('sqs-legacy-token'),
+    );
+
+    expect(identity.user_uuid).toBe('legacy-conn-user');
+    expect(identity.sqs_installation_id).toBe('sqs-old-server');
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+    ).toHaveLength(1);
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/system/status'),
+    ).toHaveLength(0);
+    getSafeSpy.mockRestore();
+  });
+
+  it('caches sqs_installation_id for on-premise and does not re-fetch', async () => {
+    const auth = serverAuth('sqs-cache-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      status: [{ ok: true, id: 'sqs-cached' }],
+    });
+
+    await resolveTelemetryIdentity(auth);
+    await resolveTelemetryIdentity(serverAuth('sqs-cache-token'));
+
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/system/status'),
+    ).toHaveLength(1);
+    getSafeSpy.mockRestore();
+  });
+});

--- a/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
@@ -192,8 +192,8 @@ describe('tallyFromSqaaJsonReport()', () => {
 });
 
 describe('emitSqaaAnalysisTelemetry()', () => {
-  it('writes CliAnalysisCompleted only on a clean run', () => {
-    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, makeTally(), 123, 0);
+  it('writes CliAnalysisCompleted only on a clean run', async () => {
+    await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, makeTally(), 123, 0);
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(1);
@@ -209,15 +209,20 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     expect(completed.event_payload.analysis_id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
-  it('emits null exit_code when the handler does not pass one', () => {
-    emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, makeTally(), 123);
+  it('emits null exit_code when the handler does not pass one', async () => {
+    await emitSqaaAnalysisTelemetry(
+      SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
+      AUTH,
+      makeTally(),
+      123,
+    );
 
     const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.exit_code).toBeNull();
     expect(completed.event_payload.failures_count).toBe(0);
   });
 
-  it('emits failures_count when files fail even without exit_code', () => {
+  it('emits failures_count when files fail even without exit_code', async () => {
     const tally = makeTally({
       totalFailures: 1,
       allResults: [
@@ -229,14 +234,14 @@ describe('emitSqaaAnalysisTelemetry()', () => {
       ],
     });
 
-    emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, tally, 123);
+    await emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, tally, 123);
 
     const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.exit_code).toBeNull();
     expect(completed.event_payload.failures_count).toBe(1);
   });
 
-  it('writes Completed and FindingsDetected with matching analysis_id when issues exist', () => {
+  it('writes Completed and FindingsDetected with matching analysis_id when issues exist', async () => {
     const tally = makeTally({
       totalIssues: 2,
       allResults: [
@@ -249,7 +254,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
       ],
     });
 
-    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 456, 51);
+    await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 456, 51);
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(2);
@@ -271,7 +276,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     });
   });
 
-  it('writes exit code 1 when failures exist without issues', () => {
+  it('writes exit code 1 when failures exist without issues', async () => {
     const tally = makeTally({
       totalFailures: 1,
       allResults: [
@@ -283,7 +288,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
       ],
     });
 
-    emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, tally, 789, 1);
+    await emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, tally, 789, 1);
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(1);
@@ -295,7 +300,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     expect(completed.event_payload.findings_count).toBe(0);
   });
 
-  it('counts API errors from successful analyses in errors_count', () => {
+  it('counts API errors from successful analyses in errors_count', async () => {
     const tally = makeTally({
       totalIssues: 1,
       totalErrors: 2,
@@ -312,14 +317,14 @@ describe('emitSqaaAnalysisTelemetry()', () => {
       ],
     });
 
-    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 51);
+    await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 51);
 
     const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.exit_code).toBe(51);
     expect(completed.event_payload.errors_count).toBe(2);
   });
 
-  it('uses exit code 1 when failures coexist with findings', () => {
+  it('uses exit code 1 when failures coexist with findings', async () => {
     const tally = makeTally({
       totalIssues: 2,
       totalFailures: 1,
@@ -338,7 +343,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
       ],
     });
 
-    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 1);
+    await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 1);
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(2);
@@ -349,10 +354,10 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     expect(completed.event_payload.failures_count).toBe(1);
   });
 
-  it('does not write when telemetry is disabled', () => {
+  it('does not write when telemetry is disabled', async () => {
     loadStateSpy.mockReturnValue(makeTelemetryState(false));
 
-    emitSqaaAnalysisTelemetry(
+    await emitSqaaAnalysisTelemetry(
       SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
       AUTH,
       makeTally({ totalIssues: 1, allResults: [] }),
@@ -362,12 +367,12 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     expect(readEvents(testSonarUserHome)).toHaveLength(0);
   });
 
-  it('does not write when installationId is absent', () => {
+  it('does not write when installationId is absent', async () => {
     const stateWithoutId = makeTelemetryState();
     stateWithoutId.telemetry.installationId = undefined;
     loadStateSpy.mockReturnValue(stateWithoutId);
 
-    emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, makeTally(), 100);
+    await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, makeTally(), 100);
 
     expect(readEvents(testSonarUserHome)).toHaveLength(0);
   });

--- a/tests/unit/telemetry/telemetry.test.ts
+++ b/tests/unit/telemetry/telemetry.test.ts
@@ -32,6 +32,8 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import type { Command } from 'commander';
 
 import * as agentDetector from '../../../src/lib/agent-detector.js';
+import * as authResolver from '../../../src/lib/auth-resolver.js';
+import { ENV_ORG, ENV_SERVER, ENV_TOKEN } from '../../../src/lib/auth-resolver.js';
 import { ENV_DO_NOT_TRACK, ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
 import { DISTRIBUTION } from '../../../src/lib/distribution.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
@@ -48,7 +50,10 @@ import {
   storeEvent,
   TELEMETRY_FLUSH_MODE_ENV,
 } from '../../../src/telemetry';
+import { resolveTelemetryIdentity } from '../../../src/telemetry/identity.js';
 import * as userModule from '../../../src/telemetry/user.js';
+import * as ui from '../../../src/ui';
+import { mockIdentityGetSafe } from './identity-api-mock.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -140,6 +145,10 @@ afterEach(() => {
   delete process.env.CURSOR_AGENT;
   delete process.env.CURSOR_PROJECT_DIR;
   delete process.env.CURSOR_TRACE_ID;
+  delete process.env[ENV_TOKEN];
+  delete process.env[ENV_ORG];
+  delete process.env[ENV_SERVER];
+  delete process.env.SONARQUBE_CLI_SERVER;
   rmSync(testDir, { recursive: true, force: true });
 });
 
@@ -360,6 +369,43 @@ describe('storeEvent', () => {
       expect(event.event_payload.organization_uuid_v4).toBe('org-uuid-xyz');
     });
 
+    it('does not resolve auth from state when the active connection already has UUIDs', async () => {
+      const resolveFromStateSpy = spyOn(authResolver, 'resolveFromState');
+      const state = getDefaultState('1.0.0');
+      const conn = stateManager.addOrUpdateConnection(state, 'https://sonarcloud.io', 'cloud', {
+        orgKey: 'my-org',
+      });
+      conn.userUuid = 'user-uuid-abc';
+      conn.organizationUuidV4 = 'org-uuid-xyz';
+      loadStateSpy.mockReturnValue(state);
+
+      await storeEvent(makeCommand('auth login'), true);
+
+      expect(resolveFromStateSpy).not.toHaveBeenCalled();
+      resolveFromStateSpy.mockRestore();
+    });
+
+    it('still stores an event when identity enrichment throws', async () => {
+      const resolveFromStateSpy = spyOn(authResolver, 'resolveFromState').mockRejectedValue(
+        new Error('keychain locked'),
+      );
+      const state = getDefaultState('1.0.0');
+      stateManager.addOrUpdateConnection(state, 'https://sonarcloud.io', 'cloud', {
+        orgKey: 'my-org',
+      });
+      loadStateSpy.mockReturnValue(state);
+
+      await storeEvent(makeCommand('auth login'), true);
+
+      const event = saveStateSpy.mock.calls[0][0].telemetry.events[0] as StoredTelemetryEvent;
+      expect(event.event_payload.connection_type).toBe('sqc');
+      expect(event.event_payload.user_uuid).toBeNull();
+      expect(event.event_payload.organization_uuid_v4).toBeNull();
+      expect(spawnSpy).toHaveBeenCalledTimes(1);
+
+      resolveFromStateSpy.mockRestore();
+    });
+
     it('includes sqs_installation_id from an on-premise connection', async () => {
       const state = getDefaultState('1.0.0');
       const conn = stateManager.addOrUpdateConnection(
@@ -375,6 +421,143 @@ describe('storeEvent', () => {
 
       const event = saveStateSpy.mock.calls[0][0].telemetry.events[0] as StoredTelemetryEvent;
       expect(event.event_payload.sqs_installation_id).toBe('sqs-install-id-123');
+    });
+  });
+
+  describe('environment-variable authentication identity', () => {
+    it('does not warn about partial env vars during storeEvent', async () => {
+      const warnSpy = spyOn(ui, 'warn').mockImplementation(() => undefined);
+      process.env[ENV_TOKEN] = 'partial-env-token';
+
+      await storeEvent(makeCommand('auth login'), true);
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('resolves user_uuid and organization_uuid_v4 via API on first env-auth invocation', async () => {
+      process.env[ENV_TOKEN] = 'env-auth-token-2';
+      process.env[ENV_ORG] = 'my-org';
+
+      const getSafeSpy = mockIdentityGetSafe({
+        user: [{ ok: true, id: 'user-from-api' }],
+        org: [{ ok: true, uuidV4: 'org-from-api' }],
+      });
+
+      await storeEvent(makeCommand('context'), true);
+
+      const event = saveStateSpy.mock.calls[0][0].telemetry.events[0] as StoredTelemetryEvent;
+      expect(event.event_payload.user_uuid).toBe('user-from-api');
+      expect(event.event_payload.organization_uuid_v4).toBe('org-from-api');
+      expect(
+        getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+      ).toHaveLength(1);
+
+      getSafeSpy.mockRestore();
+    });
+
+    it('does not re-fetch organization_uuid when the API confirms absence', async () => {
+      process.env[ENV_TOKEN] = 'env-auth-token-null-org';
+      process.env[ENV_ORG] = 'my-org';
+
+      const getSafeSpy = mockIdentityGetSafe({
+        user: [{ ok: true, id: 'cached-user' }],
+        org: [{ ok: true }],
+      });
+
+      await storeEvent(makeCommand('context'), true);
+      await storeEvent(makeCommand('analyze'), true);
+
+      expect(
+        getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+      ).toHaveLength(1);
+      expect(
+        getSafeSpy.mock.calls.filter(
+          (call: [string]) => call[0] === '/organizations/organizations',
+        ),
+      ).toHaveLength(1);
+
+      const secondEvent = saveStateSpy.mock.calls[1][0].telemetry.events[0] as StoredTelemetryEvent;
+      expect(secondEvent.event_payload.user_uuid).toBe('cached-user');
+      expect(secondEvent.event_payload.organization_uuid_v4).toBeNull();
+
+      getSafeSpy.mockRestore();
+    });
+
+    it('retries user_uuid fetch after a transient API failure', async () => {
+      const auth = {
+        token: 'env-auth-token-retry-user',
+        serverUrl: 'https://sonarcloud.io',
+        orgKey: 'my-org',
+        connectionType: 'cloud' as const,
+      };
+      const getSafeSpy = mockIdentityGetSafe({
+        user: [{ ok: false }, { ok: true, id: 'user-after-retry' }],
+        org: [{ ok: true, uuidV4: 'cached-org' }],
+      });
+
+      const first = await resolveTelemetryIdentity(auth);
+      const second = await resolveTelemetryIdentity(auth);
+
+      expect(first.user_uuid).toBeNull();
+      expect(second.user_uuid).toBe('user-after-retry');
+      expect(
+        getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+      ).toHaveLength(2);
+      expect(
+        getSafeSpy.mock.calls.filter(
+          (call: [string]) => call[0] === '/organizations/organizations',
+        ),
+      ).toHaveLength(1);
+
+      getSafeSpy.mockRestore();
+    });
+
+    it('resolves user_uuid and sqs_installation_id via API for env-auth on-premise', async () => {
+      process.env[ENV_TOKEN] = 'env-auth-server-token';
+      process.env[ENV_SERVER] = 'https://sonarqube.example.com';
+
+      const getSafeSpy = mockIdentityGetSafe({
+        user: [{ ok: true, id: 'server-user-from-api' }],
+        status: [{ ok: true, id: 'sqs-from-api' }],
+      });
+
+      await storeEvent(makeCommand('context'), true);
+
+      const event = saveStateSpy.mock.calls[0][0].telemetry.events[0] as StoredTelemetryEvent;
+      expect(event.event_payload.connection_type).toBe('sqs');
+      expect(event.event_payload.user_uuid).toBe('server-user-from-api');
+      expect(event.event_payload.sqs_installation_id).toBe('sqs-from-api');
+
+      getSafeSpy.mockRestore();
+    });
+
+    it('reuses the disk identity cache on subsequent invocations with the same token', async () => {
+      process.env[ENV_TOKEN] = 'env-auth-token-3';
+      process.env[ENV_ORG] = 'my-org';
+
+      const getSafeSpy = mockIdentityGetSafe({
+        user: [{ ok: true, id: 'cached-user' }],
+        org: [{ ok: true, uuidV4: 'cached-org' }],
+      });
+
+      await storeEvent(makeCommand('context'), true);
+      await storeEvent(makeCommand('analyze'), true);
+
+      expect(
+        getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+      ).toHaveLength(1);
+      expect(
+        getSafeSpy.mock.calls.filter(
+          (call: [string]) => call[0] === '/organizations/organizations',
+        ),
+      ).toHaveLength(1);
+
+      const secondEvent = saveStateSpy.mock.calls[1][0].telemetry.events[0] as StoredTelemetryEvent;
+      expect(secondEvent.event_payload.user_uuid).toBe('cached-user');
+      expect(secondEvent.event_payload.organization_uuid_v4).toBe('cached-org');
+
+      getSafeSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry identity resolution:**
  - Refactored core telemetry logic to asynchronously resolve and enrich identity fields (`user_uuid`, `organization_uuid_v4`, `sqs_installation_id`).
  - Added disk-based caching (`identity-cache.json`) to persist identity fields and minimize redundant API calls across CLI runs.
  - Implemented `resolveCommandTelemetryIdentity` to support identity enrichment for environment-variable-based authentication.
- **API Integration:**
  - Integrated `SonarQubeClient` to fetch missing identity metadata via `/api/users/current`, `/organizations/organizations`, and `/api/system/status`.
- **Refactoring:**
  - Converted `emitAnalysisCompleted`, `emitAnalysisFindingsDetected`, and `emitSqaaAnalysisTelemetry` to async to support non-blocking identity resolution.
  - Updated `storeEvent` to handle safe identity resolution without blocking command execution.
- **Documentation:**
  - Added comprehensive telemetry documentation in `CLAUDE.md` detailing resolution order, caching policies, and field requirements.

<sub>This will update automatically on new commits.</sub>