### PR TITLE
CLI-733 Emit CliAnalysisCompleted and CliAnalysisFindingsDetected telemetry from SCA call sites

### DIFF
--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { SCA_SCANNER_CACHE_DIR } from '../../../../lib/config-constants';
 import logger, { getLogLevelConfig } from '../../../../lib/logger';
+import { timed } from '../../../../lib/timed';
 import { type SonarQubeClient } from '../../../../sonarqube/client';
 import type { SettingsValue } from '../../../../sonarqube/settings-value';
 import { withSpinner } from '../../../../ui';
@@ -37,6 +38,12 @@ import type { ScaScannerInvocation } from './sca-scanner-runner-base';
 import type { ScaScannerSpawner } from './sca-scanner-spawner';
 import { buildScaUrls } from './sca-urls';
 
+/** SCA scan result plus the wall-clock duration of the scan itself (excludes settings sync and the secrets pre-scan), for `scan_duration_ms` telemetry. */
+export interface ScaScanResult {
+  response: AnalyzeProjectResponse;
+  scanDurationMs: number;
+}
+
 export class ScaScanOrchestrator {
   constructor(
     private readonly client: SonarQubeClient,
@@ -45,7 +52,7 @@ export class ScaScanOrchestrator {
     private readonly secretsInstaller: SecretsInstaller,
   ) {}
 
-  async run(auth: ResolvedAuth, projectKey: string): Promise<AnalyzeProjectResponse> {
+  async run(auth: ResolvedAuth, projectKey: string): Promise<ScaScanResult> {
     const settings = await this.synchronizeSettings(auth, projectKey);
     const properties = parseAnalysisProperties(settings);
     logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
@@ -74,7 +81,8 @@ export class ScaScanOrchestrator {
       secretsInstaller: this.secretsInstaller,
     });
 
-    return this.analyzeDependencyRisks(invocation);
+    const { result, durationMs } = await timed(() => this.analyzeDependencyRisks(invocation));
+    return { response: result, scanDurationMs: durationMs };
   }
 
   private synchronizeSettings(auth: ResolvedAuth, projectKey: string): Promise<SettingsValue[]> {

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -60,6 +60,10 @@ export class ScaScanOrchestrator {
     projectKey: string,
     callerCommand: ScaCallerCommand,
   ): Promise<ScaScanResult> {
+    // Only the SCA scan itself is telemetered (below). Pre-flight failures — settings sync,
+    // `assertScaAvailable`, and the secrets pre-scan — intentionally emit no SCA event: they
+    // mean the scanner never ran (mirroring the secrets/SQAA producers, which likewise only
+    // measure the analyzer run). Command-level failures remain visible via CliCommandExecuted.
     const settings = await this.synchronizeSettings(auth, projectKey);
     const properties = parseAnalysisProperties(settings);
     logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);

--- a/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
+++ b/src/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.ts
@@ -24,9 +24,12 @@ import { join } from 'node:path';
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { SCA_SCANNER_CACHE_DIR } from '../../../../lib/config-constants';
 import logger, { getLogLevelConfig } from '../../../../lib/logger';
-import { timed } from '../../../../lib/timed';
 import { type SonarQubeClient } from '../../../../sonarqube/client';
 import type { SettingsValue } from '../../../../sonarqube/settings-value';
+import {
+  emitScaAnalysisTelemetry,
+  type ScaCallerCommand,
+} from '../../../../telemetry/sca-analysis-telemetry';
 import { withSpinner } from '../../../../ui';
 import type { ScaScannerInstaller } from '../../_common/install/sca-scanner';
 import type { SecretsInstaller } from '../../_common/install/secrets';
@@ -52,7 +55,11 @@ export class ScaScanOrchestrator {
     private readonly secretsInstaller: SecretsInstaller,
   ) {}
 
-  async run(auth: ResolvedAuth, projectKey: string): Promise<ScaScanResult> {
+  async run(
+    auth: ResolvedAuth,
+    projectKey: string,
+    callerCommand: ScaCallerCommand,
+  ): Promise<ScaScanResult> {
     const settings = await this.synchronizeSettings(auth, projectKey);
     const properties = parseAnalysisProperties(settings);
     logger.debug(`Resolved analysis properties: ${JSON.stringify(properties)}`);
@@ -72,6 +79,8 @@ export class ScaScanOrchestrator {
       debug: getLogLevelConfig() === 'DEBUG',
     };
 
+    // A secret found here throws before the SCA scanner ever spawns; that throw propagates
+    // WITHOUT emitting an SCA event (the secrets analyzer owns its own telemetry).
     await preScanManifestsForSecrets({
       invocation,
       baseDir,
@@ -81,8 +90,22 @@ export class ScaScanOrchestrator {
       secretsInstaller: this.secretsInstaller,
     });
 
-    const { result, durationMs } = await timed(() => this.analyzeDependencyRisks(invocation));
-    return { response: result, scanDurationMs: durationMs };
+    // Time and telemeter only the SCA scan, so scan_duration_ms and a failures_count:1 event
+    // reflect the sca-scanner alone — never the settings sync or the secrets pre-scan above.
+    const scanStart = performance.now();
+    try {
+      const response = await this.analyzeDependencyRisks(invocation);
+      return { response, scanDurationMs: Math.round(performance.now() - scanStart) };
+    } catch (err) {
+      await emitScaAnalysisTelemetry(
+        callerCommand,
+        auth,
+        null,
+        Math.round(performance.now() - scanStart),
+        null,
+      );
+      throw err;
+    }
   }
 
   private synchronizeSettings(auth: ResolvedAuth, projectKey: string): Promise<SettingsValue[]> {

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -35,10 +35,7 @@ import { formatDependencyRisksJson } from './dependency-risk-helpers/format-depe
 import { formatDependencyRisksToon } from './dependency-risk-helpers/format-dependency-risks-toon.ts';
 import { pluralize } from './dependency-risk-helpers/pluralize.ts';
 import { buildRiskFilter } from './dependency-risk-helpers/risk-filter.ts';
-import {
-  ScaScanOrchestrator,
-  type ScaScanResult,
-} from './dependency-risk-helpers/sca-scan-orchestrator.ts';
+import { ScaScanOrchestrator } from './dependency-risk-helpers/sca-scan-orchestrator.ts';
 import type { Severity } from './dependency-risk-helpers/sca-scanner.ts';
 import { formatDependencyRisksTable } from './dependency-risk-helpers/table';
 import type { DependencyRisksViewModel } from './dependency-risk-helpers/view-model';
@@ -80,21 +77,9 @@ export async function analyzeDependencyRisks(
     new DefaultSecretsInstaller(),
   );
 
-  const scanStart = performance.now();
-  let scan: ScaScanResult;
-  try {
-    scan = await orchestrator.run(auth, projectKey);
-  } catch (err) {
-    // Record the failed-to-run scan (best-effort duration) before the error propagates.
-    await emitScaAnalysisTelemetry(
-      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
-      auth,
-      null,
-      Math.round(performance.now() - scanStart),
-      null,
-    );
-    throw err;
-  }
+  // The orchestrator emits the failures_count:1 event itself if the SCA scan throws (scoped so a
+  // secrets pre-scan abort never counts as an SCA failure); any throw here just propagates.
+  const scan = await orchestrator.run(auth, projectKey, SCA_CALLER_COMMANDS.analyzeDependencyRisks);
 
   const viewModel = buildDependencyRisksViewModel(scan.response, filter);
   switch (options.format) {

--- a/src/cli/commands/analyze/dependency-risks.ts
+++ b/src/cli/commands/analyze/dependency-risks.ts
@@ -21,6 +21,10 @@
 import { type ResolvedAuth } from '../../../lib/auth-resolver';
 import { discoverProject } from '../../../lib/project-workspace';
 import { SonarQubeClient } from '../../../sonarqube/client';
+import {
+  emitScaAnalysisTelemetry,
+  SCA_CALLER_COMMANDS,
+} from '../../../telemetry/sca-analysis-telemetry';
 import { error, print, warn } from '../../../ui';
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
 import { DefaultScaScannerInstaller } from '../_common/install/sca-scanner.ts';
@@ -31,7 +35,10 @@ import { formatDependencyRisksJson } from './dependency-risk-helpers/format-depe
 import { formatDependencyRisksToon } from './dependency-risk-helpers/format-dependency-risks-toon.ts';
 import { pluralize } from './dependency-risk-helpers/pluralize.ts';
 import { buildRiskFilter } from './dependency-risk-helpers/risk-filter.ts';
-import { ScaScanOrchestrator } from './dependency-risk-helpers/sca-scan-orchestrator.ts';
+import {
+  ScaScanOrchestrator,
+  type ScaScanResult,
+} from './dependency-risk-helpers/sca-scan-orchestrator.ts';
 import type { Severity } from './dependency-risk-helpers/sca-scanner.ts';
 import { formatDependencyRisksTable } from './dependency-risk-helpers/table';
 import type { DependencyRisksViewModel } from './dependency-risk-helpers/view-model';
@@ -66,14 +73,30 @@ export async function analyzeDependencyRisks(
   const projectKey = await resolveProjectKey(options.project, auth);
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
-  const result = await new ScaScanOrchestrator(
+  const orchestrator = new ScaScanOrchestrator(
     client,
     new DefaultScaScannerInstaller(),
     new DefaultScaScannerSpawner(),
     new DefaultSecretsInstaller(),
-  ).run(auth, projectKey);
+  );
 
-  const viewModel = buildDependencyRisksViewModel(result, filter);
+  const scanStart = performance.now();
+  let scan: ScaScanResult;
+  try {
+    scan = await orchestrator.run(auth, projectKey);
+  } catch (err) {
+    // Record the failed-to-run scan (best-effort duration) before the error propagates.
+    await emitScaAnalysisTelemetry(
+      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+      auth,
+      null,
+      Math.round(performance.now() - scanStart),
+      null,
+    );
+    throw err;
+  }
+
+  const viewModel = buildDependencyRisksViewModel(scan.response, filter);
   switch (options.format) {
     case 'json':
       print(formatDependencyRisksJson(projectKey, viewModel));
@@ -85,7 +108,16 @@ export async function analyzeDependencyRisks(
       print(formatDependencyRisksTable(viewModel));
   }
 
-  handleResult(countUnresolvedIssues(viewModel), result.errors.length);
+  handleResult(countUnresolvedIssues(viewModel), scan.response.errors.length);
+
+  // Emit after handleResult so exit_code carries the CLI's final process.exitCode (0/1/51).
+  await emitScaAnalysisTelemetry(
+    SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+    auth,
+    scan.response,
+    scan.scanDurationMs,
+    typeof process.exitCode === 'number' ? process.exitCode : null,
+  );
 }
 
 async function resolveProjectKey(

--- a/src/cli/commands/hook/git-pre-commit-dependency-risks.ts
+++ b/src/cli/commands/hook/git-pre-commit-dependency-risks.ts
@@ -85,7 +85,6 @@ export async function runDepRisksStage(options: DepRisksStageOptions): Promise<v
 
   let scan: ScaScanResult;
   let viewModel: DependencyRisksViewModel;
-  const scanStart = performance.now();
   try {
     const client = new SonarQubeClient(options.auth.serverUrl, options.auth.token);
     scan = await new ScaScanOrchestrator(
@@ -93,17 +92,11 @@ export async function runDepRisksStage(options: DepRisksStageOptions): Promise<v
       new ScaScannerNoopInstaller(binaryPath),
       new DefaultScaScannerSpawner(),
       new ResolveOnlySecretsInstaller(),
-    ).run(options.auth, options.project);
+    ).run(options.auth, options.project, SCA_CALLER_COMMANDS.gitPreCommit);
     viewModel = buildDependencyRisksViewModel(scan.response, filter);
   } catch (err) {
-    // Record the failed-to-run scan even though the hook fails open (commit proceeds).
-    await emitScaAnalysisTelemetry(
-      SCA_CALLER_COMMANDS.gitPreCommit,
-      options.auth,
-      null,
-      Math.round(performance.now() - scanStart),
-      null,
-    );
+    // The orchestrator already emitted a failures_count:1 event if the SCA scan itself failed;
+    // a secrets pre-scan abort also lands here and must NOT be recorded as an SCA failure.
     warn(`Dependency-risks scan failed; commit not blocked. Reason: ${(err as Error).message}`);
     return;
   }

--- a/src/cli/commands/hook/git-pre-commit-dependency-risks.ts
+++ b/src/cli/commands/hook/git-pre-commit-dependency-risks.ts
@@ -27,6 +27,10 @@
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import logger from '../../../lib/logger';
 import { SonarQubeClient } from '../../../sonarqube/client';
+import {
+  emitScaAnalysisTelemetry,
+  SCA_CALLER_COMMANDS,
+} from '../../../telemetry/sca-analysis-telemetry';
 import { discreetSuccess, success, warn } from '../../../ui';
 import { CommandFailedError } from '../_common/error';
 import {
@@ -38,7 +42,10 @@ import { countSelectedRisks } from '../analyze/dependency-risk-helpers/count-sel
 import { DefaultScaScannerSpawner } from '../analyze/dependency-risk-helpers/default-sca-scanner-spawner';
 import { pluralize } from '../analyze/dependency-risk-helpers/pluralize';
 import { buildRiskFilter } from '../analyze/dependency-risk-helpers/risk-filter';
-import { ScaScanOrchestrator } from '../analyze/dependency-risk-helpers/sca-scan-orchestrator';
+import {
+  ScaScanOrchestrator,
+  type ScaScanResult,
+} from '../analyze/dependency-risk-helpers/sca-scan-orchestrator';
 import type { Severity } from '../analyze/dependency-risk-helpers/sca-scanner';
 import {
   anyFileMatches,
@@ -76,20 +83,39 @@ export async function runDepRisksStage(options: DepRisksStageOptions): Promise<v
     return;
   }
 
-  let viewModel;
+  let scan: ScaScanResult;
+  let viewModel: DependencyRisksViewModel;
+  const scanStart = performance.now();
   try {
     const client = new SonarQubeClient(options.auth.serverUrl, options.auth.token);
-    const result = await new ScaScanOrchestrator(
+    scan = await new ScaScanOrchestrator(
       client,
       new ScaScannerNoopInstaller(binaryPath),
       new DefaultScaScannerSpawner(),
       new ResolveOnlySecretsInstaller(),
     ).run(options.auth, options.project);
-    viewModel = buildDependencyRisksViewModel(result, filter);
+    viewModel = buildDependencyRisksViewModel(scan.response, filter);
   } catch (err) {
+    // Record the failed-to-run scan even though the hook fails open (commit proceeds).
+    await emitScaAnalysisTelemetry(
+      SCA_CALLER_COMMANDS.gitPreCommit,
+      options.auth,
+      null,
+      Math.round(performance.now() - scanStart),
+      null,
+    );
     warn(`Dependency-risks scan failed; commit not blocked. Reason: ${(err as Error).message}`);
     return;
   }
+
+  // Hook has no analyze-style 0/1/51 exit code, so exit_code is null.
+  await emitScaAnalysisTelemetry(
+    SCA_CALLER_COMMANDS.gitPreCommit,
+    options.auth,
+    scan.response,
+    scan.scanDurationMs,
+    null,
+  );
 
   const matchedCount = countSelectedRisks(viewModel);
   if (matchedCount === 0) {

--- a/src/telemetry/sca-analysis-telemetry.ts
+++ b/src/telemetry/sca-analysis-telemetry.ts
@@ -1,0 +1,133 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+import type { AnalyzeProjectResponse } from '../cli/commands/analyze/dependency-risk-helpers/sca-scanner.js';
+import type { ResolvedAuth } from '../lib/auth-resolver.js';
+import { emitAnalysisCompleted, emitAnalysisFindingsDetected } from './findings.js';
+
+/**
+ * Schema version of the sca-scanner-cli CliAnalysisFindingsDetected `details` blob
+ * ({ counts_by_rule } keyed by `<ScaIssueType>:<Severity>`). Bump when that shape changes;
+ * independent of SQAA_DETAILS_SCHEMA_VERSION / SECRETS_DETAILS_SCHEMA_VERSION because each
+ * analyzer owns the shape of its own `details`.
+ */
+export const SCA_DETAILS_SCHEMA_VERSION = 1;
+
+/**
+ * The `caller_command` value recorded on every SCA analysis event, one per call site.
+ * `gitPreCommit` matches the sonar-secrets stage of the same hook (SECRETS_CALLER_COMMANDS);
+ * the two stages are distinguished by `analyzer`, not `caller_command`.
+ */
+export const SCA_CALLER_COMMANDS = {
+  analyzeDependencyRisks: 'analyze dependency-risks',
+  gitPreCommit: 'git-pre-commit',
+} as const;
+
+/** Union of the valid SCA `caller_command` values. */
+export type ScaCallerCommand = (typeof SCA_CALLER_COMMANDS)[keyof typeof SCA_CALLER_COMMANDS];
+
+/** Allowlisted, privacy-safe details blob: per-`<type>:<severity>` counts only. */
+export interface ScaFindingsDetails {
+  counts_by_rule: Record<string, number>;
+}
+
+/**
+ * Pure summariser of a successful SCA response. Counts only issues on newly-introduced
+ * releases (`AnalyzeProjectRelease.newlyIntroduced === true`) — pre-existing releases are
+ * excluded from both the count and the details blob. Keys are raw-enum `<ScaIssueType>:<Severity>`
+ * composites (e.g. `VULNERABILITY:HIGH`); no rule keys, paths, or free-form text.
+ */
+export function summarizeScaFindings(response: AnalyzeProjectResponse): {
+  findingsCount: number;
+  details: ScaFindingsDetails;
+} {
+  const countsByRule: Record<string, number> = {};
+  let findingsCount = 0;
+  for (const release of response.releases) {
+    if (!release.newlyIntroduced) continue;
+    for (const issue of release.issues) {
+      findingsCount += 1;
+      const key = `${issue.type}:${issue.severity}`;
+      countsByRule[key] = (countsByRule[key] ?? 0) + 1;
+    }
+  }
+  return { findingsCount, details: { counts_by_rule: countsByRule } };
+}
+
+/**
+ * Emits CliAnalysisCompleted (always) and CliAnalysisFindingsDetected (when findings > 0)
+ * for one SCA run. Fire-and-forget — telemetry failures are swallowed downstream.
+ *
+ * Pass `response: null` for a run that failed to execute (scanner spawn/parse error or a
+ * non-zero exit that threw): the completed event is emitted with `exit_code` as supplied
+ * (callers pass `null` on the throw path) and `failures_count: 1`, and no findings event.
+ *
+ * `exitCode` is the CLI command's final `process.exitCode` (0/1/51 for `analyze`), not the
+ * sca-scanner subprocess code; pass `null` when there is no analyze-style exit (hook) or the
+ * run threw.
+ */
+export async function emitScaAnalysisTelemetry(
+  callerCommand: ScaCallerCommand,
+  auth: ResolvedAuth,
+  response: AnalyzeProjectResponse | null,
+  durationMs: number,
+  exitCode: number | null,
+): Promise<void> {
+  const analysisId = randomUUID();
+
+  if (!response) {
+    await emitAnalysisCompleted(auth, {
+      caller_command: callerCommand,
+      analyzer: 'sca-scanner-cli',
+      analysis_id: analysisId,
+      findings_count: 0,
+      exit_code: exitCode,
+      errors_count: 0,
+      failures_count: 1,
+      scan_duration_ms: durationMs,
+    });
+    return;
+  }
+
+  const { findingsCount, details } = summarizeScaFindings(response);
+
+  await emitAnalysisCompleted(auth, {
+    caller_command: callerCommand,
+    analyzer: 'sca-scanner-cli',
+    analysis_id: analysisId,
+    findings_count: findingsCount,
+    exit_code: exitCode,
+    errors_count: response.errors.length,
+    failures_count: 0,
+    scan_duration_ms: durationMs,
+  });
+
+  if (findingsCount === 0) return;
+
+  await emitAnalysisFindingsDetected(auth, {
+    caller_command: callerCommand,
+    analyzer: 'sca-scanner-cli',
+    analysis_id: analysisId,
+    details_schema_version: SCA_DETAILS_SCHEMA_VERSION,
+    details: JSON.stringify(details),
+  });
+}

--- a/src/telemetry/sca-analysis-telemetry.ts
+++ b/src/telemetry/sca-analysis-telemetry.ts
@@ -75,7 +75,11 @@ export function summarizeScaFindings(response: AnalyzeProjectResponse): {
 
 /**
  * Emits CliAnalysisCompleted (always) and CliAnalysisFindingsDetected (when findings > 0)
- * for one SCA run. Fire-and-forget — telemetry failures are swallowed downstream.
+ * for one SCA run. Strictly fire-and-forget: the entire body is guarded, so no telemetry
+ * failure — identity resolution (`getOrCreateUserId`) or the file write — can ever propagate
+ * to the caller. This matters because the analyze call site emits *after* `process.exitCode`
+ * is set, and the hook call site must keep failing open; a thrown error here would otherwise
+ * turn a successful scan into a failure.
  *
  * Pass `response: null` for a run that failed to execute (scanner spawn/parse error or a
  * non-zero exit that threw): the completed event is emitted with `exit_code` as supplied
@@ -92,42 +96,46 @@ export async function emitScaAnalysisTelemetry(
   durationMs: number,
   exitCode: number | null,
 ): Promise<void> {
-  const analysisId = randomUUID();
+  try {
+    const analysisId = randomUUID();
 
-  if (!response) {
+    if (!response) {
+      await emitAnalysisCompleted(auth, {
+        caller_command: callerCommand,
+        analyzer: 'sca-scanner-cli',
+        analysis_id: analysisId,
+        findings_count: 0,
+        exit_code: exitCode,
+        errors_count: 0,
+        failures_count: 1,
+        scan_duration_ms: durationMs,
+      });
+      return;
+    }
+
+    const { findingsCount, details } = summarizeScaFindings(response);
+
     await emitAnalysisCompleted(auth, {
       caller_command: callerCommand,
       analyzer: 'sca-scanner-cli',
       analysis_id: analysisId,
-      findings_count: 0,
+      findings_count: findingsCount,
       exit_code: exitCode,
-      errors_count: 0,
-      failures_count: 1,
+      errors_count: response.errors.length,
+      failures_count: 0,
       scan_duration_ms: durationMs,
     });
-    return;
+
+    if (findingsCount === 0) return;
+
+    await emitAnalysisFindingsDetected(auth, {
+      caller_command: callerCommand,
+      analyzer: 'sca-scanner-cli',
+      analysis_id: analysisId,
+      details_schema_version: SCA_DETAILS_SCHEMA_VERSION,
+      details: JSON.stringify(details),
+    });
+  } catch {
+    // Telemetry is strictly fire-and-forget; never surface to the command handler.
   }
-
-  const { findingsCount, details } = summarizeScaFindings(response);
-
-  await emitAnalysisCompleted(auth, {
-    caller_command: callerCommand,
-    analyzer: 'sca-scanner-cli',
-    analysis_id: analysisId,
-    findings_count: findingsCount,
-    exit_code: exitCode,
-    errors_count: response.errors.length,
-    failures_count: 0,
-    scan_duration_ms: durationMs,
-  });
-
-  if (findingsCount === 0) return;
-
-  await emitAnalysisFindingsDetected(auth, {
-    caller_command: callerCommand,
-    analyzer: 'sca-scanner-cli',
-    analysis_id: analysisId,
-    details_schema_version: SCA_DETAILS_SCHEMA_VERSION,
-    details: JSON.stringify(details),
-  });
 }

--- a/tests/e2e/sca/sca-staging.test.ts
+++ b/tests/e2e/sca/sca-staging.test.ts
@@ -189,6 +189,67 @@ for (const region of STAGING_REGIONS) {
         },
         SCAN_TIMEOUT_MS,
       );
+
+      it(
+        'writes CliAnalysisCompleted + CliAnalysisFindingsDetected to findings.ndjson',
+        async () => {
+          harness.state().withTelemetryEnabled();
+
+          const result = await harness.run(
+            `analyze dependency-risks --project ${projectKey} --format json`,
+            // __SQ_CLI_TELEMETRY_FLUSH__=1 writes the findings.ndjson sink without POSTing.
+            {
+              extraEnv: { ...cfg.cliEnv, __SQ_CLI_TELEMETRY_FLUSH__: '1' },
+              timeoutMs: SCAN_TIMEOUT_MS,
+            },
+          );
+
+          expect(
+            result.exitCode,
+            `expected exit ${EXIT_UNRESOLVED_RISKS} (unresolved risks found)\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+          ).toBe(EXIT_UNRESOLVED_RISKS);
+
+          const findingsFile = harness.cliHome.file('telemetry', 'findings.ndjson');
+          expect(findingsFile.exists()).toBe(true);
+
+          interface AnalysisEvent {
+            metadata: { event_type: string };
+            event_payload: Record<string, unknown>;
+          }
+          const events = findingsFile
+            .asText()
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .map((line) => JSON.parse(line) as AnalysisEvent);
+
+          const completed = events.find(
+            (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
+          );
+          const detected = events.find(
+            (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
+          );
+          expect(completed).toBeDefined();
+          expect(detected).toBeDefined();
+          if (!completed || !detected) throw new Error('expected both analysis events');
+
+          expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
+          expect(completed.event_payload.caller_command).toBe('analyze dependency-risks');
+          expect(completed.event_payload.failures_count).toBe(0);
+          expect(completed.event_payload.exit_code).toBe(EXIT_UNRESOLVED_RISKS);
+          expect(completed.event_payload.findings_count as number).toBeGreaterThanOrEqual(1);
+          expect(completed.event_payload.analysis_id).toBe(detected.event_payload.analysis_id);
+
+          const details = JSON.parse(detected.event_payload.details as string) as {
+            counts_by_rule: Record<string, number>;
+          };
+          const ruleKeys = Object.keys(details.counts_by_rule);
+          expect(ruleKeys.length).toBeGreaterThanOrEqual(1);
+          // Raw-enum <ScaIssueType>:<Severity> keys; the fixture's lodash CVE is a VULNERABILITY.
+          expect(ruleKeys.some((k) => k.startsWith('VULNERABILITY:'))).toBe(true);
+        },
+        SCAN_TIMEOUT_MS,
+      );
     },
   );
 }

--- a/tests/e2e/sca/sca-staging.test.ts
+++ b/tests/e2e/sca/sca-staging.test.ts
@@ -223,15 +223,21 @@ for (const region of STAGING_REGIONS) {
             .filter(Boolean)
             .map((line) => JSON.parse(line) as AnalysisEvent);
 
+          // The command also runs the secrets pre-scan, which emits its own sonar-secrets
+          // events into the same file — select the SCA ones by analyzer.
           const completed = events.find(
-            (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
+            (e) =>
+              e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted' &&
+              e.event_payload.analyzer === 'sca-scanner-cli',
           );
           const detected = events.find(
-            (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
+            (e) =>
+              e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected' &&
+              e.event_payload.analyzer === 'sca-scanner-cli',
           );
           expect(completed).toBeDefined();
           expect(detected).toBeDefined();
-          if (!completed || !detected) throw new Error('expected both analysis events');
+          if (!completed || !detected) throw new Error('expected both SCA analysis events');
 
           expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
           expect(completed.event_payload.caller_command).toBe('analyze dependency-risks');

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
@@ -74,7 +74,8 @@ describe('ScaScanOrchestrator', () => {
 
     const result = await orchestrator.run(CLOUD_AUTH, 'my-project');
 
-    expect(result).toEqual(EMPTY_RESPONSE);
+    expect(result.response).toEqual(EMPTY_RESPONSE);
+    expect(result.scanDurationMs).toBeGreaterThanOrEqual(0);
   });
 
   it('throws when SCA is not available for the connection', () => {

--- a/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risk-helpers/sca-scan-orchestrator.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { describe, expect, it, mock } from 'bun:test';
+import { describe, expect, it, mock, spyOn } from 'bun:test';
 
 import { CommandFailedError } from '../../../../../../src/cli/commands/_common/error.ts';
 import type { SecretsInstaller } from '../../../../../../src/cli/commands/_common/install/secrets.ts';
@@ -26,6 +26,8 @@ import { ScaScanOrchestrator } from '../../../../../../src/cli/commands/analyze/
 import type { ResolvedAuth } from '../../../../../../src/lib/auth-resolver.ts';
 import type { SonarQubeClient } from '../../../../../../src/sonarqube/client.ts';
 import type { SettingsValue } from '../../../../../../src/sonarqube/settings-value.ts';
+import * as scaTelemetry from '../../../../../../src/telemetry/sca-analysis-telemetry.ts';
+import { SCA_CALLER_COMMANDS } from '../../../../../../src/telemetry/sca-analysis-telemetry.ts';
 import { okScaInstaller as okInstaller } from './_helpers.ts';
 
 const CLOUD_AUTH: ResolvedAuth = {
@@ -72,7 +74,11 @@ describe('ScaScanOrchestrator', () => {
       noopSecretsInstaller,
     );
 
-    const result = await orchestrator.run(CLOUD_AUTH, 'my-project');
+    const result = await orchestrator.run(
+      CLOUD_AUTH,
+      'my-project',
+      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+    );
 
     expect(result.response).toEqual(EMPTY_RESPONSE);
     expect(result.scanDurationMs).toBeGreaterThanOrEqual(0);
@@ -86,7 +92,9 @@ describe('ScaScanOrchestrator', () => {
       noopSecretsInstaller,
     );
 
-    expect(orchestrator.run(CLOUD_AUTH, 'my-project')).rejects.toBeInstanceOf(CommandFailedError);
+    expect(
+      orchestrator.run(CLOUD_AUTH, 'my-project', SCA_CALLER_COMMANDS.analyzeDependencyRisks),
+    ).rejects.toBeInstanceOf(CommandFailedError);
   });
 
   it('passes projectKey and token from auth into the scanner invocation', async () => {
@@ -98,7 +106,7 @@ describe('ScaScanOrchestrator', () => {
       noopSecretsInstaller,
     );
 
-    await orchestrator.run(CLOUD_AUTH, 'my-project');
+    await orchestrator.run(CLOUD_AUTH, 'my-project', SCA_CALLER_COMMANDS.analyzeDependencyRisks);
 
     const analyzeCall = spawn.mock.calls.find(([, args]) => args[0] === 'analyze-project');
     expect(analyzeCall).toBeDefined();
@@ -108,7 +116,8 @@ describe('ScaScanOrchestrator', () => {
     expect(env).toMatchObject({ SONAR_TOKEN: 'test-token' });
   });
 
-  it('skips the analyze-project scan when the manifest pre-scan throws', async () => {
+  it('skips the analyze-project scan and emits no SCA telemetry when the manifest pre-scan throws', async () => {
+    const emitSpy = spyOn(scaTelemetry, 'emitScaAnalysisTelemetry').mockResolvedValue();
     const spawn = mock((_binaryPath: string, args: string[]) => {
       if (args[0] === 'discover-manifests') {
         return Promise.reject(new Error('secrets pre-scan failed'));
@@ -122,13 +131,51 @@ describe('ScaScanOrchestrator', () => {
       noopSecretsInstaller,
     );
 
-    // eslint-disable-next-line @typescript-eslint/await-thenable
-    await expect(orchestrator.run(CLOUD_AUTH, 'my-project')).rejects.toThrow(
-      'secrets pre-scan failed',
+    try {
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(
+        orchestrator.run(CLOUD_AUTH, 'my-project', SCA_CALLER_COMMANDS.analyzeDependencyRisks),
+      ).rejects.toThrow('secrets pre-scan failed');
+
+      const subcommands = spawn.mock.calls.map(([, args]) => args[0]);
+      expect(subcommands).toContain('discover-manifests');
+      expect(subcommands).not.toContain('analyze-project');
+      // A secrets pre-scan abort must never be recorded as an SCA failure.
+      expect(emitSpy).not.toHaveBeenCalled();
+    } finally {
+      emitSpy.mockRestore();
+    }
+  });
+
+  it('emits an SCA failures_count:1 event when the analyze-project scan itself fails', async () => {
+    const emitSpy = spyOn(scaTelemetry, 'emitScaAnalysisTelemetry').mockResolvedValue();
+    const spawn = mock((_binaryPath: string, args: string[]) => {
+      if (args[0] === 'discover-manifests') {
+        return Promise.resolve({ exitCode: 0, stdout: JSON.stringify({ files: [] }), stderr: '' });
+      }
+      // analyze-project exits non-zero → ScaScannerRunner throws.
+      return Promise.resolve({ exitCode: 2, stdout: '', stderr: 'scanner boom' });
+    });
+    const orchestrator = new ScaScanOrchestrator(
+      makeClient(),
+      okInstaller,
+      { spawn },
+      noopSecretsInstaller,
     );
 
-    const subcommands = spawn.mock.calls.map(([, args]) => args[0]);
-    expect(subcommands).toContain('discover-manifests');
-    expect(subcommands).not.toContain('analyze-project');
+    try {
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(
+        orchestrator.run(CLOUD_AUTH, 'my-project', SCA_CALLER_COMMANDS.analyzeDependencyRisks),
+      ).rejects.toBeInstanceOf(CommandFailedError);
+
+      expect(emitSpy).toHaveBeenCalledTimes(1);
+      const [callerCommand, , response, , exitCode] = emitSpy.mock.calls[0];
+      expect(callerCommand).toBe(SCA_CALLER_COMMANDS.analyzeDependencyRisks);
+      expect(response).toBeNull(); // null response ⇒ failures_count:1
+      expect(exitCode).toBeNull();
+    } finally {
+      emitSpy.mockRestore();
+    }
   });
 });

--- a/tests/unit/cli/commands/analyze/dependency-risks.smoke.test.ts
+++ b/tests/unit/cli/commands/analyze/dependency-risks.smoke.test.ts
@@ -238,7 +238,10 @@ describe('analyzeDependencyRisks - output format', () => {
 
   beforeEach(() => {
     setMockUi(true);
-    runSpy = spyOn(ScaScanOrchestrator.prototype, 'run').mockResolvedValue(SCAN_RESULT_STUB);
+    runSpy = spyOn(ScaScanOrchestrator.prototype, 'run').mockResolvedValue({
+      response: SCAN_RESULT_STUB,
+      scanDurationMs: 0,
+    });
   });
 
   afterEach(() => {

--- a/tests/unit/cli/commands/hook/git-pre-commit-dependency-risks.mocked.test.ts
+++ b/tests/unit/cli/commands/hook/git-pre-commit-dependency-risks.mocked.test.ts
@@ -143,6 +143,11 @@ const SCAN_RESULT_MULTI_SEVERITY: AnalyzeProjectResponse = {
   errors: [],
 };
 
+// Wraps a scanner response in the orchestrator's { response, scanDurationMs } return shape.
+function asScan(response: AnalyzeProjectResponse) {
+  return { response, scanDurationMs: 0 };
+}
+
 // Derives a scan result from the SCAN_RESULT_WITH_RISK template, replacing its single
 // issue with one NEW VULNERABILITY issue per requested severity.
 function withSeverities(...severities: Severity[]): AnalyzeProjectResponse {
@@ -179,7 +184,7 @@ describe('runDepRisksStage', () => {
       'package.json',
     ]);
     orchestratorRunSpy = spyOn(ScaScanOrchestrator.prototype, 'run').mockResolvedValue(
-      SCAN_RESULT_WITH_RISK,
+      asScan(SCAN_RESULT_WITH_RISK),
     );
   });
 
@@ -208,7 +213,7 @@ describe('runDepRisksStage', () => {
   });
 
   it('reports the severity breakdown highest-first when multiple risks are found', async () => {
-    orchestratorRunSpy.mockResolvedValue(SCAN_RESULT_MULTI_SEVERITY);
+    orchestratorRunSpy.mockResolvedValue(asScan(SCAN_RESULT_MULTI_SEVERITY));
 
     let thrown: unknown;
     try {
@@ -224,7 +229,7 @@ describe('runDepRisksStage', () => {
   });
 
   it('does not block when all risks are below MEDIUM severity', async () => {
-    orchestratorRunSpy.mockResolvedValue(withSeverities('LOW', 'INFO'));
+    orchestratorRunSpy.mockResolvedValue(asScan(withSeverities('LOW', 'INFO')));
 
     await runDepRisksStage({ project: 'demo', changedFiles: ['package.json'], auth: FAKE_AUTH });
 
@@ -233,7 +238,7 @@ describe('runDepRisksStage', () => {
   });
 
   it('blocks on MEDIUM-and-above risks while excluding lower severities from the count', async () => {
-    orchestratorRunSpy.mockResolvedValue(withSeverities('HIGH', 'MEDIUM', 'LOW'));
+    orchestratorRunSpy.mockResolvedValue(asScan(withSeverities('HIGH', 'MEDIUM', 'LOW')));
 
     let thrown: unknown;
     try {
@@ -249,7 +254,7 @@ describe('runDepRisksStage', () => {
   });
 
   it('reports success and does not throw when the scan finds no risks', async () => {
-    orchestratorRunSpy.mockResolvedValue(SCAN_RESULT_EMPTY);
+    orchestratorRunSpy.mockResolvedValue(asScan(SCAN_RESULT_EMPTY));
 
     await runDepRisksStage({ project: 'demo', changedFiles: ['package.json'], auth: FAKE_AUTH });
 

--- a/tests/unit/telemetry/sca-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sca-analysis-telemetry.test.ts
@@ -338,4 +338,23 @@ describe('emitScaAnalysisTelemetry()', () => {
 
     expect(readEvents(testSonarUserHome)).toHaveLength(0);
   });
+
+  it('never throws when identity resolution fails (strictly fire-and-forget)', async () => {
+    // getOrCreateUserId does mkdirSync/openSync and can throw on permission/disk errors.
+    getUserIdSpy.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+    const response = makeResponse([makeRelease(true, [makeIssue('VULNERABILITY', 'HIGH')])]);
+
+    // Must resolve, not reject — a telemetry failure must never reach the command handler.
+    await emitScaAnalysisTelemetry(
+      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+      AUTH,
+      response,
+      100,
+      51,
+    );
+
+    expect(readEvents(testSonarUserHome)).toHaveLength(0);
+  });
 });

--- a/tests/unit/telemetry/sca-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sca-analysis-telemetry.test.ts
@@ -1,0 +1,341 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import type {
+  AnalysisErrorResource,
+  AnalyzeProjectIssue,
+  AnalyzeProjectRelease,
+  AnalyzeProjectResponse,
+  ScaIssueType,
+  Severity,
+} from '../../../src/cli/commands/analyze/dependency-risk-helpers/sca-scanner.js';
+import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
+import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
+import * as stateRepository from '../../../src/lib/repository/state-repository.js';
+import type {
+  StoredAnalysisCompletedEvent,
+  StoredAnalysisEvent,
+  StoredAnalysisFindingsDetectedEvent,
+} from '../../../src/lib/state.js';
+import { getDefaultState } from '../../../src/lib/state.js';
+import * as stateManager from '../../../src/lib/state-manager.js';
+import {
+  emitScaAnalysisTelemetry,
+  SCA_CALLER_COMMANDS,
+  SCA_DETAILS_SCHEMA_VERSION,
+  summarizeScaFindings,
+} from '../../../src/telemetry/sca-analysis-telemetry.js';
+import * as userModule from '../../../src/telemetry/user.js';
+
+const AUTH: ResolvedAuth = {
+  connectionType: 'cloud',
+  serverUrl: 'https://sonarcloud.io',
+  token: 'test-token',
+  orgKey: 'my-org',
+};
+
+function makeIssue(type: ScaIssueType, severity: Severity): AnalyzeProjectIssue {
+  return {
+    key: `issue-${type}-${severity}`,
+    severity,
+    showIncreasedSeverityWarning: null,
+    type,
+    quality: 'SECURITY',
+    status: null,
+    vulnerabilityId: null,
+    cweIds: null,
+    cvssScore: null,
+    spdxLicenseId: null,
+    versionOptions: null,
+  };
+}
+
+function makeRelease(
+  newlyIntroduced: boolean,
+  issues: AnalyzeProjectIssue[],
+): AnalyzeProjectRelease {
+  return {
+    key: 'pkg@1.0.0',
+    packageUrl: 'pkg:npm/pkg@1.0.0',
+    packageManager: 'npm',
+    packageName: 'pkg',
+    version: '1.0.0',
+    licenseExpression: null,
+    known: true,
+    knownPackage: true,
+    newlyIntroduced,
+    issues,
+    dependencyFilePaths: [],
+    dependencyChains: [],
+  };
+}
+
+function makeResponse(
+  releases: AnalyzeProjectRelease[],
+  errors: AnalysisErrorResource[] = [],
+): AnalyzeProjectResponse {
+  return { releases, parsedFiles: [], errors };
+}
+
+function makeError(
+  code: AnalysisErrorResource['code'] = 'NO_DEPENDENCIES_FOUND',
+): AnalysisErrorResource {
+  return { id: `err-${code}`, code, path: null, message: 'error' };
+}
+
+function findingsPath(sonarUserHome: string): string {
+  return join(sonarUserHome, 'sonarqube-cli', 'telemetry', 'findings.ndjson');
+}
+
+function readEvents(sonarUserHome: string): StoredAnalysisEvent[] {
+  const path = findingsPath(sonarUserHome);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as StoredAnalysisEvent);
+}
+
+function makeTelemetryState(enabled = true) {
+  const state = getDefaultState('1.0.0');
+  state.telemetry.enabled = enabled;
+  state.telemetry.installationId = 'install-id';
+  return state;
+}
+
+let testSonarUserHome: string;
+const previousSonarUserHome = process.env[ENV_SONAR_USER_HOME];
+let loadStateSpy: ReturnType<typeof spyOn>;
+let getConnectionSpy: ReturnType<typeof spyOn>;
+let getUserIdSpy: ReturnType<typeof spyOn>;
+let savedDoNotTrack: string | undefined;
+
+beforeEach(async () => {
+  testSonarUserHome = await mkdtemp(join(tmpdir(), 'cli-sca-telemetry-test-'));
+  process.env[ENV_SONAR_USER_HOME] = testSonarUserHome;
+
+  savedDoNotTrack = process.env.DO_NOT_TRACK;
+  delete process.env.DO_NOT_TRACK;
+
+  loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeTelemetryState());
+  getConnectionSpy = spyOn(stateManager, 'getActiveConnection').mockReturnValue(undefined);
+  getUserIdSpy = spyOn(userModule, 'getOrCreateUserId').mockReturnValue('machine-id');
+});
+
+afterEach(async () => {
+  if (savedDoNotTrack !== undefined) {
+    process.env.DO_NOT_TRACK = savedDoNotTrack;
+  } else {
+    delete process.env.DO_NOT_TRACK;
+  }
+
+  loadStateSpy.mockRestore();
+  getConnectionSpy.mockRestore();
+  getUserIdSpy.mockRestore();
+
+  await rm(testSonarUserHome, { recursive: true, force: true });
+  if (previousSonarUserHome === undefined) {
+    delete process.env[ENV_SONAR_USER_HOME];
+  } else {
+    process.env[ENV_SONAR_USER_HOME] = previousSonarUserHome;
+  }
+});
+
+describe('summarizeScaFindings()', () => {
+  it('counts only issues on newly-introduced releases, keyed by <type>:<severity>', () => {
+    const response = makeResponse([
+      makeRelease(true, [
+        makeIssue('VULNERABILITY', 'HIGH'),
+        makeIssue('VULNERABILITY', 'HIGH'),
+        makeIssue('MALWARE', 'BLOCKER'),
+      ]),
+      // Pre-existing release — excluded from both count and details.
+      makeRelease(false, [makeIssue('VULNERABILITY', 'LOW')]),
+    ]);
+
+    expect(summarizeScaFindings(response)).toEqual({
+      findingsCount: 3,
+      details: { counts_by_rule: { 'VULNERABILITY:HIGH': 2, 'MALWARE:BLOCKER': 1 } },
+    });
+  });
+
+  it('maps PROHIBITED_LICENSE as a raw-enum key', () => {
+    const response = makeResponse([makeRelease(true, [makeIssue('PROHIBITED_LICENSE', 'MEDIUM')])]);
+
+    expect(summarizeScaFindings(response).details.counts_by_rule).toEqual({
+      'PROHIBITED_LICENSE:MEDIUM': 1,
+    });
+  });
+
+  it('returns zero for an empty response', () => {
+    expect(summarizeScaFindings(makeResponse([]))).toEqual({
+      findingsCount: 0,
+      details: { counts_by_rule: {} },
+    });
+  });
+
+  it('returns zero when only pre-existing releases carry issues', () => {
+    const response = makeResponse([makeRelease(false, [makeIssue('VULNERABILITY', 'HIGH')])]);
+
+    expect(summarizeScaFindings(response)).toEqual({
+      findingsCount: 0,
+      details: { counts_by_rule: {} },
+    });
+  });
+
+  it('ignores a newly-introduced release with no issues', () => {
+    const response = makeResponse([makeRelease(true, [])]);
+
+    expect(summarizeScaFindings(response).findingsCount).toBe(0);
+  });
+});
+
+describe('emitScaAnalysisTelemetry()', () => {
+  it('writes only CliAnalysisCompleted on a clean run (no new findings)', async () => {
+    const response = makeResponse([makeRelease(false, [makeIssue('VULNERABILITY', 'HIGH')])]);
+
+    await emitScaAnalysisTelemetry(
+      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+      AUTH,
+      response,
+      123,
+      0,
+    );
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(1);
+    const completed = events[0] as StoredAnalysisCompletedEvent;
+    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    expect(completed.event_payload.caller_command).toBe('analyze dependency-risks');
+    expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
+    expect(completed.event_payload.findings_count).toBe(0);
+    expect(completed.event_payload.exit_code).toBe(0);
+    expect(completed.event_payload.errors_count).toBe(0);
+    expect(completed.event_payload.failures_count).toBe(0);
+    expect(completed.event_payload.scan_duration_ms).toBe(123);
+    expect(completed.event_payload.analysis_id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('writes Completed and FindingsDetected with matching analysis_id when new findings exist', async () => {
+    const response = makeResponse(
+      [makeRelease(true, [makeIssue('VULNERABILITY', 'HIGH'), makeIssue('VULNERABILITY', 'HIGH')])],
+      [makeError()],
+    );
+
+    await emitScaAnalysisTelemetry(
+      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+      AUTH,
+      response,
+      456,
+      51,
+    );
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(2);
+    const completed = events.find(
+      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
+    ) as StoredAnalysisCompletedEvent | undefined;
+    const findings = events.find(
+      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
+    ) as StoredAnalysisFindingsDetectedEvent | undefined;
+
+    expect(completed).toBeDefined();
+    expect(findings).toBeDefined();
+    expect(completed!.event_payload.analysis_id).toBe(findings!.event_payload.analysis_id);
+    expect(completed!.event_payload.findings_count).toBe(2);
+    expect(completed!.event_payload.exit_code).toBe(51);
+    expect(completed!.event_payload.errors_count).toBe(1);
+    expect(completed!.event_payload.failures_count).toBe(0);
+    expect(findings!.event_payload.analyzer).toBe('sca-scanner-cli');
+    expect(findings!.event_payload.details_schema_version).toBe(SCA_DETAILS_SCHEMA_VERSION);
+    expect(JSON.parse(findings!.event_payload.details)).toEqual({
+      counts_by_rule: { 'VULNERABILITY:HIGH': 2 },
+    });
+  });
+
+  it('records a failed-to-run scan (response null) as failures_count 1 with no findings event', async () => {
+    await emitScaAnalysisTelemetry(SCA_CALLER_COMMANDS.gitPreCommit, AUTH, null, 77, null);
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(1);
+    const completed = events[0] as StoredAnalysisCompletedEvent;
+    expect(completed.event_payload.caller_command).toBe('git-pre-commit');
+    expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
+    expect(completed.event_payload.findings_count).toBe(0);
+    expect(completed.event_payload.exit_code).toBeNull();
+    expect(completed.event_payload.errors_count).toBe(0);
+    expect(completed.event_payload.failures_count).toBe(1);
+    expect(completed.event_payload.scan_duration_ms).toBe(77);
+  });
+
+  it('emits FindingsDetected for the git-pre-commit caller too (Model B)', async () => {
+    const response = makeResponse([makeRelease(true, [makeIssue('MALWARE', 'BLOCKER')])]);
+
+    await emitScaAnalysisTelemetry(SCA_CALLER_COMMANDS.gitPreCommit, AUTH, response, 10, null);
+
+    const events = readEvents(testSonarUserHome);
+    expect(events).toHaveLength(2);
+    const findings = events.find(
+      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
+    ) as StoredAnalysisFindingsDetectedEvent | undefined;
+    expect(findings).toBeDefined();
+    expect(findings!.event_payload.caller_command).toBe('git-pre-commit');
+    expect(JSON.parse(findings!.event_payload.details)).toEqual({
+      counts_by_rule: { 'MALWARE:BLOCKER': 1 },
+    });
+  });
+
+  it('does not write when telemetry is disabled', async () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+
+    await emitScaAnalysisTelemetry(
+      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+      AUTH,
+      makeResponse([makeRelease(true, [makeIssue('VULNERABILITY', 'HIGH')])]),
+      100,
+      51,
+    );
+
+    expect(readEvents(testSonarUserHome)).toHaveLength(0);
+  });
+
+  it('does not write when installationId is absent', async () => {
+    const stateWithoutId = makeTelemetryState();
+    stateWithoutId.telemetry.installationId = undefined;
+    loadStateSpy.mockReturnValue(stateWithoutId);
+
+    await emitScaAnalysisTelemetry(
+      SCA_CALLER_COMMANDS.analyzeDependencyRisks,
+      AUTH,
+      null,
+      100,
+      null,
+    );
+
+    expect(readEvents(testSonarUserHome)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Adds the SCA (dependency-risks) producer for the shared analysis-telemetry events, completing the trio alongside `sonar-secrets` (CLI-730) and SQAA (CLI-731). Every SCA scan now emits a `CliAnalysisCompleted` event, plus a `CliAnalysisFindingsDetected` event when newly-introduced risks exist, joined on a single `analysis_id`.

New `src/telemetry/sca-analysis-telemetry.ts` (`emitScaAnalysisTelemetry` + pure `summarizeScaFindings`) mirrors the merged `sonar-secrets` helper.

## Key decisions

- **Emit at the two call sites, not the orchestrator.** `exit_code` carries the CLI's final `process.exitCode` (0/1/51 for `analyze`), which is only known after `handleResult()`. The orchestrator just returns `{ response, scanDurationMs }` and times the SCA scan alone, so `scan_duration_ms` excludes settings sync and the secrets pre-scan.
- **`findings_count`** = issues on releases with `newlyIntroduced === true` only (pre-existing excluded), read off the raw response — independent of `--statuses` / `--min-severity`, so it intentionally won't match the on-screen or hook-block counts.
- **`exit_code`**: `analyze` = `process.exitCode`; hook = `null` (no analyze-style code; fail-open makes the commit exit ambiguous). On a scanner throw both callers emit `failures_count:1` with `response=null` — the hook emits it even while failing open, so silently-swallowed scanner failures are still measured.
- **`details.counts_by_rule`** uses raw-enum `<ScaIssueType>:<Severity>` keys (e.g. `VULNERABILITY:HIGH`) to avoid a mapping table that could drift; no `rule_keys`. `SCA_DETAILS_SCHEMA_VERSION` bumps independently.
- **Hook `caller_command`** = `'git-pre-commit'` (same as the secrets stage of that hook); `analyzer` disambiguates the two.

## Testing

The in-process fake server has no SCA backend, and a dependency-risks run dies at the secrets-guard `discover-manifests` step before the SCA scan is reached — so a finding-bearing run **cannot** be exercised in the black-box integration harness. Coverage is therefore:

- **Unit** — pure `summarizeScaFindings` + behavioral `emitScaAnalysisTelemetry` asserting `findings.ndjson` (11 tests).
- **e2e staging** — a supplementary `findings.ndjson` assertion in the credential-gated `sca-staging.test.ts` (real backend). Not run in CI; should be validated with staging tokens.
- Intentionally **no integration test** for this path (documented above).

`typecheck`, `lint`, `format` all clean. Targeted suite 36/36 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)