### PR TITLE
CLI-799 Record sonar api endpoint in telemetry

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -58,7 +58,12 @@ import {
 } from './commands/analyze/sqaa';
 import { SQAA_DEPTH_CHOICES } from './commands/analyze/sqaa-depth';
 import { collectSqaaFileOption } from './commands/analyze/sqaa-file-arg';
-import { apiCommand, type ApiCommandOptions, apiExtraHelpText } from './commands/api/api';
+import {
+  apiCommand,
+  type ApiCommandOptions,
+  apiExtraHelpText,
+  deriveApiSubcommand,
+} from './commands/api/api';
 import { authLogin, type AuthLoginOptions } from './commands/auth/login';
 import { authLogout } from './commands/auth/logout';
 import { authStatus } from './commands/auth/status';
@@ -245,6 +250,10 @@ COMMAND_TREE.command('api')
   .option('-v, --verbose', 'Print request and response details for debugging.')
   .description('Make authenticated API requests to SonarQube')
   .addHelpText('after', apiExtraHelpText())
+  .hook('preAction', (_thisCommand, actionCommand) => {
+    const [method, endpoint] = actionCommand.args;
+    setPassthroughSubcommand(actionCommand, deriveApiSubcommand(method, endpoint));
+  })
   .authenticatedAction((auth, method: string, endpoint: string, options: ApiCommandOptions) =>
     apiCommand(auth, method, endpoint, options),
   );

--- a/src/cli/commands/api/api.ts
+++ b/src/cli/commands/api/api.ts
@@ -64,6 +64,16 @@ API Usage Documentation:
 `;
 }
 
+/**
+ * Derive the telemetry subcommand for a `sonar api` invocation: "<method> <path>",
+ * lowercased method, endpoint with the query string stripped. Query params and
+ * --data are never captured since they may contain sensitive data.
+ */
+export function deriveApiSubcommand(method: string, endpoint: string): string {
+  const path = endpoint.split('?')[0];
+  return `${method.toLowerCase()} ${path}`;
+}
+
 export async function apiCommand(
   auth: ResolvedAuth,
   method: string,

--- a/src/lib/config-constants.ts
+++ b/src/lib/config-constants.ts
@@ -241,8 +241,9 @@ export function getTelemetryDir(): string {
   return join(getCliDir(), 'telemetry');
 }
 
-/** Telemetry ingest endpoint shared by all event types. */
-export const TELEMETRY_ENDPOINT = 'https://events.sonardata.io/cli';
+/** Telemetry ingest endpoint shared by all event types. Override via SONARQUBE_CLI_TELEMETRY_ENDPOINT for test environments. */
+export const TELEMETRY_ENDPOINT =
+  process.env.SONARQUBE_CLI_TELEMETRY_ENDPOINT ?? 'https://events.sonardata.io/cli';
 
 /** Write-only ingest API key — intentionally embedded in the binary. */
 export const TELEMETRY_API_KEY = 'hJPRohLsOsasZeOhSCSNDiL4h2yR96S5fOWJqRch';

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -309,6 +309,9 @@ export class EnvironmentBuilder {
    * Use when a test needs to assert telemetry side effects such as findings.ndjson.
    * Pair with extraEnv `__SQ_CLI_TELEMETRY_FLUSH__=1` so the sink is written but the
    * detached flush worker never spawns, and nothing is POSTed to the telemetry endpoint.
+   * To assert on the actual POSTed CliCommandExecuted payload instead, use
+   * harness.newFakeTelemetryServer() and skip the flush-mode env var, so the
+   * detached flush worker really posts — to the fake server instead of production.
    */
   withTelemetryEnabled(): this {
     this._telemetryEnabled = true;

--- a/tests/integration/harness/fake-telemetry-server.ts
+++ b/tests/integration/harness/fake-telemetry-server.ts
@@ -1,0 +1,73 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Minimal HTTP server that captures telemetry events POSTed by flushTelemetry().
+// Used in place of the real TELEMETRY_ENDPOINT so tests can assert on the actual
+// wire payload instead of only on state.json.
+
+import type { StoredTelemetryEvent } from '../../../src/lib/state.js';
+
+export class FakeTelemetryServer {
+  private readonly server: ReturnType<typeof Bun.serve>;
+  private readonly events: StoredTelemetryEvent[];
+
+  private constructor(server: ReturnType<typeof Bun.serve>, events: StoredTelemetryEvent[]) {
+    this.server = server;
+    this.events = events;
+  }
+
+  static start(): FakeTelemetryServer {
+    const events: StoredTelemetryEvent[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch: async (req) => {
+        events.push((await req.json()) as StoredTelemetryEvent);
+        return new Response(null, { status: 200 });
+      },
+    });
+    return new FakeTelemetryServer(server, events);
+  }
+
+  baseUrl(): string {
+    return `http://localhost:${this.server.port}`;
+  }
+
+  getEvents(): StoredTelemetryEvent[] {
+    return [...this.events];
+  }
+
+  /**
+   * storeEvent() writes to state.json, then spawns a detached, unref'd flush-worker
+   * process that POSTs asynchronously — harness.run() resolves before that POST
+   * necessarily lands. Poll until the expected event count arrives instead of
+   * asserting immediately after run().
+   */
+  async waitForEvents(count: number, timeoutMs = 5000): Promise<StoredTelemetryEvent[]> {
+    const deadline = Date.now() + timeoutMs;
+    while (this.events.length < count && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    return this.getEvents();
+  }
+
+  async stop(): Promise<void> {
+    await this.server.stop(true);
+  }
+}

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -35,6 +35,7 @@ import { Dir } from './dir';
 import { EnvironmentBuilder } from './environment-builder.js';
 import { FakeBinariesServer, FakeBinariesServerBuilder } from './fake-binaries-server.js';
 import { FakeSonarQubeServer, FakeSonarQubeServerBuilder } from './fake-sonarqube-server.js';
