### PR TITLE
CLI-794 Use error icon for feature-removal prompt instead of warning icon

### DIFF
--- a/src/cli/commands/integrate/_common/registry/selection.ts
+++ b/src/cli/commands/integrate/_common/registry/selection.ts
@@ -19,7 +19,7 @@
  */
 
 import { confirmPrompt, discreetSuccess, info, text } from '../../../../../ui';
-import { yellow } from '../../../../../ui/colors.js';
+import { red } from '../../../../../ui/colors.js';
 import { CommandFailedError } from '../../../_common/error';
 import { findInstalledFeature } from './installation-recorder';
 import type {
@@ -152,14 +152,14 @@ async function shouldRemoveInstalledFeature<TOptions>(
 
 /**
  * One-off, local to the keep/remove flow — not a shared `prompts.ts` primitive.
- * The generic `warn()` writes `⚠️ <msg>` to stderr at column 0 with a
+ * The generic `error()` writes `❌ <msg>` to stderr at column 0 with a
  * double-width emoji, so it juts left of the clack prompts that bracket it
  * (`Keep?` / `Proceed with removal?`). We instead reproduce the prompt gutter:
- * `  <glyph>  <message>` on stdout, with a single-width `⚠` (U+26A0, no VS16 —
- * the emoji is double-width and shifts the text a column).
+ * `  <glyph>  <message>` on stdout, with a single-width `✗` (U+2717) —
+ * the emoji is double-width and shifts the text a column.
  */
 function warnFeatureRemoval(message: string): void {
-  text(`  ${yellow('⚠')}  ${message}`);
+  text(`  ${red('✗')}  ${message}`);
 }
 
 /**


### PR DESCRIPTION
----
## Summary by Gitar

- **UI enhancements:**
  - Replaced the warning icon with an error icon in the feature-removal prompt inside `selection.ts`.
  - Updated the glyph color from `yellow` to `red` to align with the error prompt style.

<sub>This will update automatically on new commits.</sub>