### PR TITLE
CLI-808 Update docs to mention Homebrew and Mise installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,27 @@ Before installing, you need:
 
 ### Step 1: Install
 
-**Linux/macOS:**
+Choose the install channel that fits your setup:
+
+**Homebrew (macOS/Linux):**
+
+```bash
+brew install sonarqube-cli
+```
+
+**Mise (macOS, Linux, or Windows):**
+
+```bash
+mise use -g sonarqube-cli@latest
+```
+
+**Install script (Linux/macOS):**
 
 ```bash
 curl -o- https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.sh | bash
 ```
 
-**Windows (from PowerShell):**
+**Install script (Windows, from PowerShell):**
 
 ```powershell
 irm https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.ps1 | iex
@@ -113,7 +127,7 @@ sonar --version
 # Example output: 1.0.0
 ```
 
-**Note:** You may need to restart your terminal for the `sonar` command to be available.
+**Note:** Restart your terminal after using the install scripts so your updated `PATH` is reloaded. Homebrew manages `PATH` automatically, and Mise assumes its shell activation is already configured.
 
 ### Step 2: Authenticate
 
@@ -493,31 +507,37 @@ For SonarQube Cloud, ensure you're using the correct region:
 
 ### "Command not found: sonar" after installation
 
-**Symptom:** After running the installer, terminal doesn't recognize `sonar`
+**Symptom:** After installing, terminal doesn't recognize `sonar`
 
 **Solution:**
 
-1. **Restart your terminal** (required to reload PATH)
+1. **Restart your terminal** if you used the install script, or if you just changed your shell setup.
 
-2. If still not working, manually add to PATH:
+2. If you installed with **Homebrew**, make sure Homebrew itself is already on your `PATH`, then retry `brew install sonarqube-cli`.
+
+3. If you installed with **Mise**, make sure your shell is already configured for Mise and reopen your terminal.
+
+4. If you used the **install script** and it still doesn't work, manually add it to `PATH`:
 
    **Linux/macOS** — Add to `~/.bashrc` or `~/.zshrc`:
+
    ```bash
    export PATH="$HOME/.local/share/sonarqube-cli/bin:$PATH"
    ```
+
    Then reload: `source ~/.bashrc` (or `~/.zshrc`)
 
    **Windows** — The installer should have updated PATH automatically. Try:
+   - Open a new PowerShell window
+   - Restart your computer if the issue persists
 
-- Opening a new PowerShell window
-- Restarting your computer if the issue persists
+5. Verify the binary exists:
 
-3. Verify the binary exists:
    ```bash
-   # Linux/macOS:
+   # Install script on Linux/macOS:
    ls -la ~/.local/share/sonarqube-cli/bin/sonar
 
-   # Windows (PowerShell):
+   # Install script on Windows (PowerShell):
    ls $env:LOCALAPPDATA\sonarqube-cli\bin\sonar.exe
    ```
 
@@ -569,12 +589,25 @@ See [State Management](./docs/state-management.md) for more information.
 
 ## Uninstalling
 
-### Linux/Mac OS
+### Homebrew
+
+```bash
+brew uninstall sonarqube-cli
+```
+
+### Mise
+
+```bash
+mise use -g --remove sonarqube-cli
+mise uninstall --all sonarqube-cli
+```
+
+### Install script (Linux/macOS)
 
 1. Delete the `~/.local/share/sonarqube-cli/` folder.
 2. Remove `export PATH="$HOME/.local/share/sonarqube-cli/bin:$PATH"` from your `~/.bashrc` or `~/.zshrc` files.
 
