### PR TITLE
CLI-791 Collapse analysis telemetry to a single CliAnalysisCompleted event

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ The CAG installer (`src/cli/commands/_common/install/context-augmentation.ts`) h
 
 ### Telemetry
 
-Command telemetry (`storeEvent` in `src/telemetry/index.ts`) and analysis telemetry (`emitAnalysisCompleted` / `emitAnalysisFindingsDetected` in `src/telemetry/findings.ts`) share a tiered identity resolver in `src/telemetry/identity.ts`. It fills `connection_type`, `user_uuid`, `organization_uuid_v4`, and `sqs_installation_id` on every event — including env-var auth (`SONARQUBE_CLI_TOKEN` + `SONARQUBE_CLI_ORG` or `SONARQUBE_CLI_SERVER`) where those fields were previously always null.
+Command telemetry (`storeEvent` in `src/telemetry/index.ts`) and analysis telemetry (`emitAnalysisCompleted` in `src/telemetry/findings.ts`) share a tiered identity resolver in `src/telemetry/identity.ts`. Each analyzer run (sonar-secrets, SQAA, SCA) emits exactly one `CliAnalysisCompleted` event; its required `details` field carries a JSON-encoded, analyzer-specific per-rule blob when `findings_count > 0` and is `""` (empty string, never `null`, so `flushFindings`'s null-stripping replacer keeps the column) otherwise. Each analyzer helper builds its own `details`; the shared emitter stays analyzer-agnostic. It fills `connection_type`, `user_uuid`, `organization_uuid_v4`, and `sqs_installation_id` on every event — including env-var auth (`SONARQUBE_CLI_TOKEN` + `SONARQUBE_CLI_ORG` or `SONARQUBE_CLI_SERVER`) where those fields were previously always null.
 
 **Resolution order** (per auth token, keyed by connection type + server URL + org key + token fingerprint):
 

--- a/src/cli/commands/analyze/secrets.ts
+++ b/src/cli/commands/analyze/secrets.ts
@@ -25,13 +25,9 @@ import { buildSubprocessNetworkEnv } from '../../../lib/connectivity/network-con
 import logger from '../../../lib/logger';
 import type { SpawnResult, StdioMode } from '../../../lib/process';
 import { spawnProcessWithTimeout } from '../../../lib/process';
-import {
-  emitAnalysisCompleted,
-  emitAnalysisFindingsDetected,
-} from '../../../telemetry/findings.js';
+import { emitAnalysisCompleted } from '../../../telemetry/findings.js';
 import {
   SECRETS_CALLER_COMMANDS,
-  SECRETS_DETAILS_SCHEMA_VERSION,
   type SecretsCallerCommand,
 } from '../../../telemetry/secrets-analysis-telemetry.js';
 import { blank, print, success, warn } from '../../../ui';
@@ -101,8 +97,9 @@ export function parseSecretsJson(stdout: string): SecretsJsonOutput {
 }
 
 /**
- * Emits CliAnalysisCompleted (always) and CliAnalysisFindingsDetected (when findings > 0)
- * for one sonar-secrets run. Telemetry write failures are swallowed by the emit helpers.
+ * Emits a single CliAnalysisCompleted event for one sonar-secrets run, carrying `details`
+ * (JSON-encoded blob when findings were reported, `""` otherwise). Telemetry write failures
+ * are swallowed by the emit helper.
  *
  * Pass `result: null` for a run that failed to execute (spawn error or timeout): the completed
  * event is emitted with `exit_code: null` and `failures_count: 1` so failed-to-run scans are
@@ -123,6 +120,22 @@ async function emitSecretsRunTelemetry(
   const failuresCount = exitCode === 0 || exitCode === EXIT_CODE_SECRETS_FOUND ? 0 : 1;
   const analysisId = randomUUID();
 
+  let details = '';
+  if (issues.length > 0) {
+    const countsByRule: Record<string, number> = {};
+    const filesWithFindings = new Set<string>();
+    for (const issue of issues) {
+      countsByRule[issue.ruleKey] = (countsByRule[issue.ruleKey] ?? 0) + 1;
+      if (issue.file) filesWithFindings.add(issue.file);
+    }
+    const source: 'files' | 'stdin' = filesWithFindings.size > 0 ? 'files' : 'stdin';
+    details = JSON.stringify({
+      counts_by_rule: countsByRule,
+      files_with_findings_count: filesWithFindings.size,
+      source,
+    });
+  }
+
   await emitAnalysisCompleted(auth, {
     caller_command: callerCommand,
     analyzer: 'sonar-secrets',
@@ -132,28 +145,8 @@ async function emitSecretsRunTelemetry(
     errors_count: errors?.length ?? 0,
     failures_count: failuresCount,
     scan_duration_ms: durationMs,
+    details,
   });
-
-  if (issues.length > 0) {
-    const countsByRule: Record<string, number> = {};
-    const filesWithFindings = new Set<string>();
-    for (const issue of issues) {
-      countsByRule[issue.ruleKey] = (countsByRule[issue.ruleKey] ?? 0) + 1;
-      if (issue.file) filesWithFindings.add(issue.file);
-    }
-    const source: 'files' | 'stdin' = filesWithFindings.size > 0 ? 'files' : 'stdin';
-    await emitAnalysisFindingsDetected(auth, {
-      caller_command: callerCommand,
-      analyzer: 'sonar-secrets',
-      analysis_id: analysisId,
-      details_schema_version: SECRETS_DETAILS_SCHEMA_VERSION,
-      details: JSON.stringify({
-        counts_by_rule: countsByRule,
-        files_with_findings_count: filesWithFindings.size,
-        source,
-      }),
-    });
-  }
 
   return parsed;
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -495,7 +495,7 @@ export interface AnalysisCompletedEventPayload extends AnalysisEventIdentityPayl
   /** Literal CLI subcommand path (e.g. "analyze agentic", "hook git-pre-commit") */
   caller_command: string;
   analyzer: AnalysisTelemetryAnalyzer;
-  /** UUID minted once per run; join key with CliAnalysisFindingsDetected */
+  /** Per-run UUID; foreign key for a future per-finding child event. */
   analysis_id: string;
   findings_count: number;
   /**
@@ -519,19 +519,12 @@ export interface AnalysisCompletedEventPayload extends AnalysisEventIdentityPayl
    */
   failures_count: number;
   scan_duration_ms: number;
-}
-
-/**
- * Payload for a CliAnalysisFindingsDetected event — intended for runs that
- * reported findings, carrying a versioned per-rule details blob joined to
- * CliAnalysisCompleted via analysis_id.
- */
-export interface AnalysisFindingsDetectedEventPayload extends AnalysisEventIdentityPayload {
-  caller_command: string;
-  analyzer: AnalysisTelemetryAnalyzer;
-  analysis_id: string;
-  details_schema_version: number;
-  /** JSON-encoded allowlist blob (rule keys and per-rule counts only) */
+  /**
+   * JSON-encoded, analyzer-specific allowlist blob (rule keys and per-rule counts only) when
+   * `findings_count > 0`; empty string otherwise. Always a flat JSON-encoded string, never a
+   * nested object — the ingestion endpoint requires flat event payloads. Empty string (not
+   * `null`) so the field survives the `flushFindings` replacer, which strips `null` values.
+   */
   details: string;
 }
 
