### PR TITLE
CLI-187 notify users when new version is available

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -24,6 +24,7 @@ import { version as VERSION } from '../../package.json';
 import { IS_STANDALONE_DISTRIBUTION } from '../lib/distribution';
 import { loadState } from '../lib/repository/state-repository';
 import { initSentry } from '../lib/sentry';
+import { maybeNotifyUpdateAvailable } from '../lib/update-notification';
 import { GENERIC_HTTP_METHODS } from '../sonarqube/client';
 import { MAX_PAGE_SIZE } from '../sonarqube/projects';
 import {
@@ -137,7 +138,8 @@ const auth = COMMAND_TREE.command('auth')
   .description('Manage authentication tokens and credentials')
   .rootHelp({
     category: 'cli-management',
-  });
+  })
+  .updateNotification();
 
 auth
   .command('login')
@@ -180,6 +182,10 @@ const listIssuesFormatOption = new Option('--format <format>', 'Output format')
 list
   .command('issues')
   .description('Search for issues in SonarQube')
+  .updateNotification((opts) => {
+    const format = typeof opts.format === 'string' ? opts.format : 'json';
+    return format.toLowerCase() === 'table';
+  })
   .requiredOption('-p, --project <project>', 'Project key')
   .option(
     '--statuses <statuses>',
@@ -199,6 +205,7 @@ list
 list
   .command('projects')
   .description('Search for projects in SonarQube')
+  .updateNotification()
   .option('-q, --query <query>', 'Search query to filter projects by name or key')
   .addOption(pageOption)
   .addOption(pageSizeOption)
@@ -234,6 +241,7 @@ const integrateCommand = COMMAND_TREE.command('integrate')
   .rootHelp({
     category: 'integrate',
   })
+  .updateNotification((opts) => !opts.nonInteractive)
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('-g, --global', 'Install integrations globally.')
   // allowExcessArguments + preAction: when a parent command has both an action and subcommands,
@@ -381,6 +389,7 @@ const analyze = COMMAND_TREE.command('analyze')
     category: 'core',
     expandSubcommands: true,
   })
+  .updateNotification()
   .enablePositionalOptions();
 
 analyze
@@ -542,6 +551,7 @@ const system = COMMAND_TREE.command('system')
 system
   .command('status')
   .description('Show overall system status: authentication, installed binaries, and integrations')
+  .updateNotification((opts) => !opts.json)
   .option('--json', 'Output as JSON for machine consumption')
   .anonymousAction((options: SystemStatusOptions) => systemStatus(options));
 
