### PR TITLE
CLI-789 Handle Vortex 403 gracefully in commands

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -294,7 +294,7 @@ Alternatively, add SonarQube for IDE shared binding JSON under .sonarlint/ (for 
 integrateCommand
   .command('claude')
   .description(
-    'Setup SonarQube integration for Claude Code. This will install secrets scanning hooks, configure SonarQube Agentic Analysis and MCP Server.',
+    'Setup SonarQube integration for Claude Code. This will install secrets scanning hooks, configure Vortex agentic analysis and MCP Server.',
   )
   .option('-p, --project <project>', 'Project key. Ignored when --global is used.')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
@@ -309,7 +309,7 @@ integrateCommand
 integrateCommand
   .command('copilot')
   .description(
-    'Setup SonarQube integration for Copilot. This will install secrets scanning hooks, configure SonarQube Agentic Analysis and MCP Server.',
+    'Setup SonarQube integration for Copilot. This will install secrets scanning hooks, configure Vortex agentic analysis and MCP Server.',
   )
   .option(
     '-g, --global',
@@ -358,7 +358,7 @@ integrateCommand
 integrateCommand
   .command('antigravity')
   .description(
-    'Setup SonarQube integration for Antigravity. Installs secrets scanning hooks, prompt-secrets instructions, and Context Augmentation.',
+    'Setup SonarQube integration for Antigravity. Installs secrets scanning hooks, prompt-secrets instructions, and Vortex context augmentation.',
   )
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
@@ -375,7 +375,7 @@ integrateCommand
 integrateCommand
   .command('cursor')
   .description(
-    'Setup SonarQube integration for Cursor. This will configure the SonarQube MCP Server, install secrets scanning hooks, and configure SonarQube Agentic Analysis.',
+    'Setup SonarQube integration for Cursor. This will configure the SonarQube MCP Server, install secrets scanning hooks, and configure Vortex agentic analysis.',
   )
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
@@ -504,14 +504,14 @@ analyze
 applySqaaOptions(
   analyze
     .command('agentic')
-    .description('Run server-side Agentic Analysis (SonarQube Cloud only). Limitations apply.'),
+    .description('Run server-side agentic analysis (SonarQube Cloud only). Limitations apply.'),
   { telemetryCallerCommand: SQAA_ANALYZE_AGENTIC_CALLER_COMMAND },
 );
 
 // `verify` is deprecated in favour of `sonar analyze`.
 const verifyCmd = applySqaaOptions(
   COMMAND_TREE.command('verify', { hidden: true }).description(
-    "Run server-side SonarQube Agentic Analysis (deprecated — use 'sonar analyze' instead)",
+    "Run server-side Vortex agentic analysis (deprecated — use 'sonar analyze' instead)",
   ),
   { telemetryCallerCommand: SQAA_VERIFY_CALLER_COMMAND },
 );
@@ -657,14 +657,14 @@ hookCommand
 
 hookCommand
   .command('claude-post-tool-use')
-  .description('PostToolUse handler: run Agentic Analysis after agent edits or writes a file')
+  .description('PostToolUse handler: run agentic analysis after agent edits or writes a file')
   .requiredOption('--project <key>', 'SonarQube Cloud project key')
   .anonymousAction((options: AgentPostToolUseOptions) => agentPostToolUse(options));
 
 hookCommand
   .command('codex-post-tool-use')
   .description(
-    'PostToolUse handler for Codex: run Agentic Analysis on the git change set after apply_patch',
+    'PostToolUse handler for Codex: run agentic analysis on the git change set after apply_patch',
   )
   .requiredOption('--project <key>', 'SonarQube Cloud project key')
   .anonymousAction((options: CodexPostToolUseOptions) => codexPostToolUse(options));

--- a/src/cli/commands/analyze/sqaa-analysis.ts
+++ b/src/cli/commands/analyze/sqaa-analysis.ts
@@ -22,6 +22,7 @@
 
 import { getSqaaRetry503BaseDelayMs } from '../../../lib/config-constants';
 import type { SqaaAnalysisDepth, SqaaIssue } from '../../../sonarqube/client';
+import { SqaaForbiddenError } from '../../../sonarqube/errors.js';
 import type { SqaaProgress } from '../../../ui/components/sqaa-progress.js';
 import {
   fetchChunkWith413Split,
@@ -255,6 +256,10 @@ async function processChunk(
     ctx.progress.updateChunk(chunkIndex, 'done');
     return shouldContinueAfterChunk(parts, groupErrors);
   } catch (err) {
+    // Propagate so hook handlers (codex-post-tool-use) can show the nudge message.
+    if (err instanceof SqaaForbiddenError) {
+      throw err;
+    }
     recordChunkFailure(ctx.progress, tally, chunkIndex, fileIndices, chunkPaths, err as Error);
     return false;
   }

--- a/src/cli/commands/analyze/sqaa-analysis.ts
+++ b/src/cli/commands/analyze/sqaa-analysis.ts
@@ -56,6 +56,7 @@ export interface RunContext {
   progress: SqaaProgress;
   analysisDepth?: SqaaDeepWireDepth;
   displayAnalysisDepth: SqaaAnalysisDepth;
+  propagateForbiddenError?: boolean;
 }
 
 export interface RunTally {
@@ -256,8 +257,7 @@ async function processChunk(
     ctx.progress.updateChunk(chunkIndex, 'done');
     return shouldContinueAfterChunk(parts, groupErrors);
   } catch (err) {
-    // Propagate so hook handlers (codex-post-tool-use) can show the nudge message.
-    if (err instanceof SqaaForbiddenError) {
+    if (err instanceof SqaaForbiddenError && ctx.propagateForbiddenError) {
       throw err;
     }
     recordChunkFailure(ctx.progress, tally, chunkIndex, fileIndices, chunkPaths, err as Error);

--- a/src/cli/commands/analyze/sqaa-api.ts
+++ b/src/cli/commands/analyze/sqaa-api.ts
@@ -26,7 +26,11 @@ import { getSqaaRetry503BaseDelayMs } from '../../../lib/config-constants';
 import { toRelativePosixPath as toRelativePosixPathOrNull } from '../../../lib/fs-utils';
 import type { SqaaAnalysisFile, SqaaIssue } from '../../../sonarqube/client';
 import { SonarQubeClient } from '../../../sonarqube/client';
-import { RequestPayloadTooLargeError, ServiceUnavailableError } from '../../../sonarqube/errors.js';
+import {
+  RequestPayloadTooLargeError,
+  ServiceUnavailableError,
+  SqaaForbiddenError,
+} from '../../../sonarqube/errors.js';
 import { CommandFailedError, InvalidOptionError } from '../_common/error.js';
 import type { CloudAuth } from './sqaa-auth';
 import { type PackChunksLimits, packFilesIntoChunks, type SqaaChunkFile } from './sqaa-chunking';
@@ -134,6 +138,10 @@ async function postSqaaAnalysis(
     });
     return { response, rejected };
   } catch (err) {
+    // Propagate typed errors so hook handlers can distinguish them.
+    if (err instanceof SqaaForbiddenError) {
+      throw err;
+    }
     if (isRetryableSqaaError(err, options.includePayloadTooLarge ?? false)) {
       throw err;
     }

--- a/src/cli/commands/analyze/sqaa-auth.ts
+++ b/src/cli/commands/analyze/sqaa-auth.ts
@@ -90,14 +90,14 @@ export function resolveCloudAuth(
   if (auth.connectionType != 'cloud' || auth.orgKey == null) {
     if (explicitProject) {
       throw new CommandFailedError(
-        'SonarQube Agentic Analysis requires a SonarQube Cloud connection.',
+        'Vortex agentic analysis requires a SonarQube Cloud connection.',
         {
           remediationHint: "Run 'sonar auth login' and connect to SonarQube Cloud, then retry.",
         },
       );
     }
     warn(
-      'SonarQube Agentic Analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
+      'Vortex agentic analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
     );
     return null;
   }
@@ -127,15 +127,13 @@ export async function resolveSqaaProjectKey(projectRoot?: string): Promise<strin
     );
 
     if (!sqaaExt?.projectKey) {
-      logger.debug(
-        'SonarQube Agentic Analysis skipped: no project key found in extensions registry',
-      );
+      logger.debug('Vortex agentic analysis skipped: no project key found in extensions registry');
       return null;
     }
 
     return sqaaExt.projectKey;
   } catch {
-    logger.debug('SonarQube Agentic Analysis skipped: failed to resolve extensions');
+    logger.debug('Vortex agentic analysis skipped: failed to resolve extensions');
     return null;
   }
 }

--- a/src/cli/commands/analyze/sqaa-context.ts
+++ b/src/cli/commands/analyze/sqaa-context.ts
@@ -62,7 +62,7 @@ export function resolveSqaaContext(
     case 'no-project':
       if (policy.requireProject) {
         throw new CommandFailedError(
-          'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
+          'Vortex agentic analysis requires a project, but none is configured for this directory.',
           {
             remediationHint:
               "Specify one with --project, or run 'sonar integrate' to configure this project.",
@@ -70,7 +70,7 @@ export function resolveSqaaContext(
         );
       }
       warn(
-        'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
+        'Vortex agentic analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
       );
       return null;
   }

--- a/src/cli/commands/analyze/sqaa-json-report.ts
+++ b/src/cli/commands/analyze/sqaa-json-report.ts
@@ -81,6 +81,7 @@ async function buildSqaaJsonReportFromEntries(
       branch,
       wireDepth,
       displayDepth,
+      runOptions.propagateForbiddenError,
     ),
   );
   const report = buildJsonReport(tally, [], allPaths, cwd, displayDepth);
@@ -118,7 +119,15 @@ async function buildSqaaJsonReportFromChangeSet(
   const { files, ignored, repoRoot } = changeSet;
   const allPaths = files.map((f) => toRelativePosixPath(f, repoRoot));
   const { result: tally, durationMs } = await timed(() =>
-    runSqaaAnalysesTallyForResolved(files, allPaths, resolved, branch, wireDepth, displayDepth),
+    runSqaaAnalysesTallyForResolved(
+      files,
+      allPaths,
+      resolved,
+      branch,
+      wireDepth,
+      displayDepth,
+      runOptions.propagateForbiddenError,
+    ),
   );
   const report = buildJsonReport(tally, ignored, allPaths, repoRoot, displayDepth);
   await finishSqaaTelemetryFromReport(report, auth, runOptions, durationMs);

--- a/src/cli/commands/analyze/sqaa-run.ts
+++ b/src/cli/commands/analyze/sqaa-run.ts
@@ -119,6 +119,7 @@ export async function runSqaaAnalysesTallyForResolved(
   branch: string | undefined,
   wireDepth: SqaaDeepWireDepth | undefined,
   displayDepth: SqaaAnalysisDepth,
+  propagateForbiddenError?: boolean,
 ): Promise<RunTally> {
   const silentProgress = new SqaaProgress({ files: allPaths, silent: true });
   const ctx: RunContext = {
@@ -130,6 +131,7 @@ export async function runSqaaAnalysesTallyForResolved(
     progress: silentProgress,
     analysisDepth: wireDepth,
     displayAnalysisDepth: displayDepth,
+    propagateForbiddenError,
   };
   return runAnalyses(ctx);
 }

--- a/src/cli/commands/analyze/sqaa-types.ts
+++ b/src/cli/commands/analyze/sqaa-types.ts
@@ -32,6 +32,11 @@ export interface AnalyzeSqaaRunOptions {
   telemetryCallerCommand?: SqaaTelemetryCallerCommand;
   /** Overrides computed CLI exit for telemetry only (e.g. non-blocking hooks always exit 0). */
   telemetryProcessExitCode?: number | null;
+  /**
+   * When true, SqaaForbiddenError propagates out of the analysis instead of being
+   * recorded as a chunk failure. Set by hook callers that want to show a nudge message.
+   */
+  propagateForbiddenError?: boolean;
 }
 
 export interface AnalyzeSqaaOptions {

--- a/src/cli/commands/analyze/sqaa.ts
+++ b/src/cli/commands/analyze/sqaa.ts
@@ -188,13 +188,13 @@ async function analyzeSqaaChangeSet(params: {
   const changeSet = await resolveChangeSet(process.cwd(), { staged, base });
 
   if (changeSet.files.length === 0 && changeSet.ignored.length === 0) {
-    text('SonarQube Agentic Analysis: no files in the change set to analyze.');
+    text('Vortex agentic analysis: no files in the change set to analyze.');
     return;
   }
 
   if (changeSet.files.length === 0) {
     text(
-      'SonarQube Agentic Analysis: no files to analyze — all change set files were excluded (binary or oversized).',
+      'Vortex agentic analysis: no files to analyze — all change set files were excluded (binary or oversized).',
     );
     return;
   }

--- a/src/cli/commands/context/index.ts
+++ b/src/cli/commands/context/index.ts
@@ -140,7 +140,7 @@ function resolveRecordedContextAugmentationConfig(cwd: string): RecordedContextA
     };
   } catch (err) {
     logger.debug(
-      `Failed to resolve recorded Context Augmentation config: ${(err as Error).message}`,
+      `Failed to resolve recorded context augmentation config: ${(err as Error).message}`,
     );
     return {};
   }
@@ -167,7 +167,7 @@ async function resolveContextToken(
 
   const connection = organization ? `${serverUrl} (${organization})` : serverUrl;
   throw new CommandFailedError(
-    `Not authenticated for the recorded Context Augmentation connection: ${connection}.`,
+    `Not authenticated for the recorded Vortex context augmentation connection: ${connection}.`,
     {
       remediationHint:
         'Run: sonar auth login, then re-run sonar integrate claude or sonar integrate copilot from this project.',
@@ -213,7 +213,7 @@ export async function runContextPassthrough(
     child.on('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'ENOENT') {
         reject(
-          new CommandFailedError('Context Augmentation is not installed.', {
+          new CommandFailedError('Vortex context augmentation is not installed.', {
             remediationHint:
               'Run "sonar integrate claude" or "sonar integrate copilot" to install it.',
           }),

--- a/src/cli/commands/hook/agent-post-tool-use.ts
+++ b/src/cli/commands/hook/agent-post-tool-use.ts
@@ -24,9 +24,11 @@
 import { existsSync, readFileSync } from 'node:fs';
 
 import { resolveAuth } from '../../../lib/auth-resolver';
+import { AGENTIC_PACK_URL } from '../../../lib/config-constants';
 import { canonicalizePath, toRelativePosixPath } from '../../../lib/fs-utils';
 import logger from '../../../lib/logger';
 import { timed } from '../../../lib/timed.js';
+import { SqaaForbiddenError } from '../../../sonarqube/errors';
 import {
   emitSqaaHookFailureTelemetry,
   SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
@@ -116,6 +118,12 @@ export async function agentPostToolUse(options: AgentPostToolUseOptions): Promis
   }
 
   if (fetchResult.error) {
+    if (fetchResult.error instanceof SqaaForbiddenError) {
+      writePostToolUseHookOutput(
+        `Run \`sonar integrate\` to uninstall unavailable hooks. See ${AGENTIC_PACK_URL}`,
+      );
+      return;
+    }
     logger.debug(`PostToolUse SQAA analysis failed: ${fetchResult.error.message}`);
     return;
   }

--- a/src/cli/commands/hook/codex-post-tool-use.ts
+++ b/src/cli/commands/hook/codex-post-tool-use.ts
@@ -58,7 +58,7 @@ export async function codexPostToolUse(options: CodexPostToolUseOptions): Promis
     report = await buildSqaaJsonReport(
       { project: projectKey, force: true, format: 'json', forcedDepth: 'STANDARD' },
       auth,
-      CODEX_HOOK_TELEMETRY_OPTIONS,
+      { ...CODEX_HOOK_TELEMETRY_OPTIONS, propagateForbiddenError: true },
     );
   } catch (err) {
     if (err instanceof SqaaForbiddenError) {

--- a/src/cli/commands/hook/codex-post-tool-use.ts
+++ b/src/cli/commands/hook/codex-post-tool-use.ts
@@ -21,7 +21,9 @@
 // PostToolUse callback handler for Codex — runs git change-set SQAA after apply_patch.
 
 import { resolveAuth } from '../../../lib/auth-resolver';
+import { AGENTIC_PACK_URL } from '../../../lib/config-constants';
 import logger from '../../../lib/logger';
+import { SqaaForbiddenError } from '../../../sonarqube/errors';
 import {
   emitSqaaHookFailureTelemetry,
   SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
@@ -59,6 +61,12 @@ export async function codexPostToolUse(options: CodexPostToolUseOptions): Promis
       CODEX_HOOK_TELEMETRY_OPTIONS,
     );
   } catch (err) {
+    if (err instanceof SqaaForbiddenError) {
+      writePostToolUseHookOutput(
+        `Run \`sonar integrate\` to uninstall unavailable hooks. See ${AGENTIC_PACK_URL}`,
+      );
+      return;
+    }
     await emitSqaaHookFailureTelemetry(
       SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
       auth,

--- a/src/cli/commands/integrate/_common/context-augmentation.ts
+++ b/src/cli/commands/integrate/_common/context-augmentation.ts
@@ -97,7 +97,7 @@ export async function resolveContextAugmentationSetup(
 ): Promise<ResolvedContextAugmentationSetup | null> {
   const isCloud = isSonarQubeCloud(p.auth.serverUrl);
   if (!isCloud) {
-    text('Skipping Context Augmentation: not available on SonarQube Server.');
+    text('Skipping Vortex context augmentation: not available on SonarQube Server.');
     return null;
   }
 
@@ -109,7 +109,7 @@ export async function resolveContextAugmentationSetup(
       const client = new SonarQubeClient(p.auth.serverUrl, p.auth.token);
       if ((await client.hasCagEntitlement(p.auth.orgKey)) === 'allowed') {
         warn(
-          'Skipping Context Augmentation: not supported with --global. Re-run without --global from a project directory to install it there.',
+          'Skipping Vortex context augmentation: not supported with --global. Re-run without --global from a project directory to install it there.',
         );
       }
     }
@@ -118,7 +118,7 @@ export async function resolveContextAugmentationSetup(
 
   if (!p.projectKey || !p.auth.orgKey) {
     warn(
-      'Skipping Context Augmentation: a project key and organization are required (configure your project or pass --project).',
+      'Skipping Vortex context augmentation: a project key and organization are required (configure your project or pass --project).',
     );
     return null;
   }
@@ -127,13 +127,13 @@ export async function resolveContextAugmentationSetup(
   const entitlement = await client.hasCagEntitlement(p.auth.orgKey);
   if (entitlement === 'check_failed') {
     warn(
-      'Skipping Context Augmentation: could not verify entitlement (server unreachable or returned an error).',
+      'Skipping Vortex context augmentation: could not verify entitlement (server unreachable or returned an error).',
     );
     return null;
   }
   if (entitlement === 'not_allowed') {
     warn(
-      'Skipping Context Augmentation: not available for your organization. Access requires an eligible SonarQube Cloud plan.',
+      'Skipping Vortex context augmentation: not available for your organization. Access requires an eligible SonarQube Cloud plan.',
     );
     return null;
   }
@@ -151,7 +151,7 @@ export async function resolveContextAugmentationSetup(
 export async function runToolIntegrateCommand(
   p: ApplyContextAugmentationToolIntegrationParams,
 ): Promise<void> {
-  text('     Installing SonarQube Context Augmentation...');
+  text('     Installing Vortex context augmentation...');
 
   const initEnv = buildContextAugmentationEnv({
     organization: p.auth.orgKey,
@@ -162,13 +162,13 @@ export async function runToolIntegrateCommand(
 
   await runCagStepOrThrow(
     `sonar-context-augmentation ${SONAR_CONTEXT_AUGMENTATION_VERSION}`,
-    'Context Augmentation tool integration failed.',
+    'Vortex context augmentation tool integration failed.',
     p.binaryPath,
     ['tool', 'integrate', '--invocation-prefix', SONAR_CONTEXT_INVOCATION],
     p.projectRoot,
     initEnv,
   );
-  discreetSuccess('SonarQube Context Augmentation configured');
+  discreetSuccess('Vortex context augmentation configured');
 }
 
 export async function printContextAugmentationSkill({

--- a/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
+++ b/src/cli/commands/integrate/_common/features/context-augmentation-feature.ts
@@ -46,7 +46,7 @@ export function createContextAugmentationFeature<
 >(options: ContextAugmentationSkillFeatureOptions): FeatureDeclaration<TOptions> {
   return {
     id: CONTEXT_AUGMENTATION_FEATURE_ID,
-    displayName: 'Context Augmentation',
+    displayName: 'context augmentation',
     benefitDescription: CONTEXT_AUGMENTATION_FEATURE_BENEFIT,
     previewDescription: CONTEXT_AUGMENTATION_FEATURE_PREVIEW,
     shouldInstall: ({ options: integrationOptions }) =>
@@ -55,7 +55,7 @@ export function createContextAugmentationFeature<
     resources: [
       wholeFile({
         id: CONTEXT_AUGMENTATION_SKILL_RESOURCE_ID,
-        displayName: 'Context Augmentation skill file',
+        displayName: 'context augmentation skill file',
         version: SONAR_CONTEXT_AUGMENTATION_VERSION,
         targetPath: options.targetPath,
         content: async (context) =>
@@ -69,7 +69,7 @@ export function createContextAugmentationFeature<
     operations: [
       {
         id: CONTEXT_AUGMENTATION_TOOL_INTEGRATION_OPERATION_ID,
-        displayName: 'Context Augmentation tool integration',
+        displayName: 'context augmentation tool integration',
         shouldApply: (context) => context.executionMode === 'install',
         apply: async (context) =>
           runToolIntegrateCommand({
@@ -87,14 +87,14 @@ export function createContextAugmentationFeature<
 function resolveContextAugmentationBinaryPath(context: IntegrationContext): string {
   const binaryPath = context.resolvedDependencies.get(CONTEXT_AUGMENTATION_BINARY_NAME)?.path;
   if (!binaryPath) {
-    throw new CommandFailedError('Context Augmentation binary path is unavailable.');
+    throw new CommandFailedError('Vortex context augmentation binary path is unavailable.');
   }
   return binaryPath;
 }
 
 function getRequiredAuth(context: IntegrationContext) {
   if (!context.auth) {
-    throw new CommandFailedError('Authentication is unavailable for Context Augmentation.');
+    throw new CommandFailedError('Authentication is unavailable for Vortex context augmentation.');
   }
   return context.auth;
 }

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -27,12 +27,12 @@ import { info, warn } from '../../../../ui';
  * Analysis is skipped because the integration is global.
  */
 export const SQAA_GLOBAL_SKIP_MESSAGE =
-  'Skipping SonarQube Agentic Analysis: not supported with --global. Re-run without --global from a project directory to install it there.';
+  'Skipping Vortex agentic analysis: not supported with --global. Re-run without --global from a project directory to install it there.';
 
 /**
  * Shown when SonarQube Agentic Analysis is not available for the current connection.
  */
-export const SQAA_PROMOTION_MESSAGE = `SonarQube Agentic Analysis is available on SonarQube Cloud. Learn more: ${AGENTIC_ANALYSIS_DOCS_URL}`;
+export const SQAA_PROMOTION_MESSAGE = `Vortex agentic analysis is available on SonarQube Cloud. Learn more: ${AGENTIC_ANALYSIS_DOCS_URL}`;
 
 export interface ResolveSqaaSetupParams {
   serverURL: string;
@@ -55,7 +55,7 @@ export async function resolveSqaaSetup(params: ResolveSqaaSetupParams): Promise<
   }
 
   if (status === 'check_failed') {
-    warn('Could not determine SonarQube Agentic Analysis entitlement — skipping.');
+    warn('Could not determine Vortex agentic analysis entitlement — skipping.');
     return false;
   }
   if (status === 'not_enabled') {

--- a/src/cli/commands/integrate/antigravity/declaration.ts
+++ b/src/cli/commands/integrate/antigravity/declaration.ts
@@ -128,7 +128,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
     },
     {
       id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis rules',
+      displayName: 'Vortex agentic analysis rules',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
@@ -138,7 +138,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
       resources: [
         wholeFile({
           id: 'sqaa-rule-file',
-          displayName: 'SonarQube Agentic Analysis rule for Antigravity',
+          displayName: 'Vortex agentic analysis rule for Antigravity',
           targetPath: resolveSqaaRulePath,
           content: (context) =>
             buildAntigravityAlwaysOnRule(

--- a/src/cli/commands/integrate/antigravity/index.ts
+++ b/src/cli/commands/integrate/antigravity/index.ts
@@ -41,7 +41,7 @@ export async function integrateAntigravity(
   const ctx = await displayAgentIntegratePrelude('Antigravity', 'antigravity', options, auth);
 
   if (options.skipContext) {
-    info('Skipping Context Augmentation (--skip-context).');
+    info('Skipping Vortex context augmentation (--skip-context).');
   }
 
   const sqaaEligible = await resolveSqaaSetup({

--- a/src/cli/commands/integrate/claude/declaration.ts
+++ b/src/cli/commands/integrate/claude/declaration.ts
@@ -125,7 +125,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     }),
     {
       id: 'sonar-sqaa-hook',
-      displayName: 'SonarQube Agentic Analysis hook',
+      displayName: 'Vortex agentic analysis hook',
       benefitDescription: AGENTIC_ANALYSIS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) => {
@@ -160,7 +160,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
         }),
         jsonPatch({
           id: 'claude-settings-sqaa-hook',
-          displayName: 'Claude SonarQube Agentic Analysis hook configuration',
+          displayName: 'Claude Vortex agentic analysis hook configuration',
           targetPath: resolveClaudeSettingsPath,
           defaultValue: { hooks: {} },
           patch: (document, context) =>
@@ -180,7 +180,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
     },
     {
       id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis instructions',
+      displayName: 'Vortex agentic analysis instructions',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
@@ -190,7 +190,7 @@ export const claudeIntegration: IntegrationDeclaration<ClaudeIntegrationOptions>
       resources: [
         textSnippet({
           id: 'sqaa-instructions-file',
-          displayName: 'Claude SonarQube Agentic Analysis instructions',
+          displayName: 'Claude Vortex agentic analysis instructions',
           targetPath: resolveClaudeMdPath,
           startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
           endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),

--- a/src/cli/commands/integrate/codex/declaration.ts
+++ b/src/cli/commands/integrate/codex/declaration.ts
@@ -111,7 +111,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
     }),
     {
       id: 'sonar-sqaa-hook',
-      displayName: 'SonarQube Agentic Analysis hook',
+      displayName: 'Vortex agentic analysis hook',
       benefitDescription: AGENTIC_ANALYSIS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) => {
@@ -141,7 +141,7 @@ export const codexIntegration: IntegrationDeclaration<CodexIntegrationOptions> =
         }),
         jsonPatch({
           id: 'codex-hooks-sqaa-hook',
-          displayName: 'Codex SonarQube Agentic Analysis hook configuration',
+          displayName: 'Codex Vortex agentic analysis hook configuration',
           targetPath: resolveCodexHooksPath,
           defaultValue: { hooks: {} },
           patch: (document, context) =>

--- a/src/cli/commands/integrate/copilot/declaration.ts
+++ b/src/cli/commands/integrate/copilot/declaration.ts
@@ -141,7 +141,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
     },
     {
       id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis instructions',
+      displayName: 'Vortex agentic analysis instructions',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
@@ -151,7 +151,7 @@ export const copilotIntegration: IntegrationDeclaration<CopilotIntegrationOption
       resources: [
         textSnippet({
           id: 'sqaa-instructions-file',
-          displayName: 'Copilot SonarQube Agentic Analysis instructions',
+          displayName: 'Copilot Vortex agentic analysis instructions',
           targetPath: resolveInstructionsPath,
           startMarker: sonarBeginMarker('sonarqube-agentic-analysis-protocol'),
           endMarker: sonarEndMarker('sonarqube-agentic-analysis-protocol'),

--- a/src/cli/commands/integrate/cursor/declaration.ts
+++ b/src/cli/commands/integrate/cursor/declaration.ts
@@ -80,7 +80,7 @@ const SQAA_RULE_MARKER = '# SonarQube Agentic Analysis protocol';
 export interface CursorIntegrationOptions extends IntegrateAgentOptions {
   globalSecretsHookExists?: boolean;
   /**
-   * Write the SonarQube Agentic Analysis rule (`.cursor/rules`) instructing the
+   * Write the Vortex agentic analysis rule (`.cursor/rules`) instructing the
    * agent to run `sonar analyze agentic` after edits. Cursor's `afterFileEdit`
    * hook cannot inject analysis results back into the conversation, so SQAA is
    * delivered as an always-applied rule rather than a hook (project scope).
@@ -111,7 +111,7 @@ function resolveCursorSqaaRulePath(context: IntegrationContext): string {
 }
 
 /**
- * Render the SonarQube Agentic Analysis rule as a Cursor `.mdc` file. The
+ * Render the Vortex agentic analysis rule as a Cursor `.mdc` file. The
  * `alwaysApply: true` front-matter makes Cursor inject the protocol into every
  * session without the user attaching it manually.
  */
@@ -220,7 +220,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
     },
     {
       id: 'sqaa-instructions',
-      displayName: 'SonarQube Agentic Analysis instructions',
+      displayName: 'Vortex agentic analysis instructions',
       benefitDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_BENEFIT,
       previewDescription: AGENTIC_ANALYSIS_INSTRUCTIONS_FEATURE_PREVIEW,
       shouldInstall: ({ options }) =>
@@ -229,7 +229,7 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
       resources: [
         wholeFile({
           id: 'sqaa-instructions-rule',
-          displayName: 'Cursor SonarQube Agentic Analysis rule',
+          displayName: 'Cursor Vortex agentic analysis rule',
           targetPath: resolveCursorSqaaRulePath,
           content: buildCursorSqaaRule,
           managedMarker: SQAA_RULE_MARKER,

--- a/src/cli/commands/remediate/index.ts
+++ b/src/cli/commands/remediate/index.ts
@@ -21,7 +21,11 @@
 // Remediate command - triggers AI agent remediation for eligible issues
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
-import { AGENT_ACTIVITY_PATH, AI_REMEDIATION_DOCS_URL } from '../../../lib/config-constants';
+import {
+  AGENT_ACTIVITY_PATH,
+  AGENTIC_PACK_URL,
+  AI_REMEDIATION_DOCS_URL,
+} from '../../../lib/config-constants';
 import logger from '../../../lib/logger';
 import { discoverProject } from '../../../lib/project-workspace';
 import type { SonarQubeIssue } from '../../../lib/types';
@@ -82,14 +86,16 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
 
   const { status: entitlement } = await client.checkAiRemediationEntitlement(orgKey);
   if (entitlement === 'not_eligible') {
-    throw new CommandFailedError('Remediation Agent unavailable.', {
-      remediationHint: `Ask an organization administrator to check eligibility and enable the feature. Learn more: ${AI_REMEDIATION_DOCS_URL}`,
-    });
+    blank();
+    info(`The Remediation Agent is not available for your organisation. See ${AGENTIC_PACK_URL}`);
+    return;
   }
   if (entitlement === 'not_enabled') {
-    throw new CommandFailedError('Remediation Agent unavailable.', {
-      remediationHint: `Ask an organization administrator to enable the feature. Learn more: ${AI_REMEDIATION_DOCS_URL}`,
-    });
+    blank();
+    info(
+      `The Remediation Agent is not enabled for your organisation. Contact your admin to enable it.`,
+    );
+    return;
   }
   if (entitlement === 'unknown') {
     throw new CommandFailedError('Remediation Agent unavailable.', {

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -201,6 +201,7 @@ export const SERVER_API_DOCS_URL =
 export const SUPPORT_URL = 'https://community.sonarsource.com';
 export const AGENTIC_ANALYSIS_DOCS_URL =
   'https://docs.sonarsource.com/agent-centric-development-cycle/features/agentic-analysis';
+export const AGENTIC_PACK_URL = 'https://www.sonarsource.com/products/agent-essentials/';
 
 // ---------------------------------------------------------------------------
 // Application paths

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -28,10 +28,12 @@ import logger from '../lib/logger';
 import { print } from '../ui';
 import {
   BadRequestError,
+  ForbiddenApiError,
   RateLimitError,
   RequestPayloadTooLargeError,
   type RequestPayloadTooLargeMeta,
   ServiceUnavailableError,
+  SqaaForbiddenError,
 } from './errors';
 import { stripGitRemoteUrlUserinfo } from './git-remote-url';
 import type { SettingsValue } from './settings-value';
@@ -98,6 +100,9 @@ export class SonarQubeClient {
     }
     if (method === 'POST' && response.status === HTTP_STATUS_PAYLOAD_TOO_LARGE) {
       throw await parseRequestPayloadTooLargeError(response);
+    }
+    if (method === 'POST' && response.status === HTTP_STATUS_FORBIDDEN) {
+      throw new ForbiddenApiError(await response.text());
     }
 
     if (method === 'GET') {
@@ -651,11 +656,19 @@ export class SonarQubeClient {
    */
   async createAnalysis(request: SqaaAnalysisRequest): Promise<SqaaAnalysisResponse> {
     const endpoint = '/a3s-analysis/analyses';
-    return await this.post<SqaaAnalysisResponse>(
-      endpoint,
-      request,
-      resolveFromEndpoint(this.serverURL, endpoint),
-    );
+    try {
+      return await this.post<SqaaAnalysisResponse>(
+        endpoint,
+        request,
+        resolveFromEndpoint(this.serverURL, endpoint),
+      );
+    } catch (err) {
+      // 403 on this endpoint means Agentic Pack entitlement was revoked.
+      if (err instanceof ForbiddenApiError) {
+        throw new SqaaForbiddenError();
+      }
+      throw err;
+    }
   }
 }
 

--- a/src/sonarqube/errors.ts
+++ b/src/sonarqube/errors.ts
@@ -54,6 +54,22 @@ export interface RequestPayloadTooLargeMeta {
   maxFiles?: number;
 }
 
+/** Thrown by the API client on any HTTP 403 (Forbidden) POST response. */
+export class ForbiddenApiError extends Error {
+  constructor(body: string) {
+    super(body);
+    this.name = 'ForbiddenApiError';
+  }
+}
+
+/** Thrown when the SQAA analysis endpoint returns 403 — Agentic Pack entitlement revoked. */
+export class SqaaForbiddenError extends Error {
+  constructor() {
+    super('Vortex agentic analysis is not available for this organization (403 Forbidden).');
+    this.name = 'SqaaForbiddenError';
+  }
+}
+
 /** Thrown by the API client on HTTP 413 (Payload Too Large) for SQAA requests. */
 export class RequestPayloadTooLargeError extends Error {
   readonly code?: RequestPayloadTooLargeCode;

--- a/tests/e2e/context/cag-integrate.test.ts
+++ b/tests/e2e/context/cag-integrate.test.ts
@@ -97,7 +97,7 @@ describe('sonar integrate <agent> — CAG pre-flight skip paths (real CLI, fake 
 
     expect(result.exitCode, result.stderr).toBe(0);
     expect(result.stdout).toContain(
-      'Skipping Context Augmentation: not available on SonarQube Server.',
+      'Skipping Vortex context augmentation: not available on SonarQube Server.',
     );
     expect(existsSync(cagBinaryPath), 'no CAG download on SonarQube Server').toBe(false);
     expect(findRecordedCagFeature(harness.stateJsonFile.asJson() as CliState)).toBeUndefined();
@@ -132,7 +132,7 @@ describe('sonar integrate <agent> — CAG pre-flight skip paths (real CLI, fake 
 
     expect(result.exitCode, result.stderr).toBe(0);
     expect(result.stderr).toContain(
-      'Skipping Context Augmentation: not available for your organization. Access requires an eligible SonarQube Cloud plan.',
+      'Skipping Vortex context augmentation: not available for your organization. Access requires an eligible SonarQube Cloud plan.',
     );
     expect(existsSync(cagBinaryPath), 'no CAG download when access is denied').toBe(false);
     expect(findRecordedCagFeature(harness.stateJsonFile.asJson() as CliState)).toBeUndefined();
@@ -157,7 +157,7 @@ describe('sonar integrate <agent> — CAG pre-flight skip paths (real CLI, fake 
 
     expect(result.exitCode, result.stderr).toBe(0);
     expect(result.stdout).toContain(
-      'Skipping Context Augmentation: not available on SonarQube Server.',
+      'Skipping Vortex context augmentation: not available on SonarQube Server.',
     );
     expect(existsSync(cagBinaryPath), 'no CAG download on SonarQube Server').toBe(false);
     expect(findRecordedCagFeature(harness.stateJsonFile.asJson() as CliState)).toBeUndefined();

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -298,7 +298,7 @@ describe('analyze (no subcommand)', () => {
       const output = result.stdout + result.stderr;
       expect(result.exitCode).toBe(0);
       expect(output).toContain('No issues found');
-      expect(output).toContain('SonarQube Agentic Analysis skipped: no project configured');
+      expect(output).toContain('Vortex agentic analysis skipped: no project configured');
       expect(output).not.toContain('Usage: sonar analyze');
       const sqaaCalls = server
         .getRecordedRequests()
@@ -576,7 +576,7 @@ describe('analyze agentic', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(
-        'SonarQube Agentic Analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
+        'Vortex agentic analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -604,7 +604,7 @@ describe('analyze agentic', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
+        'Vortex agentic analysis requires a project, but none is configured for this directory.',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -1555,7 +1555,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
+        'Vortex agentic analysis requires a project, but none is configured for this directory.',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -1585,7 +1585,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(
-        'SonarQube Agentic Analysis skipped: no project configured',
+        'Vortex agentic analysis skipped: no project configured',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -1977,7 +1977,7 @@ describe('analyze agentic — API error codes', () => {
       // Issue details are on stdout.
       expect(result.stdout).toContain('TODO');
       // No Sonar error text should appear on stdout.
-      expect(result.stdout).not.toContain('❌ SonarQube Agentic Analysis failed');
+      expect(result.stdout).not.toContain('❌ Vortex agentic analysis failed');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/context/passthrough.test.ts
+++ b/tests/integration/specs/context/passthrough.test.ts
@@ -223,7 +223,7 @@ describe('sonar context passthrough', () => {
       const result = await harness.run('context status');
 
       expect(result.exitCode).not.toBe(0);
-      expect(result.stderr).toContain('recorded Context Augmentation connection');
+      expect(result.stderr).toContain('recorded Vortex context augmentation connection');
       expect(readInvocations(harness).some((i) => i.argv[0] === 'status')).toBe(false);
     },
     { timeout: 30000 },
@@ -245,7 +245,7 @@ describe('sonar context passthrough', () => {
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toContain(
-        `Not authenticated for the recorded Context Augmentation connection: ${recordedServerUrl} (${ORG_KEY}).`,
+        `Not authenticated for the recorded Vortex context augmentation connection: ${recordedServerUrl} (${ORG_KEY}).`,
       );
       expect(result.stderr).toContain('sonar auth login');
       expect(readInvocations(harness).some((i) => i.argv[0] === 'status')).toBe(false);

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -49,7 +49,7 @@ function getExpectedRootHelp(): string {
     '    analyze                                                  Analyze code for quality and security issues',
     '    analyze secrets                                          Scan files or stdin for hardcoded secrets',
     '    analyze dependency-risks                                 Analyze project dependencies for security and license risks (beta: subject to change)',
-    '    analyze agentic                                          Run server-side Agentic Analysis (SonarQube Cloud only). Limitations apply.',
+    '    analyze agentic                                          Run server-side agentic analysis (SonarQube Cloud only). Limitations apply.',
     '    remediate                                                Trigger AI agent remediation for eligible issues (SonarQube Cloud only)',
     '',
     '    list <issues|projects>                                   List issues and projects from SonarQube Cloud or Server',

--- a/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
@@ -71,6 +71,31 @@ describe('sonar hook claude-post-tool-use', () => {
   );
 
   it(
+    'exits 0 and outputs nudge message when SQAA returns 403 (entitlement revoked)',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaStatusCode(403)
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+      harness.cwd.writeFile('src/main.ts', 'const x = 1;');
+      const filePath = join(harness.cwd.path, 'src/main.ts');
+
+      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
+        stdin: postToolUseStdin(filePath),
+      });
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout.trim());
+      expect(output.hookSpecificOutput.additionalContext).toContain(
+        'Run `sonar integrate` to uninstall unavailable hooks. See https://www.sonarsource.com/products/agent-essentials/',
+      );
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'exits 0 and outputs no hook response when not authenticated',
     async () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');

--- a/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
@@ -101,6 +101,28 @@ describe('sonar hook codex-post-tool-use', () => {
   );
 
   it(
+    'exits 0 and outputs nudge message when SQAA returns 403 (entitlement revoked)',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaStatusCode(403)
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+      harness.cwd.writeFile('src/main.ts', 'const x = 1;');
+
+      const result = await harness.run(`hook codex-post-tool-use --project ${TEST_PROJECT}`);
+
+      expect(result.exitCode).toBe(0);
+      const output = JSON.parse(result.stdout.trim());
+      expect(output.hookSpecificOutput.additionalContext).toContain(
+        'Run `sonar integrate` to uninstall unavailable hooks. See https://www.sonarsource.com/products/agent-essentials/',
+      );
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'exits 0 and outputs no hook response when not authenticated',
     async () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -176,7 +176,7 @@ describe('integrate antigravity', () => {
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout + result.stderr).toContain(
-          'Skipping Context Augmentation (--skip-context)',
+          'Skipping Vortex context augmentation (--skip-context)',
         );
       },
       { timeout: 30000 },

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -2021,8 +2021,8 @@ describe('integrate claude — interactive feature selection', () => {
       expect(output).toContain('Install MCP server?');
       // SQAA is not eligible, so it is skipped without a prompt but the shared
       // promotion message is surfaced.
-      expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
-      expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
+      expect(output).not.toContain('Install Vortex agentic analysis hook?');
+      expect(output).toContain('Vortex agentic analysis is available on SonarQube Cloud');
 
       // Accepted features are installed on disk.
       expect(
@@ -2094,7 +2094,7 @@ describe('integrate claude — interactive feature selection', () => {
 
       expect(result.exitCode).toBe(0);
       const output = `${result.stdout}\n${result.stderr}`;
-      expect(output).toContain('Install SonarQube Agentic Analysis hook?');
+      expect(output).toContain('Install Vortex agentic analysis hook?');
 
       // Accepting installs the PostToolUse SQAA hook script and SQAA instructions.
       expect(
@@ -2143,8 +2143,8 @@ describe('integrate claude — interactive feature selection', () => {
 
       expect(result.exitCode).toBe(0);
       const output = `${result.stdout}\n${result.stderr}`;
-      expect(output).toContain('Could not determine SonarQube Agentic Analysis entitlement');
-      expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
+      expect(output).toContain('Could not determine Vortex agentic analysis entitlement');
+      expect(output).not.toContain('Install Vortex agentic analysis hook?');
       expect(findClaudeFeature(harness, 'sonar-sqaa-hook')).toBeUndefined();
     },
     { timeout: 30000 },

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -571,7 +571,7 @@ describe('integrate codex', () => {
         expect(body).toContain(SECRETS_HEADING);
         expect(body).not.toContain(SQAA_HEADING);
         const output = `${result.stdout}\n${result.stderr}`;
-        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
+        expect(output).toContain('Vortex agentic analysis is available on SonarQube Cloud');
       },
       { timeout: 30000 },
     );
@@ -605,7 +605,7 @@ describe('integrate codex', () => {
         expect(globalBody).not.toContain(SQAA_HEADING);
 
         const output = `${result.stdout}\n${result.stderr}`;
-        expect(output).toContain('Skipping SonarQube Agentic Analysis');
+        expect(output).toContain('Skipping Vortex agentic analysis');
         expect(output).toContain('not supported with --global');
       },
       { timeout: 30000 },
@@ -632,8 +632,8 @@ describe('integrate codex', () => {
         expect(output).toContain('Install MCP server?');
         // SQAA is not eligible, so it is skipped without a prompt but the shared
         // promotion message is surfaced.
-        expect(output).not.toContain('Install SonarQube Agentic Analysis hook?');
-        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
+        expect(output).not.toContain('Install Vortex agentic analysis hook?');
+        expect(output).toContain('Vortex agentic analysis is available on SonarQube Cloud');
         // Accepted features are installed on disk.
         expect(
           harness.cwd.file(...PROMPT_SCRIPT_DIRS, hookScriptName('prompt-secrets')).exists(),
@@ -728,7 +728,7 @@ describe('integrate codex', () => {
 
         expect(result.exitCode).toBe(0);
         const output = `${result.stdout}\n${result.stderr}`;
-        expect(output).toContain('Install SonarQube Agentic Analysis hook?');
+        expect(output).toContain('Install Vortex agentic analysis hook?');
         expect(
           harness.cwd.file(...SQAA_SCRIPT_DIRS, hookScriptName('posttool-sqaa')).exists(),
         ).toBe(true);

--- a/tests/integration/specs/integrate/context-augmentation.test.ts
+++ b/tests/integration/specs/integrate/context-augmentation.test.ts
@@ -525,7 +525,7 @@ describe('integrate claude — Context Augmentation', () => {
       expect(result.exitCode).toBe(1);
       expect(result.stdout).toContain('  cag-stdout-diagnostic');
       expect(result.stderr).toContain('  cag-stderr-diagnostic');
-      expect(result.stderr).toContain('Context Augmentation tool integration failed.');
+      expect(result.stderr).toContain('Vortex context augmentation tool integration failed.');
     },
     { timeout: 30000 },
   );
@@ -565,7 +565,7 @@ describe('integrate claude — Context Augmentation', () => {
       const state = loadState(harness);
       expect(findRecordedCagFeature(state)).toBeUndefined();
       expectSkillFile(harness, CLAUDE_SKILL_PATH, false);
-      expect(result.stderr).toContain('Context Augmentation tool integration failed.');
+      expect(result.stderr).toContain('Vortex context augmentation tool integration failed.');
     },
     { timeout: 30000 },
   );
@@ -921,7 +921,9 @@ describe('integrate <agent> --global — Context Augmentation', () => {
       expect(harness.cwd.file(CLAUDE_SKILL_PATH).exists()).toBe(false);
       expect(harness.cwd.file(COPILOT_SKILL_PATH).exists()).toBe(false);
       expect(harness.cwd.file(CODEX_SKILL_PATH).exists()).toBe(false);
-      expect(result.stderr).toContain('Skipping Context Augmentation: not supported with --global');
+      expect(result.stderr).toContain(
+        'Skipping Vortex context augmentation: not supported with --global',
+      );
     },
     { timeout: 30000 },
   );
@@ -951,7 +953,7 @@ describe('integrate <agent> --global — Context Augmentation', () => {
       const state = loadState(harness);
       expect(findRecordedCagFeature(state)).toBeUndefined();
       expect(`${result.stdout}\n${result.stderr}`).not.toContain(
-        'Skipping Context Augmentation: not supported with --global',
+        'Skipping Vortex context augmentation: not supported with --global',
       );
     },
     { timeout: 30000 },

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -681,7 +681,7 @@ describe('integrate copilot', () => {
 
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;
-        expect(output).toContain('Install SonarQube Agentic Analysis instructions?');
+        expect(output).toContain('Install Vortex agentic analysis instructions?');
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube Agentic Analysis protocol');
         expect(findCopilotFeature(harness, 'sqaa-instructions')?.scope).toBe('project');
@@ -855,11 +855,8 @@ describe('integrate copilot', () => {
         expect(output).toContain('Install pre-tool-use hook?');
         expect(output).toContain('Install prompt-secrets instructions?');
         expect(output).toContain('Install MCP server?');
-        // SQAA is skipped with the shared promotion message + docs link.
-        expect(output).toContain('SonarQube Agentic Analysis is available on SonarQube Cloud');
-        expect(output).toContain(
-          'docs.sonarsource.com/agent-centric-development-cycle/features/agentic-analysis',
-        );
+        // SQAA is skipped with the promotion message.
+        expect(output).toContain('Vortex agentic analysis is available on SonarQube Cloud');
         // Accepted features are installed on disk.
         expect(harness.cwd.file(...PROJECT_HOOK_SCRIPT_PATH).exists()).toBe(true);
         expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(true);

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -22,6 +22,7 @@
 // PR 1 (CLI-619): covers MCP server setup, scope semantics, idempotency, and
 // state recording. Hook and CAG tests are added in subsequent PRs.
 
+import { readFileSync } from 'node:fs';
 import { isAbsolute } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
@@ -530,7 +531,7 @@ describe('integrate cursor', () => {
 
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;
-        expect(output).toContain('Install SonarQube Agentic Analysis instructions?');
+        expect(output).toContain('Install Vortex agentic analysis instructions?');
         const body = harness.cwd.file(...SQAA_RULE_DIRS).asText();
         expect(body).toContain('# SonarQube Agentic Analysis protocol');
         expect(
@@ -585,7 +586,7 @@ describe('integrate cursor', () => {
 
         expect(result.exitCode).toBe(0);
         expect(`${result.stdout}\n${result.stderr}`).toContain(
-          'SonarQube Agentic Analysis is available on SonarQube Cloud',
+          'Vortex agentic analysis is available on SonarQube Cloud',
         );
         expect(harness.cwd.file(...SQAA_RULE_DIRS).exists()).toBe(false);
         expect(findInstalledFeature(harness, 'cursor', 'sqaa-instructions')).toBeUndefined();
@@ -610,6 +611,30 @@ describe('integrate cursor', () => {
 
         expect(result.exitCode).toBe(0);
         expect(harness.cwd.file(...SQAA_RULE_DIRS).asText()).toBe(firstBody);
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'system reset removes the SQAA rule file',
+      async () => {
+        const { extraEnv } = await setupCloudWithEntitlement();
+
+        const integrateResult = await harness.run(
+          `integrate cursor --project ${TEST_PROJECT} --non-interactive`,
+          { extraEnv },
+        );
+        expect(integrateResult.exitCode).toBe(0);
+        expect(harness.cwd.exists(...SQAA_RULE_DIRS)).toBe(true);
+
+        // Preserve the post-integrate state so reset sees the installed features.
+        const stateAfterIntegrate = readFileSync(harness.stateJsonFile.path, 'utf-8');
+        harness.state().withRawState(stateAfterIntegrate);
+
+        const result = await harness.run('system reset --force');
+
+        expect(result.exitCode).toBe(0);
+        expect(harness.cwd.exists(...SQAA_RULE_DIRS)).toBe(false);
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -91,7 +91,7 @@ describe('sonar remediate', () => {
   );
 
   it(
-    'exits with code 1 and shows not-available message when org is not eligible for AI remediation',
+    'exits with code 0 and shows buy-it message when org is not eligible for AI remediation',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -105,18 +105,17 @@ describe('sonar remediate', () => {
 
       const result = await harness.run(`remediate --project ${TEST_PROJECT}`);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('Remediation Agent unavailable.');
-      expect(output).toContain('check eligibility');
-      expect(output).toContain('docs.sonarsource.com');
+      expect(output).toContain('Remediation Agent is not available for your organisation');
+      expect(output).toContain('sonarsource.com/products/agent-essentials');
       expect(output).not.toContain('Which issues');
     },
     { timeout: 15000 },
   );
 
   it(
-    'exits with code 1 and shows not-enabled message when delegate issues is disabled',
+    'exits with code 0 and shows contact-admin message when delegate issues is disabled',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -130,18 +129,17 @@ describe('sonar remediate', () => {
 
       const result = await harness.run(`remediate --project ${TEST_PROJECT}`);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('Remediation Agent unavailable.');
-      expect(output).toContain('enable the feature');
-      expect(output).toContain('docs.sonarsource.com');
+      expect(output).toContain('Remediation Agent is not enabled for your organisation');
+      expect(output).toContain('Contact your admin to enable it');
       expect(output).not.toContain('Which issues');
     },
     { timeout: 15000 },
   );
 
   it(
-    'exits with code 1 and shows not-available message when the org lookup returns an empty array',
+    'exits with code 0 and shows buy-it message when the org lookup returns an empty array',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -155,11 +153,10 @@ describe('sonar remediate', () => {
 
       const result = await harness.run(`remediate --project ${TEST_PROJECT}`);
 
-      expect(result.exitCode).toBe(1);
+      expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
-      expect(output).toContain('Remediation Agent unavailable.');
-      expect(output).toContain('check eligibility');
-      expect(output).toContain('docs.sonarsource.com');
+      expect(output).toContain('Remediation Agent is not available for your organisation');
+      expect(output).toContain('sonarsource.com/products/agent-essentials');
       expect(output).not.toContain('Which issues');
     },
     { timeout: 15000 },
@@ -753,7 +750,7 @@ describe('sonar remediate', () => {
     );
 
     it(
-      'short-circuits on entitlement failure before submitting any keys',
+      'short-circuits gracefully before submitting any keys when feature is not enabled by admin',
       async () => {
         const server = await harness
           .newFakeServer()
@@ -765,9 +762,10 @@ describe('sonar remediate', () => {
 
         const result = await harness.run(`remediate --project ${TEST_PROJECT} --issues k1`);
 
-        expect(result.exitCode).toBe(1);
-        expect(result.stdout + result.stderr).toContain('Remediation Agent unavailable.');
-        expect(result.stdout + result.stderr).toContain('enable the feature');
+        expect(result.exitCode).toBe(0);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('Remediation Agent is not enabled for your organisation');
+        expect(output).toContain('Contact your admin to enable it');
 
         const agentJobCalls = server
           .getRecordedRequests()

--- a/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/cli/commands/analyze/analyze-sqaa.test.ts
@@ -168,7 +168,7 @@ describe('analyzeSqaa: auth resolution', () => {
 
     expect(thrown).toBeInstanceOf(CommandFailedError);
     expect((thrown as Error).message).toContain(
-      'SonarQube Agentic Analysis requires a project, but none is configured for this directory.',
+      'Vortex agentic analysis requires a project, but none is configured for this directory.',
     );
     expect(createAnalysisSpy).not.toHaveBeenCalled();
   });
@@ -183,7 +183,7 @@ describe('analyzeSqaa: auth resolution', () => {
       .map((c) => String(c.args[0]))
       .join('\n');
     expect(output).toContain(
-      'SonarQube Agentic Analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
+      'Vortex agentic analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
     );
   });
 });

--- a/tests/unit/cli/commands/hook/codex-post-tool-use.test.ts
+++ b/tests/unit/cli/commands/hook/codex-post-tool-use.test.ts
@@ -74,6 +74,7 @@ describe('codexPostToolUse', () => {
       {
         telemetryCallerCommand: SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
         telemetryProcessExitCode: SQAA_HOOK_TELEMETRY_EXIT_CODE,
+        propagateForbiddenError: true,
       },
     );
     expect(stdoutSpy).toHaveBeenCalledTimes(1);

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../../../src/lib/config-constants.js';
 import { fetchGuarded } from '../../../src/lib/fetch-guarded.js';
 import { SonarQubeClient } from '../../../src/sonarqube/client.js';
+import { ForbiddenApiError } from '../../../src/sonarqube/errors.js';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../src/ui';
 
 // ---------------------------------------------------------------------------
@@ -1359,7 +1360,7 @@ describe('SonarQubeClient', () => {
       expect(result.taskId).toBe('task-xyz-789');
     });
 
-    it('throws on non-OK response', () => {
+    it('throws ForbiddenApiError on 403 response', () => {
       const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
       fetchSpy = mockFetch({ message: 'Insufficient privileges' }, false, 403);
       expect(
@@ -1368,7 +1369,7 @@ describe('SonarQubeClient', () => {
           issueKeys: ['KEY-1'],
           triggerSource: 'CLI',
         }),
-      ).rejects.toThrow('403');
+      ).rejects.toBeInstanceOf(ForbiddenApiError);
     });
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Error handling:**
  - Propagated `SqaaForbiddenError` to hook callers to allow for graceful handling of 403 status codes.
  - Updated `codex-post-tool-use.ts` and `agent-post-tool-use.ts` to suggest `sonar integrate` when entitlements are revoked.
- **Remediation command:**
  - Changed `remediate` command to exit with code 0 instead of 1 when features are unavailable or disabled, ensuring a non-breaking experience.
- **Terminology:**
  - Standardized branding across various command descriptions, logs, and error messages to use "Vortex" terminology instead of legacy names.
- **Testing:**
  - Added regression tests in `cursor.test.ts` for system reset, and new hook tests to verify graceful 403 handling.
- **Infrastructure:**
  - Updated `sqaa-json-report.ts` and `sqaa-run.ts` to support propagation of `SqaaForbiddenError` through analysis pipelines.

<sub>This will update automatically on new commits.</sub>