### PR TITLE
CLI-700 Report unknown subcommands for analyze command

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -258,17 +258,7 @@ const integrateCommand = COMMAND_TREE.command('integrate')
   .showUpdateNotification((opts) => !opts.nonInteractive)
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('-g, --global', 'Install integrations globally.')
-  // allowExcessArguments + preAction: when a parent command has both an action and subcommands,
-  // Commander v15 (allowExcessArguments defaults to false) emits "too many arguments" for unknown
-  // subcommands instead of "unknown command 'X'" with a "Did you mean?" suggestion. Allow excess
-  // args so Commander doesn't error early, then re-raise as unknownCommand in the hook.
-  .allowExcessArguments(true)
-  .hook('preAction', (thisCommand, actionCommand) => {
-    if (actionCommand.name() === thisCommand.name() && thisCommand.args.length > 0) {
-      // unknownCommand() is public in Commander 15 but absent from its typings.
-      (thisCommand as Command & { unknownCommand(): void }).unknownCommand();
-    }
-  })
+  .rejectUnknownSubcommands()
   .authenticatedAction((auth, options: IntegrateBareOptions) => integrateBare(auth, options));
 
 integrateCommand
@@ -404,7 +394,8 @@ const analyze = COMMAND_TREE.command('analyze')
     expandSubcommands: true,
   })
   .showUpdateNotification()
-  .enablePositionalOptions();
+  .enablePositionalOptions()
+  .rejectUnknownSubcommands();
 
 analyze
   .command('secrets')

--- a/src/cli/commands/_common/sonar-command.ts
+++ b/src/cli/commands/_common/sonar-command.ts
@@ -137,6 +137,26 @@ export class SonarCommand extends Command {
     );
   }
 
+  /**
+   * For a parent command that has both an action and subcommands, make unknown
+   * subcommands report a proper "unknown command 'X'" error (with Commander's
+   * "Did you mean?" suggestion) instead of "too many arguments".
+   *
+   * Commander v15 (allowExcessArguments defaults to false) errors early with
+   * "too many arguments" for unknown subcommands. This enables allowExcessArguments
+   * so Commander doesn't error early, then a preAction hook re-raises excess args
+   * on the parent as unknownCommand().
+   */
+  rejectUnknownSubcommands(): this {
+    this.allowExcessArguments(true).hook('preAction', (thisCommand, actionCommand) => {
+      if (actionCommand.name() === thisCommand.name() && thisCommand.args.length > 0) {
+        // unknownCommand() is public in Commander 15 but absent from its typings.
+        (thisCommand as Command & { unknownCommand(): void }).unknownCommand();
+      }
+    });
+    return this;
+  }
+
   /** True when this command was registered with authenticatedAction(). */
   get requiresAuth(): boolean {
     return this._requiresAuth;

--- a/tests/integration/specs/analyze/analyze-secrets.test.ts
+++ b/tests/integration/specs/analyze/analyze-secrets.test.ts
@@ -312,4 +312,17 @@ describe('analyze secrets', () => {
     },
     { timeout: 30000 },
   );
+
+  it(
+    'reports an unknown subcommand with a "Did you mean?" suggestion',
+    async () => {
+      const result = await harness.run('analyze secret');
+
+      expect(result.exitCode).toBe(1);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain("error: unknown command 'secret'");
+      expect(output).toContain('(Did you mean secrets?)');
+    },
+    { timeout: 15000 },
+  );
 });

--- a/tests/unit/cli/commands/_common/sonar-command.test.ts
+++ b/tests/unit/cli/commands/_common/sonar-command.test.ts
@@ -188,6 +188,45 @@ describe('SonarCommand', () => {
     });
   });
 
+  // ─── rejectUnknownSubcommands() ───────────────────────────────────────────
+
+  describe('rejectUnknownSubcommands()', () => {
+    let parent: SonarCommand;
+    let parentAction: ReturnType<typeof mock>;
+    let subAction: ReturnType<typeof mock>;
+
+    beforeEach(() => {
+      parentAction = mock(() => {});
+      subAction = mock(() => {});
+      parent = new SonarCommand('parent');
+      parent.exitOverride().configureOutput({ writeErr: () => {} });
+      parent.rejectUnknownSubcommands().anonymousAction(parentAction);
+      parent.command('build').anonymousAction(subAction);
+    });
+
+    it('reports an unknown subcommand with a "Did you mean?" suggestion', async () => {
+      let caught: { code?: string; message?: string } | undefined;
+      try {
+        await parent.parseAsync(['buil'], { from: 'user' });
+      } catch (err) {
+        caught = err as { code?: string; message?: string };
+      }
+      expect(caught?.code).toBe('commander.unknownCommand');
+      expect(caught?.message).toContain("unknown command 'buil'");
+      expect(caught?.message).toContain('(Did you mean build?)');
+    });
+
+    it('still runs the parent action when no excess args are given', async () => {
+      await parent.parseAsync([], { from: 'user' });
+      expect(parentAction).toHaveBeenCalledTimes(1);
+    });
+
+    it('still dispatches to a known subcommand', async () => {
+      await parent.parseAsync(['build'], { from: 'user' });
+      expect(subAction).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ─── anonymousAction() ────────────────────────────────────────────────────
 
   describe('anonymousAction()', () => {


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactored CLI command logic:**
  - Extracted shared subcommand rejection logic into `rejectUnknownSubcommands` helper in `SonarCommand`.
  - Applied `rejectUnknownSubcommands` to `integrate` and `analyze` commands to provide better error messaging.

<sub>This will update automatically on new commits.</sub>