+import { FakeTelemetryServer } from './fake-telemetry-server.js';
 import { FakeUpdateScriptServer } from './fake-update-script-server.js';
 import { File } from './file';
 import { buildHomeEnv, IS_WINDOWS } from './platform';
@@ -54,6 +55,7 @@ export class TestHarness {
   private readonly servers: FakeSonarQubeServer[] = [];
   private readonly binariesServers: FakeBinariesServer[] = [];
   private readonly updateScriptServers: FakeUpdateScriptServer[] = [];
+  private readonly telemetryServers: FakeTelemetryServer[] = [];
   private _envBuilder?: EnvironmentBuilder;
   private systemEnvVars: Record<string, string> = {};
 
@@ -191,6 +193,18 @@ export class TestHarness {
   }
 
   /**
+   * Creates a fake telemetry ingest server and points TELEMETRY_ENDPOINT at it via
+   * SONARQUBE_CLI_TELEMETRY_ENDPOINT, so storeEvent()'s detached flush worker posts
+   * here instead of the real backend. Does not enable telemetry itself — pair with
+   * harness.state().withTelemetryEnabled().
+   */
+  newFakeTelemetryServer(): FakeTelemetryServer {
+    const server = FakeTelemetryServer.start();
+    this.telemetryServers.push(server);
+    return server;
+  }
+
+  /**
    * Runs the CLI binary with the given command string.
    *
    * Before spawning, applies the configured environment (writes state.json + seeds tokens).
@@ -236,12 +250,18 @@ export class TestHarness {
       ? { SONARQUBE_CLI_UPDATE_SCRIPT_BASE_URL: activeUpdateServer.baseUrl() }
       : {};
 
+    const activeTelemetryServer = this.telemetryServers.at(-1);
+    const fakeTelemetryEnv: Record<string, string> = activeTelemetryServer
+      ? { SONARQUBE_CLI_TELEMETRY_ENDPOINT: activeTelemetryServer.baseUrl() }
+      : {};
+
     const composed: Record<string, string> = {
       ...this.systemEnvVars,
       ...builderExtraEnv,
       ...fakeBinariesEnv,
       ...fakeSonarcloudApiEnv,
       ...fakeUpdateScriptEnv,
+      ...fakeTelemetryEnv,
       SONARQUBE_CLI_KEYCHAIN_FILE: this.keychainJsonFile,
       CI: 'true',
       [ENV_SQAA_RETRY_BASE_DELAY_MS]: '0',
@@ -278,6 +298,7 @@ export class TestHarness {
       ),
     );
     await Promise.all(this.updateScriptServers.map((s) => s.stop().catch(() => {})));
+    await Promise.all(this.telemetryServers.map((s) => s.stop().catch(() => {})));
 
     await rm(this.tempDir.path, {
       recursive: true,

--- a/tests/integration/specs/api/api.test.ts
+++ b/tests/integration/specs/api/api.test.ts
@@ -189,3 +189,50 @@ describe('api', () => {
     { timeout: 15000 },
   );
 });
+
+describe('api — telemetry', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'records "<method> <path>" as subcommand, stripping the query string',
+    async () => {
+      const apiServer = await harness.newFakeServer().withAuthToken('valid-token').start();
+      const telemetryServer = harness.newFakeTelemetryServer();
+      harness.withAuth(apiServer.baseUrl(), 'valid-token');
+      harness.state().withTelemetryEnabled();
+
+      await harness.run('api get "/api/rules/search?organization=demo"');
+
+      const events = await telemetryServer.waitForEvents(1);
+      expect(events).toHaveLength(1);
+      expect(events[0].event_payload.command).toBe('api');
+      expect(events[0].event_payload.subcommand).toBe('get /api/rules/search');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'never records the --data body',
+    async () => {
+      const apiServer = await harness.newFakeServer().withAuthToken('valid-token').start();
+      const telemetryServer = harness.newFakeTelemetryServer();
+      harness.withAuth(apiServer.baseUrl(), 'valid-token');
+      harness.state().withTelemetryEnabled();
+
+      await harness.run(`api post /api/issues/do_transition --data '{"comment":"secret"}'`);
+
+      const events = await telemetryServer.waitForEvents(1);
+      expect(JSON.stringify(events[0])).not.toContain('secret');
+      expect(events[0].event_payload.subcommand).toBe('post /api/issues/do_transition');
+    },
+    { timeout: 15000 },
+  );
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry instrumentation:**
  - Added `deriveApiSubcommand` to capture the API method and path, stripping sensitive query parameters.
  - Updated `command-tree.ts` to hook into `api` commands and record the derived subcommand for telemetry.
- **Test harness enhancements:**
  - Added `FakeTelemetryServer` to capture telemetry events in integration tests.
  - Updated `TestHarness` to allow routing telemetry traffic to the fake server via `SONARQUBE_CLI_TELEMETRY_ENDPOINT`.
- **Environment configuration:**
  - Modified `TELEMETRY_ENDPOINT` to support overriding via `SONARQUBE_CLI_TELEMETRY_ENDPOINT` for testability.


<sub>This will update automatically on new commits.</sub>