@@ -550,18 +543,8 @@ export interface StoredAnalysisCompletedEvent {
   event_payload: AnalysisCompletedEventPayload;
 }
 
-/** Full CliAnalysisFindingsDetected event written to findings.ndjson. */
-export interface StoredAnalysisFindingsDetectedEvent {
-  metadata: AnalysisEventMetadataBase & {
-    event_type: 'Analytics.Cli.CliAnalysisFindingsDetected';
-  };
-  event_payload: AnalysisFindingsDetectedEventPayload;
-}
-
 /** Any event stored in findings.ndjson and drained by flushFindings. */
-export type StoredAnalysisEvent =
-  | StoredAnalysisCompletedEvent
-  | StoredAnalysisFindingsDetectedEvent;
+export type StoredAnalysisEvent = StoredAnalysisCompletedEvent;
 
 /**
  * Telemetry configuration and pending event batch

--- a/src/telemetry/findings.ts
+++ b/src/telemetry/findings.ts
@@ -31,7 +31,6 @@ import { INVOCATION_ID } from '../lib/invocation-id.js';
 import type {
   AnalysisCompletedEventPayload,
   AnalysisEventIdentityPayload,
-  AnalysisFindingsDetectedEventPayload,
   StoredAnalysisEvent,
 } from '../lib/state.js';
 import { getActiveConnection, loadState } from '../lib/state-manager.js';
@@ -90,11 +89,6 @@ export type AnalysisCompletedFields = Omit<
   keyof AnalysisEventIdentityPayload
 >;
 
-export type AnalysisFindingsDetectedFields = Omit<
-  AnalysisFindingsDetectedEventPayload,
-  keyof AnalysisEventIdentityPayload
->;
-
 /**
  * Emits one CliAnalysisCompleted event when telemetry is enabled.
  * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
@@ -110,29 +104,6 @@ export async function emitAnalysisCompleted(
       event_id: randomUUID(),
       source: { domain: 'CLI' },
       event_type: 'Analytics.Cli.CliAnalysisCompleted',
-      event_timestamp: String(Date.now()),
-    },
-    event_payload: { ...base, ...fields },
-  });
-}
-
-/**
- * Emits one CliAnalysisFindingsDetected event when telemetry is enabled.
- * Callers should emit only when the paired CliAnalysisCompleted run reported
- * findings; this helper does not enforce findings_count > 0.
- * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
- */
-export async function emitAnalysisFindingsDetected(
-  auth: ResolvedAuth,
-  fields: AnalysisFindingsDetectedFields,
-): Promise<void> {
-  const base = await buildAnalysisIdentityBase(auth);
-  if (!base) return;
-  appendAnalysisEvent({
-    metadata: {
-      event_id: randomUUID(),
-      source: { domain: 'CLI' },
-      event_type: 'Analytics.Cli.CliAnalysisFindingsDetected',
       event_timestamp: String(Date.now()),
     },
     event_payload: { ...base, ...fields },

--- a/src/telemetry/sca-analysis-telemetry.ts
+++ b/src/telemetry/sca-analysis-telemetry.ts
@@ -22,15 +22,7 @@ import { randomUUID } from 'node:crypto';
 
 import type { AnalyzeProjectResponse } from '../cli/commands/analyze/dependency-risk-helpers/sca-scanner.js';
 import type { ResolvedAuth } from '../lib/auth-resolver.js';
-import { emitAnalysisCompleted, emitAnalysisFindingsDetected } from './findings.js';
-
-/**
- * Schema version of the sca-scanner-cli CliAnalysisFindingsDetected `details` blob
- * ({ counts_by_rule } keyed by `<ScaIssueType>:<Severity>`). Bump when that shape changes;
- * independent of SQAA_DETAILS_SCHEMA_VERSION / SECRETS_DETAILS_SCHEMA_VERSION because each
- * analyzer owns the shape of its own `details`.
- */
-export const SCA_DETAILS_SCHEMA_VERSION = 1;
+import { emitAnalysisCompleted } from './findings.js';
 
 /**
  * The `caller_command` value recorded on every SCA analysis event, one per call site.
@@ -74,16 +66,17 @@ export function summarizeScaFindings(response: AnalyzeProjectResponse): {
 }
 
 /**
- * Emits CliAnalysisCompleted (always) and CliAnalysisFindingsDetected (when findings > 0)
- * for one SCA run. Strictly fire-and-forget: the entire body is guarded, so no telemetry
- * failure — identity resolution (`getOrCreateUserId`) or the file write — can ever propagate
- * to the caller. This matters because the analyze call site emits *after* `process.exitCode`
- * is set, and the hook call site must keep failing open; a thrown error here would otherwise
- * turn a successful scan into a failure.
+ * Emits a single CliAnalysisCompleted event for one SCA run, carrying `details`
+ * (JSON-encoded blob when findings were reported, `""` otherwise). Strictly fire-and-forget:
+ * the entire body is guarded, so no telemetry failure — identity resolution
+ * (`getOrCreateUserId`) or the file write — can ever propagate to the caller. This matters
+ * because the analyze call site emits *after* `process.exitCode` is set, and the hook call
+ * site must keep failing open; a thrown error here would otherwise turn a successful scan
+ * into a failure.
  *
  * Pass `response: null` for a run that failed to execute (scanner spawn/parse error or a
  * non-zero exit that threw): the completed event is emitted with `exit_code` as supplied
- * (callers pass `null` on the throw path) and `failures_count: 1`, and no findings event.
+ * (callers pass `null` on the throw path), `failures_count: 1`, and `details: ""`.
  *
  * `exitCode` is the CLI command's final `process.exitCode` (0/1/51 for `analyze`), not the
  * sca-scanner subprocess code; pass `null` when there is no analyze-style exit (hook) or the
@@ -109,6 +102,7 @@ export async function emitScaAnalysisTelemetry(
         errors_count: 0,
         failures_count: 1,
         scan_duration_ms: durationMs,
+        details: '',
       });
       return;
     }
@@ -124,16 +118,7 @@ export async function emitScaAnalysisTelemetry(
       errors_count: response.errors.length,
       failures_count: 0,
       scan_duration_ms: durationMs,
-    });
-
-    if (findingsCount === 0) return;
-
-    await emitAnalysisFindingsDetected(auth, {
-      caller_command: callerCommand,
-      analyzer: 'sca-scanner-cli',
-      analysis_id: analysisId,
-      details_schema_version: SCA_DETAILS_SCHEMA_VERSION,
-      details: JSON.stringify(details),
+      details: findingsCount > 0 ? JSON.stringify(details) : '',
     });
   } catch {
     // Telemetry is strictly fire-and-forget; never surface to the command handler.

--- a/src/telemetry/secrets-analysis-telemetry.ts
+++ b/src/telemetry/secrets-analysis-telemetry.ts
@@ -18,18 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Telemetry constants for the sonar-secrets analyzer's CliAnalysisCompleted /
-// CliAnalysisFindingsDetected events. Versioned independently of other analyzers
-// (e.g. SQAA) because each analyzer owns the shape of its own `details` blob.
+// Telemetry constants for the sonar-secrets analyzer's CliAnalysisCompleted event.
+// Each analyzer owns the shape of its own `details` blob
+// ({ counts_by_rule, files_with_findings_count, source }).
 // Bare `sonar analyze` uses caller_command `analyze` (same as SQAA); the dedicated
 // `analyze secrets` subcommand uses `analyze secrets`.
-
-/**
- * Schema version of the sonar-secrets CliAnalysisFindingsDetected `details` blob
- * ({ counts_by_rule, files_with_findings_count, source }). Bump when that shape changes;
- * independent of SQAA_DETAILS_SCHEMA_VERSION.
- */
-export const SECRETS_DETAILS_SCHEMA_VERSION = 1;
 
 /**
  * The `caller_command` value recorded on every sonar-secrets analysis event, one per

--- a/src/telemetry/sqaa-analysis-telemetry.ts
+++ b/src/telemetry/sqaa-analysis-telemetry.ts
@@ -24,9 +24,7 @@ import type { FileResult, RunTally } from '../cli/commands/analyze/sqaa-analysis
 import type { SqaaJsonReport } from '../cli/commands/analyze/sqaa-display-json.js';
 import type { ResolvedAuth } from '../lib/auth-resolver.js';
 import type { SqaaIssue } from '../sonarqube/client.js';
-import { emitAnalysisCompleted, emitAnalysisFindingsDetected } from './findings.js';
-
-export const SQAA_DETAILS_SCHEMA_VERSION = 1;
+import { emitAnalysisCompleted } from './findings.js';
 
 export const SQAA_ANALYZE_CALLER_COMMAND = 'analyze';
 
@@ -130,8 +128,8 @@ export function tallyFromSqaaJsonReport(report: SqaaJsonReport): RunTally {
 }
 
 /**
- * Emits CliAnalysisCompleted (always) and CliAnalysisFindingsDetected (when issues exist)
- * for one SQAA run. No-ops when telemetry is disabled.
+ * Emits a single CliAnalysisCompleted event for one SQAA run, carrying `details`
+ * (JSON-encoded blob when issues exist, `""` otherwise). No-ops when telemetry is disabled.
  *
  * Pass `exitCode` from the command handler. Omit or pass `null` when the invocation has no exit.
  * PostToolUse hooks pass {@link SQAA_HOOK_TELEMETRY_EXIT_CODE} (always 0) because they never
@@ -149,6 +147,8 @@ export async function emitSqaaAnalysisTelemetry(
 ): Promise<void> {
   const analysisId = randomUUID();
   const findingsCount = tally.totalIssues;
+  const details =
+    findingsCount > 0 ? JSON.stringify(collectRuleCounts(collectIssuesFromTally(tally))) : '';
 
   await emitAnalysisCompleted(auth, {
     caller_command: callerCommand,
@@ -159,15 +159,6 @@ export async function emitSqaaAnalysisTelemetry(
     errors_count: tally.totalErrors,
     failures_count: tally.totalFailures,
     scan_duration_ms: durationMs,
-  });
-
-  if (findingsCount === 0) return;
-
-  await emitAnalysisFindingsDetected(auth, {
-    caller_command: callerCommand,
-    analyzer: 'sqaa',
-    analysis_id: analysisId,
-    details_schema_version: SQAA_DETAILS_SCHEMA_VERSION,
-    details: JSON.stringify(collectRuleCounts(collectIssuesFromTally(tally))),
+    details,
   });
 }

--- a/tests/e2e/sca/sca-staging.test.ts
+++ b/tests/e2e/sca/sca-staging.test.ts
@@ -191,7 +191,7 @@ for (const region of STAGING_REGIONS) {
       );
 
       it(
-        'writes CliAnalysisCompleted + CliAnalysisFindingsDetected to findings.ndjson',
+        'writes a single CliAnalysisCompleted with populated details to findings.ndjson',
         async () => {
           harness.state().withTelemetryEnabled();
 
@@ -224,29 +224,22 @@ for (const region of STAGING_REGIONS) {
             .map((line) => JSON.parse(line) as AnalysisEvent);
 
           // The command also runs the secrets pre-scan, which emits its own sonar-secrets
-          // events into the same file — select the SCA ones by analyzer.
+          // event into the same file — select the SCA one by analyzer.
           const completed = events.find(
             (e) =>
               e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted' &&
               e.event_payload.analyzer === 'sca-scanner-cli',
           );
-          const detected = events.find(
-            (e) =>
-              e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected' &&
-              e.event_payload.analyzer === 'sca-scanner-cli',
-          );
           expect(completed).toBeDefined();
-          expect(detected).toBeDefined();
-          if (!completed || !detected) throw new Error('expected both SCA analysis events');
+          if (!completed) throw new Error('expected a SCA CliAnalysisCompleted event');
 
           expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
           expect(completed.event_payload.caller_command).toBe('analyze dependency-risks');
           expect(completed.event_payload.failures_count).toBe(0);
           expect(completed.event_payload.exit_code).toBe(EXIT_UNRESOLVED_RISKS);
           expect(completed.event_payload.findings_count as number).toBeGreaterThanOrEqual(1);
-          expect(completed.event_payload.analysis_id).toBe(detected.event_payload.analysis_id);
 
-          const details = JSON.parse(detected.event_payload.details as string) as {
+          const details = JSON.parse(completed.event_payload.details as string) as {
             counts_by_rule: Record<string, number>;
           };
           const ruleKeys = Object.keys(details.counts_by_rule);

--- a/tests/integration/specs/analyze/analyze-secrets.test.ts
+++ b/tests/integration/specs/analyze/analyze-secrets.test.ts
@@ -262,7 +262,7 @@ describe('analyze secrets', () => {
   );
 
   it(
-    'writes CliAnalysisCompleted + CliAnalysisFindingsDetected to findings.ndjson from a real scan',
+    'writes a single CliAnalysisCompleted with populated details to findings.ndjson from a real scan',
     async () => {
       harness.state().withSecretsBinaryInstalled().withTelemetryEnabled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
@@ -288,18 +288,13 @@ describe('analyze secrets', () => {
         .filter(Boolean)
         .map((line) => JSON.parse(line) as AnalysisEvent);
 
-      // One completed event (always) + one findings-detected event (findings present).
-      // Select by event_type rather than position so the assertions don't depend on emit order.
-      expect(events).toHaveLength(2);
+      // Exactly one completed event, carrying the details blob when findings are present.
+      expect(events).toHaveLength(1);
       const completed = events.find(
         (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
       );
-      const detected = events.find(
-        (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
-      );
       expect(completed).toBeDefined();
-      expect(detected).toBeDefined();
-      if (!completed || !detected) throw new Error('expected both analysis events');
+      if (!completed) throw new Error('expected a CliAnalysisCompleted event');
 
       expect(completed.event_payload.analyzer).toBe('sonar-secrets');
       expect(completed.event_payload.caller_command).toBe('analyze secrets');
@@ -307,16 +302,13 @@ describe('analyze secrets', () => {
       expect(completed.event_payload.exit_code).toBe(EXIT_CODE_SECRETS_FOUND);
       expect(completed.event_payload.findings_count as number).toBeGreaterThanOrEqual(1);
 
-      const details = JSON.parse(detected.event_payload.details as string) as {
+      const details = JSON.parse(completed.event_payload.details as string) as {
         counts_by_rule: Record<string, number>;
         files_with_findings_count: number;
         source: string;
       };
       expect(Object.keys(details.counts_by_rule).length).toBeGreaterThanOrEqual(1);
       expect(details.source).toBe('files');
-
-      // The two events are joinable on a shared analysis_id.
-      expect(completed.event_payload.analysis_id).toBe(detected.event_payload.analysis_id);
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -28,7 +28,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type {
   StoredAnalysisCompletedEvent,
   StoredAnalysisEvent,
-  StoredAnalysisFindingsDetectedEvent,
 } from '../../../../src/lib/state.js';
 import { TELEMETRY_FLUSH_MODE_ENV } from '../../../../src/telemetry/index.js';
 import { SECRETS_CALLER_COMMANDS } from '../../../../src/telemetry/secrets-analysis-telemetry.js';
@@ -987,7 +986,7 @@ describe('analyze agentic — analysis telemetry', () => {
       const events = readAnalysisEvents();
       expect(events).toHaveLength(1);
       expect(events[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-      const completed = events[0] as StoredAnalysisCompletedEvent;
+      const completed = events[0];
       expect(completed.event_payload.caller_command).toBe(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND);
       expect(completed.event_payload.analyzer).toBe('sqaa');
       expect(completed.event_payload.findings_count).toBe(0);
@@ -1001,7 +1000,7 @@ describe('analyze agentic — analysis telemetry', () => {
   );
 
   it(
-    'writes CliAnalysisCompleted and CliAnalysisFindingsDetected when issues are found',
+    'writes a single CliAnalysisCompleted with populated details when issues are found',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -1027,19 +1026,14 @@ describe('analyze agentic — analysis telemetry', () => {
 
       expect(result.exitCode).toBe(EXIT_CODE_SECRETS_FOUND);
       const events = readAnalysisEvents();
-      expect(events).toHaveLength(2);
+      expect(events).toHaveLength(1);
       const completed = events.find(
         (event) => event.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
-      ) as StoredAnalysisCompletedEvent | undefined;
-      const findings = events.find(
-        (event) => event.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
-      ) as StoredAnalysisFindingsDetectedEvent | undefined;
+      );
       expect(completed).toBeDefined();
-      expect(findings).toBeDefined();
-      expect(completed!.event_payload.analysis_id).toBe(findings!.event_payload.analysis_id);
       expect(completed!.event_payload.findings_count).toBe(2);
       expect(completed!.event_payload.exit_code).toBe(EXIT_CODE_SECRETS_FOUND);
-      expect(JSON.parse(findings!.event_payload.details)).toEqual({
+      expect(JSON.parse(completed!.event_payload.details)).toEqual({
         rule_keys: ['typescript:S1234'],
         counts_by_rule: { 'typescript:S1234': 2 },
       });
@@ -1079,7 +1073,7 @@ describe('sonar analyze — analysis telemetry', () => {
       .filter(
         (event): event is StoredAnalysisCompletedEvent =>
           event.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted' &&
-          (event as StoredAnalysisCompletedEvent).event_payload.analyzer === analyzer,
+          event.event_payload.analyzer === analyzer,
       );
   }
 

--- a/tests/unit/telemetry/findings.test.ts
+++ b/tests/unit/telemetry/findings.test.ts
@@ -20,9 +20,8 @@
 
 /**
  * Tests for telemetry/findings.ts:
- *   emitAnalysisCompleted         — CliAnalysisCompleted envelope + telemetry gate
- *   emitAnalysisFindingsDetected  — CliAnalysisFindingsDetected envelope + telemetry gate
- *   flushFindings                 — atomic rename, retention cap, send, re-queue, concurrent safety
+ *   emitAnalysisCompleted — CliAnalysisCompleted envelope + telemetry gate
+ *   flushFindings         — atomic rename, retention cap, send, re-queue, concurrent safety
  */
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -41,18 +40,14 @@ import * as stateRepository from '../../../src/lib/repository/state-repository.j
 import type { CliState } from '../../../src/lib/state.js';
 import type {
   AnalysisCompletedEventPayload,
-  AnalysisFindingsDetectedEventPayload,
   StoredAnalysisCompletedEvent,
   StoredAnalysisEvent,
-  StoredAnalysisFindingsDetectedEvent,
 } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as stateManager from '../../../src/lib/state-manager.js';
 import {
   type AnalysisCompletedFields,
-  type AnalysisFindingsDetectedFields,
   emitAnalysisCompleted,
-  emitAnalysisFindingsDetected,
   flushFindings,
 } from '../../../src/telemetry/findings.js';
 import { SECRETS_CALLER_COMMANDS } from '../../../src/telemetry/secrets-analysis-telemetry.js';
@@ -88,6 +83,7 @@ function makeCompletedFields(
     errors_count: 0,
     failures_count: 0,
     scan_duration_ms: 456,
+    details: '',
     ...overrides,
   };
 }
@@ -98,32 +94,6 @@ function makeCompletedPayload(
   return {
     ...makeIdentityPayload(),
     ...makeCompletedFields(),
-    ...overrides,
-  };
-}
-
-function makeFindingsDetectedFields(
-  overrides: Partial<AnalysisFindingsDetectedFields> = {},
-): AnalysisFindingsDetectedFields {
-  return {
-    caller_command: SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
-    analyzer: 'sqaa',
-    analysis_id: 'analysis-id-123',
-    details_schema_version: 1,
-    details: JSON.stringify({
-      rule_keys: ['sqaa:S1234'],
-      counts_by_rule: { 'sqaa:S1234': 1 },
-    }),
-    ...overrides,
-  };
-}
-
-function makeFindingsDetectedPayload(
-  overrides: Partial<AnalysisFindingsDetectedEventPayload> = {},
-): AnalysisFindingsDetectedEventPayload {
-  return {
-    ...makeIdentityPayload(),
-    ...makeFindingsDetectedFields(),
     ...overrides,
   };
 }
@@ -139,20 +109,6 @@ function makeStoredCompletedEvent(
       event_timestamp: String(Date.now()),
     },
     event_payload: makeCompletedPayload(overrides),
-  };
-}
-
-function makeStoredFindingsDetectedEvent(
-  overrides: Partial<AnalysisFindingsDetectedEventPayload> = {},
-): StoredAnalysisFindingsDetectedEvent {
-  return {
-    metadata: {
-      event_id: 'findings-id',
-      source: { domain: 'CLI' },
-      event_type: 'Analytics.Cli.CliAnalysisFindingsDetected',
-      event_timestamp: String(Date.now()),
-    },
-    event_payload: makeFindingsDetectedPayload(overrides),
   };
 }
 