@@ -687,4 +697,5 @@ COMMAND_TREE.hook('preAction', () => {
 // Collect a telemetry event after every command action.
 COMMAND_TREE.hook('postAction', async (_thisCommand, actionCommand) => {
   await storeEvent(actionCommand, (process.exitCode ?? 0) === 0);
+  await maybeNotifyUpdateAvailable(actionCommand);
 });

--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -139,7 +139,7 @@ const auth = COMMAND_TREE.command('auth')
   .rootHelp({
     category: 'cli-management',
   })
-  .updateNotification();
+  .showUpdateNotification();
 
 auth
   .command('login')
@@ -182,7 +182,7 @@ const listIssuesFormatOption = new Option('--format <format>', 'Output format')
 list
   .command('issues')
   .description('Search for issues in SonarQube')
-  .updateNotification((opts) => {
+  .showUpdateNotification((opts) => {
     const format = typeof opts.format === 'string' ? opts.format : 'json';
     return format.toLowerCase() === 'table';
   })
@@ -205,7 +205,7 @@ list
 list
   .command('projects')
   .description('Search for projects in SonarQube')
-  .updateNotification()
+  .showUpdateNotification()
   .option('-q, --query <query>', 'Search query to filter projects by name or key')
   .addOption(pageOption)
   .addOption(pageSizeOption)
@@ -241,7 +241,7 @@ const integrateCommand = COMMAND_TREE.command('integrate')
   .rootHelp({
     category: 'integrate',
   })
-  .updateNotification((opts) => !opts.nonInteractive)
+  .showUpdateNotification((opts) => !opts.nonInteractive)
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('-g, --global', 'Install integrations globally.')
   // allowExcessArguments + preAction: when a parent command has both an action and subcommands,
@@ -389,7 +389,7 @@ const analyze = COMMAND_TREE.command('analyze')
     category: 'core',
     expandSubcommands: true,
   })
-  .updateNotification()
+  .showUpdateNotification()
   .enablePositionalOptions();
 
 analyze
@@ -551,7 +551,7 @@ const system = COMMAND_TREE.command('system')
 system
   .command('status')
   .description('Show overall system status: authentication, installed binaries, and integrations')
-  .updateNotification((opts) => !opts.json)
+  .showUpdateNotification((opts) => !opts.json)
   .option('--json', 'Output as JSON for machine consumption')
   .anonymousAction((options: SystemStatusOptions) => systemStatus(options));
 

--- a/src/cli/commands/_common/sonar-command.ts
+++ b/src/cli/commands/_common/sonar-command.ts
@@ -58,7 +58,7 @@ type CommandResult = void | Promise<void>;
 export class SonarCommand extends Command {
   private _requiresAuth = false;
   private _rootHelp: RootHelpMetadata = {};
-  private _updateNotification?: true | UpdateNotificationCondition;
+  private _showUpdateNotification?: true | UpdateNotificationCondition;
 
   /** Ensures subcommands created via .command() are also SonarCommand instances. */
   createCommand(name?: string): SonarCommand {
@@ -80,8 +80,8 @@ export class SonarCommand extends Command {
    * Pass a condition to show the notice only when it returns true for the
    * merged action-command options (parsed by Commander).
    */
-  updateNotification(when?: UpdateNotificationCondition): this {
-    this._updateNotification = when ?? true;
+  showUpdateNotification(when?: UpdateNotificationCondition): this {
+    this._showUpdateNotification = when ?? true;
     return this;
   }
 
@@ -148,8 +148,8 @@ export class SonarCommand extends Command {
   }
 
   /** Update-notification opt-in and optional show condition for this command. */
-  get updateNotificationWhen(): true | UpdateNotificationCondition | undefined {
-    return this._updateNotification;
+  get showUpdateNotificationWhen(): true | UpdateNotificationCondition | undefined {
+    return this._showUpdateNotification;
   }
 
   async runCommand(fn: () => Promise<void>): Promise<void> {

--- a/src/cli/commands/_common/sonar-command.ts
+++ b/src/cli/commands/_common/sonar-command.ts
@@ -37,6 +37,9 @@ export interface RootHelpMetadata {
   label?: string;
 }
 
+/** When to show the post-command update notice for a opted-in command. */
+export type UpdateNotificationCondition = (opts: Record<string, unknown>) => boolean;
+
 type CommandArgs = unknown[];
 type CommandResult = void | Promise<void>;
 
@@ -55,6 +58,7 @@ type CommandResult = void | Promise<void>;
 export class SonarCommand extends Command {
   private _requiresAuth = false;
   private _rootHelp: RootHelpMetadata = {};
+  private _updateNotification?: true | UpdateNotificationCondition;
 
   /** Ensures subcommands created via .command() are also SonarCommand instances. */
   createCommand(name?: string): SonarCommand {
@@ -68,6 +72,16 @@ export class SonarCommand extends Command {
    */
   rootHelp(metadata: RootHelpMetadata): this {
     this._rootHelp = { ...this._rootHelp, ...metadata };
+    return this;
+  }
+
+  /**
+   * Opt in to the post-command "new version available" stderr notice.
+   * Pass a condition to show the notice only when it returns true for the
+   * merged action-command options (parsed by Commander).
+   */
+  updateNotification(when?: UpdateNotificationCondition): this {
+    this._updateNotification = when ?? true;
     return this;
   }
 
@@ -131,6 +145,11 @@ export class SonarCommand extends Command {
   /** Metadata used by the custom root help menu. */
   get rootHelpMetadata(): RootHelpMetadata {
     return this._rootHelp;
+  }
+
+  /** Update-notification opt-in and optional show condition for this command. */
+  get updateNotificationWhen(): true | UpdateNotificationCondition | undefined {
+    return this._updateNotification;
   }
 
   async runCommand(fn: () => Promise<void>): Promise<void> {

--- a/src/cli/commands/self-update/update-check.ts
+++ b/src/cli/commands/self-update/update-check.ts
@@ -36,6 +36,8 @@ import { CommandFailedError } from '../_common/error';
 import { Version } from '../_common/version';
 
 const UPDATE_CHECK_TIMEOUT_MS = 5000;
+/** Best-effort background fetch after eligible commands — fail fast to avoid blocking UX. */
+export const BACKGROUND_UPDATE_CHECK_TIMEOUT_MS = 1500;
 const STABLE_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
 const TEMP_SCRIPT_PREFIX = 'sonar-update-';
 const TEMP_SCRIPT_CREATE_ATTEMPTS = 5;
@@ -164,9 +166,13 @@ export interface UpdateCheckResult {
   upToDate: boolean;
 }
 
-async function fetchText(url: string, description: string): Promise<string> {
+async function fetchText(
+  url: string,
+  description: string,
+  timeoutMs = UPDATE_CHECK_TIMEOUT_MS,
+): Promise<string> {
   const response = await fetch(url, {
-    signal: AbortSignal.timeout(UPDATE_CHECK_TIMEOUT_MS),
+    signal: AbortSignal.timeout(timeoutMs),
     ...buildFetchNetworkOptions(url),
   });
   if (!response.ok) {
@@ -185,9 +191,9 @@ function parseStableVersion(raw: string): string | null {
 /**
  * Reads the published stable.version string from binaries.sonarsource.com.
  */
-export async function fetchLatestVersion(): Promise<string> {
+export async function fetchLatestVersion(timeoutMs = UPDATE_CHECK_TIMEOUT_MS): Promise<string> {
   const stableVersionUrl = `${SONARSOURCE_BINARIES_URL}/${CLI_STABLE_VERSION_PATH}`;
-  const body = await fetchText(stableVersionUrl, 'stable version');
+  const body = await fetchText(stableVersionUrl, 'stable version', timeoutMs);
   const version = parseStableVersion(body);
   if (!version) {
     throw new CommandFailedError('Could not determine the latest version.', {

--- a/src/cli/commands/self-update/update-check.ts
+++ b/src/cli/commands/self-update/update-check.ts
@@ -25,14 +25,17 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { version as CURRENT_VERSION } from '../../../../package.json';
-import { SONARSOURCE_BINARIES_URL, UPDATE_SCRIPT_BASE_URL } from '../../../lib/config-constants';
+import {
+  CLI_STABLE_VERSION_PATH,
+  SONARSOURCE_BINARIES_URL,
+  UPDATE_SCRIPT_BASE_URL,
+} from '../../../lib/config-constants';
 import { buildFetchNetworkOptions } from '../../../lib/connectivity/network-config';
 import { isWindows } from '../../../lib/platform-detector';
 import { CommandFailedError } from '../_common/error';
 import { Version } from '../_common/version';
 
 const UPDATE_CHECK_TIMEOUT_MS = 5000;
-const STABLE_VERSION_PATH = 'Distribution/sonarqube-cli/stable.version';
 const STABLE_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
 const TEMP_SCRIPT_PREFIX = 'sonar-update-';
 const TEMP_SCRIPT_CREATE_ATTEMPTS = 5;
@@ -174,19 +177,28 @@ async function fetchText(url: string, description: string): Promise<string> {
   return response.text();
 }
 
-async function fetchLatestVersion(): Promise<string> {
-  const stableVersionUrl = `${SONARSOURCE_BINARIES_URL}/${STABLE_VERSION_PATH}`;
-  const latestVersion = (await fetchText(stableVersionUrl, 'stable version metadata')).trim();
-  if (!STABLE_VERSION_PATTERN.test(latestVersion)) {
+function parseStableVersion(raw: string): string | null {
+  const latestVersion = raw.trim();
+  return STABLE_VERSION_PATTERN.test(latestVersion) ? latestVersion : null;
+}
+
+/**
+ * Reads the published stable.version string from binaries.sonarsource.com.
+ */
+export async function fetchLatestVersion(): Promise<string> {
+  const stableVersionUrl = `${SONARSOURCE_BINARIES_URL}/${CLI_STABLE_VERSION_PATH}`;
+  const body = await fetchText(stableVersionUrl, 'stable version');
+  const version = parseStableVersion(body);
+  if (!version) {
     throw new CommandFailedError('Could not determine the latest version.', {
       remediationHint: 'Retry later or update manually using the installer script.',
     });
   }
-  return latestVersion;
+  return version;
 }
 
 /**
- * Reads the published stable.version metadata from binaries.sonarsource.com and
+ * Reads the published stable version from binaries.sonarsource.com and
  * returns version comparison data for update checks.
  */
 export async function checkForUpdate(): Promise<UpdateCheckResult> {

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -167,6 +167,7 @@ export const SCA_SCANNER_CLI_DIST_PREFIX = 'CommercialDistribution/sca-scanner-c
  * path embeds the platform: `${SONAR_CONTEXT_AUGMENTATION_DIST_PREFIX}-${platform}/...`.
  */
 export const SONAR_CONTEXT_AUGMENTATION_DIST_PREFIX = 'Distribution/sonar-context-augmentation';
+export const CLI_STABLE_VERSION_PATH = 'Distribution/sonarqube-cli/stable.version';
 export const UPDATE_SCRIPT_BASE_URL =
   'https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts';
 

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -230,11 +230,23 @@ export interface AgentsState {
 }
 
 /**
+ * Cached CLI update-check metadata for throttled background version fetches.
+ */
+export interface CliUpdateCheckState {
+  /** ISO timestamp of the last remote stable-version fetch */
+  lastCheckedAt?: string;
+  /** Latest stable version string returned by the last fetch */
+  latestVersion?: string;
+}
+
+/**
  * CLI configuration
  */
 export interface CliConfig {
   /** Current CLI version */
   cliVersion: string;
+  /** Throttled update-check cache (remote fetch at most once per day) */
+  updateCheck?: CliUpdateCheckState;
 }
 
 /**

--- a/src/lib/update-notification.ts
+++ b/src/lib/update-notification.ts
@@ -1,0 +1,199 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { Command } from 'commander';
+
+import { version as CURRENT_VERSION } from '../../package.json';
+import {
+  SonarCommand,
+  type UpdateNotificationCondition,
+} from '../cli/commands/_common/sonar-command.js';
+import { Version } from '../cli/commands/_common/version.js';
+import { fetchLatestVersion } from '../cli/commands/self-update/update-check.js';
+import { TELEMETRY_FLUSH_MODE_ENV } from '../telemetry/index.js';
+import { cyan } from '../ui/colors.js';
+import { isFormattedOutputMode, text } from '../ui/index.js';
+import type { CliUpdateCheckState } from './state.js';
+import { loadState, saveState } from './state-manager.js';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Persist only canonical fields so legacy notification keys are pruned from state.json. */
+function toPersistedUpdateCheck(
+  updateCheck: CliUpdateCheckState | undefined,
+  overrides: Partial<CliUpdateCheckState> = {},
+): CliUpdateCheckState {
+  const merged = { ...updateCheck, ...overrides };
+  const persisted: CliUpdateCheckState = {};
+  if (merged.lastCheckedAt !== undefined) {
+    persisted.lastCheckedAt = merged.lastCheckedAt;
+  }
+  if (merged.latestVersion !== undefined) {
+    persisted.latestVersion = merged.latestVersion;
+  }
+  return persisted;
+}
+
+function collectCommandOpts(command: Command): Record<string, unknown> {
+  const names: Command[] = [];
+  let current: Command | null = command;
+  while (current.parent !== null) {
+    names.unshift(current);
+    current = current.parent;
+  }
+
+  const merged: Record<string, unknown> = {};
+  for (const cmd of names) {
+    Object.assign(merged, cmd.opts());
+  }
+  return merged;
+}
+
+function resolveUpdateNotification(
+  command: Command,
+): true | UpdateNotificationCondition | undefined {
+  let current: Command | null = command;
+  while (current !== null) {
+    if (current instanceof SonarCommand) {
+      const when = current.updateNotificationWhen;
+      if (when !== undefined) {
+        return when;
+      }
+    }
+    current = current.parent;
+  }
+  return undefined;
+}
+
+export function isUpdateNotificationEligible(command: Command): boolean {
+  return resolveUpdateNotification(command) !== undefined;
+}
+
+export function shouldSuppressUpdateNotification(command: Command): boolean {
+  if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {
+    return true;
+  }
+  if (process.env.CI === 'true') {
+    return true;
+  }
+  if (!process.stderr.isTTY || !process.stdout.isTTY) {
+    return true;
+  }
+  if (isFormattedOutputMode()) {
+    return true;
+  }
+
+  const when = resolveUpdateNotification(command);
+  if (typeof when === 'function' && !when(collectCommandOpts(command))) {
+    return true;
+  }
+
+  return false;
+}
+
+function isWithinCooldown(isoTimestamp: string | undefined, cooldownMs: number): boolean {
+  if (!isoTimestamp) {
+    return false;
+  }
+  const elapsed = Date.now() - Date.parse(isoTimestamp);
+  return Number.isFinite(elapsed) && elapsed >= 0 && elapsed < cooldownMs;
+}
+
+async function resolveLatestVersion(
+  updateCheck: CliUpdateCheckState | undefined,
+): Promise<{ latestVersion: string | undefined; updateCheck: CliUpdateCheckState }> {
+  if (isWithinCooldown(updateCheck?.lastCheckedAt, ONE_DAY_MS)) {
+    // Checked within the last day: reuse the cached result (which is undefined
+    // when the previous check failed) instead of hitting the network again.
+    return {
+      latestVersion: updateCheck?.latestVersion,
+      updateCheck: toPersistedUpdateCheck(updateCheck),
+    };
+  }
+
+  const lastCheckedAt = new Date().toISOString();
+  try {
+    const latestVersion = await fetchLatestVersion();
+    return {
+      latestVersion,
+      updateCheck: toPersistedUpdateCheck(updateCheck, { lastCheckedAt, latestVersion }),
+    };
+  } catch {
+    // Record the attempt so a failing check does not re-hit the network — and
+    // stall the command for up to the fetch timeout — on every invocation.
+    // Any previously cached version is preserved so we can still notify from it.
+    return {
+      latestVersion: updateCheck?.latestVersion,
+      updateCheck: toPersistedUpdateCheck(updateCheck, { lastCheckedAt }),
+    };
+  }
+}
+
+function renderUpdateNotification(currentNoBuild: string, latestNoBuild: string): void {
+  // Keep the whole notice on stderr so it never contaminates a command's stdout.
+  text('', undefined, 'stderr');
+  text(
+    `  ${cyan('ℹ')}  A new version of SonarQube CLI is available: ${currentNoBuild} → ${latestNoBuild}`,
+    undefined,
+    'stderr',
+  );
+  text('   → Run `sonar self-update` to upgrade.', undefined, 'stderr');
+}
+
+/**
+ * After eligible interactive commands, fetch binaries.sonarsource.com at most once
+ * per day and print a stderr notice when a newer stable version exists.
+ */
+export async function maybeNotifyUpdateAvailable(command: Command): Promise<void> {
+  if ((process.exitCode ?? 0) !== 0) {
+    return;
+  }
+  if (shouldSuppressUpdateNotification(command) || !isUpdateNotificationEligible(command)) {
+    return;
+  }
+
+  try {
+    const state = loadState();
+    const currentVersion = new Version(CURRENT_VERSION);
+    const currentNoBuild = currentVersion.noBuild.text;
+
+    const resolved = await resolveLatestVersion(state.config.updateCheck);
+
+    // Persist the fetch timestamp on every attempt (success or failure) so the
+    // remote version check stays throttled to once per day.
+    state.config.updateCheck = resolved.updateCheck;
+    saveState(state);
+
+    if (!resolved.latestVersion) {
+      return;
+    }
+
+    const latestVersion = new Version(resolved.latestVersion);
+    const latestNoBuild = latestVersion.noBuild.text;
+
+    if (!latestVersion.noBuild.isNewerThan(currentVersion)) {
+      return;
+    }
+
+    renderUpdateNotification(currentNoBuild, latestNoBuild);
+  } catch {
+    // Best-effort only — never fail the user's command because of update metadata.
+  }
+}

--- a/src/lib/update-notification.ts
+++ b/src/lib/update-notification.ts
@@ -26,7 +26,10 @@ import {
   type UpdateNotificationCondition,
 } from '../cli/commands/_common/sonar-command.js';
 import { Version } from '../cli/commands/_common/version.js';
-import { fetchLatestVersion } from '../cli/commands/self-update/update-check.js';
+import {
+  BACKGROUND_UPDATE_CHECK_TIMEOUT_MS,
+  fetchLatestVersion,
+} from '../cli/commands/self-update/update-check.js';
 import { TELEMETRY_FLUSH_MODE_ENV } from '../telemetry/index.js';
 import { cyan } from '../ui/colors.js';
 import { isFormattedOutputMode, text } from '../ui/index.js';
@@ -34,22 +37,6 @@ import type { CliUpdateCheckState } from './state.js';
 import { loadState, saveState } from './state-manager.js';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
-
-/** Persist only canonical fields so legacy notification keys are pruned from state.json. */
-function toPersistedUpdateCheck(
-  updateCheck: CliUpdateCheckState | undefined,
-  overrides: Partial<CliUpdateCheckState> = {},
-): CliUpdateCheckState {
-  const merged = { ...updateCheck, ...overrides };
-  const persisted: CliUpdateCheckState = {};
-  if (merged.lastCheckedAt !== undefined) {
-    persisted.lastCheckedAt = merged.lastCheckedAt;
-  }
-  if (merged.latestVersion !== undefined) {
-    persisted.latestVersion = merged.latestVersion;
-  }
-  return persisted;
-}
 
 function collectCommandOpts(command: Command): Record<string, unknown> {
   const names: Command[] = [];
@@ -72,7 +59,7 @@ function resolveUpdateNotification(
   let current: Command | null = command;
   while (current !== null) {
     if (current instanceof SonarCommand) {
-      const when = current.updateNotificationWhen;
+      const when = current.showUpdateNotificationWhen;
       if (when !== undefined) {
         return when;
       }
@@ -124,16 +111,16 @@ async function resolveLatestVersion(
     // when the previous check failed) instead of hitting the network again.
     return {
       latestVersion: updateCheck?.latestVersion,
-      updateCheck: toPersistedUpdateCheck(updateCheck),
+      updateCheck: { ...updateCheck },
     };
   }
 
   const lastCheckedAt = new Date().toISOString();
   try {
-    const latestVersion = await fetchLatestVersion();
+    const latestVersion = await fetchLatestVersion(BACKGROUND_UPDATE_CHECK_TIMEOUT_MS);
     return {
       latestVersion,
-      updateCheck: toPersistedUpdateCheck(updateCheck, { lastCheckedAt, latestVersion }),
+      updateCheck: { ...updateCheck, lastCheckedAt, latestVersion },
     };
   } catch {
     // Record the attempt so a failing check does not re-hit the network — and
@@ -141,7 +128,7 @@ async function resolveLatestVersion(
     // Any previously cached version is preserved so we can still notify from it.
     return {
       latestVersion: updateCheck?.latestVersion,
-      updateCheck: toPersistedUpdateCheck(updateCheck, { lastCheckedAt }),
+      updateCheck: { ...updateCheck, lastCheckedAt },
     };
   }
 }

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -41,6 +41,7 @@ export {
   error,
   getMessagesForFormattedOutput,
   info,
+  isFormattedOutputMode,
   print,
   setFormattedOutputMode,
   success,

--- a/src/ui/messages.ts
+++ b/src/ui/messages.ts
@@ -40,6 +40,11 @@ export function setFormattedOutputMode(active: boolean): void {
   }
 }
 
+/** True when stdout messages are buffered for machine-readable command output. */
+export function isFormattedOutputMode(): boolean {
+  return _formattedOutputMode;
+}
+
 /** Returns messages collected since the last setFormattedOutputMode(true) call. */
 export function getMessagesForFormattedOutput(): string[] {
   return [..._collectedMessages];

--- a/tests/unit/cli/commands/self-update/self-update.test.ts
+++ b/tests/unit/cli/commands/self-update/self-update.test.ts
@@ -127,6 +127,26 @@ describe('checkForUpdate', () => {
     expect(result).toBe('88.1.2.300');
   });
 
+  it('uses the default 5s fetch timeout for self-update checks', async () => {
+    const timeoutSpy = spyOn(AbortSignal, 'timeout');
+    fetchSpy.mockResolvedValue(stableVersionResponse('88.1.2.300'));
+
+    await fetchLatestVersion();
+
+    expect(timeoutSpy).toHaveBeenCalledWith(5000);
+    timeoutSpy.mockRestore();
+  });
+
+  it('accepts a custom fetch timeout', async () => {
+    const timeoutSpy = spyOn(AbortSignal, 'timeout');
+    fetchSpy.mockResolvedValue(stableVersionResponse('88.1.2.300'));
+
+    await fetchLatestVersion(1500);
+
+    expect(timeoutSpy).toHaveBeenCalledWith(1500);
+    timeoutSpy.mockRestore();
+  });
+
   it('throws on HTTP error', () => {
     fetchSpy.mockResolvedValue({ ok: false, status: 404 });
 

--- a/tests/unit/cli/commands/self-update/self-update.test.ts
+++ b/tests/unit/cli/commands/self-update/self-update.test.ts
@@ -71,8 +71,16 @@ void mock.module('../../../../../src/lib/version', () => ({
   stripBuildNumber: mock(realStripBuildNumber),
 }));
 
-const { checkForUpdate } = await import('../../../../../src/cli/commands/self-update/update-check');
+const { checkForUpdate, fetchLatestVersion } =
+  await import('../../../../../src/cli/commands/self-update/update-check');
 const { selfUpdate } = await import('../../../../../src/cli/commands/self-update');
+
+function stableVersionResponse(version: string) {
+  return {
+    ok: true,
+    text: async () => Promise.resolve(`${version}\n`),
+  };
+}
 
 describe('checkForUpdate', () => {
   let fetchSpy: ReturnType<typeof spyOn>;
@@ -86,10 +94,7 @@ describe('checkForUpdate', () => {
   });
 
   it('returns the latest update and marks upToDate false when stable.version is newer', async () => {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      text: async () => Promise.resolve('99.0.0.241\n'),
-    });
+    fetchSpy.mockResolvedValue(stableVersionResponse('99.0.0.241'));
 
     const result = await checkForUpdate();
 
@@ -99,15 +104,13 @@ describe('checkForUpdate', () => {
       (await import('../../../../../package.json')).version,
     );
     expect(result.upToDate).toBe(false);
+    expect(String(fetchSpy.mock.calls[0]?.[0])).toContain('stable.version');
   });
 
   it('returns the latest update and marks upToDate true when the current version matches', async () => {
     // Same major.minor.patch as current; build number must be ignored.
     const [major, minor, patch] = (await import('../../../../../package.json')).version.split('.');
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      text: async () => Promise.resolve(`${major}.${minor}.${patch}.999\n`),
-    });
+    fetchSpy.mockResolvedValue(stableVersionResponse(`${major}.${minor}.${patch}.999`));
 
     const result = await checkForUpdate();
 
@@ -116,13 +119,21 @@ describe('checkForUpdate', () => {
     expect(result.upToDate).toBe(true);
   });
 
+  it('reads the version from stable.version', async () => {
+    fetchSpy.mockResolvedValue(stableVersionResponse('88.1.2.300'));
+
+    const result = await fetchLatestVersion();
+
+    expect(result).toBe('88.1.2.300');
+  });
+
   it('throws on HTTP error', () => {
     fetchSpy.mockResolvedValue({ ok: false, status: 404 });
 
     expect(checkForUpdate()).rejects.toThrow('HTTP 404');
   });
 
-  it('throws when stable.version is not a version', () => {
+  it('throws when stable.version is invalid', () => {
     fetchSpy.mockResolvedValue({
       ok: true,
       text: async () => Promise.resolve('not-a-version'),
@@ -150,7 +161,7 @@ describe('checkForUpdate', () => {
     });
 
     it('passes proxy option to fetch', async () => {
-      fetchSpy.mockResolvedValue({ ok: true, text: async () => Promise.resolve('1.0.0\n') });
+      fetchSpy.mockResolvedValue(stableVersionResponse('1.0.0'));
 
       await checkForUpdate();
 
@@ -177,10 +188,7 @@ describe('selfUpdate --status', () => {
   });
 
   it('reports an available update without installing', async () => {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      text: async () => Promise.resolve('99.0.0.241\n'),
-    });
+    fetchSpy.mockResolvedValue(stableVersionResponse('99.0.0.241'));
 
     await selfUpdate({ status: true });
 
@@ -191,10 +199,7 @@ describe('selfUpdate --status', () => {
   });
 
   it('reports already up to date', async () => {
-    fetchSpy.mockResolvedValue({
-      ok: true,
-      text: async () => Promise.resolve('0.0.1\n'),
-    });
+    fetchSpy.mockResolvedValue(stableVersionResponse('0.0.1'));
 
     await selfUpdate({ status: true });
 
@@ -225,13 +230,17 @@ describe('selfUpdate --force', () => {
     latestVersion: string,
     scriptContent = '#!/usr/bin/env bash\necho hi\n',
   ): Promise<void> {
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      text: async () => Promise.resolve(`${latestVersion}\n`),
-    });
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      text: async () => Promise.resolve(scriptContent),
+    fetchSpy.mockImplementation((url: string) => {
+      if (String(url).endsWith('stable.version')) {
+        return Promise.resolve(stableVersionResponse(latestVersion));
+      }
+      if (String(url).includes('install.')) {
+        return Promise.resolve({
+          ok: true,
+          text: async () => Promise.resolve(scriptContent),
+        });
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
     });
     await selfUpdate({ force: true });
   }

--- a/tests/unit/lib/update-notification.test.ts
+++ b/tests/unit/lib/update-notification.test.ts
@@ -202,48 +202,11 @@ describe('maybeNotifyUpdateAvailable', () => {
         updateCheck?: {
           latestVersion?: string;
           lastCheckedAt?: string;
-          lastNotifiedVersion?: string;
-          lastNotifiedAt?: string;
         };
       };
     };
     expect(state.config.updateCheck?.latestVersion).toBe('99.0.0.241');
     expect(state.config.updateCheck?.lastCheckedAt).toBeDefined();
-    expect(state.config.updateCheck?.lastNotifiedVersion).toBeUndefined();
-    expect(state.config.updateCheck?.lastNotifiedAt).toBeUndefined();
-  });
-
-  it('prunes legacy notification fields from updateCheck on save', async () => {
-    const statePath = join(tempHome, 'sonarqube-cli', 'state.json');
-    const { mkdirSync, writeFileSync } = await import('node:fs');
-    const recentCheck = new Date().toISOString();
-    mkdirSync(join(tempHome, 'sonarqube-cli'), { recursive: true });
-    writeFileSync(
-      statePath,
-      JSON.stringify({
-        version: '1.0',
-        config: {
-          cliVersion: CURRENT_VERSION,
-          updateCheck: {
-            lastCheckedAt: recentCheck,
-            latestVersion: '99.0.0.241',
-            lastNotifiedVersion: '99.0.0',
-            lastNotifiedAt: '2020-01-01T00:00:00.000Z',
-          },
-        },
-      }),
-    );
-
-    await maybeNotifyUpdateAvailable(resolveCommand(['auth', 'status']));
-
-    const state = JSON.parse(readFileSync(statePath, 'utf8')) as {
-      config: { updateCheck?: Record<string, string> };
-    };
-    expect(state.config.updateCheck).toEqual({
-      lastCheckedAt: recentCheck,
-      latestVersion: '99.0.0.241',
-    });
-    expect(fetchSpy.mock.calls).toHaveLength(0);
   });
 
   it('notifies on every eligible command when an update is available', async () => {

--- a/tests/unit/lib/update-notification.test.ts
+++ b/tests/unit/lib/update-notification.test.ts
@@ -1,0 +1,274 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import type { Command } from 'commander';
+
+import { version as CURRENT_VERSION } from '../../../package.json';
+import { COMMAND_TREE } from '../../../src/cli/command-tree.js';
+import { TELEMETRY_FLUSH_MODE_ENV } from '../../../src/telemetry/index.js';
+import { setFormattedOutputMode } from '../../../src/ui/index.js';
+
+const originalEnvForNotify = { ...process.env };
+const tempHome = mkdtempSync(join(tmpdir(), 'sonar-update-notify-'));
+process.env.SONAR_USER_HOME = tempHome;
+
+const {
+  isUpdateNotificationEligible,
+  maybeNotifyUpdateAvailable,
+  shouldSuppressUpdateNotification,
+} = await import('../../../src/lib/update-notification.js');
+
+function resolveCommand(path: string[]): Command {
+  let current: Command = COMMAND_TREE;
+  for (const segment of path) {
+    const next = current.commands.find((command) => command.name() === segment);
+    if (!next) {
+      throw new Error(`Unknown command segment: ${segment}`);
+    }
+    current = next;
+  }
+  return current;
+}
+
+describe('update notification eligibility', () => {
+  it('allows auth commands', () => {
+    expect(isUpdateNotificationEligible(resolveCommand(['auth', 'status']))).toBe(true);
+  });
+
+  it('allows analyze and list data commands', () => {
+    expect(isUpdateNotificationEligible(resolveCommand(['analyze', 'agentic']))).toBe(true);
+    expect(isUpdateNotificationEligible(resolveCommand(['list', 'issues']))).toBe(true);
+    expect(isUpdateNotificationEligible(resolveCommand(['list', 'projects']))).toBe(true);
+  });
+
+  it('blocks integrate when non-interactive', () => {
+    const command = resolveCommand(['integrate', 'claude']);
+    command.setOptionValue('nonInteractive', true);
+    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+    expect(isUpdateNotificationEligible(command)).toBe(true);
+  });
+
+  it('blocks api, context, and hook commands', () => {
+    expect(isUpdateNotificationEligible(resolveCommand(['api']))).toBe(false);
+    expect(isUpdateNotificationEligible(resolveCommand(['context']))).toBe(false);
+    expect(isUpdateNotificationEligible(resolveCommand(['hook', 'git-pre-commit']))).toBe(false);
+    expect(isUpdateNotificationEligible(resolveCommand(['config', 'telemetry']))).toBe(false);
+    expect(isUpdateNotificationEligible(resolveCommand(['system', 'reset']))).toBe(false);
+  });
+});
+
+describe('update notification suppression', () => {
+  const originalStdoutIsTTY = process.stdout.isTTY;
+  const originalStderrIsTTY = process.stderr.isTTY;
+
+  beforeEach(() => {
+    process.env = { ...originalEnvForNotify, SONAR_USER_HOME: tempHome };
+    delete process.env.CI;
+    delete process.env[TELEMETRY_FLUSH_MODE_ENV];
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true });
+    setFormattedOutputMode(false);
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnvForNotify, SONAR_USER_HOME: tempHome };
+    Object.defineProperty(process.stdout, 'isTTY', {
+      configurable: true,
+      value: originalStdoutIsTTY,
+    });
+    Object.defineProperty(process.stderr, 'isTTY', {
+      configurable: true,
+      value: originalStderrIsTTY,
+    });
+    setFormattedOutputMode(false);
+  });
+
+  it('suppresses in CI and machine-readable modes', () => {
+    const command = resolveCommand(['auth', 'status']);
+    process.env.CI = 'true';
+    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+
+    delete process.env.CI;
+    setFormattedOutputMode(true);
+    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+  });
+
+  it('suppresses list issues when format is json', () => {
+    const command = resolveCommand(['list', 'issues']);
+    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+
+    command.setOptionValue('format', 'table');
+    expect(shouldSuppressUpdateNotification(command)).toBe(false);
+  });
+
+  it('suppresses system status when --json is set', () => {
+    const command = resolveCommand(['system', 'status']);
+    command.setOptionValue('json', true);
+    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+  });
+});
+
+function fetchUrlString(url: string | URL | Request): string {
+  if (typeof url === 'string') {
+    return url;
+  }
+  if (url instanceof URL) {
+    return url.href;
+  }
+  return url.url;
+}
+
+describe('maybeNotifyUpdateAvailable', () => {
+  let stdoutSpy: ReturnType<typeof spyOn>;
+  let stderrSpy: ReturnType<typeof spyOn>;
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnvForNotify, SONAR_USER_HOME: tempHome };
+    delete process.env.CI;
+    delete process.env[TELEMETRY_FLUSH_MODE_ENV];
+    Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
+    Object.defineProperty(process.stderr, 'isTTY', { configurable: true, value: true });
+    setFormattedOutputMode(false);
+    process.exitCode = 0;
+    fetchSpy = spyOn(globalThis, 'fetch').mockImplementation(((url: string | URL | Request) => {
+      const fetchUrl = fetchUrlString(url);
+      if (fetchUrl.endsWith('stable.version')) {
+        return Promise.resolve({
+          ok: true,
+          text: () => Promise.resolve('99.0.0.241\n'),
+        } as Response);
+      }
+      return Promise.reject(new Error(`Unexpected fetch: ${fetchUrl}`));
+    }) as typeof fetch);
+    stdoutSpy = spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+    rmSync(join(tempHome, 'sonarqube-cli', 'state.json'), { force: true });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    setFormattedOutputMode(false);
+  });
+
+  function notificationOutput(): string {
+    const stdout = (stdoutSpy.mock.calls as string[][]).map((call) => call[0] ?? '').join('');
+    const stderr = (stderrSpy.mock.calls as string[][]).map((call) => call[0] ?? '').join('');
+    return `${stdout}${stderr}`;
+  }
+
+  it('prints a stderr notice when a newer version is available', async () => {
+    await maybeNotifyUpdateAvailable(resolveCommand(['auth', 'status']));
+
+    const output = notificationOutput();
+    const [major, minor, patch] = CURRENT_VERSION.split('.');
+    expect(output).toContain(
+      `A new version of SonarQube CLI is available: ${major}.${minor}.${patch} → 99.0.0`,
+    );
+    expect(output).toContain('Run `sonar self-update` to upgrade.');
+  });
+
+  it('persists fetch metadata in state', async () => {
+    await maybeNotifyUpdateAvailable(resolveCommand(['auth', 'status']));
+
+    const state = JSON.parse(
+      readFileSync(join(tempHome, 'sonarqube-cli', 'state.json'), 'utf8'),
+    ) as {
+      config: {
+        updateCheck?: {
+          latestVersion?: string;
+          lastCheckedAt?: string;
+          lastNotifiedVersion?: string;
+          lastNotifiedAt?: string;
+        };
+      };
+    };
+    expect(state.config.updateCheck?.latestVersion).toBe('99.0.0.241');
+    expect(state.config.updateCheck?.lastCheckedAt).toBeDefined();
+    expect(state.config.updateCheck?.lastNotifiedVersion).toBeUndefined();
+    expect(state.config.updateCheck?.lastNotifiedAt).toBeUndefined();
+  });
+
+  it('prunes legacy notification fields from updateCheck on save', async () => {
+    const statePath = join(tempHome, 'sonarqube-cli', 'state.json');
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    const recentCheck = new Date().toISOString();
+    mkdirSync(join(tempHome, 'sonarqube-cli'), { recursive: true });
+    writeFileSync(
+      statePath,
+      JSON.stringify({
+        version: '1.0',
+        config: {
+          cliVersion: CURRENT_VERSION,
+          updateCheck: {
+            lastCheckedAt: recentCheck,
+            latestVersion: '99.0.0.241',
+            lastNotifiedVersion: '99.0.0',
+            lastNotifiedAt: '2020-01-01T00:00:00.000Z',
+          },
+        },
+      }),
+    );
+
+    await maybeNotifyUpdateAvailable(resolveCommand(['auth', 'status']));
+
+    const state = JSON.parse(readFileSync(statePath, 'utf8')) as {
+      config: { updateCheck?: Record<string, string> };
+    };
+    expect(state.config.updateCheck).toEqual({
+      lastCheckedAt: recentCheck,
+      latestVersion: '99.0.0.241',
+    });
+    expect(fetchSpy.mock.calls).toHaveLength(0);
+  });
+
+  it('notifies on every eligible command when an update is available', async () => {
+    const command = resolveCommand(['auth', 'status']);
+
+    await maybeNotifyUpdateAvailable(command);
+    stdoutSpy.mockClear();
+    stderrSpy.mockClear();
+    await maybeNotifyUpdateAvailable(command);
+
+    const output = notificationOutput();
+    expect(output).toContain('A new version of SonarQube CLI is available');
+    expect(output).toContain('Run `sonar self-update` to upgrade.');
+  });
+
+  it('does not re-fetch within 24h after a failed check', async () => {
+    const command = resolveCommand(['auth', 'status']);
+    fetchSpy.mockImplementation(() => Promise.reject(new Error('offline')));
+
+    await maybeNotifyUpdateAvailable(command);
+    expect(fetchSpy.mock.calls).toHaveLength(1);
+
+    // The failed attempt is recorded, so the next command must not hit the
+    // network again (which would stall on the fetch timeout).
+    await maybeNotifyUpdateAvailable(command);
+    expect(fetchSpy.mock.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **New feature:**
  - Added background check and user notification when a newer CLI version is available.
  - Implemented daily throttling for update checks and notifications via persistent state.
- **Infrastructure:**
  - Added `maybeNotifyUpdateAvailable` hook to post-command execution flow.
  - Configured command-specific opt-ins for update notifications with optional conditional logic.
  - Suppressed notifications automatically in CI, non-interactive, or machine-readable (JSON) output modes.
- **Testing:**
  - Added comprehensive unit tests in `update-notification.test.ts` covering notification logic, suppression, and state persistence.

<sub>This will update automatically on new commits.</sub>