### PR TITLE
CLI-809 Support container runtimes from WSL in `run mcp` command

### DIFF
--- a/src/cli/commands/run/mcp.ts
+++ b/src/cli/commands/run/mcp.ts
@@ -26,7 +26,7 @@ import { homedir } from 'node:os';
 import type { ResolvedAuth } from '../../../lib/auth-resolver.js';
 import { canonicalizePath } from '../../../lib/fs-utils.js';
 import logger from '../../../lib/logger';
-import { getMcpContainerCommand, type McpServerContext } from '../../../lib/mcp/mcp-helper.js';
+import { type McpServerContext, resolveMcpContainerCommand } from '../../../lib/mcp/mcp-helper.js';
 import { discoverProject } from '../../../lib/project-workspace';
 import { detectContainerRuntime } from '../../../lib/tool-detector.js';
 import { warn } from '../../../ui';
@@ -45,8 +45,8 @@ function debugLog(message: string): void {
 }
 
 export async function runMcp(auth: ResolvedAuth, options: McpRunOptions = {}): Promise<void> {
-  const runtime = await detectContainerRuntime();
-  if (!runtime) {
+  const detection = await detectContainerRuntime();
+  if (!detection.runtime) {
     throw new CommandFailedError('A container runtime (Docker/Podman/Nerdctl) is required.', {
       remediationHint: 'Install and start Docker, Podman, or Nerdctl, then rerun this command.',
     });
@@ -69,10 +69,10 @@ export async function runMcp(auth: ResolvedAuth, options: McpRunOptions = {}): P
     ? { withFsMount: true, projectRoot, projectKey }
     : { withFsMount: false, projectKey };
 
-  const config = getMcpContainerCommand(auth, runtime, context, options);
+  const config = resolveMcpContainerCommand(auth, detection, context, options);
 
   if (options.debug) {
-    debugLog(`runtime: ${runtime}`);
+    debugLog(`runtime: ${detection.runtime}${detection.viaWsl ? ' (via WSL)' : ''}`);
     debugLog(`projectRoot: ${projectRoot ?? '(none)'}`);
     debugLog(`projectKey: ${projectKey ?? '(none)'}`);
     debugLog(`launching: ${config.command} ${config.args.join(' ')}`);

--- a/src/lib/mcp/mcp-helper.ts
+++ b/src/lib/mcp/mcp-helper.ts
@@ -171,7 +171,7 @@ function getMcpWslContainerCommand(
 
   env.WSLENV = wslenv.join(':');
 
-  return { command: 'wsl.exe', args: ['bash', '-c', [runtime, ...args].join(' ')], env };
+  return { command: 'wsl.exe', args: ['sh', '-c', [runtime, ...args].join(' ')], env };
 }
 
 export function resolveMcpContainerCommand(

--- a/src/lib/mcp/mcp-helper.ts
+++ b/src/lib/mcp/mcp-helper.ts
@@ -29,7 +29,7 @@ import {
   SONARQUBE_MCP_DOCKER_IMAGE_NAME,
 } from '../config-constants';
 import { normalizePath } from '../fs-utils';
-import type { ContainerRuntime } from '../tool-detector';
+import type { ContainerRuntime, ContainerRuntimeDetection } from '../tool-detector';
 
 export interface McpServerConfig {
   command: string;
@@ -86,12 +86,12 @@ export function getMcpConfig(
 export const MCP_DEFAULT_TOOLSETS =
   'analysis,issues,projects,quality-gates,rules,duplications,measures,security-hotspots,dependency-risks,coverage';
 
-export function getMcpContainerCommand(
+function buildDockerRunArgsAndEnv(
   auth: ResolvedAuth,
-  runtime: ContainerRuntime,
   context: McpServerContext,
-  options: McpServerOptions = {},
-): McpContainerCommand {
+  options: McpServerOptions,
+  mountSource: string | undefined,
+): { args: string[]; env: Record<string, string> } {
   const { token, orgKey: org, serverUrl } = auth;
 
   const args = [
@@ -117,9 +117,8 @@ export function getMcpContainerCommand(
     env.SONARQUBE_PROJECT_KEY = context.projectKey;
   }
 
-  if (context.withFsMount) {
-    const hostPath = normalizePath(context.projectRoot);
-    args.push('-v', `${hostPath}:/app/mcp-workspace:ro`);
+  if (mountSource) {
+    args.push('-v', `${mountSource}:/app/mcp-workspace:ro`);
   }
 
   if (options.debug) {
@@ -138,7 +137,55 @@ export function getMcpContainerCommand(
 
   args.push(SONARQUBE_MCP_DOCKER_IMAGE_NAME);
 
+  return { args, env };
+}
+
+export function getMcpContainerCommand(
+  auth: ResolvedAuth,
+  runtime: ContainerRuntime,
+  context: McpServerContext,
+  options: McpServerOptions = {},
+): McpContainerCommand {
+  const mountSource = context.withFsMount ? normalizePath(context.projectRoot) : undefined;
+  const { args, env } = buildDockerRunArgsAndEnv(auth, context, options, mountSource);
   return { command: runtime, args, env };
+}
+
+const WSL_HOST_PATH_ENV_VAR = 'SONARQUBE_MCP_HOST_PATH';
+
+function getMcpWslContainerCommand(
+  auth: ResolvedAuth,
+  runtime: ContainerRuntime,
+  context: McpServerContext,
+  options: McpServerOptions = {},
+): McpContainerCommand {
+  const mountSource = context.withFsMount ? `"$${WSL_HOST_PATH_ENV_VAR}"` : undefined;
+  const { args, env } = buildDockerRunArgsAndEnv(auth, context, options, mountSource);
+
+  const wslenv = Object.keys(env).map((name) => `${name}/u`);
+
+  if (context.withFsMount) {
+    env[WSL_HOST_PATH_ENV_VAR] = context.projectRoot;
+    wslenv.push(`${WSL_HOST_PATH_ENV_VAR}/p`);
+  }
+
+  env.WSLENV = wslenv.join(':');
+
+  return { command: 'wsl.exe', args: ['bash', '-c', [runtime, ...args].join(' ')], env };
+}
+
+export function resolveMcpContainerCommand(
+  auth: ResolvedAuth,
+  detection: ContainerRuntimeDetection,
+  context: McpServerContext,
+  options: McpServerOptions = {},
+): McpContainerCommand {
+  if (!detection.runtime) {
+    throw new Error('resolveMcpContainerCommand requires a detected container runtime');
+  }
+  return detection.viaWsl
+    ? getMcpWslContainerCommand(auth, detection.runtime, context, options)
+    : getMcpContainerCommand(auth, detection.runtime, context, options);
 }
 
 export async function writeMcpServerEntry(filePath: string, serverConfig: object): Promise<void> {

--- a/src/lib/tool-detector.ts
+++ b/src/lib/tool-detector.ts
@@ -20,10 +20,13 @@
 
 // Tool detector - checks presence and availability of system tools
 
+import { isWindows } from './platform-detector';
 import { spawnProcess } from './process';
 
 const CONTAINER_RUNTIMES = ['docker', 'podman', 'nerdctl'] as const;
 export type ContainerRuntime = (typeof CONTAINER_RUNTIMES)[number];
+
+const WSL_EXECUTABLE = 'wsl.exe';
 
 async function isRuntimeAvailable(runtime: ContainerRuntime): Promise<boolean> {
   try {
@@ -34,15 +37,40 @@ async function isRuntimeAvailable(runtime: ContainerRuntime): Promise<boolean> {
   }
 }
 
+async function isRuntimeAvailableViaWsl(runtime: ContainerRuntime): Promise<boolean> {
+  try {
+    const result = await spawnProcess(WSL_EXECUTABLE, [runtime, 'info']); // only support the default distro
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+export interface ContainerRuntimeDetection {
+  runtime: ContainerRuntime | null;
+  viaWsl: boolean;
+}
+
 /**
  * Detect the first available container runtime, checking in priority order:
- * docker, then podman, then nerdctl. Returns null when neither is available/reachable.
+ * docker, then podman, then nerdctl. On Windows, falls back to checking the same
+ * runtimes from inside WSL when none is reachable natively (e.g. Docker installed
+ * in a WSL distro without Docker Desktop's Windows integration).
  */
-export async function detectContainerRuntime(): Promise<ContainerRuntime | null> {
+export async function detectContainerRuntime(): Promise<ContainerRuntimeDetection> {
   for (const runtime of CONTAINER_RUNTIMES) {
     if (await isRuntimeAvailable(runtime)) {
-      return runtime;
+      return { runtime, viaWsl: false };
     }
   }
-  return null;
+
+  if (isWindows()) {
+    for (const runtime of CONTAINER_RUNTIMES) {
+      if (await isRuntimeAvailableViaWsl(runtime)) {
+        return { runtime, viaWsl: true };
+      }
+    }
+  }
+
+  return { runtime: null, viaWsl: false };
 }

--- a/tests/unit/cli/commands/integrate/claude/mcp.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/mcp.test.ts
@@ -287,7 +287,7 @@ describe('getMcpContainerConfig', () => {
 });
 
 describe('resolveMcpContainerCommand (via WSL)', () => {
-  it('returns a wsl.exe/bash -c command with SONARQUBE_TOKEN and SONARQUBE_URL forwarded via WSLENV', () => {
+  it('returns a wsl.exe/sh -c command with SONARQUBE_TOKEN and SONARQUBE_URL forwarded via WSLENV', () => {
     const config = resolveMcpContainerCommand(
       ON_PREMISE_AUTH,
       { runtime: 'docker', viaWsl: true },
@@ -296,7 +296,7 @@ describe('resolveMcpContainerCommand (via WSL)', () => {
     expect(config).toEqual({
       command: 'wsl.exe',
       args: [
-        'bash',
+        'sh',
         '-c',
         `docker run --init --pull=always -i --rm -e SONARQUBE_TOKEN -e SONARQUBE_URL -e SONARQUBE_TOOLSETS ${SONARQUBE_MCP_DOCKER_IMAGE_NAME}`,
       ],
@@ -340,7 +340,7 @@ describe('resolveMcpContainerCommand (via WSL)', () => {
     expect(config).toEqual({
       command: 'wsl.exe',
       args: [
-        'bash',
+        'sh',
         '-c',
         `docker run --init --pull=always -i --rm -e SONARQUBE_TOKEN -e SONARQUBE_URL -v "$SONARQUBE_MCP_HOST_PATH":/app/mcp-workspace:ro -e SONARQUBE_TOOLSETS ${SONARQUBE_MCP_DOCKER_IMAGE_NAME}`,
       ],

--- a/tests/unit/cli/commands/integrate/claude/mcp.test.ts
+++ b/tests/unit/cli/commands/integrate/claude/mcp.test.ts
@@ -31,6 +31,7 @@ import {
   getMcpConfigFilePath,
   getMcpContainerCommand,
   MCP_DEFAULT_TOOLSETS,
+  resolveMcpContainerCommand,
   writeMcpServerEntry,
 } from '../../../../../../src/lib/mcp/mcp-helper';
 import { DiscoveredProject } from '../../../../../../src/lib/project-workspace';
@@ -282,6 +283,87 @@ describe('getMcpContainerConfig', () => {
         SONARQUBE_TOOLSETS: MCP_DEFAULT_TOOLSETS,
       },
     });
+  });
+});
+
+describe('resolveMcpContainerCommand (via WSL)', () => {
+  it('returns a wsl.exe/bash -c command with SONARQUBE_TOKEN and SONARQUBE_URL forwarded via WSLENV', () => {
+    const config = resolveMcpContainerCommand(
+      ON_PREMISE_AUTH,
+      { runtime: 'docker', viaWsl: true },
+      { withFsMount: false },
+    );
+    expect(config).toEqual({
+      command: 'wsl.exe',
+      args: [
+        'bash',
+        '-c',
+        `docker run --init --pull=always -i --rm -e SONARQUBE_TOKEN -e SONARQUBE_URL -e SONARQUBE_TOOLSETS ${SONARQUBE_MCP_DOCKER_IMAGE_NAME}`,
+      ],
+      env: {
+        SONARQUBE_TOKEN: 'squ_test',
+        SONARQUBE_URL: 'https://sonarqube.example.com',
+        SONARQUBE_TOOLSETS: MCP_DEFAULT_TOOLSETS,
+        WSLENV: 'SONARQUBE_TOKEN/u:SONARQUBE_URL/u:SONARQUBE_TOOLSETS/u',
+      },
+    });
+  });
+
+  it('runs the detected runtime (e.g. podman) inside WSL', () => {
+    const config = resolveMcpContainerCommand(
+      ON_PREMISE_AUTH,
+      { runtime: 'podman', viaWsl: true },
+      { withFsMount: false },
+    );
+    expect(config.command).toBe('wsl.exe');
+    expect(config.args[2]).toStartWith('podman run ');
+  });
+
+  it('includes SONARQUBE_ORG for cloud, forwarded via WSLENV', () => {
+    const auth: ResolvedAuth = { ...CLOUD_AUTH, orgKey: 'my-org' };
+    const config = resolveMcpContainerCommand(
+      auth,
+      { runtime: 'docker', viaWsl: true },
+      { withFsMount: false },
+    );
+    expect(config.args[2]).toContain('-e SONARQUBE_ORG');
+    expect(config.env.SONARQUBE_ORG).toBe('my-org');
+    expect(config.env.WSLENV).toContain('SONARQUBE_ORG/u');
+  });
+
+  it('references the project root via a WSLENV-translated shell variable instead of a literal path', () => {
+    const config = resolveMcpContainerCommand(
+      ON_PREMISE_AUTH,
+      { runtime: 'docker', viaWsl: true },
+      { withFsMount: true, projectRoot: String.raw`C:\Users\tdd\source\repos\sonarlint-core` },
+    );
+    expect(config).toEqual({
+      command: 'wsl.exe',
+      args: [
+        'bash',
+        '-c',
+        `docker run --init --pull=always -i --rm -e SONARQUBE_TOKEN -e SONARQUBE_URL -v "$SONARQUBE_MCP_HOST_PATH":/app/mcp-workspace:ro -e SONARQUBE_TOOLSETS ${SONARQUBE_MCP_DOCKER_IMAGE_NAME}`,
+      ],
+      env: {
+        SONARQUBE_TOKEN: 'squ_test',
+        SONARQUBE_URL: 'https://sonarqube.example.com',
+        SONARQUBE_TOOLSETS: MCP_DEFAULT_TOOLSETS,
+        // Left untranslated (native Windows separators) so WSL can translate it via the `/p` flag.
+        SONARQUBE_MCP_HOST_PATH: String.raw`C:\Users\tdd\source\repos\sonarlint-core`,
+        WSLENV: 'SONARQUBE_TOKEN/u:SONARQUBE_URL/u:SONARQUBE_TOOLSETS/u:SONARQUBE_MCP_HOST_PATH/p',
+      },
+    });
+  });
+
+  it('includes SONARQUBE_PROJECT_KEY for project-scoped config, forwarded via WSLENV', () => {
+    const config = resolveMcpContainerCommand(
+      ON_PREMISE_AUTH,
+      { runtime: 'docker', viaWsl: true },
+      { withFsMount: true, projectRoot: '/fake/project', projectKey: 'my-project' },
+    );
+    expect(config.args[2]).toContain('-e SONARQUBE_PROJECT_KEY');
+    expect(config.env.SONARQUBE_PROJECT_KEY).toBe('my-project');
+    expect(config.env.WSLENV).toContain('SONARQUBE_PROJECT_KEY/u');
   });
 });
 

--- a/tests/unit/cli/commands/run/mcp.test.ts
+++ b/tests/unit/cli/commands/run/mcp.test.ts
@@ -91,7 +91,7 @@ describe('runMcp', () => {
 
       expect(spawnSpy).toHaveBeenCalledWith(
         'wsl.exe',
-        ['bash', '-c', expect.stringContaining(`${runtime} run`)],
+        ['sh', '-c', expect.stringContaining(`${runtime} run`)],
         expect.objectContaining({ stdio: 'inherit' }),
       );
       const spawnEnv = spawnSpy.mock.calls[0][2].env as Record<string, string>;

--- a/tests/unit/cli/commands/run/mcp.test.ts
+++ b/tests/unit/cli/commands/run/mcp.test.ts
@@ -70,13 +70,40 @@ describe('runMcp', () => {
   });
 
   it('throws CommandFailedError when no container runtime is available', () => {
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue(null);
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: null,
+      viaWsl: false,
+    });
 
     expect(runMcp(FAKE_AUTH)).rejects.toBeInstanceOf(CommandFailedError);
   });
 
+  it.each(['docker', 'podman', 'nerdctl'] as const)(
+    'runs a WSL-wrapped command when detection reports viaWsl for %s',
+    async (runtime) => {
+      detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+        runtime,
+        viaWsl: true,
+      });
+      spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
+
+      await runMcp(FAKE_AUTH);
+
+      expect(spawnSpy).toHaveBeenCalledWith(
+        'wsl.exe',
+        ['bash', '-c', expect.stringContaining(`${runtime} run`)],
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+      const spawnEnv = spawnSpy.mock.calls[0][2].env as Record<string, string>;
+      expect(spawnEnv.WSLENV).toContain('SONARQUBE_TOKEN/u');
+    },
+  );
+
   it('spawns with podman when podman is the detected runtime', async () => {
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue('podman');
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: 'podman',
+      viaWsl: false,
+    });
     spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
 
     await runMcp(FAKE_AUTH);
@@ -89,7 +116,10 @@ describe('runMcp', () => {
   });
 
   it('sets SONARQUBE_DEBUG_ENABLED=true in spawn env when --debug is set', async () => {
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue('docker');
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: 'docker',
+      viaWsl: false,
+    });
     spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
 
     await runMcp(FAKE_AUTH, { debug: true });
@@ -101,7 +131,10 @@ describe('runMcp', () => {
   });
 
   it('sets SONARQUBE_READ_ONLY=true in spawn env when --read-only is set', async () => {
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue('docker');
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: 'docker',
+      viaWsl: false,
+    });
     spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
 
     await runMcp(FAKE_AUTH, { readOnly: true });
@@ -112,7 +145,10 @@ describe('runMcp', () => {
   });
 
   it('sets SONARQUBE_TOOLSETS in spawn env when --toolsets is set', async () => {
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue('docker');
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: 'docker',
+      viaWsl: false,
+    });
     spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
 
     await runMcp(FAKE_AUTH, { toolsets: 'issues,rules' });
@@ -123,7 +159,10 @@ describe('runMcp', () => {
   });
 
   it('sets SONARQUBE_PROJECT_KEY in spawn env when --project is set even when discovery runs', async () => {
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue('docker');
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: 'docker',
+      viaWsl: false,
+    });
     spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
 
     await runMcp(FAKE_AUTH, { project: 'my-project' });
@@ -141,7 +180,10 @@ describe('runMcp', () => {
       isGitRepo: true,
       configSources: [],
     });
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue('docker');
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: 'docker',
+      viaWsl: false,
+    });
     spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
 
     await runMcp(FAKE_AUTH, { project: 'my-project' });
@@ -154,7 +196,10 @@ describe('runMcp', () => {
   it('skips project discovery when cwd is user home directory', async () => {
     homeDirSpy = spyOn(os, 'homedir').mockReturnValue('/tmp/home');
     cwdSpy = spyOn(process, 'cwd').mockReturnValue('/tmp/home');
-    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue('docker');
+    detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({
+      runtime: 'docker',
+      viaWsl: false,
+    });
     spawnSpy = spyOn(childProcess, 'spawn').mockReturnValue(makeFakeChild());
 
     await runMcp(FAKE_AUTH, { project: 'my-project' });

--- a/tests/unit/lib/tool-detector.test.ts
+++ b/tests/unit/lib/tool-detector.test.ts
@@ -18,16 +18,27 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { afterEach, describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
 import * as process from '../../../src/lib/process';
-import { detectContainerRuntime } from '../../../src/lib/tool-detector';
+
+// Mock platform-detector so both Windows and non-Windows branches are reachable on any OS.
+const platformDetector = await import('../../../src/lib/platform-detector');
+const isWindowsMock = mock(() => false);
+void mock.module('../../../src/lib/platform-detector', () => ({
+  ...platformDetector,
+  isWindows: isWindowsMock,
+}));
+
+const { detectContainerRuntime } = await import('../../../src/lib/tool-detector');
 
 describe('detectContainerRuntime', () => {
   let spawnSpy: ReturnType<typeof spyOn>;
 
   afterEach(() => {
     spawnSpy.mockRestore();
+    isWindowsMock.mockReset();
+    isWindowsMock.mockImplementation(() => false);
   });
 
   it('returns "docker" when docker is available', async () => {
@@ -37,7 +48,7 @@ describe('detectContainerRuntime', () => {
       stderr: '',
     });
 
-    expect(await detectContainerRuntime()).toBe('docker');
+    expect(await detectContainerRuntime()).toEqual({ runtime: 'docker', viaWsl: false });
     expect(spawnSpy).toHaveBeenCalledWith('docker', ['info']);
   });
 
@@ -49,7 +60,7 @@ describe('detectContainerRuntime', () => {
       return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
     });
 
-    expect(await detectContainerRuntime()).toBe('podman');
+    expect(await detectContainerRuntime()).toEqual({ runtime: 'podman', viaWsl: false });
     expect(spawnSpy).toHaveBeenCalledWith('docker', ['info']);
     expect(spawnSpy).toHaveBeenCalledWith('podman', ['info']);
   });
@@ -62,16 +73,18 @@ describe('detectContainerRuntime', () => {
       return Promise.reject(new Error(`spawn ${cmd} ENOENT`));
     });
 
-    expect(await detectContainerRuntime()).toBe('nerdctl');
+    expect(await detectContainerRuntime()).toEqual({ runtime: 'nerdctl', viaWsl: false });
     expect(spawnSpy).toHaveBeenCalledWith('docker', ['info']);
     expect(spawnSpy).toHaveBeenCalledWith('podman', ['info']);
     expect(spawnSpy).toHaveBeenCalledWith('nerdctl', ['info']);
   });
 
-  it('returns null when no container runtime is available', async () => {
+  it('returns null when no container runtime is available and not on Windows', async () => {
+    isWindowsMock.mockImplementation(() => false);
     spawnSpy = spyOn(process, 'spawnProcess').mockRejectedValue(new Error('ENOENT'));
 
-    expect(await detectContainerRuntime()).toBeNull();
+    expect(await detectContainerRuntime()).toEqual({ runtime: null, viaWsl: false });
+    expect(spawnSpy).not.toHaveBeenCalledWith('wsl.exe', expect.anything());
   });
 
   it('returns "docker" when docker daemon is running even if other runtimes are also available', async () => {
@@ -81,18 +94,57 @@ describe('detectContainerRuntime', () => {
       stderr: '',
     });
 
-    expect(await detectContainerRuntime()).toBe('docker');
+    expect(await detectContainerRuntime()).toEqual({ runtime: 'docker', viaWsl: false });
     // Should not have checked podman/nerdctl since docker succeeded
     expect(spawnSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('returns null when all runtime daemons are not running', async () => {
+  it('returns null when all runtime daemons are not running and not on Windows', async () => {
+    isWindowsMock.mockImplementation(() => false);
     spawnSpy = spyOn(process, 'spawnProcess').mockResolvedValue({
       exitCode: 1,
       stdout: '',
       stderr: 'Cannot connect to daemon',
     });
 
-    expect(await detectContainerRuntime()).toBeNull();
+    expect(await detectContainerRuntime()).toEqual({ runtime: null, viaWsl: false });
+  });
+
+  it('falls back to WSL when no native runtime is available on Windows', async () => {
+    isWindowsMock.mockImplementation(() => true);
+    spawnSpy = spyOn(process, 'spawnProcess').mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'wsl.exe' && args[0] === 'docker') {
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+      }
+      return Promise.reject(new Error('ENOENT'));
+    });
+
+    expect(await detectContainerRuntime()).toEqual({ runtime: 'docker', viaWsl: true });
+    expect(spawnSpy).toHaveBeenCalledWith('wsl.exe', ['docker', 'info']);
+  });
+
+  it('falls through to nerdctl via WSL when native and earlier WSL runtimes are unavailable', async () => {
+    isWindowsMock.mockImplementation(() => true);
+    spawnSpy = spyOn(process, 'spawnProcess').mockImplementation((cmd: string, args: string[]) => {
+      if (cmd === 'wsl.exe' && args[0] === 'nerdctl') {
+        return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+      }
+      return Promise.reject(new Error('ENOENT'));
+    });
+
+    expect(await detectContainerRuntime()).toEqual({ runtime: 'nerdctl', viaWsl: true });
+    expect(spawnSpy).toHaveBeenCalledWith('docker', ['info']);
+    expect(spawnSpy).toHaveBeenCalledWith('podman', ['info']);
+    expect(spawnSpy).toHaveBeenCalledWith('nerdctl', ['info']);
+    expect(spawnSpy).toHaveBeenCalledWith('wsl.exe', ['docker', 'info']);
+    expect(spawnSpy).toHaveBeenCalledWith('wsl.exe', ['podman', 'info']);
+    expect(spawnSpy).toHaveBeenCalledWith('wsl.exe', ['nerdctl', 'info']);
+  });
+
+  it('returns null when neither a native nor a WSL runtime is available on Windows', async () => {
+    isWindowsMock.mockImplementation(() => true);
+    spawnSpy = spyOn(process, 'spawnProcess').mockRejectedValue(new Error('ENOENT'));
+
+    expect(await detectContainerRuntime()).toEqual({ runtime: null, viaWsl: false });
   });
 });


### PR DESCRIPTION
Part of CLI-411

----
## Summary by Gitar

- **Runtime detection:**
  - Updated `detectContainerRuntime` to identify runtimes inside WSL on Windows systems.
  - Introduced `ContainerRuntimeDetection` interface to track both the runtime and its execution environment.
- **Command execution:**
  - Added `resolveMcpContainerCommand` to handle native vs. WSL-based container execution.
  - Implemented `getMcpWslContainerCommand` to wrap container commands in `wsl.exe` and manage `WSLENV` for path/variable translation.
- **CLI updates:**
  - Updated `run mcp` to utilize the new detection logic and support WSL-based command execution.
  - Added debug logging to indicate whether a runtime is being used via WSL.


<sub>This will update automatically on new commits.</sub>