@@ -251,7 +207,7 @@ describe('emitAnalysisCompleted()', () => {
 
     const [event] = readLines(testSonarUserHome);
     expect(event.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-    const completedEvent = event as StoredAnalysisCompletedEvent;
+    const completedEvent = event;
     expect(completedEvent.event_payload.analyzer).toBe('sqaa');
     expect(completedEvent.event_payload.findings_count).toBe(2);
     expect(completedEvent.event_payload.exit_code).toBe(51);
@@ -280,14 +236,14 @@ describe('emitAnalysisCompleted()', () => {
     await emitAnalysisCompleted({ ...AUTH, connectionType: 'cloud' }, makeCompletedFields());
 
     const [event] = readLines(testSonarUserHome);
-    expect((event as StoredAnalysisCompletedEvent).event_payload.connection_type).toBe('sqc');
+    expect(event.event_payload.connection_type).toBe('sqc');
   });
 
   it('sets connection_type to sqs for server connections', async () => {
     await emitAnalysisCompleted({ ...AUTH, connectionType: 'on-premise' }, makeCompletedFields());
 
     const [event] = readLines(testSonarUserHome);
-    expect((event as StoredAnalysisCompletedEvent).event_payload.connection_type).toBe('sqs');
+    expect(event.event_payload.connection_type).toBe('sqs');
   });
 
   it('includes connection identity fields from the active connection', async () => {
@@ -304,7 +260,7 @@ describe('emitAnalysisCompleted()', () => {
 
     await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
-    const payload = (readLines(testSonarUserHome)[0] as StoredAnalysisCompletedEvent).event_payload;
+    const payload = readLines(testSonarUserHome)[0].event_payload;
     expect(payload.user_uuid).toBe('user-uuid-abc');
     expect(payload.organization_uuid_v4).toBe('org-uuid-xyz');
     expect(payload.sqs_installation_id).toBe('sqs-install-id-123');
@@ -315,7 +271,7 @@ describe('emitAnalysisCompleted()', () => {
 
     await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
-    const payload = (readLines(testSonarUserHome)[0] as StoredAnalysisCompletedEvent).event_payload;
+    const payload = readLines(testSonarUserHome)[0].event_payload;
     expect(payload.caller_agent).toBe('cursor');
   });
 
@@ -326,35 +282,6 @@ describe('emitAnalysisCompleted()', () => {
     await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     expect(existsSync(telemetryDir)).toBe(true);
-  });
-});
-
-// ─── emitAnalysisFindingsDetected ──────────────────────────────────────────────
-
-describe('emitAnalysisFindingsDetected()', () => {
-  it('writes a valid CliAnalysisFindingsDetected envelope', async () => {
-    await emitAnalysisFindingsDetected(
-      AUTH,
-      makeFindingsDetectedFields({ analysis_id: 'abc-123', details_schema_version: 1 }),
-    );
-
-    const [event] = readLines(testSonarUserHome);
-    expect(event.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingsDetected');
-    const findingsEvent = event as StoredAnalysisFindingsDetectedEvent;
-    expect(findingsEvent.event_payload.analysis_id).toBe('abc-123');
-    expect(findingsEvent.event_payload.details_schema_version).toBe(1);
-    expect(JSON.parse(findingsEvent.event_payload.details)).toEqual({
-      rule_keys: ['sqaa:S1234'],
-      counts_by_rule: { 'sqaa:S1234': 1 },
-    });
-  });
-
-  it('does not append when telemetry is disabled', async () => {
-    loadStateSpy.mockReturnValue(makeTelemetryState(false));
-
-    await emitAnalysisFindingsDetected(AUTH, makeFindingsDetectedFields());
-
-    expect(readLines(testSonarUserHome)).toHaveLength(0);
   });
 });
 
@@ -379,26 +306,6 @@ describe('flushFindings()', () => {
     try {
       await flushFindings(Date.now() + 60_000);
       expect(fetchSpy).toHaveBeenCalledTimes(2);
-    } finally {
-      fetchSpy.mockRestore();
-    }
-  });
-
-  it('POSTs CliAnalysisCompleted and CliAnalysisFindingsDetected events from the same ndjson file', async () => {
-    writeStoredEvent(makeStoredCompletedEvent({ analysis_id: 'run-1' }));
-    writeStoredEvent(makeStoredFindingsDetectedEvent({ analysis_id: 'run-1' }));
-
-    const fetchSpy = mockFetch();
-    try {
-      await flushFindings(Date.now() + 60_000);
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
-      const types = fetchSpy.mock.calls.map((call: unknown[]) => {
-        const body = JSON.parse((call[1] as RequestInit).body as string) as StoredAnalysisEvent;
-        expect(body.event_payload.analysis_id).toBe('run-1');
-        return body.metadata.event_type;
-      });
-      expect(types).toContain('Analytics.Cli.CliAnalysisCompleted');
-      expect(types).toContain('Analytics.Cli.CliAnalysisFindingsDetected');
     } finally {
       fetchSpy.mockRestore();
     }
@@ -556,7 +463,7 @@ describe('flushFindings()', () => {
       const requeued = readLines(testSonarUserHome);
       expect(requeued).toHaveLength(1);
       expect(requeued[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-      expect((requeued[0] as StoredAnalysisCompletedEvent).event_payload.analysis_id).toBe('run-a');
+      expect(requeued[0].event_payload.analysis_id).toBe('run-a');
     } finally {
       fetchSpy.mockRestore();
     }
@@ -642,7 +549,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     expect(readLines(testSonarUserHome)).toHaveLength(0);
   });
 
-  it('emits only CliAnalysisCompleted on a clean scan (exit 0, no issues)', async () => {
+  it('emits a single CliAnalysisCompleted with details "" on a clean scan (exit 0, no issues)', async () => {
     await scanAndEmitSecrets(
       SECRETS_CALLER_COMMANDS.analyzeSecrets,
       AUTH,
@@ -652,17 +559,18 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
     expect(lines[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    const completed = lines[0];
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(0);
     expect(completed.event_payload.findings_count).toBe(0);
+    expect(completed.event_payload.details).toBe('');
     expect(typeof completed.event_payload.scan_duration_ms).toBe('number');
     expect(completed.event_payload.scan_duration_ms).toBeGreaterThanOrEqual(0);
     expect(completed.event_payload.caller_command).toBe(SECRETS_CALLER_COMMANDS.analyzeSecrets);
     expect(completed.event_payload.analyzer).toBe('sonar-secrets');
   });
 
-  it('emits CliAnalysisCompleted + CliAnalysisFindingsDetected when secrets found (exit 51)', async () => {
+  it('emits a single CliAnalysisCompleted with populated details when secrets found (exit 51)', async () => {
     const stdout = JSON.stringify({
       issues: [
         { ruleKey: 'secrets:S6290', description: 'AWS key', file: 'src/config.ts' },
@@ -673,18 +581,16 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.gitPreCommit, AUTH, resolvedRun(51, stdout));
 
     const lines = readLines(testSonarUserHome);
-    expect(lines).toHaveLength(2);
+    expect(lines).toHaveLength(1);
 
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    const completed = lines[0];
     expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(51);
     expect(completed.event_payload.findings_count).toBe(3);
     expect(completed.event_payload.caller_command).toBe(SECRETS_CALLER_COMMANDS.gitPreCommit);
 
-    const detected = lines[1] as StoredAnalysisFindingsDetectedEvent;
-    expect(detected.metadata.event_type).toBe('Analytics.Cli.CliAnalysisFindingsDetected');
-    const details = JSON.parse(detected.event_payload.details) as {
+    const details = JSON.parse(completed.event_payload.details) as {
       counts_by_rule: Record<string, number>;
       files_with_findings_count: number;
       source: string;
@@ -693,8 +599,6 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     expect(details.counts_by_rule['secrets:S1234']).toBe(1);
     expect(details.files_with_findings_count).toBe(2);
     expect(details.source).toBe('files');
-
-    expect(completed.event_payload.analysis_id).toBe(detected.event_payload.analysis_id);
   });
 
   it('sets source to stdin and files_with_findings_count to 0 when no file paths in issues', async () => {
@@ -708,8 +612,8 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     );
 
     const lines = readLines(testSonarUserHome);
-    const detected = lines[1] as StoredAnalysisFindingsDetectedEvent;
-    const details = JSON.parse(detected.event_payload.details) as {
+    const completed = lines[0];
+    const details = JSON.parse(completed.event_payload.details) as {
       files_with_findings_count: number;
       source: string;
     };
@@ -722,7 +626,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    const completed = lines[0];
     expect(completed.event_payload.failures_count).toBe(1);
     expect(completed.event_payload.findings_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(2);
@@ -737,7 +641,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    const completed = lines[0];
     expect(completed.event_payload.failures_count).toBe(1);
     expect(completed.event_payload.exit_code).toBeNull();
   });
@@ -748,7 +652,7 @@ describe('scanAndEmitSecrets() — emitted event fields', () => {
     await scanAndEmitSecrets(SECRETS_CALLER_COMMANDS.analyzeSecrets, AUTH, resolvedRun(2, stdout));
 
     const lines = readLines(testSonarUserHome);
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    const completed = lines[0];
     expect(completed.event_payload.errors_count).toBe(2);
     expect(completed.event_payload.failures_count).toBe(1);
   });
@@ -769,11 +673,12 @@ describe('scanAndEmitSecrets() — wrapper behavior', () => {
     expect(out.parsed.issues).toHaveLength(1);
 
     const lines = readLines(testSonarUserHome);
-    // one Completed + one FindingsDetected (findings present)
-    expect(lines).toHaveLength(2);
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    // a single Completed event carrying details (findings present)
+    expect(lines).toHaveLength(1);
+    const completed = lines[0];
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.exit_code).toBe(51);
+    expect(completed.event_payload.details).not.toBe('');
   });
 
   it('emits a failures_count:1 event and re-throws when the scan fails to run', async () => {
@@ -789,7 +694,7 @@ describe('scanAndEmitSecrets() — wrapper behavior', () => {
 
     const lines = readLines(testSonarUserHome);
     expect(lines).toHaveLength(1);
-    const completed = lines[0] as StoredAnalysisCompletedEvent;
+    const completed = lines[0];
     expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
     expect(completed.event_payload.failures_count).toBe(1);
     expect(completed.event_payload.exit_code).toBeNull();

--- a/tests/unit/telemetry/sca-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sca-analysis-telemetry.test.ts
@@ -36,17 +36,12 @@ import type {
 import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
 import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
-import type {
-  StoredAnalysisCompletedEvent,
-  StoredAnalysisEvent,
-  StoredAnalysisFindingsDetectedEvent,
-} from '../../../src/lib/state.js';
+import type { StoredAnalysisEvent } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as stateManager from '../../../src/lib/state-manager.js';
 import {
   emitScaAnalysisTelemetry,
   SCA_CALLER_COMMANDS,
-  SCA_DETAILS_SCHEMA_VERSION,
   summarizeScaFindings,
 } from '../../../src/telemetry/sca-analysis-telemetry.js';
 import * as userModule from '../../../src/telemetry/user.js';
@@ -215,7 +210,7 @@ describe('summarizeScaFindings()', () => {
 });
 
 describe('emitScaAnalysisTelemetry()', () => {
-  it('writes only CliAnalysisCompleted on a clean run (no new findings)', async () => {
+  it('writes a single CliAnalysisCompleted with details "" on a clean run (no new findings)', async () => {
     const response = makeResponse([makeRelease(false, [makeIssue('VULNERABILITY', 'HIGH')])]);
 
     await emitScaAnalysisTelemetry(
@@ -228,7 +223,7 @@ describe('emitScaAnalysisTelemetry()', () => {
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(1);
-    const completed = events[0] as StoredAnalysisCompletedEvent;
+    const completed = events[0];
     expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
     expect(completed.event_payload.caller_command).toBe('analyze dependency-risks');
     expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
@@ -237,10 +232,11 @@ describe('emitScaAnalysisTelemetry()', () => {
     expect(completed.event_payload.errors_count).toBe(0);
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.scan_duration_ms).toBe(123);
+    expect(completed.event_payload.details).toBe('');
     expect(completed.event_payload.analysis_id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
-  it('writes Completed and FindingsDetected with matching analysis_id when new findings exist', async () => {
+  it('writes a single CliAnalysisCompleted with populated details when new findings exist', async () => {
     const response = makeResponse(
       [makeRelease(true, [makeIssue('VULNERABILITY', 'HIGH'), makeIssue('VULNERABILITY', 'HIGH')])],
       [makeError()],
@@ -255,34 +251,25 @@ describe('emitScaAnalysisTelemetry()', () => {
     );
 
     const events = readEvents(testSonarUserHome);
-    expect(events).toHaveLength(2);
-    const completed = events.find(
-      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
-    ) as StoredAnalysisCompletedEvent | undefined;
-    const findings = events.find(
-      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
-    ) as StoredAnalysisFindingsDetectedEvent | undefined;
-
-    expect(completed).toBeDefined();
-    expect(findings).toBeDefined();
-    expect(completed!.event_payload.analysis_id).toBe(findings!.event_payload.analysis_id);
-    expect(completed!.event_payload.findings_count).toBe(2);
-    expect(completed!.event_payload.exit_code).toBe(51);
-    expect(completed!.event_payload.errors_count).toBe(1);
-    expect(completed!.event_payload.failures_count).toBe(0);
-    expect(findings!.event_payload.analyzer).toBe('sca-scanner-cli');
-    expect(findings!.event_payload.details_schema_version).toBe(SCA_DETAILS_SCHEMA_VERSION);
-    expect(JSON.parse(findings!.event_payload.details)).toEqual({
+    expect(events).toHaveLength(1);
+    const completed = events[0];
+    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    expect(completed.event_payload.findings_count).toBe(2);
+    expect(completed.event_payload.exit_code).toBe(51);
+    expect(completed.event_payload.errors_count).toBe(1);
+    expect(completed.event_payload.failures_count).toBe(0);
+    expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
+    expect(JSON.parse(completed.event_payload.details)).toEqual({
       counts_by_rule: { 'VULNERABILITY:HIGH': 2 },
     });
   });
 
-  it('records a failed-to-run scan (response null) as failures_count 1 with no findings event', async () => {
+  it('records a failed-to-run scan (response null) as failures_count 1 with details ""', async () => {
     await emitScaAnalysisTelemetry(SCA_CALLER_COMMANDS.gitPreCommit, AUTH, null, 77, null);
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(1);
-    const completed = events[0] as StoredAnalysisCompletedEvent;
+    const completed = events[0];
     expect(completed.event_payload.caller_command).toBe('git-pre-commit');
     expect(completed.event_payload.analyzer).toBe('sca-scanner-cli');
     expect(completed.event_payload.findings_count).toBe(0);
@@ -290,21 +277,20 @@ describe('emitScaAnalysisTelemetry()', () => {
     expect(completed.event_payload.errors_count).toBe(0);
     expect(completed.event_payload.failures_count).toBe(1);
     expect(completed.event_payload.scan_duration_ms).toBe(77);
+    expect(completed.event_payload.details).toBe('');
   });
 
-  it('emits FindingsDetected for the git-pre-commit caller too (Model B)', async () => {
+  it('populates details for the git-pre-commit caller too', async () => {
     const response = makeResponse([makeRelease(true, [makeIssue('MALWARE', 'BLOCKER')])]);
 
     await emitScaAnalysisTelemetry(SCA_CALLER_COMMANDS.gitPreCommit, AUTH, response, 10, null);
 
     const events = readEvents(testSonarUserHome);
-    expect(events).toHaveLength(2);
-    const findings = events.find(
-      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
-    ) as StoredAnalysisFindingsDetectedEvent | undefined;
-    expect(findings).toBeDefined();
-    expect(findings!.event_payload.caller_command).toBe('git-pre-commit');
-    expect(JSON.parse(findings!.event_payload.details)).toEqual({
+    expect(events).toHaveLength(1);
+    const completed = events[0];
+    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    expect(completed.event_payload.caller_command).toBe('git-pre-commit');
+    expect(JSON.parse(completed.event_payload.details)).toEqual({
       counts_by_rule: { 'MALWARE:BLOCKER': 1 },
     });
   });

--- a/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
+++ b/tests/unit/telemetry/sqaa-analysis-telemetry.test.ts
@@ -30,11 +30,7 @@ import type { SqaaJsonReport } from '../../../src/cli/commands/analyze/sqaa-disp
 import type { ResolvedAuth } from '../../../src/lib/auth-resolver.js';
 import { ENV_SONAR_USER_HOME } from '../../../src/lib/config-constants.js';
 import * as stateRepository from '../../../src/lib/repository/state-repository.js';
-import type {
-  StoredAnalysisCompletedEvent,
-  StoredAnalysisEvent,
-  StoredAnalysisFindingsDetectedEvent,
-} from '../../../src/lib/state.js';
+import type { StoredAnalysisEvent } from '../../../src/lib/state.js';
 import { getDefaultState } from '../../../src/lib/state.js';
 import * as stateManager from '../../../src/lib/state-manager.js';
 import type { SqaaIssue } from '../../../src/sonarqube/client.js';
@@ -43,7 +39,6 @@ import {
   emitSqaaAnalysisTelemetry,
   SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
   SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
-  SQAA_DETAILS_SCHEMA_VERSION,
   tallyFromSqaaJsonReport,
 } from '../../../src/telemetry/sqaa-analysis-telemetry.js';
 import * as userModule from '../../../src/telemetry/user.js';
@@ -172,13 +167,13 @@ describe('tallyFromSqaaJsonReport()', () => {
 });
 
 describe('emitSqaaAnalysisTelemetry()', () => {
-  it('writes CliAnalysisCompleted only on a clean run', async () => {
+  it('writes a single CliAnalysisCompleted with details "" on a clean run', async () => {
     await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, makeTally(), 123, 0);
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(1);
     expect(events[0].metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
-    const completed = events[0] as StoredAnalysisCompletedEvent;
+    const completed = events[0];
     expect(completed.event_payload.caller_command).toBe(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND);
     expect(completed.event_payload.analyzer).toBe('sqaa');
     expect(completed.event_payload.findings_count).toBe(0);
@@ -186,6 +181,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     expect(completed.event_payload.errors_count).toBe(0);
     expect(completed.event_payload.failures_count).toBe(0);
     expect(completed.event_payload.scan_duration_ms).toBe(123);
+    expect(completed.event_payload.details).toBe('');
     expect(completed.event_payload.analysis_id).toMatch(/^[0-9a-f-]{36}$/);
   });
 
@@ -197,7 +193,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
       123,
     );
 
-    const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
+    const completed = readEvents(testSonarUserHome)[0];
     expect(completed.event_payload.exit_code).toBeNull();
     expect(completed.event_payload.failures_count).toBe(0);
   });
@@ -216,12 +212,12 @@ describe('emitSqaaAnalysisTelemetry()', () => {
 
     await emitSqaaAnalysisTelemetry(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND, AUTH, tally, 123);
 
-    const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
+    const completed = readEvents(testSonarUserHome)[0];
     expect(completed.event_payload.exit_code).toBeNull();
     expect(completed.event_payload.failures_count).toBe(1);
   });
 
-  it('writes Completed and FindingsDetected with matching analysis_id when issues exist', async () => {
+  it('writes a single CliAnalysisCompleted with populated details when issues exist', async () => {
     const tally = makeTally({
       totalIssues: 2,
       allResults: [
@@ -237,20 +233,12 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 456, 51);
 
     const events = readEvents(testSonarUserHome);
-    expect(events).toHaveLength(2);
-    const completed = events.find(
-      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisCompleted',
-    ) as StoredAnalysisCompletedEvent | undefined;
-    const findings = events.find(
-      (e) => e.metadata.event_type === 'Analytics.Cli.CliAnalysisFindingsDetected',
-    ) as StoredAnalysisFindingsDetectedEvent | undefined;
-    expect(completed).toBeDefined();
-    expect(findings).toBeDefined();
-    expect(completed!.event_payload.analysis_id).toBe(findings!.event_payload.analysis_id);
-    expect(completed!.event_payload.findings_count).toBe(2);
-    expect(completed!.event_payload.exit_code).toBe(51);
-    expect(findings!.event_payload.details_schema_version).toBe(SQAA_DETAILS_SCHEMA_VERSION);
-    expect(JSON.parse(findings!.event_payload.details)).toEqual({
+    expect(events).toHaveLength(1);
+    const completed = events[0];
+    expect(completed.metadata.event_type).toBe('Analytics.Cli.CliAnalysisCompleted');
+    expect(completed.event_payload.findings_count).toBe(2);
+    expect(completed.event_payload.exit_code).toBe(51);
+    expect(JSON.parse(completed.event_payload.details)).toEqual({
       rule_keys: ['sqaa:S1234'],
       counts_by_rule: { 'sqaa:S1234': 2 },
     });
@@ -272,7 +260,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
 
     const events = readEvents(testSonarUserHome);
     expect(events).toHaveLength(1);
-    const completed = events[0] as StoredAnalysisCompletedEvent;
+    const completed = events[0];
     expect(completed.event_payload.caller_command).toBe(SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND);
     expect(completed.event_payload.exit_code).toBe(1);
     expect(completed.event_payload.errors_count).toBe(0);
@@ -299,7 +287,7 @@ describe('emitSqaaAnalysisTelemetry()', () => {
 
     await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 51);
 
-    const completed = readEvents(testSonarUserHome)[0] as StoredAnalysisCompletedEvent;
+    const completed = readEvents(testSonarUserHome)[0];
     expect(completed.event_payload.exit_code).toBe(51);
     expect(completed.event_payload.errors_count).toBe(2);
   });
@@ -326,8 +314,8 @@ describe('emitSqaaAnalysisTelemetry()', () => {
     await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 1);
 
     const events = readEvents(testSonarUserHome);
-    expect(events).toHaveLength(2);
-    const completed = events[0] as StoredAnalysisCompletedEvent;
+    expect(events).toHaveLength(1);
+    const completed = events[0];
     expect(completed.event_payload.exit_code).toBe(1);
     expect(completed.event_payload.findings_count).toBe(2);
     expect(completed.event_payload.errors_count).toBe(0);

--- a/tests/unit/telemetry/telemetry.test.ts
+++ b/tests/unit/telemetry/telemetry.test.ts
@@ -782,6 +782,7 @@ describe('flushTelemetry', () => {
           errors_count: 0,
           failures_count: 0,
           scan_duration_ms: 123,
+          details: '',
         },
       };
       writeFileSync(join(telemetryDir, 'findings.ndjson'), JSON.stringify(finding) + '\n');


### PR DESCRIPTION
## What

Merge the two analysis-telemetry events into one. `CliAnalysisFindingsDetected` is deleted, and its `details` blob moves onto the always-emitted `CliAnalysisCompleted` event, so every analyzer run (sonar-secrets, SQAA, SCA) now emits exactly **one** event.

- `details` is a **required `string`** on `AnalysisCompletedEventPayload`: a JSON-encoded, analyzer-specific per-rule blob when `findings_count > 0`, and `""` (empty string) otherwise.
- Empty string — never `null` — because `flushFindings` serializes with a replacer that strips `null` values off the wire; `""` keeps the column always present.
- `details` stays a flat JSON-encoded string, never a nested object (the ingestion endpoint requires flat, primitive-scalar payloads).
- `analysis_id` is retained as a per-run UUID (foreign key for a future per-finding child event); its doc comment is reworded away from "join key with CliAnalysisFindingsDetected".
- Each analyzer helper builds its own `details`; the shared `emitAnalysisCompleted` stays analyzer-agnostic. A required field means `tsc` forces every call site to supply `details`.

## Why

This is a refinement of merged-but-**unreleased** epic work (CLI-728/730/731/733). The analysis-telemetry events have never shipped in a released binary and nothing consumes them yet (still "Draft" in the data Tracking Plan), so there is no wire-schema migration, no transition window, and no backward-compat shim — it is a clean refactor. Collapsing to one event removes the fan-out/join between two events on `analysis_id` and the redundant per-analyzer `*_DETAILS_SCHEMA_VERSION` constants (details-shape versioning is inferred out-of-band from `(analyzer, cli_version)`).

## Changes

**Source**
- `src/lib/state.ts` — add required `details: string` to `AnalysisCompletedEventPayload`; delete `AnalysisFindingsDetectedEventPayload` and `StoredAnalysisFindingsDetectedEvent`; collapse `StoredAnalysisEvent` to `StoredAnalysisCompletedEvent`; reword the `analysis_id` doc comment.
- `src/telemetry/findings.ts` — delete `emitAnalysisFindingsDetected` and `AnalysisFindingsDetectedFields`; drop the removed import. `emitAnalysisCompleted` / `AnalysisCompletedFields` pick up `details` from the payload type.
- `src/cli/commands/analyze/secrets.ts` — compute the secrets blob inline always and pass `details` into the single `emitAnalysisCompleted` call; delete `SECRETS_DETAILS_SCHEMA_VERSION` usage/import.
- `src/telemetry/secrets-analysis-telemetry.ts` — delete `SECRETS_DETAILS_SCHEMA_VERSION`.
- `src/telemetry/sqaa-analysis-telemetry.ts` — build `details` inline and pass it into the completed emit; remove the trailing findings-detected emit; delete `SQAA_DETAILS_SCHEMA_VERSION`.
- `src/telemetry/sca-analysis-telemetry.ts` — pass `details` (`""` on the null/throw path, blob when findings exist) into the completed emit; remove the trailing findings-detected emit; delete `SCA_DETAILS_SCHEMA_VERSION`.

**Tests**
- `tests/unit/telemetry/findings.test.ts` — drop the `emitAnalysisFindingsDetected` envelope tests, the two-event helpers, and the "POSTs both events" flush case; add `details` to the completed fixture; assert single-event shape in `scanAndEmitSecrets`.
- `tests/unit/telemetry/sca-analysis-telemetry.test.ts`, `tests/unit/telemetry/sqaa-analysis-telemetry.test.ts` — assert one event per run; `details` parses to the expected blob on finding runs and equals `""` on clean/failed runs; drop schema-version imports/assertions.
- `tests/unit/telemetry/telemetry.test.ts` — add the required `details` field to the findings-drain fixture.
- `tests/integration/specs/analyze/analyze-secrets.test.ts`, `tests/integration/specs/analyze/analyze-sqaa.test.ts` — updated to the single-event shape.
- `tests/e2e/sca/sca-staging.test.ts` — assertion reworked to "writes a single CliAnalysisCompleted with populated `details`".

**Docs**
- `CLAUDE.md` (and `AGENTS.md`, a symlink) — telemetry section updated to the single-event model.

## Testing

Commands run locally (macOS):

- `bun run format` — clean.
- `bun run lint` — 0 errors (18 pre-existing warnings, none introduced by this change).
- `bun run typecheck` — clean.
- `bun run test:unit` — telemetry suites green (`bun test tests/unit/telemetry/` → 146 pass, 0 fail).
- `bun run pretest:integration` — binary built, resources set up.
- `bun test tests/integration/specs/analyze/analyze-secrets.test.ts` — 13 pass, 0 fail.
- `bun test tests/integration/specs/analyze/analyze-sqaa.test.ts` — 68 pass, 1 fail. The single failure (`--base <branch>: analyzes files changed vs base branch`) is a pre-existing, telemetry-unrelated git-base-branch environment issue — confirmed it fails identically on clean `master` with these changes stashed. The new single-event telemetry assertion in this file passes.
- Credential-gated e2e suite (`tests/e2e/sca/sca-staging.test.ts`) not run; its assertion was updated to compile/match the single-event shape.
