### PR TITLE
CLI-804 Rewrite server-style /api/v2 paths to SonarQube Cloud's API host in sonar api

### DIFF
--- a/src/cli/commands/api/api.ts
+++ b/src/cli/commands/api/api.ts
@@ -58,6 +58,11 @@ V1 and V2 routing:
   Both cloud and server have V1 and V2 versions of their APIs.
   This tool automatically switches its behavior based on the endpoint path you choose.
 
+  SonarQube Server's V2 paths (/api/v2/...) have no such prefix on SonarQube Cloud —
+  the same endpoint lives on the API host (api.<domain>) without it. This tool detects
+  that and rewrites the request automatically, so a path copied from SonarQube Server
+  docs, such as "/api/v2/sca/issues-releases", also works unchanged against Cloud.
+
 API Usage Documentation:
   SonarQube Cloud:  ${CLOUD_API_DOCS_URL}
   SonarQube Server: ${SERVER_API_DOCS_URL}

--- a/src/lib/auth-resolver.ts
+++ b/src/lib/auth-resolver.ts
@@ -176,3 +176,20 @@ export function cloudRegionFromUrl(serverUrl: string): CloudRegion | undefined {
 export function isSonarQubeCloud(serverUrl: string): boolean {
   return cloudRegionFromUrl(serverUrl) !== undefined;
 }
+
+const SERVER_V2_PREFIX = '/api/v2';
+
+/**
+ * SonarQube Server's V2 API paths (`/api/v2/...`) have no equivalent under that
+ * prefix on SonarCloud: the same functionality lives at the API host without it
+ * (e.g. Server's `/api/v2/sca/issues-releases` is SonarCloud's `/sca/issues-releases`).
+ * A request with that prefix 404s or 403s on SonarCloud regardless of host, so
+ * stripping it is always correct there. Only relevant for `sonar api`'s free-form
+ * endpoint — every other caller already picks the right path per connection type.
+ */
+export function normalizeCloudV2Endpoint(serverUrl: string, endpoint: string): string {
+  if (isSonarQubeCloud(serverUrl) && endpoint.startsWith(`${SERVER_V2_PREFIX}/`)) {
+    return endpoint.slice(SERVER_V2_PREFIX.length);
+  }
+  return endpoint;
+}

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -21,7 +21,11 @@
 // SonarQube API HTTP client
 
 import { version as VERSION } from '../../package.json';
-import { isSonarQubeCloud, resolveFromEndpoint } from '../lib/auth-resolver';
+import {
+  isSonarQubeCloud,
+  normalizeCloudV2Endpoint,
+  resolveFromEndpoint,
+} from '../lib/auth-resolver';
 import { buildFetchNetworkOptions } from '../lib/connectivity/network-config.js';
 import { buildFetchInit, fetchGuarded } from '../lib/fetch-guarded.js';
 import logger from '../lib/logger';
@@ -168,8 +172,9 @@ export class SonarQubeClient {
 
     const timeout = method === 'GET' ? GET_REQUEST_TIMEOUT_MS : POST_REQUEST_TIMEOUT_MS;
 
-    const transformedServerURL = resolveFromEndpoint(this.serverURL, endpoint);
-    const url = `${transformedServerURL}${endpoint}`;
+    const normalizedEndpoint = normalizeCloudV2Endpoint(this.serverURL, endpoint);
+    const transformedServerURL = resolveFromEndpoint(this.serverURL, normalizedEndpoint);
+    const url = `${transformedServerURL}${normalizedEndpoint}`;
 
     if (debug) {
       print(`request method: ${method}`, 'stderr');

--- a/tests/integration/specs/api/api.test.ts
+++ b/tests/integration/specs/api/api.test.ts
@@ -176,6 +176,44 @@ describe('api', () => {
   );
 
   it(
+    'a /api/v2-prefixed endpoint is rewritten and routed to the SonarCloud API host',
+    async () => {
+      const mainServer = await harness.newFakeServer().withAuthToken('cloud-token').start();
+      const apiServer = await harness.newFakeServer().withAuthToken('cloud-token').start();
+      const mainServerUrl = mainServer.baseUrl();
+      harness.withAuth(mainServerUrl, 'cloud-token', 'my-org');
+
+      await harness.run('api get "/api/v2/sca/issues-releases?projectKey=my-project"', {
+        extraEnv: {
+          SONARQUBE_CLI_SONARCLOUD_URL: mainServerUrl,
+          SONARQUBE_CLI_SONARCLOUD_API_URL: apiServer.baseUrl(),
+        },
+      });
+
+      expect(apiServer.getRecordedRequests().some((r) => r.path === '/sca/issues-releases')).toBe(
+        true,
+      );
+      expect(mainServer.getRecordedRequests()).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'a /api/v2-prefixed endpoint is left unchanged on SonarQube Server',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('valid-token').start();
+      harness.withAuth(server.baseUrl(), 'valid-token');
+
+      await harness.run('api get "/api/v2/sca/issues-releases?projectKey=my-project"');
+
+      expect(
+        server.getRecordedRequests().some((r) => r.path === '/api/v2/sca/issues-releases'),
+      ).toBe(true);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'exits with code 1 when server returns 401 for invalid token',
     async () => {
       const server = await harness.newFakeServer().withAuthToken('correct-token').start();

--- a/tests/unit/cli/commands/auth/auth-resolver.test.ts
+++ b/tests/unit/cli/commands/auth/auth-resolver.test.ts
@@ -26,6 +26,7 @@ import {
   cloudRegionFromUrl,
   ENV_SERVER,
   ENV_TOKEN,
+  normalizeCloudV2Endpoint,
   resolveAuth,
   resolveFromEndpoint,
 } from '../../../../../src/lib/auth-resolver.js';
@@ -255,6 +256,31 @@ describe('resolveBaseUrl', () => {
   it('returns the SonarCloud US API URL for non-/api endpoints', () => {
     const result = resolveFromEndpoint('https://sonarqube.us', '/organizations/search');
     expect(result).toBe('https://api.sonarqube.us');
+  });
+});
+
+describe('normalizeCloudV2Endpoint', () => {
+  it('strips the /api/v2 prefix for SonarCloud EU', () => {
+    const result = normalizeCloudV2Endpoint('https://sonarcloud.io', '/api/v2/sca/issues-releases');
+    expect(result).toBe('/sca/issues-releases');
+  });
+
+  it('strips the /api/v2 prefix for SonarCloud US', () => {
+    const result = normalizeCloudV2Endpoint('https://sonarqube.us', '/api/v2/sca/issues-releases');
+    expect(result).toBe('/sca/issues-releases');
+  });
+
+  it('leaves non-/api/v2 endpoints unchanged on SonarCloud', () => {
+    const result = normalizeCloudV2Endpoint('https://sonarcloud.io', '/api/system/status');
+    expect(result).toBe('/api/system/status');
+  });
+
+  it('leaves /api/v2 endpoints unchanged on self-hosted servers', () => {
+    const result = normalizeCloudV2Endpoint(
+      'https://sonar.mycompany.com',
+      '/api/v2/sca/issues-releases',
+    );
+    expect(result).toBe('/api/v2/sca/issues-releases');
   });
 });
 

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -1129,13 +1129,22 @@ describe('SonarQubeClient', () => {
       expect(client.genericRequest('GET', '/api/system/status')).rejects.toThrow('Access denied');
     });
 
-    it('resolves SonarCloud endpoint correctly', async () => {
+    it('resolves a plain SonarCloud /api endpoint correctly', async () => {
       const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
       fetchSpy = mockFetch({ ok: true });
-      await cloudClient.genericRequest('GET', '/api/v2/issues');
+      await cloudClient.genericRequest('GET', '/api/issues/search');
 
       const url = (fetchSpy.mock.calls[0][0] as string).toString();
-      expect(url).toBe(`${SONARCLOUD_URL}/api/v2/issues`);
+      expect(url).toBe(`${SONARCLOUD_URL}/api/issues/search`);
+    });
+
+    it('strips the /api/v2 prefix and routes to the API host on SonarCloud', async () => {
+      const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
+      fetchSpy = mockFetch({ ok: true });
+      await cloudClient.genericRequest('GET', '/api/v2/sca/issues-releases');
+
+      const url = (fetchSpy.mock.calls[0][0] as string).toString();
+      expect(url).toBe(`${SONARCLOUD_API_URL}/sca/issues-releases`);
     });
   });
 


### PR DESCRIPTION
----
## Summary by Gitar

- **API Routing:**
  - Added `normalizeCloudV2Endpoint` to automatically strip `/api/v2` prefixes when targeting SonarQube Cloud.
  - Updated `SonarQubeClient` to apply this normalization during request dispatching.
- **Documentation:**
  - Updated `api` command help text to explain that `/api/v2` paths are now automatically rewritten for Cloud requests.
- **Testing:**
  - Added unit tests for endpoint normalization and integration tests verifying correct routing for both Cloud and self-hosted environments.


<sub>This will update automatically on new commits.</sub>