### PR TITLE
CLI-779 Emit CliIntegrationConfigured telemetry event on successful integration

### DIFF
--- a/src/cli/commands/integrate/_common/agent-integrate-postlude.ts
+++ b/src/cli/commands/integrate/_common/agent-integrate-postlude.ts
@@ -93,6 +93,7 @@ export async function finalizeAgentInstall<TOptions extends IntegrateAgentOption
     scope: installScope,
     auth,
     nonInteractive: options.nonInteractive,
+    isFromRouter: options.isFromRouter,
     attrs,
   });
 }

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -21,6 +21,7 @@
 import { version as VERSION } from '../../../../../../package.json';
 import type { ResolvedAuth } from '../../../../../lib/auth-resolver';
 import logger from '../../../../../lib/logger';
+import { findGitRoot } from '../../../../../lib/project-workspace/project-info';
 import { loadState, saveState } from '../../../../../lib/repository/state-repository';
 import type {
   CliState,
@@ -29,6 +30,7 @@ import type {
   IntegrationStateAttribute,
 } from '../../../../../lib/state';
 import { getDefaultState } from '../../../../../lib/state';
+import { emitIntegrationConfiguredTelemetry } from '../../../../../telemetry/integrate-telemetry';
 import { text, warn } from '../../../../../ui';
 import { CommandFailedError } from '../../../_common/error';
 import { renderCompletionSummary } from './completion-summary';
@@ -54,6 +56,8 @@ export interface InstallIntegrationOptions<TOptions> {
   force?: boolean;
   attrs?: Record<string, IntegrationStateAttribute>;
   nonInteractive?: boolean;
+  /** True when invoked via the bare `sonar integrate` router (telemetry only). */
+  isFromRouter?: boolean;
 }
 
 export async function installIntegration<TOptions>({
@@ -66,6 +70,7 @@ export async function installIntegration<TOptions>({
   force,
   attrs,
   nonInteractive,
+  isFromRouter,
 }: InstallIntegrationOptions<TOptions>): Promise<InstalledIntegrationFeature[]> {
   const integration = getIntegrationDeclaration<TOptions>(registry, integrationId);
   const state = loadStateForInstallation();
@@ -137,6 +142,19 @@ export async function installIntegration<TOptions>({
 
     renderCompletionSummary(integration, installedFeatures, removedFeatures);
 
+    emitIntegrationConfiguredTelemetry({
+      // `integrate` is an authenticatedAction, so auth is always present here.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      auth: auth!,
+      integrationId,
+      scope,
+      nonInteractive: nonInteractive ?? false,
+      isFromRouter: isFromRouter ?? false,
+      installedFeatures,
+      declaredFeatureIds: collectDeclaredFeatureIds(integration),
+      repoRoot: resolveRepoRootForScope(scope, targetRoot),
+    });
+
     return saveInstalledFeatures(state) ? installedFeatures : [];
   } catch (error) {
     saveInstalledFeatures(state);
@@ -163,6 +181,36 @@ export function makeContext(
     attrs,
     resolvedDependencies: new Map(),
   };
+}
+
+/**
+ * All feature ids an integration declares, including the subfeatures nested in
+ * container features. Telemetry derives `features_skipped` as this set minus the
+ * features actually installed.
+ */
+function collectDeclaredFeatureIds<TOptions>(
+  integration: IntegrationDeclaration<TOptions>,
+): string[] {
+  const ids: string[] = [];
+  for (const feature of integration.features) {
+    ids.push(feature.id);
+    if (isFeatureContainer(feature)) {
+      for (const subfeature of feature.subfeatures) {
+        ids.push(subfeature.id);
+      }
+    }
+  }
+  return ids;
+}
+
+/**
+ * Repo root for telemetry `repo_id`: the git root for
+ * project-scope installs, or null for global scope / non-git targets.
+ */
+function resolveRepoRootForScope(scope: IntegrationScope, targetRoot: string): string | null {
+  if (scope === 'global') return null;
+  const { gitRoot, isGit } = findGitRoot(targetRoot);
+  return isGit ? gitRoot : null;
 }
 
 function saveInstalledFeatures(state: CliState): boolean {

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -85,7 +85,7 @@ export async function installIntegration<TOptions>({
     state,
   };
   const applications = await buildApplications(invocation, integration.features);
-  const { toInstall, toRemove } = await selectFeaturesForInvocation(
+  const { toInstall, toRemove, declined } = await selectFeaturesForInvocation(
     integration,
     invocation,
     applications,
@@ -151,7 +151,7 @@ export async function installIntegration<TOptions>({
       nonInteractive: nonInteractive ?? false,
       isFromRouter: isFromRouter ?? false,
       installedFeatures,
-      declaredFeatureIds: collectDeclaredFeatureIds(integration),
+      featuresSkipped: [...declined, ...toRemove.map((application) => application.feature.id)],
       repoRoot: resolveRepoRootForScope(scope, targetRoot),
     });
 
@@ -181,26 +181,6 @@ export function makeContext(
     attrs,
     resolvedDependencies: new Map(),
   };
-}
-
-/**
- * All feature ids an integration declares, including the subfeatures nested in
- * container features. Telemetry derives `features_skipped` as this set minus the
- * features actually installed.
- */
-function collectDeclaredFeatureIds<TOptions>(
-  integration: IntegrationDeclaration<TOptions>,
-): string[] {
-  const ids: string[] = [];
-  for (const feature of integration.features) {
-    ids.push(feature.id);
-    if (isFeatureContainer(feature)) {
-      for (const subfeature of feature.subfeatures) {
-        ids.push(subfeature.id);
-      }
-    }
-  }
-  return ids;
 }
 
 /**

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -153,7 +153,8 @@ export async function installIntegration<TOptions>({
         nonInteractive: nonInteractive ?? false,
         isFromRouter: isFromRouter ?? false,
         installedFeatures,
-        featuresSkipped: [...declined, ...toRemove.map((application) => application.feature.id)],
+        featuresDeclined: declined,
+        featuresUninstalled: toRemove.map((application) => application.feature.id),
         repoRoot: resolveRepoRootForScope(scope, targetRoot),
       });
     }

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -144,7 +144,7 @@ export async function installIntegration<TOptions>({
 
     const stateSaved = saveInstalledFeatures(state);
     if (stateSaved) {
-      emitIntegrationConfiguredTelemetry({
+      await emitIntegrationConfiguredTelemetry({
         // `integrate` is an authenticatedAction, so auth is always present here.
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         auth: auth!,

--- a/src/cli/commands/integrate/_common/registry/install-integration.ts
+++ b/src/cli/commands/integrate/_common/registry/install-integration.ts
@@ -142,20 +142,23 @@ export async function installIntegration<TOptions>({
 
     renderCompletionSummary(integration, installedFeatures, removedFeatures);
 
-    emitIntegrationConfiguredTelemetry({
-      // `integrate` is an authenticatedAction, so auth is always present here.
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      auth: auth!,
-      integrationId,
-      scope,
-      nonInteractive: nonInteractive ?? false,
-      isFromRouter: isFromRouter ?? false,
-      installedFeatures,
-      featuresSkipped: [...declined, ...toRemove.map((application) => application.feature.id)],
-      repoRoot: resolveRepoRootForScope(scope, targetRoot),
-    });
+    const stateSaved = saveInstalledFeatures(state);
+    if (stateSaved) {
+      emitIntegrationConfiguredTelemetry({
+        // `integrate` is an authenticatedAction, so auth is always present here.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        auth: auth!,
+        integrationId,
+        scope,
+        nonInteractive: nonInteractive ?? false,
+        isFromRouter: isFromRouter ?? false,
+        installedFeatures,
+        featuresSkipped: [...declined, ...toRemove.map((application) => application.feature.id)],
+        repoRoot: resolveRepoRootForScope(scope, targetRoot),
+      });
+    }
 
-    return saveInstalledFeatures(state) ? installedFeatures : [];
+    return stateSaved ? installedFeatures : [];
   } catch (error) {
     saveInstalledFeatures(state);
     throw error;

--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -93,6 +93,7 @@ export async function selectFeaturesForInvocation<TOptions>(
 ): Promise<FeatureSelectionResult<TOptions>> {
   const toInstall: FeatureApplication<TOptions>[] = [];
   const toRemove: FeatureApplication<TOptions>[] = [];
+  const declined: string[] = [];
 
   for (const application of applications) {
     const feature = application.feature;
@@ -100,14 +101,19 @@ export async function selectFeaturesForInvocation<TOptions>(
       if (await shouldRemoveInstalledFeature(feature, invocation)) {
         toRemove.push(application);
       } else {
-        toInstall.push(await materializeApplication(application, invocation));
+        toInstall.push(await materializeApplication(application, invocation, declined));
       }
-    } else if (await shouldInstallFeature(feature, invocation)) {
-      toInstall.push(await materializeApplication(application, invocation));
+    } else {
+      const outcome = await shouldInstallFeature(feature, invocation);
+      if (outcome === 'install') {
+        toInstall.push(await materializeApplication(application, invocation, declined));
+      } else if (outcome === 'declined') {
+        declined.push(feature.id);
+      }
     }
   }
 
-  return { toInstall, toRemove };
+  return { toInstall, toRemove, declined };
 }
 
 function isFeatureInstalled<TOptions>(
@@ -162,29 +168,41 @@ function warnFeatureRemoval(message: string): void {
   text(`  ${red('✗')}  ${message}`);
 }
 
+/** `install`: install it. `declined`: user was asked and said no. `skipped`: auto-skipped, no user decline. */
+type FeatureSelectionOutcome = 'install' | 'declined' | 'skipped';
+
 /**
  * For a container application, narrow its subfeatures to those whose
  * `shouldInstall` is active; non-container applications are returned unchanged.
+ * Declined subfeature ids are appended to `declined`.
  */
 async function materializeApplication<TOptions>(
   application: FeatureApplication<TOptions>,
   invocation: IntegrationInvocation<TOptions>,
+  declined: string[],
 ): Promise<FeatureApplication<TOptions>> {
   const feature = application.feature;
   if (!isFeatureContainer(feature)) {
     return application;
   }
-  return { ...application, feature: await selectActiveSubfeatures(feature, invocation) };
+  return {
+    ...application,
+    feature: await selectActiveSubfeatures(feature, invocation, declined),
+  };
 }
 
 async function selectActiveSubfeatures<TOptions>(
   container: FeatureContainer<TOptions>,
   invocation: IntegrationInvocation<TOptions>,
+  declined: string[],
 ): Promise<FeatureContainer<TOptions>> {
   const active: SubfeatureDeclaration<TOptions>[] = [];
   for (const subfeature of container.subfeatures) {
-    if (await shouldInstallFeature(subfeature, invocation)) {
+    const outcome = await shouldInstallFeature(subfeature, invocation);
+    if (outcome === 'install') {
       active.push(subfeature);
+    } else if (outcome === 'declined') {
+      declined.push(subfeature.id);
     }
   }
   return { ...container, subfeatures: active };
@@ -193,22 +211,22 @@ async function selectActiveSubfeatures<TOptions>(
 async function shouldInstallFeature<TOptions>(
   feature: FeatureDeclaration<TOptions>,
   invocation: IntegrationInvocation<TOptions>,
-): Promise<boolean> {
+): Promise<FeatureSelectionOutcome> {
   const decision = normalizeDecision(await feature.shouldInstall?.(invocation));
   switch (decision.action) {
     case 'install':
       if (decision.message) {
         discreetSuccess(decision.message);
       }
-      return true;
+      return 'install';
     case 'skip':
       if (decision.message) {
         info(decision.message);
       }
-      return false;
+      return 'skipped';
     case 'ask': {
       if (invocation.nonInteractive) {
-        return true;
+        return 'install';
       }
       const defaultQuestion = feature.benefitDescription
         ? `Install ${feature.displayName}? (${feature.benefitDescription})`
@@ -217,7 +235,7 @@ async function shouldInstallFeature<TOptions>(
       if (confirmed === null) {
         throw new CommandFailedError('Installation cancelled');
       }
-      return confirmed;
+      return confirmed ? 'install' : 'declined';
     }
   }
 }

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -106,7 +106,7 @@ export interface FeatureApplication<TOptions = Record<string, unknown>> {
 export interface FeatureSelectionResult<TOptions = Record<string, unknown>> {
   toInstall: FeatureApplication<TOptions>[];
   toRemove: FeatureApplication<TOptions>[];
-  /** Ids of features offered (`ask`) and deliberately declined; feeds telemetry's `features_skipped`. */
+  /** Ids of features offered (`ask`) and deliberately declined; feeds telemetry's `features_declined`. */
   declined: string[];
 }
 

--- a/src/cli/commands/integrate/_common/registry/types.ts
+++ b/src/cli/commands/integrate/_common/registry/types.ts
@@ -106,6 +106,8 @@ export interface FeatureApplication<TOptions = Record<string, unknown>> {
 export interface FeatureSelectionResult<TOptions = Record<string, unknown>> {
   toInstall: FeatureApplication<TOptions>[];
   toRemove: FeatureApplication<TOptions>[];
+  /** Ids of features offered (`ask`) and deliberately declined; feeds telemetry's `features_skipped`. */
+  declined: string[];
 }
 
 export type FeaturePreview = string | ((activeSubfeatureIds: readonly string[]) => string);

--- a/src/cli/commands/integrate/_common/types.ts
+++ b/src/cli/commands/integrate/_common/types.ts
@@ -24,6 +24,8 @@ export interface IntegrateAgentOptions {
   global?: boolean;
   /** Skip the sonar-context-augmentation install/init/skill step. */
   skipContext?: boolean;
+  /** Set by the bare `sonar integrate` router; forwarded to telemetry only. */
+  isFromRouter?: boolean;
 }
 
 export interface HookCommand {

--- a/src/cli/commands/integrate/antigravity/index.ts
+++ b/src/cli/commands/integrate/antigravity/index.ts
@@ -83,6 +83,7 @@ export async function integrateAntigravity(
     scope,
     auth,
     nonInteractive: options.nonInteractive,
+    isFromRouter: options.isFromRouter,
     attrs: {
       ...buildIntegrationAttrs(ctx),
       ...(contextAugmentation

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -121,6 +121,7 @@ export async function integrateClaude(
       auth: { ...auth, token: config.token },
       attrs: featureAttrs,
       nonInteractive: options.nonInteractive,
+      isFromRouter: options.isFromRouter,
     });
   } catch (error) {
     installError = error instanceof Error ? error : new Error(String(error));

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -218,6 +218,7 @@ async function installGitFeatures(
     auth,
     force: options.force,
     nonInteractive: options.nonInteractive,
+    isFromRouter: options.isFromRouter,
     // Attrs are project-scope only; global hooks do not support a project key.
     attrs: scope === 'project' ? { projectKey: options.project ?? null } : undefined,
   });

--- a/src/cli/commands/integrate/git/options.ts
+++ b/src/cli/commands/integrate/git/options.ts
@@ -29,4 +29,6 @@ export interface IntegrateGitOptions {
   dependencyRisks?: boolean;
   /** Project key baked into the dependency-risks hook. Required when `dependencyRisks` is set. */
   project?: string;
+  /** Set by the bare `sonar integrate` router; forwarded to telemetry only. */
+  isFromRouter?: boolean;
 }

--- a/src/cli/commands/integrate/integrate-bare.ts
+++ b/src/cli/commands/integrate/integrate-bare.ts
@@ -37,6 +37,8 @@ import { integrateGit } from './git';
 export interface IntegrateBareOptions {
   project?: string;
   global?: boolean;
+  /** Marks handlers as invoked via the bare router; forwarded to telemetry only. */
+  isFromRouter?: boolean;
 }
 
 type Handler = (options: IntegrateBareOptions, auth: ResolvedAuth) => Promise<void>;
@@ -65,5 +67,5 @@ export async function integrateBare(
 
   if (!selected) throw new CommandFailedError('No integration selected');
 
-  await selected.handler(options, auth);
+  await selected.handler({ ...options, isFromRouter: true }, auth);
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -557,8 +557,10 @@ export interface IntegrationConfiguredEventPayload extends AnalysisEventIdentity
   repo_id: string | null;
   /** Installed feature ids, including active subfeature ids. */
   features_installed: string[];
-  /** Non-installed feature ids, including non-installed subfeature ids. */
-  features_skipped: string[];
+  /** Feature ids offered via an `ask` prompt that the user declined (never installed). */
+  features_declined: string[];
+  /** Previously-installed feature ids the user removed this run. */
+  features_uninstalled: string[];
   is_global: boolean;
   is_interactive: boolean;
   /** True when invoked via the bare `sonar integrate` router, not `sonar integrate <tool>`. */

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -543,8 +543,38 @@ export interface StoredAnalysisCompletedEvent {
   event_payload: AnalysisCompletedEventPayload;
 }
 
+/**
+ * Payload for a CliIntegrationConfigured event.
+ * One event per successful `sonar integrate` run.
+ */
+export interface IntegrationConfiguredEventPayload extends AnalysisEventIdentityPayload {
+  /** Integration id, e.g. "claude", "codex", "git". */
+  integration_id: string;
+  /**
+   * SHA-256 hex (full 64 chars) of the canonical repo root path. Null when the
+   * run is `--global` or not inside a git repository.
+   */
+  repo_id: string | null;
+  /** Installed feature ids, including active subfeature ids. */
+  features_installed: string[];
+  /** Non-installed feature ids, including non-installed subfeature ids. */
+  features_skipped: string[];
+  is_global: boolean;
+  is_interactive: boolean;
+  /** True when invoked via the bare `sonar integrate` router, not `sonar integrate <tool>`. */
+  is_from_router: boolean;
+}
+
+/** Full CliIntegrationConfigured event written to findings.ndjson. */
+export interface StoredIntegrationConfiguredEvent {
+  metadata: AnalysisEventMetadataBase & {
+    event_type: 'Analytics.Cli.CliIntegrationConfigured';
+  };
+  event_payload: IntegrationConfiguredEventPayload;
+}
+
 /** Any event stored in findings.ndjson and drained by flushFindings. */
-export type StoredAnalysisEvent = StoredAnalysisCompletedEvent;
+export type StoredAnalysisEvent = StoredAnalysisCompletedEvent | StoredIntegrationConfiguredEvent;
 
 /**
  * Telemetry configuration and pending event batch

--- a/src/telemetry/findings.ts
+++ b/src/telemetry/findings.ts
@@ -31,6 +31,7 @@ import { INVOCATION_ID } from '../lib/invocation-id.js';
 import type {
   AnalysisCompletedEventPayload,
   AnalysisEventIdentityPayload,
+  IntegrationConfiguredEventPayload,
   StoredAnalysisEvent,
 } from '../lib/state.js';
 import { getActiveConnection, loadState } from '../lib/state-manager.js';
@@ -89,6 +90,11 @@ export type AnalysisCompletedFields = Omit<
   keyof AnalysisEventIdentityPayload
 >;
 
+export type IntegrationConfiguredFields = Omit<
+  IntegrationConfiguredEventPayload,
+  keyof AnalysisEventIdentityPayload
+>;
+
 /**
  * Emits one CliAnalysisCompleted event when telemetry is enabled.
  * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
@@ -104,6 +110,27 @@ export async function emitAnalysisCompleted(
       event_id: randomUUID(),
       source: { domain: 'CLI' },
       event_type: 'Analytics.Cli.CliAnalysisCompleted',
+      event_timestamp: String(Date.now()),
+    },
+    event_payload: { ...base, ...fields },
+  });
+}
+
+/**
+ * Emits one CliIntegrationConfigured event when telemetry is enabled.
+ * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
+ */
+export function emitIntegrationConfigured(
+  auth: ResolvedAuth,
+  fields: IntegrationConfiguredFields,
+): void {
+  const base = buildAnalysisIdentityBase(auth);
+  if (!base) return;
+  appendAnalysisEvent({
+    metadata: {
+      event_id: randomUUID(),
+      source: { domain: 'CLI' },
+      event_type: 'Analytics.Cli.CliIntegrationConfigured',
       event_timestamp: String(Date.now()),
     },
     event_payload: { ...base, ...fields },

--- a/src/telemetry/findings.ts
+++ b/src/telemetry/findings.ts
@@ -120,11 +120,11 @@ export async function emitAnalysisCompleted(
  * Emits one CliIntegrationConfigured event when telemetry is enabled.
  * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
  */
-export function emitIntegrationConfigured(
+export async function emitIntegrationConfigured(
   auth: ResolvedAuth,
   fields: IntegrationConfiguredFields,
-): void {
-  const base = buildAnalysisIdentityBase(auth);
+): Promise<void> {
+  const base = await buildAnalysisIdentityBase(auth);
   if (!base) return;
   appendAnalysisEvent({
     metadata: {

--- a/src/telemetry/integrate-telemetry.ts
+++ b/src/telemetry/integrate-telemetry.ts
@@ -34,10 +34,7 @@ export interface IntegrationConfiguredTelemetryParams {
   isFromRouter: boolean;
   /** Features actually installed by this run (including active subfeatures). */
   installedFeatures: InstalledIntegrationFeature[];
-  /**
-   * Feature ids the user deliberately skipped: those offered (`ask`) and declined,
-   * plus already-installed features the user chose to uninstall this run.
-   */
+  /** Feature ids the user declined (offered via `ask`) or chose to uninstall this run. */
   featuresSkipped: string[];
   /** Repo root path when known (project scope, inside a git repo); null otherwise. */
   repoRoot: string | null;

--- a/src/telemetry/integrate-telemetry.ts
+++ b/src/telemetry/integrate-telemetry.ts
@@ -34,8 +34,10 @@ export interface IntegrationConfiguredTelemetryParams {
   isFromRouter: boolean;
   /** Features actually installed by this run (including active subfeatures). */
   installedFeatures: InstalledIntegrationFeature[];
-  /** Feature ids the user declined (offered via `ask`) or chose to uninstall this run. */
-  featuresSkipped: string[];
+  /** Feature ids the user declined (offered via `ask`, never installed). */
+  featuresDeclined: string[];
+  /** Previously-installed feature ids the user removed this run. */
+  featuresUninstalled: string[];
   /** Repo root path when known (project scope, inside a git repo); null otherwise. */
   repoRoot: string | null;
 }
@@ -54,7 +56,8 @@ export async function emitIntegrationConfiguredTelemetry(
       integration_id: params.integrationId,
       repo_id: hashRepoRoot(params.repoRoot),
       features_installed: featuresInstalled,
-      features_skipped: params.featuresSkipped,
+      features_declined: params.featuresDeclined,
+      features_uninstalled: params.featuresUninstalled,
       is_global: params.scope === 'global',
       is_interactive: !params.nonInteractive,
       is_from_router: params.isFromRouter,

--- a/src/telemetry/integrate-telemetry.ts
+++ b/src/telemetry/integrate-telemetry.ts
@@ -1,0 +1,85 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { createHash } from 'node:crypto';
+
+import type { ResolvedAuth } from '../lib/auth-resolver.js';
+import { canonicalizePath } from '../lib/fs-utils.js';
+import logger from '../lib/logger.js';
+import type { InstalledIntegrationFeature, IntegrationScope } from '../lib/state.js';
+import { emitIntegrationConfigured } from './findings.js';
+
+export interface IntegrationConfiguredTelemetryParams {
+  auth: ResolvedAuth;
+  integrationId: string;
+  scope: IntegrationScope;
+  nonInteractive: boolean;
+  isFromRouter: boolean;
+  /** Features actually installed by this run (including active subfeatures). */
+  installedFeatures: InstalledIntegrationFeature[];
+  /** Every feature id the integration declares (including subfeatures). */
+  declaredFeatureIds: string[];
+  /** Repo root path when known (project scope, inside a git repo); null otherwise. */
+  repoRoot: string | null;
+}
+
+/**
+ * Assembles and emits a single CliIntegrationConfigured
+ * event for a successful `sonar integrate` run.
+ */
+export function emitIntegrationConfiguredTelemetry(
+  params: IntegrationConfiguredTelemetryParams,
+): void {
+  try {
+    const featuresInstalled = collectInstalledFeatureIds(params.installedFeatures);
+    const installedSet = new Set(featuresInstalled);
+    const featuresSkipped = params.declaredFeatureIds.filter((id) => !installedSet.has(id));
+
+    emitIntegrationConfigured(params.auth, {
+      integration_id: params.integrationId,
+      repo_id: hashRepoRoot(params.repoRoot),
+      features_installed: featuresInstalled,
+      features_skipped: featuresSkipped,
+      is_global: params.scope === 'global',
+      is_interactive: !params.nonInteractive,
+      is_from_router: params.isFromRouter,
+    });
+  } catch (err) {
+    logger.debug(`Failed to emit CliIntegrationConfigured telemetry: ${(err as Error).message}`);
+  }
+}
+
+/** Flattens installed features to their ids plus active subfeature ids. */
+function collectInstalledFeatureIds(installedFeatures: InstalledIntegrationFeature[]): string[] {
+  const ids: string[] = [];
+  for (const feature of installedFeatures) {
+    ids.push(feature.featureId);
+    for (const subfeature of feature.subfeatures ?? []) {
+      ids.push(subfeature.featureId);
+    }
+  }
+  return ids;
+}
+
+/** SHA-256 hex of the repo root path. */
+function hashRepoRoot(repoRoot: string | null): string | null {
+  if (!repoRoot) return null;
+  return createHash('sha256').update(canonicalizePath(repoRoot)).digest('hex');
+}

--- a/src/telemetry/integrate-telemetry.ts
+++ b/src/telemetry/integrate-telemetry.ts
@@ -47,13 +47,13 @@ export interface IntegrationConfiguredTelemetryParams {
  * Assembles and emits a single CliIntegrationConfigured
  * event for a successful `sonar integrate` run.
  */
-export function emitIntegrationConfiguredTelemetry(
+export async function emitIntegrationConfiguredTelemetry(
   params: IntegrationConfiguredTelemetryParams,
-): void {
+): Promise<void> {
   try {
     const featuresInstalled = collectInstalledFeatureIds(params.installedFeatures);
 
-    emitIntegrationConfigured(params.auth, {
+    await emitIntegrationConfigured(params.auth, {
       integration_id: params.integrationId,
       repo_id: hashRepoRoot(params.repoRoot),
       features_installed: featuresInstalled,

--- a/src/telemetry/integrate-telemetry.ts
+++ b/src/telemetry/integrate-telemetry.ts
@@ -34,8 +34,11 @@ export interface IntegrationConfiguredTelemetryParams {
   isFromRouter: boolean;
   /** Features actually installed by this run (including active subfeatures). */
   installedFeatures: InstalledIntegrationFeature[];
-  /** Every feature id the integration declares (including subfeatures). */
-  declaredFeatureIds: string[];
+  /**
+   * Feature ids the user deliberately skipped: those offered (`ask`) and declined,
+   * plus already-installed features the user chose to uninstall this run.
+   */
+  featuresSkipped: string[];
   /** Repo root path when known (project scope, inside a git repo); null otherwise. */
   repoRoot: string | null;
 }
@@ -49,14 +52,12 @@ export function emitIntegrationConfiguredTelemetry(
 ): void {
   try {
     const featuresInstalled = collectInstalledFeatureIds(params.installedFeatures);
-    const installedSet = new Set(featuresInstalled);
-    const featuresSkipped = params.declaredFeatureIds.filter((id) => !installedSet.has(id));
 
     emitIntegrationConfigured(params.auth, {
       integration_id: params.integrationId,
       repo_id: hashRepoRoot(params.repoRoot),
       features_installed: featuresInstalled,
-      features_skipped: featuresSkipped,
+      features_skipped: params.featuresSkipped,
       is_global: params.scope === 'global',
       is_interactive: !params.nonInteractive,
       is_from_router: params.isFromRouter,

--- a/tests/_common/isolated-cli-env.ts
+++ b/tests/_common/isolated-cli-env.ts
@@ -25,3 +25,12 @@ import { ENV_DO_NOT_TRACK } from '../../src/lib/config-constants.js';
 export const ISOLATED_CLI_SPAWN_ENV: Record<string, string> = {
   [ENV_DO_NOT_TRACK]: '1',
 };
+
+/** Restore an env var to a captured value, deleting it when the value was unset. */
+export function restoreEnv(key: string, previous: string | undefined): void {
+  if (previous === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = previous;
+  }
+}

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -25,10 +25,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import type {
-  StoredAnalysisCompletedEvent,
-  StoredAnalysisEvent,
-} from '../../../../src/lib/state.js';
+import type { StoredAnalysisCompletedEvent } from '../../../../src/lib/state.js';
 import { TELEMETRY_FLUSH_MODE_ENV } from '../../../../src/telemetry/index.js';
 import { SECRETS_CALLER_COMMANDS } from '../../../../src/telemetry/secrets-analysis-telemetry.js';
 import {
@@ -949,13 +946,13 @@ describe('analyze agentic — analysis telemetry', () => {
     return join(harness.cliHome.path, 'telemetry', 'findings.ndjson');
   }
 
-  function readAnalysisEvents(): StoredAnalysisEvent[] {
+  function readAnalysisEvents(): StoredAnalysisCompletedEvent[] {
     const path = findingsPath();
     if (!existsSync(path)) return [];
     return readFileSync(path, 'utf-8')
       .split('\n')
       .filter(Boolean)
-      .map((line) => JSON.parse(line) as StoredAnalysisEvent);
+      .map((line) => JSON.parse(line) as StoredAnalysisCompletedEvent);
   }
 
   function enableFlushTelemetry(): void {
@@ -1069,7 +1066,7 @@ describe('sonar analyze — analysis telemetry', () => {
     return readFileSync(path, 'utf-8')
       .split('\n')
       .filter(Boolean)
-      .map((line) => JSON.parse(line) as StoredAnalysisEvent)
+      .map((line) => JSON.parse(line) as StoredAnalysisCompletedEvent)
       .filter(
         (event): event is StoredAnalysisCompletedEvent =>
           event.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted' &&

--- a/tests/unit/cli/commands/config/telemetry.test.ts
+++ b/tests/unit/cli/commands/config/telemetry.test.ts
@@ -25,12 +25,18 @@ import { ENV_DO_NOT_TRACK } from '../../../../../src/lib/config-constants.js';
 import * as stateRepository from '../../../../../src/lib/repository/state-repository.js';
 import { getDefaultState } from '../../../../../src/lib/state.js';
 import { clearMockUiCalls, findMockUiCall, getMockUiCalls, setMockUi } from '../../../../../src/ui';
+import { restoreEnv } from '../../../../_common/isolated-cli-env.js';
 
 let loadStateSpy: ReturnType<typeof spyOn>;
 let saveStateSpy: ReturnType<typeof spyOn>;
 
+// Each test runs from an unset baseline; restore the preload's DO_NOT_TRACK afterwards
+// so we don't leak a cleared value that would re-enable telemetry for later tests.
+const PRELOAD_DO_NOT_TRACK = process.env[ENV_DO_NOT_TRACK];
+
 beforeEach(() => {
   setMockUi(true);
+  delete process.env[ENV_DO_NOT_TRACK];
   loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
   saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
 });
@@ -39,7 +45,7 @@ afterEach(() => {
   setMockUi(false);
   loadStateSpy.mockRestore();
   saveStateSpy.mockRestore();
-  delete process.env[ENV_DO_NOT_TRACK];
+  restoreEnv(ENV_DO_NOT_TRACK, PRELOAD_DO_NOT_TRACK);
 });
 
 describe('configureTelemetry', () => {

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -37,7 +37,6 @@ import {
 } from '../../../../../../src/cli/commands/integrate/_common/registry';
 import * as stateRepository from '../../../../../../src/lib/repository/state-repository';
 import { getDefaultState } from '../../../../../../src/lib/state';
-import * as integrateTelemetry from '../../../../../../src/telemetry/integrate-telemetry';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../../src/ui';
 
 describe('generic integration installer', () => {
@@ -45,7 +44,6 @@ describe('generic integration installer', () => {
   let registry: IntegrationRegistry;
   let loadStateSpy: ReturnType<typeof spyOn>;
   let saveStateSpy: ReturnType<typeof spyOn>;
-  let emitIntegrationConfiguredTelemetrySpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'sonar-cli-installer-'));
@@ -54,17 +52,12 @@ describe('generic integration installer', () => {
     clearMockUiCalls();
     loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('test'));
     saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
-    emitIntegrationConfiguredTelemetrySpy = spyOn(
-      integrateTelemetry,
-      'emitIntegrationConfiguredTelemetry',
-    ).mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     setMockUi(false);
     loadStateSpy.mockRestore();
     saveStateSpy.mockRestore();
-    emitIntegrationConfiguredTelemetrySpy.mockRestore();
     rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -57,7 +57,7 @@ describe('generic integration installer', () => {
     emitIntegrationConfiguredTelemetrySpy = spyOn(
       integrateTelemetry,
       'emitIntegrationConfiguredTelemetry',
-    ).mockImplementation(() => undefined);
+    ).mockResolvedValue(undefined);
   });
 
   afterEach(() => {

--- a/tests/unit/cli/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/installer.test.ts
@@ -37,6 +37,7 @@ import {
 } from '../../../../../../src/cli/commands/integrate/_common/registry';
 import * as stateRepository from '../../../../../../src/lib/repository/state-repository';
 import { getDefaultState } from '../../../../../../src/lib/state';
+import * as integrateTelemetry from '../../../../../../src/telemetry/integrate-telemetry';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../../../../src/ui';
 
 describe('generic integration installer', () => {
@@ -44,6 +45,7 @@ describe('generic integration installer', () => {
   let registry: IntegrationRegistry;
   let loadStateSpy: ReturnType<typeof spyOn>;
   let saveStateSpy: ReturnType<typeof spyOn>;
+  let emitIntegrationConfiguredTelemetrySpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'sonar-cli-installer-'));
@@ -52,12 +54,17 @@ describe('generic integration installer', () => {
     clearMockUiCalls();
     loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('test'));
     saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
+    emitIntegrationConfiguredTelemetrySpy = spyOn(
+      integrateTelemetry,
+      'emitIntegrationConfiguredTelemetry',
+    ).mockImplementation(() => undefined);
   });
 
   afterEach(() => {
     setMockUi(false);
     loadStateSpy.mockRestore();
     saveStateSpy.mockRestore();
+    emitIntegrationConfiguredTelemetrySpy.mockRestore();
     rmSync(tempDir, { recursive: true, force: true });
   });
 

--- a/tests/unit/cli/commands/integrate/_common/registry.test.ts
+++ b/tests/unit/cli/commands/integrate/_common/registry.test.ts
@@ -426,6 +426,7 @@ describe('declarative integration framework', () => {
       .subfeatures;
     expect(selected).toHaveLength(1);
     expect(selected[0]?.id).toBe('opted-in');
+    expect(result.declined).toEqual(['declined']);
     const confirmCalls = getMockUiCalls().filter((c) => c.method === 'confirmPrompt');
     expect(confirmCalls).toHaveLength(2);
     expect(confirmCalls[0]?.args[0]).toBe('Enable it?');
@@ -515,6 +516,29 @@ describe('declarative integration framework', () => {
     }
     expect(caughtError).toBeInstanceOf(Error);
     expect((caughtError as Error).message).toContain('Installation cancelled');
+  });
+
+  it('routes a user-confirmed uninstall to toRemove, not declined', async () => {
+    setMockUi(true);
+    const integration = makeIntegration({ features: [{ id: 'feature', displayName: 'Feature' }] });
+    const state = getDefaultState('test');
+    await installer.applyAndRecordFeatures(state, integration, [
+      { feature: integration.features[0], targetRoot: tempDir, scope: 'project' },
+    ]);
+    queueMockResponse(false); // decline "Keep?"
+    queueMockResponse(true); // confirm "Proceed with removal?"
+
+    const selected = await selectForInvocation(integration, {
+      options: {},
+      targetRoot: tempDir,
+      scope: 'project',
+      nonInteractive: false,
+      state,
+    });
+
+    expect(selected.toRemove.map((application) => application.feature.id)).toEqual(['feature']);
+    expect(selected.toInstall).toEqual([]);
+    expect(selected.declined).toEqual([]);
   });
 
   it('records active subfeatures nested under the container feature in state', async () => {
@@ -659,6 +683,7 @@ describe('declarative integration framework', () => {
     });
 
     expect(selected.toInstall).toEqual([]);
+    expect(selected.declined).toEqual([]);
     expect(findMockUiCall('info', 'covered')).toBeDefined();
     expect(getMockUiCalls().filter((call) => call.method === 'info')).toHaveLength(1);
   });
@@ -714,6 +739,8 @@ describe('declarative integration framework', () => {
     });
 
     expect(selected.toInstall.map((application) => application.feature.id)).toEqual(['accepted']);
+    expect(selected.declined).toEqual(['declined']);
+    expect(selected.toRemove).toEqual([]);
     const confirmCalls = getMockUiCalls().filter((call) => call.method === 'confirmPrompt');
     expect(confirmCalls).toHaveLength(2);
     expect(confirmCalls[1]?.args[0]).toBe('Install the thing?');
@@ -791,6 +818,7 @@ describe('declarative integration framework', () => {
       'asked',
       'defaulted',
     ]);
+    expect(selected.declined).toEqual([]);
     expect(getMockUiCalls().filter((call) => call.method === 'confirmPrompt')).toHaveLength(0);
   });
 

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -48,7 +48,6 @@ import * as processLib from '../../../../../../src/lib/process.js';
 import * as discovery from '../../../../../../src/lib/project-workspace';
 import * as stateRepository from '../../../../../../src/lib/repository/state-repository';
 import { type CliState, getDefaultState } from '../../../../../../src/lib/state';
-import * as integrateTelemetry from '../../../../../../src/telemetry/integrate-telemetry';
 import {
   clearMockUiCalls,
   getMockUiCalls,
@@ -60,19 +59,6 @@ const TEMP_DIR = join(process.cwd(), 'tests', 'unit', '.integrate-git-tmp');
 
 /** Simulate `git config core.hooksPath` returning "not set" (exit code 1). */
 const NO_HOOKS_PATH = { exitCode: 1, stdout: '', stderr: '' };
-
-let emitIntegrationConfiguredTelemetrySpy: ReturnType<typeof spyOn>;
-
-beforeEach(() => {
-  emitIntegrationConfiguredTelemetrySpy = spyOn(
-    integrateTelemetry,
-    'emitIntegrationConfiguredTelemetry',
-  ).mockResolvedValue(undefined);
-});
-
-afterEach(() => {
-  emitIntegrationConfiguredTelemetrySpy.mockRestore();
-});
 
 describe('isGitHookType', () => {
   it('returns true for valid hook types and false otherwise', () => {

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -48,6 +48,7 @@ import * as processLib from '../../../../../../src/lib/process.js';
 import * as discovery from '../../../../../../src/lib/project-workspace';
 import * as stateRepository from '../../../../../../src/lib/repository/state-repository';
 import { type CliState, getDefaultState } from '../../../../../../src/lib/state';
+import * as integrateTelemetry from '../../../../../../src/telemetry/integrate-telemetry';
 import {
   clearMockUiCalls,
   getMockUiCalls,
@@ -59,6 +60,19 @@ const TEMP_DIR = join(process.cwd(), 'tests', 'unit', '.integrate-git-tmp');
 
 /** Simulate `git config core.hooksPath` returning "not set" (exit code 1). */
 const NO_HOOKS_PATH = { exitCode: 1, stdout: '', stderr: '' };
+
+let emitIntegrationConfiguredTelemetrySpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  emitIntegrationConfiguredTelemetrySpy = spyOn(
+    integrateTelemetry,
+    'emitIntegrationConfiguredTelemetry',
+  ).mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  emitIntegrationConfiguredTelemetrySpy.mockRestore();
+});
 
 describe('isGitHookType', () => {
   it('returns true for valid hook types and false otherwise', () => {

--- a/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/cli/commands/integrate/git/integrate-git.test.ts
@@ -67,7 +67,7 @@ beforeEach(() => {
   emitIntegrationConfiguredTelemetrySpy = spyOn(
     integrateTelemetry,
     'emitIntegrationConfiguredTelemetry',
-  ).mockImplementation(() => undefined);
+  ).mockResolvedValue(undefined);
 });
 
 afterEach(() => {

--- a/tests/unit/telemetry/enabled.test.ts
+++ b/tests/unit/telemetry/enabled.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { ENV_DO_NOT_TRACK } from '../../../src/lib/config-constants.js';
 import { getDefaultState } from '../../../src/lib/state.js';
@@ -27,9 +27,18 @@ import {
   isDoNotTrackRequested,
   isTelemetryEnabled,
 } from '../../../src/telemetry/enabled.js';
+import { restoreEnv } from '../../_common/isolated-cli-env.js';
+
+// Each test runs from an unset baseline; restore the preload's DO_NOT_TRACK afterwards
+// so we don't leak a cleared value that would re-enable telemetry for later tests.
+const PRELOAD_DO_NOT_TRACK = process.env[ENV_DO_NOT_TRACK];
+
+beforeEach(() => {
+  delete process.env[ENV_DO_NOT_TRACK];
+});
 
 afterEach(() => {
-  delete process.env[ENV_DO_NOT_TRACK];
+  restoreEnv(ENV_DO_NOT_TRACK, PRELOAD_DO_NOT_TRACK);
 });
 
 describe('isDoNotTrackRequested', () => {

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -210,7 +210,7 @@ describe('emitAnalysisCompleted()', () => {
 
     const [event] = readLines(testSonarUserHome);
     expect(event.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-    const completedEvent = event;
+    const completedEvent = event as StoredAnalysisCompletedEvent;
     expect(completedEvent.event_payload.analyzer).toBe('sqaa');
     expect(completedEvent.event_payload.findings_count).toBe(2);
     expect(completedEvent.event_payload.exit_code).toBe(51);
@@ -521,7 +521,7 @@ describe('flushFindings()', () => {
       const requeued = readLines(testSonarUserHome);
       expect(requeued).toHaveLength(1);
       expect(requeued[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-      expect(requeued[0].event_payload.analysis_id).toBe('run-a');
+      expect((requeued[0] as StoredAnalysisCompletedEvent).event_payload.analysis_id).toBe('run-a');
     } finally {
       fetchSpy.mockRestore();
     }
@@ -617,7 +617,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
     expect(lines[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(0);
     expect(completed.event_payload.findings_count).toBe(0);
@@ -641,7 +641,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
 
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(51);
@@ -670,7 +670,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     );
 
     const lines = readLines(testSonarUserHome);
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     const details = JSON.parse(completed.event_payload.details) as {
       files_with_findings_count: number;
       source: string;
@@ -684,7 +684,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.failures_count).toBe(1);
     expect(completed.event_payload.findings_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(2);
@@ -699,7 +699,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.failures_count).toBe(1);
     expect(completed.event_payload.exit_code).toBeNull();
   });
@@ -710,7 +710,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.analyzeSecrets, AUTH, resolvedRun(2, stdout));
 
     const lines = readLines(testSonarUserHome);
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.errors_count).toBe(2);
     expect(completed.event_payload.failures_count).toBe(1);
   });
@@ -733,7 +733,7 @@ describe('scanAndEmitSecrets() — wrapper behavior', () => {
     const lines = readLines(testSonarUserHome);
     // a single Completed event carrying details (findings present)
     expect(lines).toHaveLength(1);
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(51);
     expect(completed.event_payload.details).not.toBe('');
@@ -752,7 +752,7 @@ describe('scanAndEmitSecrets() — wrapper behavior', () => {
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
-    const completed = lines[0];
+    const completed = lines[0] as StoredAnalysisCompletedEvent;
     expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
     expect(completed.event_payload.failures_count).toBe(1);
     expect(completed.event_payload.exit_code).toBeNull();

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -306,8 +306,8 @@ function makeIntegrationConfiguredFields(
 }
 
 describe('emitIntegrationConfigured()', () => {
-  it('writes a valid CliIntegrationConfigured envelope', () => {
-    emitIntegrationConfigured(
+  it('writes a valid CliIntegrationConfigured envelope', async () => {
+    await emitIntegrationConfigured(
       AUTH,
       makeIntegrationConfiguredFields({
         integration_id: 'git',
@@ -331,10 +331,10 @@ describe('emitIntegrationConfigured()', () => {
     expect(configured.event_payload.cli_installation_id).toBe('install-id');
   });
 
-  it('does not append when telemetry is disabled', () => {
+  it('does not append when telemetry is disabled', async () => {
     loadStateSpy.mockReturnValue(makeTelemetryState(false));
 
-    emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields());
+    await emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields());
 
     expect(readLines(testSonarUserHome)).toHaveLength(0);
   });

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -297,7 +297,8 @@ function makeIntegrationConfiguredFields(
     integration_id: 'claude',
     repo_id: 'a'.repeat(64),
     features_installed: ['sonar-secrets-hooks'],
-    features_skipped: ['sqaa-hooks'],
+    features_declined: ['sqaa-instructions'],
+    features_uninstalled: ['mcp-server'],
     is_global: false,
     is_interactive: true,
     is_from_router: false,
@@ -312,7 +313,8 @@ describe('emitIntegrationConfigured()', () => {
       makeIntegrationConfiguredFields({
         integration_id: 'git',
         features_installed: ['pre-commit-hook', 'pre-commit-secrets'],
-        features_skipped: ['pre-commit-dependency-risks'],
+        features_declined: ['pre-commit-dependency-risks'],
+        features_uninstalled: [],
         is_from_router: true,
       }),
     );
@@ -325,7 +327,8 @@ describe('emitIntegrationConfigured()', () => {
       'pre-commit-hook',
       'pre-commit-secrets',
     ]);
-    expect(configured.event_payload.features_skipped).toEqual(['pre-commit-dependency-risks']);
+    expect(configured.event_payload.features_declined).toEqual(['pre-commit-dependency-risks']);
+    expect(configured.event_payload.features_uninstalled).toEqual([]);
     expect(configured.event_payload.is_from_router).toBe(true);
     // Identity base is merged in.
     expect(configured.event_payload.cli_installation_id).toBe('install-id');

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -37,18 +37,21 @@ import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
 import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
 import type { SpawnResult } from '../../../src/lib/process.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
-import type { CliState } from '../../../src/lib/state.js';
 import type {
   AnalysisCompletedEventPayload,
+  CliState,
   StoredAnalysisCompletedEvent,
   StoredAnalysisEvent,
+  StoredIntegrationConfiguredEvent,
 } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as stateManager from '../../../src/lib/state-manager.js';
 import {
   type AnalysisCompletedFields,
   emitAnalysisCompleted,
+  emitIntegrationConfigured,
   flushFindings,
+  type IntegrationConfiguredFields,
 } from '../../../src/telemetry/findings.js';
 import { SECRETS_CALLER_COMMANDS } from '../../../src/telemetry/secrets-analysis-telemetry.js';
 import { SQAA_ANALYZE_AGENTIC_CALLER_COMMAND } from '../../../src/telemetry/sqaa-analysis-telemetry.js';
@@ -282,6 +285,58 @@ describe('emitAnalysisCompleted()', () => {
     await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     expect(existsSync(telemetryDir)).toBe(true);
+  });
+});
+
+// ─── emitIntegrationConfigured ─────────────────────────────────────────────────
+
+function makeIntegrationConfiguredFields(
+  overrides: Partial<IntegrationConfiguredFields> = {},
+): IntegrationConfiguredFields {
+  return {
+    integration_id: 'claude',
+    repo_id: 'a'.repeat(64),
+    features_installed: ['sonar-secrets-hooks'],
+    features_skipped: ['sqaa-hooks'],
+    is_global: false,
+    is_interactive: true,
+    is_from_router: false,
+    ...overrides,
+  };
+}
+
+describe('emitIntegrationConfigured()', () => {
+  it('writes a valid CliIntegrationConfigured envelope', () => {
+    emitIntegrationConfigured(
+      AUTH,
+      makeIntegrationConfiguredFields({
+        integration_id: 'git',
+        features_installed: ['pre-commit-hook', 'pre-commit-secrets'],
+        features_skipped: ['pre-commit-dependency-risks'],
+        is_from_router: true,
+      }),
+    );
+
+    const [event] = readLines(testSonarUserHome);
+    expect(event.metadata.event_type).toBe('Analytics.Cli.CliIntegrationConfigured');
+    const configured = event as StoredIntegrationConfiguredEvent;
+    expect(configured.event_payload.integration_id).toBe('git');
+    expect(configured.event_payload.features_installed).toEqual([
+      'pre-commit-hook',
+      'pre-commit-secrets',
+    ]);
+    expect(configured.event_payload.features_skipped).toEqual(['pre-commit-dependency-risks']);
+    expect(configured.event_payload.is_from_router).toBe(true);
+    // Identity base is merged in.
+    expect(configured.event_payload.cli_installation_id).toBe('install-id');
+  });
+
+  it('does not append when telemetry is disabled', () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+
+    emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields());
+
+    expect(readLines(testSonarUserHome)).toHaveLength(0);
   });
 });
 

--- a/tests/unit/telemetry/integrate-telemetry.test.ts
+++ b/tests/unit/telemetry/integrate-telemetry.test.ts
@@ -57,7 +57,7 @@ function makeInstalledFeature(
 let emitSpy: ReturnType<typeof spyOn>;
 
 beforeEach(() => {
-  emitSpy = spyOn(findings, 'emitIntegrationConfigured').mockImplementation(() => {});
+  emitSpy = spyOn(findings, 'emitIntegrationConfigured').mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -65,8 +65,8 @@ afterEach(() => {
 });
 
 describe('emitIntegrationConfiguredTelemetry()', () => {
-  it('assembles the full payload for a project-scope run', () => {
-    emitIntegrationConfiguredTelemetry({
+  it('assembles the full payload for a project-scope run', async () => {
+    await emitIntegrationConfiguredTelemetry({
       auth: AUTH,
       integrationId: 'git',
       scope: 'project',
@@ -97,8 +97,8 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
     expect(fields.is_interactive).toBe(false);
   });
 
-  it('sets repo_id to null for global scope', () => {
-    emitIntegrationConfiguredTelemetry({
+  it('sets repo_id to null for global scope', async () => {
+    await emitIntegrationConfiguredTelemetry({
       auth: AUTH,
       integrationId: 'claude',
       scope: 'global',
@@ -115,8 +115,8 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
     expect(fields.is_from_router).toBe(true);
   });
 
-  it('sets repo_id to null when repoRoot is null on project scope', () => {
-    emitIntegrationConfiguredTelemetry({
+  it('sets repo_id to null when repoRoot is null on project scope', async () => {
+    await emitIntegrationConfiguredTelemetry({
       auth: AUTH,
       integrationId: 'claude',
       scope: 'project',

--- a/tests/unit/telemetry/integrate-telemetry.test.ts
+++ b/tests/unit/telemetry/integrate-telemetry.test.ts
@@ -78,7 +78,8 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
           'pre-commit-dependency-risks',
         ]),
       ],
-      featuresSkipped: ['sqaa-hooks'],
+      featuresDeclined: [],
+      featuresUninstalled: [],
       repoRoot: '/some/repo',
     });
 
@@ -89,7 +90,8 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
       'pre-commit-secrets',
       'pre-commit-dependency-risks',
     ]);
-    expect(fields.features_skipped).toEqual(['sqaa-hooks']);
+    expect(fields.features_declined).toEqual([]);
+    expect(fields.features_uninstalled).toEqual([]);
     // repo_id is the SHA-256 hex of the canonical repo root.
     const expected = createHash('sha256').update(canonicalizePath('/some/repo')).digest('hex');
     expect(fields.repo_id).toBe(expected);
@@ -105,7 +107,8 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
       nonInteractive: false,
       isFromRouter: true,
       installedFeatures: [makeInstalledFeature('sonar-secrets-hooks')],
-      featuresSkipped: [],
+      featuresDeclined: [],
+      featuresUninstalled: [],
       repoRoot: null,
     });
 
@@ -113,6 +116,27 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
     expect(fields.repo_id).toBeNull();
     expect(fields.is_global).toBe(true);
     expect(fields.is_from_router).toBe(true);
+  });
+
+  it('records declined and uninstalled features in separate fields', async () => {
+    // Interactive run: install one feature, decline another offered via `ask`,
+    // and remove a previously-installed one.
+    await emitIntegrationConfiguredTelemetry({
+      auth: AUTH,
+      integrationId: 'claude',
+      scope: 'project',
+      nonInteractive: false,
+      isFromRouter: false,
+      installedFeatures: [makeInstalledFeature('sonar-secrets-hooks')],
+      featuresDeclined: ['sqaa-instructions'],
+      featuresUninstalled: ['mcp-server'],
+      repoRoot: '/some/repo',
+    });
+
+    const [, fields] = emitSpy.mock.calls[0] as [ResolvedAuth, Record<string, unknown>];
+    expect(fields.features_installed).toEqual(['sonar-secrets-hooks']);
+    expect(fields.features_declined).toEqual(['sqaa-instructions']);
+    expect(fields.features_uninstalled).toEqual(['mcp-server']);
   });
 
   it('sets repo_id to null when repoRoot is null on project scope', async () => {
@@ -123,7 +147,8 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
       nonInteractive: false,
       isFromRouter: false,
       installedFeatures: [makeInstalledFeature('sonar-secrets-hooks')],
-      featuresSkipped: [],
+      featuresDeclined: [],
+      featuresUninstalled: [],
       repoRoot: null,
     });
 

--- a/tests/unit/telemetry/integrate-telemetry.test.ts
+++ b/tests/unit/telemetry/integrate-telemetry.test.ts
@@ -78,13 +78,7 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
           'pre-commit-dependency-risks',
         ]),
       ],
-      // 'sqaa-hooks' is declared by the integration but not installed this run.
-      declaredFeatureIds: [
-        'pre-commit-hook',
-        'pre-commit-secrets',
-        'pre-commit-dependency-risks',
-        'sqaa-hooks',
-      ],
+      featuresSkipped: ['sqaa-hooks'],
       repoRoot: '/some/repo',
     });
 
@@ -95,7 +89,6 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
       'pre-commit-secrets',
       'pre-commit-dependency-risks',
     ]);
-    // features_skipped is declared minus installed.
     expect(fields.features_skipped).toEqual(['sqaa-hooks']);
     // repo_id is the SHA-256 hex of the canonical repo root.
     const expected = createHash('sha256').update(canonicalizePath('/some/repo')).digest('hex');
@@ -112,7 +105,7 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
       nonInteractive: false,
       isFromRouter: true,
       installedFeatures: [makeInstalledFeature('sonar-secrets-hooks')],
-      declaredFeatureIds: ['sonar-secrets-hooks'],
+      featuresSkipped: [],
       repoRoot: null,
     });
 
@@ -130,7 +123,7 @@ describe('emitIntegrationConfiguredTelemetry()', () => {
       nonInteractive: false,
       isFromRouter: false,
       installedFeatures: [makeInstalledFeature('sonar-secrets-hooks')],
-      declaredFeatureIds: ['sonar-secrets-hooks'],
+      featuresSkipped: [],
       repoRoot: null,
     });
 

--- a/tests/unit/telemetry/integrate-telemetry.test.ts
+++ b/tests/unit/telemetry/integrate-telemetry.test.ts
@@ -1,0 +1,140 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
+import { canonicalizePath } from '../../../src/lib/fs-utils.js';
+import type { InstalledIntegrationFeature } from '../../../src/lib/state.js';
+import * as findings from '../../../src/telemetry/findings.js';
+import { emitIntegrationConfiguredTelemetry } from '../../../src/telemetry/integrate-telemetry.js';
+
+const AUTH: ResolvedAuth = {
+  connectionType: 'cloud',
+  serverUrl: 'https://sonarcloud.io',
+  token: 'test-token',
+  orgKey: 'my-org',
+};
+
+function makeInstalledFeature(
+  featureId: string,
+  subfeatureIds: string[] = [],
+): InstalledIntegrationFeature {
+  return {
+    featureId,
+    scope: 'project',
+    targetRoot: '/repo',
+    installedByCliVersion: '1.0.0',
+    installedAt: '2026-01-01T00:00:00.000Z',
+    updatedByCliVersion: '1.0.0',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    dependencies: [],
+    resources: [],
+    operations: [],
+    subfeatures: subfeatureIds.map((id) => ({ featureId: id, dependencies: [] })),
+  };
+}
+
+let emitSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  emitSpy = spyOn(findings, 'emitIntegrationConfigured').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  emitSpy.mockRestore();
+});
+
+describe('emitIntegrationConfiguredTelemetry()', () => {
+  it('assembles the full payload for a project-scope run', () => {
+    emitIntegrationConfiguredTelemetry({
+      auth: AUTH,
+      integrationId: 'git',
+      scope: 'project',
+      nonInteractive: true,
+      isFromRouter: false,
+      installedFeatures: [
+        makeInstalledFeature('pre-commit-hook', [
+          'pre-commit-secrets',
+          'pre-commit-dependency-risks',
+        ]),
+      ],
+      // 'sqaa-hooks' is declared by the integration but not installed this run.
+      declaredFeatureIds: [
+        'pre-commit-hook',
+        'pre-commit-secrets',
+        'pre-commit-dependency-risks',
+        'sqaa-hooks',
+      ],
+      repoRoot: '/some/repo',
+    });
+
+    const [, fields] = emitSpy.mock.calls[0] as [ResolvedAuth, Record<string, unknown>];
+    // features_installed flattens active subfeature ids.
+    expect(fields.features_installed).toEqual([
+      'pre-commit-hook',
+      'pre-commit-secrets',
+      'pre-commit-dependency-risks',
+    ]);
+    // features_skipped is declared minus installed.
+    expect(fields.features_skipped).toEqual(['sqaa-hooks']);
+    // repo_id is the SHA-256 hex of the canonical repo root.
+    const expected = createHash('sha256').update(canonicalizePath('/some/repo')).digest('hex');
+    expect(fields.repo_id).toBe(expected);
+    expect(fields.repo_id as string).toHaveLength(64);
+    expect(fields.is_interactive).toBe(false);
+  });
+
+  it('sets repo_id to null for global scope', () => {
+    emitIntegrationConfiguredTelemetry({
+      auth: AUTH,
+      integrationId: 'claude',
+      scope: 'global',
+      nonInteractive: false,
+      isFromRouter: true,
+      installedFeatures: [makeInstalledFeature('sonar-secrets-hooks')],
+      declaredFeatureIds: ['sonar-secrets-hooks'],
+      repoRoot: null,
+    });
+
+    const [, fields] = emitSpy.mock.calls[0] as [ResolvedAuth, Record<string, unknown>];
+    expect(fields.repo_id).toBeNull();
+    expect(fields.is_global).toBe(true);
+    expect(fields.is_from_router).toBe(true);
+  });
+
+  it('sets repo_id to null when repoRoot is null on project scope', () => {
+    emitIntegrationConfiguredTelemetry({
+      auth: AUTH,
+      integrationId: 'claude',
+      scope: 'project',
+      nonInteractive: false,
+      isFromRouter: false,
+      installedFeatures: [makeInstalledFeature('sonar-secrets-hooks')],
+      declaredFeatureIds: ['sonar-secrets-hooks'],
+      repoRoot: null,
+    });
+
+    const [, fields] = emitSpy.mock.calls[0] as [ResolvedAuth, Record<string, unknown>];
+    expect(fields.repo_id).toBeNull();
+  });
+});

--- a/tests/unit/telemetry/sca-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sca-analysis-telemetry.test.ts
@@ -36,7 +36,7 @@ import type {
 import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
 import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
-import type { StoredAnalysisEvent } from '../../../src/lib/state.js';
+import type { StoredAnalysisCompletedEvent } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as stateManager from '../../../src/lib/state-manager.js';
 import {
@@ -106,13 +106,13 @@ function findingsPath(sonarUserHome: string): string {
   return join(sonarUserHome, 'sonarqube-cli', 'telemetry', 'findings.ndjson');
 }
 
-function readEvents(sonarUserHome: string): StoredAnalysisEvent[] {
+function readEvents(sonarUserHome: string): StoredAnalysisCompletedEvent[] {
   const path = findingsPath(sonarUserHome);
   if (!existsSync(path)) return [];
   return readFileSync(path, 'utf-8')
     .split('\n')
     .filter(Boolean)
-    .map((line) => JSON.parse(line) as StoredAnalysisEvent);
+    .map((line) => JSON.parse(line) as StoredAnalysisCompletedEvent);
 }
 
 function makeTelemetryState(enabled = true) {

--- a/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
@@ -30,7 +30,7 @@ import type { SqaaJsonReport } from '../../../src/cli/commands/analyze/sqaa-disp
 import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
 import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
-import type { StoredAnalysisEvent } from '../../../src/lib/state.js';
+import type { StoredAnalysisCompletedEvent } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as stateManager from '../../../src/lib/state-manager.js';
 import type { SqaaIssue } from '../../../src/sonarqube/client.js';
@@ -72,13 +72,13 @@ function findingsPath(sonarUserHome: string): string {
   return join(sonarUserHome, 'sonarqube-cli', 'telemetry', 'findings.ndjson');
 }
 
-function readEvents(sonarUserHome: string): StoredAnalysisEvent[] {
+function readEvents(sonarUserHome: string): StoredAnalysisCompletedEvent[] {
   const path = findingsPath(sonarUserHome);
   if (!existsSync(path)) return [];
   return readFileSync(path, 'utf-8')
     .split('\n')
     .filter(Boolean)
-    .map((line) => JSON.parse(line) as StoredAnalysisEvent);
+    .map((line) => JSON.parse(line) as StoredAnalysisCompletedEvent);
 }
 
 function makeTelemetryState(enabled = true) {

--- a/tests/unit/telemetry/telemetry.test.ts
+++ b/tests/unit/telemetry/telemetry.test.ts
@@ -53,6 +53,7 @@ import {
 import { resolveTelemetryIdentity } from '../../../src/telemetry/identity.js';
 import * as userModule from '../../../src/telemetry/user.js';
 import * as ui from '../../../src/ui';
+import { restoreEnv } from '../../_common/isolated-cli-env.js';
 import { mockIdentityGetSafe } from './identity-api-mock.js';
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -119,10 +120,18 @@ let saveStateSpy: ReturnType<typeof spyOn>;
 let getUserIdSpy: ReturnType<typeof spyOn>;
 let spawnSpy: ReturnType<typeof spyOn>;
 let testDir: string;
+// Preserve the preload's isolation env (DO_NOT_TRACK=1) so we don't leak a cleared
+// value to later tests, which would re-enable telemetry against the real ~/.sonar.
+let savedSonarUserHome: string | undefined;
+let savedDoNotTrack: string | undefined;
 
 beforeEach(() => {
+  savedSonarUserHome = process.env[ENV_SONAR_USER_HOME];
+  savedDoNotTrack = process.env[ENV_DO_NOT_TRACK];
   testDir = mkdtempSync(join(tmpdir(), 'telemetry-test-'));
   process.env[ENV_SONAR_USER_HOME] = testDir;
+  // Enable telemetry for these tests; writes land in the isolated testDir.
+  delete process.env[ENV_DO_NOT_TRACK];
   loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
   saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
   getUserIdSpy = spyOn(userModule, 'getOrCreateUserId').mockReturnValue('test-machine-id');
@@ -136,9 +145,9 @@ afterEach(() => {
   saveStateSpy.mockRestore();
   getUserIdSpy.mockRestore();
   spawnSpy.mockRestore();
-  delete process.env[ENV_SONAR_USER_HOME];
+  restoreEnv(ENV_SONAR_USER_HOME, savedSonarUserHome);
+  restoreEnv(ENV_DO_NOT_TRACK, savedDoNotTrack);
   delete process.env[TELEMETRY_FLUSH_MODE_ENV];
-  delete process.env[ENV_DO_NOT_TRACK];
   delete process.env.CLAUDECODE;
   delete process.env.CLAUDE_CODE_ENTRYPOINT;
   delete process.env.CLAUDE_PROJECT_DIR;


### PR DESCRIPTION
## Summary by Tom

This PR adds a `CliIntegrationConfigured` telemetry event, emitted once per successful `sonar integrate` run.

* `isFromRouter` is threaded through the handlers so we can tell whether an integration was launched via the bare router (`sonar integrate`) vs. a direct command (`sonar integrate <tool>`).
* `repo_id` / `resolveRepoRootForScope`: a hash of the repo root, so we can see whether users run different integrations against the same project. If we notice that's common, it's a signal to rethink `sonar integrate` to allow configuring multiple integrations at once instead of one at a time.
* The feature-selection logic now records features the user deliberately declined (distinct from auto-skipped), so we can flag features that are intentionally skipped/uninstalled and spot problematic ones.
* The event rides the existing `findings.ndjson` pipeline. That pipeline is analysis-centric today. [A follow-up ticket](https://sonarsource.atlassian.net/browse/CLI-792?atlOrigin=eyJpIjoiODFkNGNhMzA4NzVlNGQ5M2FlZWI0YzliM2U3MmIzNTQiLCJwIjoiaiJ9) will generalize it beyond analysis.
* `installer.test.ts` and `integrate-git.test.ts` now mock the telemetry emitter because the real one was polluting the actual `findings.ndjson` file during test runs.

----
## Summary by Gitar

- **Telemetry:**
  - Added `CliIntegrationConfigured` event to track successful integrations, including installed features and repo identification.
  - Added `emitIntegrationConfiguredTelemetry` helper to handle event payload construction, path hashing, and feature flattening.
- **State Management:**
  - Updated `StoredAnalysisEvent` to include `StoredIntegrationConfiguredEvent` for persistence in `findings.ndjson`.
- **CLI Integration:**
  - Integrated telemetry emission into `installIntegration` and updated command handlers (`claude`, `git`, etc.) to forward router status.
  - Added `isFromRouter` flag to track bare `sonar integrate` invocations.
- **Feature Selection:**
  - Refactored `selectFeaturesForInvocation` to track `declined` features and include them in telemetry.
- **Testing:**
  - Added comprehensive unit tests for telemetry event assembly and persistence verification.

<sub>This will update automatically on new commits.</sub>