-### Windows
+### Install script (Windows)
 
 1. Delete the `%localappdata%\sonarqube-cli\` folder.
 2. Remove this folder from the `PATH` user-level environment variable.

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -547,7 +547,7 @@ pre code {
   justify-content: space-between;
   margin-bottom: 8px;
 }
-.hero-install .tab-group {
+.hero-install-header .tab-group {
   border: none;
   background: none;
   gap: 0;
@@ -562,7 +562,7 @@ pre code {
   font-size: 12px;
   color: var(--text-muted);
 }
-.hero-install .tab-btn {
+.hero-install-header .tab-btn {
   background: none;
   border: none;
   padding: 0;
@@ -570,10 +570,10 @@ pre code {
   font-weight: 400;
   color: var(--text-muted);
 }
-.hero-install .tab-btn.active { background: none; color: var(--text); font-weight: 600; }
-.hero-install .tab-btn:hover { background: none; color: var(--text); }
-.hero-install .tab-btn:not(:last-child) { border-right: none; }
-.hero-install .tab-btn:not(:last-child)::after {
+.hero-install-header .tab-btn.active { background: none; color: var(--text); font-weight: 600; }
+.hero-install-header .tab-btn:hover { background: none; color: var(--text); }
+.hero-install-header .tab-btn:not(:last-child) { border-right: none; }
+.hero-install-header .tab-btn:not(:last-child)::after {
   content: ' | ';
   color: var(--border);
   padding: 0 4px;
@@ -584,6 +584,27 @@ pre code {
   text-decoration: none;
 }
 .hero-install-link:hover { color: var(--accent); }
+.install-script-tabs {
+  margin-bottom: 12px;
+}
+.install-script-tabs .tab-group {
+  margin-bottom: 0;
+}
+.install-channel-meta {
+  margin: 0 0 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+.install-channel-note {
+  margin-top: 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+@media (max-width: 640px) {
+  .hero-install-header { flex-direction: column; align-items: flex-start; gap: 8px; }
+  .hero-install-tabs,
+  .hero-install-header .tab-group { flex-wrap: wrap; }
+}
 .tab-group {
   display: flex;
   gap: 0;

--- a/docs/index.html
+++ b/docs/index.html
@@ -98,23 +98,47 @@
       <div class="hero-install-tabs">
         <span class="hero-install-label">Install:</span>
         <div class="tab-group">
-          <button class="tab-btn active" data-hero-tab="linux">Linux / macOS</button>
-          <button class="tab-btn" data-hero-tab="windows">Windows</button>
+          <button class="tab-btn active" data-tab-target-group="hero-install-channel" data-tab-name="homebrew">Homebrew</button>
+          <button class="tab-btn" data-tab-target-group="hero-install-channel" data-tab-name="mise">Mise</button>
+          <button class="tab-btn" data-tab-target-group="hero-install-channel" data-tab-name="script">Install script</button>
         </div>
       </div>
       <a href="https://github.com/SonarSource/sonarqube-cli?tab=readme-ov-file#sonarqube-cli" class="hero-install-link" target="_blank" rel="noopener">View installation instructions ↗</a>
     </div>
-    <div id="hero-tab-linux" class="tab-panel active">
+    <div class="tab-panel active" data-tab-panel-group="hero-install-channel" data-tab-name="homebrew">
+      <p class="install-channel-meta">macOS and Linux</p>
       <div class="code-block">
-        <pre><code>curl -o- https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.sh | bash</code></pre>
+        <pre><code>brew install sonarqube-cli</code></pre>
         <button class="copy-btn" data-copy-install>Copy</button>
       </div>
     </div>
-    <div id="hero-tab-windows" class="tab-panel">
+    <div class="tab-panel" data-tab-panel-group="hero-install-channel" data-tab-name="mise">
+      <p class="install-channel-meta">macOS, Linux, and Windows</p>
       <div class="code-block">
-        <pre><code>irm https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.ps1 | iex</code></pre>
+        <pre><code>mise use -g sonarqube-cli@latest</code></pre>
         <button class="copy-btn" data-copy-install>Copy</button>
       </div>
+    </div>
+    <div class="tab-panel" data-tab-panel-group="hero-install-channel" data-tab-name="script">
+      <div class="install-script-tabs">
+        <div class="tab-group">
+          <button class="tab-btn active" data-tab-target-group="hero-install-script-os" data-tab-name="posix">macOS / Linux</button>
+          <button class="tab-btn" data-tab-target-group="hero-install-script-os" data-tab-name="windows">Windows</button>
+        </div>
+      </div>
+      <div class="tab-panel active" data-tab-panel-group="hero-install-script-os" data-tab-name="posix">
+        <div class="code-block">
+          <pre><code>curl -o- https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.sh | bash</code></pre>
+          <button class="copy-btn" data-copy-install>Copy</button>
+        </div>
+      </div>
+      <div class="tab-panel" data-tab-panel-group="hero-install-script-os" data-tab-name="windows">
+        <div class="code-block">
+          <pre><code>irm https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.ps1 | iex</code></pre>
+          <button class="copy-btn" data-copy-install>Copy</button>
+        </div>
+      </div>
+      <p class="install-channel-note">Use the install script when you want the standalone installer.</p>
     </div>
   </div>
 
@@ -144,24 +168,50 @@
 <!-- ─── Install ───────────────────────────────────────────────── -->
 <section class="section" id="install" style="display:none">
   <h2 class="section-title">Installation</h2>
-  <p class="section-sub">One-line install for all platforms.</p>
+  <p class="section-sub">Choose Homebrew, Mise, or the official install script.</p>
 
   <div class="tab-group">
-    <button class="tab-btn active" data-install-tab="linux">Linux / macOS</button>
-    <button class="tab-btn" data-install-tab="windows">Windows</button>
+    <button class="tab-btn active" data-tab-target-group="install-channel" data-tab-name="homebrew">Homebrew</button>
+    <button class="tab-btn" data-tab-target-group="install-channel" data-tab-name="mise">Mise</button>
+    <button class="tab-btn" data-tab-target-group="install-channel" data-tab-name="script">Install script</button>
   </div>
 
-  <div id="tab-linux" class="tab-panel active">
+  <div class="tab-panel active" data-tab-panel-group="install-channel" data-tab-name="homebrew">
+    <p class="install-channel-meta">macOS and Linux</p>
     <div class="code-block">
-      <pre><code>curl -o- https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.sh | bash</code></pre>
+      <pre><code>brew install sonarqube-cli</code></pre>
       <button class="copy-btn" data-copy-install>Copy</button>
     </div>
+    <p class="install-channel-note">Homebrew manages the binary location and PATH automatically.</p>
   </div>
-  <div id="tab-windows" class="tab-panel">
+  <div class="tab-panel" data-tab-panel-group="install-channel" data-tab-name="mise">
+    <p class="install-channel-meta">macOS, Linux, and Windows</p>
     <div class="code-block">
-      <pre><code>irm https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.ps1 | iex</code></pre>
+      <pre><code>mise use -g sonarqube-cli@latest</code></pre>
       <button class="copy-btn" data-copy-install>Copy</button>
     </div>
+    <p class="install-channel-note">This adds the CLI to your global Mise config and installs the latest release.</p>
+  </div>
+  <div class="tab-panel" data-tab-panel-group="install-channel" data-tab-name="script">
+    <div class="install-script-tabs">
+      <div class="tab-group">
+        <button class="tab-btn active" data-tab-target-group="install-script-os" data-tab-name="posix">macOS / Linux</button>
+        <button class="tab-btn" data-tab-target-group="install-script-os" data-tab-name="windows">Windows</button>
+      </div>
+    </div>
+    <div class="tab-panel active" data-tab-panel-group="install-script-os" data-tab-name="posix">
+      <div class="code-block">
+        <pre><code>curl -o- https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.sh | bash</code></pre>
+        <button class="copy-btn" data-copy-install>Copy</button>
+      </div>
+    </div>
+    <div class="tab-panel" data-tab-panel-group="install-script-os" data-tab-name="windows">
+      <div class="code-block">
+        <pre><code>irm https://raw.githubusercontent.com/SonarSource/sonarqube-cli/refs/heads/master/user-scripts/install.ps1 | iex</code></pre>
+        <button class="copy-btn" data-copy-install>Copy</button>
+      </div>
+    </div>
+    <p class="install-channel-note">The install scripts add the CLI bin directory to your PATH. Restart your terminal after running them.</p>
   </div>
 </section>
 
@@ -235,7 +285,7 @@
     </div>
     <div class="feature-card">
       <h3>Multi-platform</h3>
-      <p>Native binaries for Linux, macOS (Apple Silicon), and Windows. One install script, zero dependencies.</p>
+      <p>Native binaries for Linux, macOS (Apple Silicon), and Windows with install script, Homebrew, and Mise channels.</p>
     </div>
     <div class="feature-card">
       <h3>Code Quality Analysis</h3>
@@ -514,18 +564,10 @@
   })();
   // ────────────────────────────────────────────────────────────────
 
-  function showHeroTab(name, btn) {
-    document.querySelectorAll('#hero-tab-linux, #hero-tab-windows').forEach(p => p.classList.remove('active'));
+  function showNamedTab(group, name, btn) {
+    document.querySelectorAll(`[data-tab-panel-group="${group}"]`).forEach(p => p.classList.remove('active'));
     btn.closest('.tab-group').querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-    document.getElementById('hero-tab-' + name).classList.add('active');
-    btn.classList.add('active');
-  }
-
-  function showTab(name, btn) {
-    const section = document.getElementById('install');
-    section.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
-    section.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
-    document.getElementById('tab-' + name).classList.add('active');
+    document.querySelectorAll(`[data-tab-panel-group="${group}"][data-tab-name="${name}"]`).forEach(p => p.classList.add('active'));
     btn.classList.add('active');
   }
 
@@ -687,12 +729,8 @@
     });
   }
 
-  document.querySelectorAll('[data-hero-tab]').forEach((btn) => {
-    btn.addEventListener('click', () => showHeroTab(btn.dataset.heroTab, btn));
-  });
-
-  document.querySelectorAll('[data-install-tab]').forEach((btn) => {
-    btn.addEventListener('click', () => showTab(btn.dataset.installTab, btn));
+  document.querySelectorAll('[data-tab-target-group]').forEach((btn) => {
+    btn.addEventListener('click', () => showNamedTab(btn.dataset.tabTargetGroup, btn.dataset.tabName, btn));
   });
 
   document.querySelectorAll('[data-copy-install]').forEach((btn) => {


### PR DESCRIPTION
----
## Summary by Gitar

- **Documentation updates:**
  - Added installation instructions for `Homebrew` and `Mise` to `README.md` and `docs/index.html`.
  - Included explicit uninstallation steps for `Homebrew` and `Mise`.
- **UI/UX improvements:**
  - Refactored `docs/index.html` to use a tabbed interface for selecting installation methods.
  - Updated `docs/assets/style.css` to support new layout components and responsive design for install headers.
- **Refactoring:**
  - Replaced hardcoded tab toggling logic with a generic `showNamedTab` function to support dynamic tab groups.


<sub>This will update automatically on new commits.</sub>