### PR TITLE
GROW-228 Bulk-import multiple repositories concurrently in sonar import

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -83,6 +83,7 @@ import { cursorPromptSubmit } from './commands/hook/cursor-prompt-submit';
 import { gitPreCommit, type GitPreCommitOptions } from './commands/hook/git-pre-commit';
 import { gitPrePush } from './commands/hook/git-pre-push';
 import { importHandler, type ImportOptions } from './commands/import';
+import { collectRepoOption } from './commands/import/_common/repo-option';
 import type { IntegrateAgentOptions } from './commands/integrate/_common/types';
 import { integrateAntigravity } from './commands/integrate/antigravity';
 import { integrateClaude } from './commands/integrate/claude';
@@ -219,9 +220,18 @@ list
 
 // Import repositories from DevOps platforms into SonarQube (hidden while in development)
 COMMAND_TREE.command('import', { hidden: true })
-  .description('Import a repository from a connected DevOps platform into SonarQube')
+  .description('Import repositories from a connected DevOps platform into SonarQube')
   .option('--org <key>', 'SonarQube organization key')
-  .option('--repo <slug>', 'DevOps platform repository slug (e.g. my-org/my-repo)')
+  .option(
+    '--repo <slug>',
+    'DevOps platform repository slug (e.g. my-org/my-repo). Repeatable and/or comma-separated to import multiple repositories.',
+    collectRepoOption,
+    [],
+  )
+  .option(
+    '--all',
+    'Import every eligible repository in the organization (not already imported, and allowed by its project visibility settings). Cannot be combined with --repo.',
+  )
   .option('--non-interactive', 'Skip all prompts; require explicit flags')
   .authenticatedAction((auth, options: ImportOptions) => importHandler(options, auth));
 

--- a/src/cli/commands/import/_common/repo-option.ts
+++ b/src/cli/commands/import/_common/repo-option.ts
@@ -18,9 +18,13 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-export interface ImportOptions {
-  org?: string;
-  repo?: string[];
-  all?: boolean;
-  nonInteractive?: boolean;
+// Parse repeatable, comma-separated `--repo` arguments for `sonar import`.
+
+/** Commander collector for repeatable `--repo <slug>` options; each value may also be comma-separated. */
+export function collectRepoOption(value: string, previous: string[] = []): string[] {
+  const parts = value
+    .split(',')
+    .map((slug) => slug.trim())
+    .filter((slug) => slug.length > 0);
+  return [...new Set([...previous, ...parts])];
 }

--- a/src/cli/commands/import/_common/repository-collection.ts
+++ b/src/cli/commands/import/_common/repository-collection.ts
@@ -28,37 +28,58 @@ type FetchPage = (
 ) => Promise<{ repositories: DopRepository[]; total: number }>;
 
 /**
- * Locally paginates repositories for the `sonar import` select prompt, fetching
- * server pages (up to `SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE` at a time)
- * lazily as the user pages through, rather than loading the entire remote list
- * up front.
+ * A repo is already imported if it's flagged for the current org, or already bound to a
+ * project at all (e.g. imported into a different org) — either way it's not a fresh import.
+ */
+export function isAlreadyImported(repo: DopRepository): boolean {
+  return repo.importedInCurrentOrg || repo.boundProjectIds.length > 0;
+}
+
+/**
+ * Filters and locally paginates repositories for the `sonar import` select prompt, mirroring
+ * `OrganizationCollection`. All repositories are fetched up front via `fetchAll` (across as
+ * many server pages as needed) before any filtering or pagination happens: filtering a
+ * lazily-loaded window instead would make the number of items shown per local page fluctuate
+ * unpredictably depending on how many of that window's repos get excluded.
  */
 export class RepositoryCollection {
-  private readonly repos: DopRepository[] = [];
-  private readonly fetchPage: FetchPage;
+  private readonly repos: DopRepository[];
   private readonly pageSize: number;
-  private page = 1;
-  private serverPageIndex = 1;
-  private total: number | null = null;
+  private page: number;
 
-  private constructor(fetchPage: FetchPage, pageSize: number) {
-    this.fetchPage = fetchPage;
+  constructor(repos: DopRepository[], pageSize = REPOSITORY_LOCAL_PAGE_SIZE) {
+    this.repos = repos;
     this.pageSize = pageSize;
+    this.page = 1;
   }
 
-  /** Create a collection and eagerly load just enough repos for the first visible page. */
-  static async create(
-    fetchPage: FetchPage,
-    pageSize = REPOSITORY_LOCAL_PAGE_SIZE,
-  ): Promise<RepositoryCollection> {
-    const collection = new RepositoryCollection(fetchPage, pageSize);
-    await collection.ensureLoaded();
-    return collection;
+  /** Fetch every repository for an organization across all server pages. */
+  static async fetchAll(fetchPage: FetchPage): Promise<DopRepository[]> {
+    const repos: DopRepository[] = [];
+    let serverPageIndex = 1;
+    let total: number | null = null;
+
+    while (total === null || repos.length < total) {
+      const { repositories, total: reportedTotal } = await fetchPage(
+        serverPageIndex,
+        SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE,
+      );
+      repos.push(...repositories);
+      serverPageIndex++;
+      // Trust the loaded count once the server stops returning full pages, so a stale or
+      // inconsistent server-reported total can't cause an infinite loop.
+      if (repositories.length < SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE) {
+        break;
+      }
+      total = reportedTotal;
+    }
+
+    return repos;
   }
 
-  /** Total number of repositories across all server pages (unaffected by pagination). */
+  /** Total number of repositories in this collection (unaffected by pagination). */
   get length(): number {
-    return this.total ?? 0;
+    return this.repos.length;
   }
 
   /** Repositories visible up to and including the current page. */
@@ -68,33 +89,11 @@ export class RepositoryCollection {
 
   /** True when there are more repositories beyond the current visible window. */
   get hasMore(): boolean {
-    return this.page * this.pageSize < this.length;
+    return this.page * this.pageSize < this.repos.length;
   }
 
-  /** Advance the visible window by one page, fetching more server pages if needed. */
-  async loadMore(): Promise<void> {
-    if (!this.hasMore) return;
-    this.page++;
-    await this.ensureLoaded();
-  }
-
-  private async ensureLoaded(): Promise<void> {
-    const needed = this.page * this.pageSize;
-    while (this.repos.length < needed && (this.total === null || this.repos.length < this.total)) {
-      const { repositories, total } = await this.fetchPage(
-        this.serverPageIndex,
-        SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE,
-      );
-      this.repos.push(...repositories);
-      this.serverPageIndex++;
-      // Trust the loaded count once the server stops returning full pages, so
-      // `hasMore` never over-reports beyond what actually exists (guards against
-      // an inconsistent/stale server-reported total causing wasted "Load more" fetches).
-      if (repositories.length < SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE) {
-        this.total = this.repos.length;
-        break;
-      }
-      this.total = total;
-    }
+  /** Advance the visible window by one page. */
+  loadMore(): void {
+    if (this.hasMore) this.page++;
   }
 }

--- a/src/cli/commands/import/_common/resolve-options.ts
+++ b/src/cli/commands/import/_common/resolve-options.ts
@@ -19,10 +19,17 @@
  */
 
 import { type DopRepository, type SonarQubeClient } from '../../../../sonarqube/client';
-import { selectPrompt, withSpinner } from '../../../../ui';
+import {
+  confirmPrompt,
+  type MultiSelectOption,
+  multiSelectPrompt,
+  selectPrompt,
+  warn,
+  withSpinner,
+} from '../../../../ui';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { OrganizationCollection } from './organization-collection';
-import { RepositoryCollection } from './repository-collection';
+import { isAlreadyImported, RepositoryCollection } from './repository-collection';
 
 /** ALM key used by GitHub-bound organizations, per `Organization.alm.key`. */
 const GITHUB_ALM_KEY = 'github';
@@ -51,6 +58,17 @@ export interface ResolvedRepo {
   slug: string;
   /** ALM-specific identifier expected by `provision_projects`' `installationKeys` param. */
   installationKey: string;
+}
+
+export interface SkippedRepo {
+  slug: string;
+  reason: string;
+}
+
+export interface ResolvedRepos {
+  repos: ResolvedRepo[];
+  /** Repos deliberately excluded by `--all`'s eligibility filtering, with a reason each. */
+  skipped: SkippedRepo[];
 }
 
 /**
@@ -180,17 +198,27 @@ async function promptForOrg(client: SonarQubeClient): Promise<ResolvedOrg> {
   }
 }
 
-export async function resolveRepo(
+/** Returned by `resolveRepos` when the user chooses "← Back" from the onboarding-mode prompt. */
+export const BACK = Symbol('back');
+
+export async function resolveRepos(
   client: SonarQubeClient,
   orgKey: string,
   almKey: string | undefined,
   onlyPrivateProjects: OnlyPrivateProjects,
-  opts: { repo?: string; nonInteractive?: boolean },
-): Promise<ResolvedRepo> {
-  if (opts.nonInteractive && !opts.repo) {
+  opts: { org?: string; repo?: string[]; all?: boolean; nonInteractive?: boolean },
+): Promise<ResolvedRepos | typeof BACK> {
+  if (opts.all && opts.repo?.length) {
     throw new InvalidOptionError(
-      '--repo is required in non-interactive mode',
-      'Pass --repo <slug> to specify a repository directly.',
+      '--all cannot be combined with --repo',
+      'Pass either --all to import every eligible repository, or --repo to choose specific ones.',
+    );
+  }
+
+  if (opts.nonInteractive && !opts.repo?.length && !opts.all) {
+    throw new InvalidOptionError(
+      '--repo or --all is required in non-interactive mode',
+      'Pass --repo <slug> to specify one or more repositories directly, or --all to import every eligible one.',
     );
   }
 
@@ -201,45 +229,156 @@ export async function resolveRepo(
     });
   }
 
-  if (opts.repo) {
-    return resolveRepoBySlug(client, organizationId, almKey, onlyPrivateProjects, opts.repo);
+  if (opts.all) {
+    return resolveAllRepos(client, organizationId, almKey, onlyPrivateProjects);
   }
 
-  return promptForRepo(client, organizationId, almKey, onlyPrivateProjects);
+  if (opts.repo?.length) {
+    const repos = await resolveReposBySlug(
+      client,
+      organizationId,
+      almKey,
+      onlyPrivateProjects,
+      opts.repo,
+    );
+    return { repos, skipped: [] };
+  }
+
+  // "← Back" only makes sense when the org itself was chosen interactively — an org pinned
+  // via `--org` has nowhere to go back to, so re-prompting for it would just loop forever.
+  return resolveOnboardingMode(client, organizationId, almKey, onlyPrivateProjects, {
+    allowBack: !opts.org,
+  });
 }
 
-async function resolveRepoBySlug(
+/**
+ * Ask how the user wants to pick repositories to import: bulk-import everything eligible
+ * (mirrors `--all`), choose specific ones interactively, or go back to organization selection.
+ *
+ * Eligibility is computed once up front (before the prompt is even shown) so an org with
+ * nothing importable fails immediately with a specific reason, the same way it always has —
+ * asking "recommended or manual?" would be pointless (and both branches would hit the same
+ * dead end) when there's nothing to import either way.
+ */
+async function resolveOnboardingMode(
   client: SonarQubeClient,
   organizationId: string,
   almKey: string | undefined,
   onlyPrivateProjects: OnlyPrivateProjects,
-  slug: string,
-): Promise<ResolvedRepo> {
-  const repo = await findRepoBySlug(client, organizationId, slug);
-  if (!repo) {
-    throw new CommandFailedError(
-      `Repository '${slug}' not found in the selected organization's DevOps platform.`,
-      { remediationHint: 'Check that the repository slug is correct and visible to the org.' },
-    );
+  opts: { allowBack: boolean },
+): Promise<ResolvedRepos | typeof BACK> {
+  const allRepos = await fetchAllReposOrThrow(client, organizationId);
+  const { eligible, skipped } = categorizeRepos(allRepos, onlyPrivateProjects);
+
+  if (eligible.length === 0) {
+    const reason = allRepos.every((repo) => isAlreadyImported(repo))
+      ? 'All repositories for the selected organization have already been imported into SonarQube.'
+      : "No repositories match this organization's project visibility settings.";
+
+    if (!opts.allowBack) {
+      throw new CommandFailedError(reason);
+    }
+
+    warn(reason);
+    const goBack = await confirmPrompt('Go back and choose a different organization?', true);
+    if (!goBack) {
+      throw new CommandFailedError(reason);
+    }
+    return BACK;
   }
-  if (!isRepoSelectable(repo, onlyPrivateProjects)) {
-    throw new CommandFailedError(
-      `Repository '${slug}' is ${repo.private ? 'private' : 'public'}, which isn't allowed by this organization's project visibility settings.`,
-    );
+
+  const RECOMMENDED = Symbol('recommended');
+  const MANUAL = Symbol('manual');
+
+  const options: Array<{ value: typeof RECOMMENDED | typeof MANUAL | typeof BACK; label: string }> =
+    [
+      { value: RECOMMENDED, label: 'Recommended — import all eligible repositories automatically' },
+      { value: MANUAL, label: 'Manual — choose repositories yourself' },
+    ];
+  if (opts.allowBack) {
+    options.push({ value: BACK, label: '← Back' });
   }
-  return { slug: repo.slug, installationKey: computeInstallationKey(repo, almKey) };
+
+  const choice = await selectPrompt('How do you want to import repositories?', options);
+
+  if (choice === null) {
+    throw new CommandFailedError('Repository selection cancelled');
+  }
+  if (choice === BACK) {
+    return BACK;
+  }
+  if (choice === RECOMMENDED) {
+    return {
+      repos: eligible.map((repo) => ({
+        slug: repo.slug,
+        installationKey: computeInstallationKey(repo, almKey),
+      })),
+      skipped,
+    };
+  }
+
+  const repos = await promptForReposFromCollection(new RepositoryCollection(eligible), almKey);
+  return { repos, skipped: [] };
 }
 
-async function promptForRepo(
+async function resolveReposBySlug(
   client: SonarQubeClient,
   organizationId: string,
   almKey: string | undefined,
   onlyPrivateProjects: OnlyPrivateProjects,
-): Promise<ResolvedRepo> {
-  let repos: RepositoryCollection;
+  slugs: string[],
+): Promise<ResolvedRepo[]> {
+  const matches = await findReposBySlugs(client, organizationId, slugs);
+
+  const notFound = slugs.filter((slug) => !matches.has(slug));
+  if (notFound.length > 0) {
+    throw new CommandFailedError(
+      `Repositor${notFound.length === 1 ? 'y' : 'ies'} not found in the selected organization's DevOps platform: ${notFound.join(', ')}`,
+      { remediationHint: 'Check that the repository slug(s) are correct and visible to the org.' },
+    );
+  }
+
+  const notSelectable = slugs
+    .map((slug) => matches.get(slug))
+    .filter(
+      (repo): repo is DopRepository =>
+        repo !== undefined && !isRepoSelectable(repo, onlyPrivateProjects),
+    );
+  if (notSelectable.length === 1) {
+    const repo = notSelectable[0];
+    throw new CommandFailedError(
+      `Repository '${repo.slug}' is ${repo.private ? 'private' : 'public'}, which isn't allowed by this organization's project visibility settings.`,
+    );
+  }
+  if (notSelectable.length > 1) {
+    throw new CommandFailedError(
+      `Repositories are not allowed by this organization's project visibility settings: ${notSelectable
+        .map((repo) => `${repo.slug} (${repo.private ? 'private' : 'public'})`)
+        .join(', ')}`,
+    );
+  }
+
+  return slugs.map((slug) => {
+    const repo = matches.get(slug);
+    if (!repo) {
+      throw new CommandFailedError(`Repository '${slug}' not found.`);
+    }
+    return { slug: repo.slug, installationKey: computeInstallationKey(repo, almKey) };
+  });
+}
+
+/**
+ * Fetch every repository for an org (across all server pages), throwing a `CommandFailedError`
+ * on a fetch failure or an org with no repositories at all.
+ */
+async function fetchAllReposOrThrow(
+  client: SonarQubeClient,
+  organizationId: string,
+): Promise<DopRepository[]> {
+  let allRepos: DopRepository[];
   try {
-    repos = await withSpinner('Loading repositories...', () =>
-      RepositoryCollection.create((pageIndex, pageSize) =>
+    allRepos = await withSpinner('Loading repositories...', () =>
+      RepositoryCollection.fetchAll((pageIndex, pageSize) =>
         client.fetchDopRepositoriesPage(organizationId, pageIndex, pageSize),
       ),
     );
@@ -250,95 +389,148 @@ async function promptForRepo(
     );
   }
 
-  if (repos.length === 0) {
+  if (allRepos.length === 0) {
     throw new CommandFailedError('No repositories found for the selected organization.', {
       remediationHint:
         'The organization may have no repositories visible to its connected DevOps platform, or the platform connection may need to be reconfigured.',
     });
   }
 
-  const LOAD_MORE = Symbol('load-more');
+  return allRepos;
+}
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  while (true) {
-    const selectable = await loadNextSelectablePage(repos, onlyPrivateProjects);
+/**
+ * Split repos into those eligible for import — not already imported (see `isAlreadyImported`)
+ * and allowed by the org's project visibility settings — and those skipped, with a reason each.
+ */
+function categorizeRepos(
+  allRepos: DopRepository[],
+  onlyPrivateProjects: OnlyPrivateProjects,
+): { eligible: DopRepository[]; skipped: SkippedRepo[] } {
+  const eligible: DopRepository[] = [];
+  const skipped: SkippedRepo[] = [];
 
-    const options: Array<{
-      value: ResolvedRepo | typeof LOAD_MORE;
-      label: string;
-    }> = selectable.map((repo) => ({
-      value: { slug: repo.slug, installationKey: computeInstallationKey(repo, almKey) },
-      label: formatRepoLabel(repo),
-    }));
-
-    if (repos.hasMore) {
-      options.push({ value: LOAD_MORE, label: 'Load more...' });
-    }
-
-    const choice = await selectPrompt('Select a repository', options);
-
-    if (choice === null) {
-      throw new CommandFailedError('Repository selection cancelled');
-    }
-
-    if (choice === LOAD_MORE) {
-      await repos.loadMore();
+  for (const repo of allRepos) {
+    if (isAlreadyImported(repo)) {
+      skipped.push({ slug: repo.slug, reason: 'already imported' });
       continue;
     }
-
-    return choice;
-  }
-}
-
-/**
- * Advances `repos` past pages with nothing selectable (already imported, or excluded by
- * the org's visibility settings), returning the selectable repos on the first page that has
- * any. Throws once the collection is exhausted without finding one.
- */
-async function loadNextSelectablePage(
-  repos: RepositoryCollection,
-  onlyPrivateProjects: OnlyPrivateProjects,
-): Promise<DopRepository[]> {
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  while (true) {
-    const importable = repos.visible.filter((repo) => !repo.importedInCurrentOrg);
-    // `selectPrompt` has no concept of disabled options, so repos that don't match the
-    // org's visibility settings must be filtered out entirely rather than merely flagged.
-    const selectable = importable.filter((repo) => isRepoSelectable(repo, onlyPrivateProjects));
-
-    if (selectable.length > 0) return selectable;
-
-    if (!repos.hasMore) {
-      throw new CommandFailedError(
-        importable.length === 0
-          ? 'All repositories for the selected organization have already been imported into SonarQube.'
-          : "No repositories match this organization's project visibility settings.",
-      );
+    if (!isRepoSelectable(repo, onlyPrivateProjects)) {
+      skipped.push({
+        slug: repo.slug,
+        reason: `${repo.private ? 'private' : 'public'} repos aren't allowed by this organization's project visibility settings`,
+      });
+      continue;
     }
-
-    await repos.loadMore();
+    eligible.push(repo);
   }
+
+  return { eligible, skipped };
 }
 
 /**
- * Search all server pages of an organization's DOP repositories for an exact `slug` match.
- * Used for the `--repo` fast path, which still needs the repo's `id` to compute the
- * `installationKey` for provisioning even though it skips the interactive select prompt.
+ * Resolve every eligible repository in the org for `--all`. Ineligible repos are reported back
+ * with a reason instead of causing the whole command to fail, since a mixed batch (some
+ * eligible, some not) is the normal case for a whole-org import.
  */
-async function findRepoBySlug(
+async function resolveAllRepos(
   client: SonarQubeClient,
   organizationId: string,
-  slug: string,
-): Promise<{ id: string; slug: string; private: boolean } | undefined> {
-  const repos = await RepositoryCollection.create((pageIndex, pageSize) =>
+  almKey: string | undefined,
+  onlyPrivateProjects: OnlyPrivateProjects,
+): Promise<ResolvedRepos> {
+  const allRepos = await fetchAllReposOrThrow(client, organizationId);
+  const { eligible, skipped } = categorizeRepos(allRepos, onlyPrivateProjects);
+
+  if (eligible.length === 0) {
+    throw new CommandFailedError(
+      `No repositories are eligible for import (${skipped.length} skipped: already imported, or excluded by project visibility settings).`,
+    );
+  }
+
+  return {
+    repos: eligible.map((repo) => ({
+      slug: repo.slug,
+      installationKey: computeInstallationKey(repo, almKey),
+    })),
+    skipped,
+  };
+}
+
+/**
+ * Fetch every repository for an org (across all server pages) and resolve a set of slugs
+ * against it in one pass — avoids N full scans for N `--repo` flags.
+ */
+async function findReposBySlugs(
+  client: SonarQubeClient,
+  organizationId: string,
+  slugs: string[],
+): Promise<Map<string, DopRepository>> {
+  const remaining = new Set(slugs);
+  const found = new Map<string, DopRepository>();
+
+  const allRepos = await RepositoryCollection.fetchAll((pageIndex, pageSize) =>
     client.fetchDopRepositoriesPage(organizationId, pageIndex, pageSize),
   );
 
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  while (true) {
-    const match = repos.visible.find((repo) => repo.slug === slug);
-    if (match) return match;
-    if (!repos.hasMore) return undefined;
-    await repos.loadMore();
+  for (const repo of allRepos) {
+    if (remaining.has(repo.slug)) found.set(repo.slug, repo);
   }
+
+  return found;
+}
+
+/**
+ * Interactive multi-select over an already-fetched, already-filtered collection of eligible
+ * repos (see `resolveOnboardingMode`, which computes eligibility once up front for both the
+ * "Recommended" and "Manual" branches).
+ */
+async function promptForReposFromCollection(
+  repos: RepositoryCollection,
+  almKey: string | undefined,
+): Promise<ResolvedRepo[]> {
+  // `multiSelectPrompt` tracks selections by `===` identity, so the same `DopRepository`
+  // must always map to the same `ResolvedRepo` object across a "Load more" reload, or
+  // previously toggled selections would be silently dropped.
+  const resolvedByRepo = new WeakMap<DopRepository, ResolvedRepo>();
+  const toOption = (repo: DopRepository): MultiSelectOption<ResolvedRepo> => {
+    let resolved = resolvedByRepo.get(repo);
+    if (!resolved) {
+      resolved = { slug: repo.slug, installationKey: computeInstallationKey(repo, almKey) };
+      resolvedByRepo.set(repo, resolved);
+    }
+    return { value: resolved, label: formatRepoLabel(repo) };
+  };
+
+  const result = await multiSelectPrompt(
+    'Select repositories to import',
+    repos.visible.map(toOption),
+    {
+      hasMore: () => repos.hasMore,
+      onLoadMore: () => {
+        repos.loadMore();
+        return repos.visible.map(toOption);
+      },
+      // 'a' bulk-selects every eligible repo, not just the currently-paged-in ones — reveal
+      // every remaining page first so the rendered list and the selection stay consistent.
+      selectAll: () => {
+        while (repos.hasMore) repos.loadMore();
+        return repos.visible.map(toOption);
+      },
+      // No business reason to cap a repo import batch (unlike `sonar remediate`'s
+      // MULTISELECT_MAX_SELECTED default, which mirrors a remediation-agent capacity limit).
+      maxSelected: Number.POSITIVE_INFINITY,
+      // The true eligible count, not just what's paginated into view yet.
+      total: () => repos.length,
+    },
+  );
+
+  if (result === null) {
+    throw new CommandFailedError('Repository selection cancelled');
+  }
+  if (result.length === 0) {
+    throw new CommandFailedError('No repositories selected.');
+  }
+
+  return result;
 }

--- a/src/cli/commands/import/index.ts
+++ b/src/cli/commands/import/index.ts
@@ -19,67 +19,124 @@
  */
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
+import { runWithConcurrencyLimit } from '../../../lib/concurrency-pool';
 import { SonarQubeClient } from '../../../sonarqube/client';
-import { info, intro, outro, withSpinner } from '../../../ui';
+import { info, intro, outro } from '../../../ui';
+import { ImportProgress } from '../../../ui/components/import-progress.js';
 import { CommandFailedError } from '../_common/error';
-import { type OnlyPrivateProjects, resolveOrg, resolveRepo } from './_common/resolve-options';
+import {
+  BACK,
+  type OnlyPrivateProjects,
+  type ResolvedRepo,
+  type ResolvedRepos,
+  resolveOrg,
+  resolveRepos,
+} from './_common/resolve-options';
 import type { ImportOptions } from './_common/types';
 
 export { type ImportOptions } from './_common/types';
 
+/** Max number of `provision_projects` calls run concurrently. */
+const IMPORT_PROVISION_CONCURRENCY_LIMIT = 10;
+
+/**
+ * Resolves org + repos together so choosing "← Back" from the repo-onboarding-mode prompt can
+ * loop back to organization selection — re-deriving `almKey`/`onlyPrivateProjects` for whichever
+ * org ends up chosen, since those are org-specific.
+ */
+async function resolveOrgAndRepos(
+  client: SonarQubeClient,
+  options: ImportOptions,
+): Promise<{ orgKey: string } & ResolvedRepos> {
+  for (;;) {
+    const {
+      key: orgKey,
+      almKey: resolvedAlmKey,
+      onlyPrivateProjectsEnabled,
+    } = await resolveOrg(client, options);
+
+    info(`Organization: ${orgKey}`);
+
+    const [almKey, privateProjectsAvailable] = await Promise.all([
+      resolvedAlmKey ?? client.getOrganizationAlmKey(orgKey),
+      client.hasPrivateProjectsEntitlement(orgKey),
+    ]);
+    const onlyPrivateProjects: OnlyPrivateProjects = {
+      enabled: onlyPrivateProjectsEnabled ?? false,
+      available: privateProjectsAvailable,
+    };
+
+    const outcome = await resolveRepos(client, orgKey, almKey, onlyPrivateProjects, options);
+    if (outcome === BACK) {
+      continue;
+    }
+
+    return { orgKey, ...outcome };
+  }
+}
+
 export async function importHandler(options: ImportOptions, auth: ResolvedAuth): Promise<void> {
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
 
-  intro('Import repository', 'SonarQube');
+  intro('Import repositories', 'SonarQube');
 
-  const {
-    key: orgKey,
-    almKey: resolvedAlmKey,
-    onlyPrivateProjectsEnabled,
-  } = await resolveOrg(client, options);
+  const { orgKey, repos, skipped } = await resolveOrgAndRepos(client, options);
 
-  info(`Organization: ${orgKey}`);
+  info(`Repositories to import: ${repos.length}`);
+  if (skipped.length > 0) {
+    info(`Repositories skipped: ${skipped.length}`);
+    const countsByReason = new Map<string, number>();
+    for (const s of skipped) {
+      countsByReason.set(s.reason, (countsByReason.get(s.reason) ?? 0) + 1);
+    }
+    for (const [reason, count] of countsByReason) {
+      info(`  - ${reason}: ${count}`);
+    }
+  }
 
-  const [almKey, privateProjectsAvailable] = await Promise.all([
-    resolvedAlmKey ?? client.getOrganizationAlmKey(orgKey),
-    client.hasPrivateProjectsEntitlement(orgKey),
-  ]);
-  const onlyPrivateProjects: OnlyPrivateProjects = {
-    enabled: onlyPrivateProjectsEnabled ?? false,
-    available: privateProjectsAvailable,
-  };
+  const progress = new ImportProgress({
+    repos: repos.map((repo) => repo.slug),
+    maxVisible: IMPORT_PROVISION_CONCURRENCY_LIMIT,
+  });
+  progress.start();
 
-  const { slug: repoSlug, installationKey } = await resolveRepo(
-    client,
-    orgKey,
-    almKey,
-    onlyPrivateProjects,
-    options,
+  await runWithConcurrencyLimit(
+    repos,
+    IMPORT_PROVISION_CONCURRENCY_LIMIT,
+    async (repo: ResolvedRepo) => {
+      progress.update(repo.slug, 'running');
+      try {
+        const result = await client.provisionProject(orgKey, repo.installationKey);
+        if (result.projects.length === 0) {
+          throw new Error(
+            'provision_projects returned no project — the repository may already be bound, or ' +
+              'the installation key was rejected by the server.',
+          );
+        }
+        const project = result.projects[0];
+        progress.update(repo.slug, 'done', 'Project created', project.projectKey);
+        return project;
+      } catch (err) {
+        progress.update(repo.slug, 'failed', err instanceof Error ? err.message : String(err));
+        throw err;
+      }
+    },
   );
 
-  info(`Repository: ${repoSlug}`);
-  let result;
-  try {
-    result = await withSpinner('Creating SonarQube project...', () =>
-      client.provisionProject(orgKey, installationKey),
-    );
-  } catch (err) {
-    throw new CommandFailedError(
-      `Failed to create project: ${err instanceof Error ? err.message : String(err)}`,
-      {
-        remediationHint:
-          'Check that the repository is not already imported and that you have permission to create projects in this organization.',
-      },
-    );
+  const { succeeded, failed } = progress.finish();
+  const skippedSuffix = skipped.length > 0 ? ` (${skipped.length} skipped)` : '';
+
+  if (failed > 0) {
+    const failedNoun = failed === 1 ? 'repository' : 'repositories';
+    const message =
+      succeeded === 0
+        ? `Failed to import ${failed} ${failedNoun}.`
+        : `Imported ${succeeded} of ${repos.length} repositories (${failed} failed)${skippedSuffix}.`;
+    throw new CommandFailedError(message, {
+      remediationHint: 'See the per-repository errors above for details.',
+    });
   }
 
-  if (result.projects.length === 0) {
-    throw new CommandFailedError(
-      'provision_projects returned no project — the repository may already be bound, or the ' +
-        'installation key was rejected by the server.',
-    );
-  }
-  const project = result.projects[0];
-
-  outro(`Project created: ${project.projectKey}`, 'success');
+  const succeededNoun = succeeded === 1 ? 'repository' : 'repositories';
+  outro(`Imported ${succeeded} ${succeededNoun}${skippedSuffix}`, 'success');
 }

--- a/src/lib/concurrency-pool.ts
+++ b/src/lib/concurrency-pool.ts
@@ -1,0 +1,58 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+export interface PooledResult<TItem, TValue> {
+  item: TItem;
+  status: 'fulfilled' | 'rejected';
+  value?: TValue;
+  reason?: unknown;
+}
+
+/**
+ * Runs `task` over `items` with at most `limit` concurrently in flight. Never rejects: each
+ * item's outcome is captured individually (`Promise.allSettled`-style), so one item's failure
+ * never aborts or blocks the others. Results are returned in the same order as `items`.
+ */
+export async function runWithConcurrencyLimit<TItem, TValue>(
+  items: TItem[],
+  limit: number,
+  task: (item: TItem, index: number) => Promise<TValue>,
+): Promise<PooledResult<TItem, TValue>[]> {
+  const results = new Array<PooledResult<TItem, TValue>>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    for (;;) {
+      const index = nextIndex++;
+      if (index >= items.length) return;
+      const item = items[index];
+      try {
+        const value = await task(item, index);
+        results[index] = { item, status: 'fulfilled', value };
+      } catch (reason) {
+        results[index] = { item, status: 'rejected', reason };
+      }
+    }
+  }
+
+  const workerCount = Math.min(limit, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}

--- a/src/ui/components/import-progress.ts
+++ b/src/ui/components/import-progress.ts
@@ -1,0 +1,201 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Live progress display for `sonar import` provisioning.
+
+import * as readline from 'node:readline';
+
+import { bold, dim, green, red, STATUS_COLORS, STATUS_ICONS, visibleLength } from '../colors.js';
+import { isMockActive, recordCall } from '../mock.js';
+import { phase, phaseItem } from './phase.js';
+
+/** Subset of `StepStatus` relevant to a repo's provisioning lifecycle. */
+export type ImportRepoStatus = 'pending' | 'running' | 'done' | 'failed';
+
+const BAR_WIDTH = 24;
+const BAR_FILLED = '█';
+const BAR_EMPTY = '░';
+const DEFAULT_MAX_VISIBLE = 10;
+
+interface RepoState {
+  status: ImportRepoStatus;
+  detail?: string;
+  ref?: string;
+}
+
+/** Maps a repo's live status to the static `phase()` component's non-TTY-fallback vocabulary. */
+function toPhaseStatus(status: ImportRepoStatus | undefined): 'done' | 'failed' | 'skipped' {
+  if (status === 'done') return 'done';
+  if (status === 'failed') return 'failed';
+  return 'skipped';
+}
+
+/**
+ * Live progress renderer for `sonar import`'s concurrent provisioning phase: one row per repo
+ * (status icon, slug, colored detail, dim reference) plus a progress bar, redrawn in place as
+ * `update()` is called. TTY-only — non-TTY output (including every integration test, which runs
+ * the binary through a piped process) falls back to the existing static `phase()` component, so
+ * CI/piped output is unaffected by this purely interactive enhancement.
+ *
+ * Shows at most `maxVisible` rows at once — mirroring the provisioning concurrency cap, since
+ * showing every repo (possibly far more than can ever be in flight at once) as idle 'pending'
+ * rows isn't useful. As a visible repo finishes (done/failed), if there's a queued repo waiting
+ * to start it takes over that same row; otherwise the finished row is left as-is, showing its
+ * done/failed state (this is the common case: batches no larger than `maxVisible` never have a
+ * queue at all, so every repo simply stays visible throughout).
+ */
+export class ImportProgress {
+  private readonly order: string[];
+  private readonly repos: Map<string, RepoState>;
+  private readonly isTTY: boolean;
+  private readonly visible: string[];
+  private readonly queue: string[];
+  private linesRendered = 0;
+
+  constructor(opts: { repos: string[]; isTTY?: boolean; maxVisible?: number }) {
+    this.order = opts.repos;
+    this.repos = new Map(opts.repos.map((slug) => [slug, { status: 'pending' as const }]));
+    this.isTTY = opts.isTTY ?? process.stdout.isTTY;
+    const maxVisible = opts.maxVisible ?? DEFAULT_MAX_VISIBLE;
+    this.visible = opts.repos.slice(0, maxVisible);
+    this.queue = opts.repos.slice(maxVisible);
+  }
+
+  start(): void {
+    if (isMockActive()) {
+      recordCall('importProgress.start');
+      return;
+    }
+    if (this.isTTY) {
+      this.render();
+    }
+  }
+
+  update(slug: string, status: ImportRepoStatus, detail?: string, ref?: string): void {
+    this.repos.set(slug, { status, detail, ref });
+    if (status === 'done' || status === 'failed') {
+      this.promoteNext(slug);
+    }
+    if (isMockActive()) {
+      recordCall('importProgress.update', slug, status, detail, ref);
+      return;
+    }
+    if (this.isTTY) {
+      this.render();
+    }
+  }
+
+  /** On a visible repo's completion, swap in the next queued repo to the same row, if any. */
+  private promoteNext(finishedSlug: string): void {
+    const slot = this.visible.indexOf(finishedSlug);
+    if (slot === -1) return;
+    const next = this.queue.shift();
+    if (next !== undefined) {
+      this.visible[slot] = next;
+    }
+  }
+
+  /** Finalizes the display and returns aggregate counts. */
+  finish(): { succeeded: number; failed: number } {
+    const states = [...this.repos.values()];
+    const succeeded = states.filter((s) => s.status === 'done').length;
+    const failed = states.filter((s) => s.status === 'failed').length;
+
+    if (isMockActive()) {
+      recordCall('importProgress.finish');
+      return { succeeded, failed };
+    }
+
+    if (this.isTTY) {
+      this.render();
+      this.printResult(succeeded, failed);
+    } else {
+      const items = this.order.map((slug) => {
+        const state = this.repos.get(slug);
+        return phaseItem(slug, toPhaseStatus(state?.status), state?.detail);
+      });
+      phase('Import results', items);
+    }
+
+    return { succeeded, failed };
+  }
+
+  private printResult(succeeded: number, failed: number): void {
+    process.stdout.write(`\n  ${bold('Result')}\n`);
+    process.stdout.write(`    ${green('✓')}  Succeeded: ${succeeded}\n`);
+    process.stdout.write(`    ${red('✗')}  Failed: ${failed}\n`);
+  }
+
+  private render(): void {
+    this.erase();
+    const lines = this.buildLines();
+    process.stdout.write(lines.join('\n') + '\n');
+    this.linesRendered = lines.length;
+  }
+
+  private erase(): void {
+    if (this.linesRendered === 0) return;
+    readline.moveCursor(process.stdout, 0, -this.linesRendered);
+    readline.cursorTo(process.stdout, 0);
+    readline.clearScreenDown(process.stdout);
+    this.linesRendered = 0;
+  }
+
+  private buildLines(): string[] {
+    // Computed from every repo (not just the currently visible ones) so column alignment
+    // stays stable as rows are swapped out — otherwise the bar/label columns would jitter
+    // depending on which slugs happen to be in the window at a given moment.
+    const maxLabelWidth = Math.max(...this.order.map((slug) => visibleLength(slug)));
+    const rows = this.visible.map((slug) => this.formatRow(slug, maxLabelWidth));
+    return [...rows, '', this.formatBar()];
+  }
+
+  private formatRow(slug: string, labelWidth: number): string {
+    const state = this.repos.get(slug) ?? { status: 'pending' as const };
+    const status: 'pending' | 'running' | 'done' | 'failed' = state.status;
+    const icon = STATUS_ICONS[status];
+    const iconColor = STATUS_COLORS[status];
+
+    const slashIndex = slug.indexOf('/');
+    const org = slashIndex === -1 ? '' : slug.slice(0, slashIndex + 1);
+    const name = slashIndex === -1 ? slug : slug.slice(slashIndex + 1);
+    const label = `${dim(org)}${bold(name)}`;
+    const padding = ' '.repeat(Math.max(0, labelWidth - visibleLength(slug)));
+
+    const detail = state.detail ? STATUS_COLORS[status](state.detail) : '';
+    const ref = state.ref ? dim(state.ref) : '';
+
+    return `    ${iconColor(icon)}  ${label}${padding}  ${detail}  ${ref}`.trimEnd();
+  }
+
+  private formatBar(): string {
+    const total = this.order.length;
+    const resolved = [...this.repos.values()].filter(
+      (s) => s.status === 'done' || s.status === 'failed',
+    ).length;
+    const pct = total === 0 ? 100 : Math.round((resolved / total) * 100);
+    const filled = Math.round((pct / 100) * BAR_WIDTH);
+    const bar = green(BAR_FILLED.repeat(filled)) + dim(BAR_EMPTY.repeat(BAR_WIDTH - filled));
+    const pctLabel = bold(`${pct}%`);
+    const fractionLabel = dim(`${resolved}/${total}`);
+
+    return `    ${bar}  ${pctLabel} ${fractionLabel}`;
+  }
+}

--- a/src/ui/components/prompts.ts
+++ b/src/ui/components/prompts.ts
@@ -132,6 +132,35 @@ export interface MultiSelectOption<T> {
   label: string;
 }
 
+export interface MultiSelectPromptOptions<T> {
+  /** True while more options can be revealed (e.g. a paginated collection's `hasMore`). */
+  hasMore?: () => boolean;
+  /**
+   * Reveal more options, returning the full updated list (existing options plus newly
+   * revealed ones). Synchronous by design: options are expected to already be fully loaded
+   * locally (see `RepositoryCollection`/`OrganizationCollection`), so paging never needs to
+   * make a network call — keeping this synchronous also avoids having to reconcile prompt
+   * state against an in-flight async load.
+   */
+  onLoadMore?: () => MultiSelectOption<T>[];
+  /**
+   * Enables the 'a' keybinding to select/deselect every option at once. Called lazily (only
+   * when 'a' is pressed) so callers paginating lazily can reveal every remaining page first
+   * (e.g. via `onLoadMore`'s underlying collection) before returning the complete option list.
+   * Pressing 'a' again when everything is already selected clears the selection.
+   */
+  selectAll?: () => MultiSelectOption<T>[];
+  /** Max number of selections. Defaults to 20; pass `Infinity` for no cap. */
+  maxSelected?: number;
+  /**
+   * True total option count, for the "N/total selected" counter. Defaults to the currently
+   * revealed `options.length`, which undercounts while paginated options remain unrevealed —
+   * pass this when the caller's backing collection knows the real total up front (e.g.
+   * `RepositoryCollection.length`).
+   */
+  total?: () => number;
+}
+
 const MULTISELECT_VIEWPORT_SIZE = 12;
 const MULTISELECT_MAX_SELECTED = 20;
 
@@ -157,14 +186,74 @@ export function toggleSelected<T>(selected: T[], val: T, max: number): void {
   }
 }
 
+/** Selection hint line shown while the multi-select prompt is active (not submitted/cancelled). */
+function buildSelectHint(countLabel: string, atCap: boolean, selectAllEnabled: boolean): string {
+  if (atCap) {
+    return dim(`(${countLabel} - at max, deselect to choose others)`);
+  }
+  const selectAllHint = selectAllEnabled ? ', a to select all' : '';
+  return dim(`(${countLabel} - space to toggle, enter to confirm${selectAllHint}, q to quit)`);
+}
+
+function renderLoadMoreRow(isCursor: boolean): string {
+  const arrow = isCursor ? cyan('❯') : ' ';
+  const label = 'Load more...';
+  return `    ${arrow}    ${isCursor ? label : dim(label)}`;
+}
+
+function renderOptionRow(
+  label: string,
+  isCursor: boolean,
+  isSelected: boolean,
+  atCap: boolean,
+): string {
+  const unavailable = atCap && !isSelected;
+  const checkbox = checkboxComponent(isSelected, unavailable);
+  const arrow = isCursor ? cyan('❯') : ' ';
+  const displayLabel = isCursor && !unavailable ? label : dim(label);
+  return `    ${arrow} ${checkbox}  ${displayLabel}`;
+}
+
 /**
- * Multi-select prompt. Space to toggle, Enter to confirm. Max 20 selections.
+ * 'a' (select-all) toggle result: everything `selectAll()` returned, or nothing if every
+ * selectable slot (capped by `maxSelected`) is already selected.
+ */
+function computeSelectAllToggle<T>(
+  allOptions: MultiSelectOption<T>[],
+  currentlySelected: T[],
+  maxSelected: number,
+): T[] {
+  const selectableCount = Math.min(allOptions.length, maxSelected);
+  const allSelected = selectableCount > 0 && currentlySelected.length >= selectableCount;
+  if (allSelected) return [];
+
+  const next: T[] = [];
+  for (const opt of allOptions) {
+    if (next.length >= maxSelected) break;
+    next.push(opt.value);
+  }
+  return next;
+}
+
+/**
+ * Multi-select prompt. Space to toggle, Enter to confirm. Max 20 selections by default
+ * (override via `loadMoreOpts.maxSelected`).
  * Returns the selected values array (may be empty) or null if cancelled (Ctrl+C or q).
  * Renders a scrolling viewport when the option list exceeds MULTISELECT_VIEWPORT_SIZE.
+ *
+ * When `loadMoreOpts` is given, a non-toggleable "Load more..." row is appended while
+ * `hasMore()` is true; pressing Enter on that row calls `onLoadMore()` instead of submitting.
+ * Selections are preserved across a load-more because they're tracked by value identity
+ * (`===`) rather than by index — callers must return `===`-stable values for options that
+ * were already present before the reload.
+ *
+ * When `loadMoreOpts.selectAll` is given, pressing 'a' selects every option it returns (or
+ * clears the selection if everything is already selected).
  */
 export async function multiSelectPrompt<T>(
   message: string,
-  options: MultiSelectOption<T>[],
+  initialOptions: MultiSelectOption<T>[],
+  loadMoreOpts?: MultiSelectPromptOptions<T>,
 ): Promise<T[] | null> {
   if (isMockActive()) {
     const value = dequeueMockResponse<T[] | null>([]);
@@ -172,28 +261,46 @@ export async function multiSelectPrompt<T>(
     return value;
   }
 
+  let options = initialOptions;
   const selected: T[] = [];
   let cursor = 0;
+  const maxSelected = loadMoreOpts?.maxSelected ?? MULTISELECT_MAX_SELECTED;
 
-  const prompt = new Prompt<T[]>(
+  const onLoadMore = loadMoreOpts?.onLoadMore;
+  const selectAll = loadMoreOpts?.selectAll;
+  const hasMore = (): boolean => onLoadMore !== undefined && (loadMoreOpts?.hasMore?.() ?? false);
+  const isOnLoadMoreRow = (): boolean => hasMore() && cursor === options.length;
+  const getTotal = (): number => loadMoreOpts?.total?.() ?? options.length;
+
+  // Calling `onLoadMore()` can reveal the last page, flipping `hasMore()` to false — so
+  // `isOnLoadMoreRow()` must be frozen BEFORE calling it. `_shouldSubmit` runs right after our
+  // 'key' handler within the same keypress, so recomputing live here would otherwise let the
+  // very keypress that triggered the load also submit the prompt in the same tick.
+  let pendingLoadMoreSubmitBlock = false;
+
+  class MultiSelectLoadMorePrompt extends Prompt<T[]> {
+    protected override _shouldSubmit(): boolean {
+      return !pendingLoadMoreSubmitBlock;
+    }
+  }
+
+  const prompt = new MultiSelectLoadMorePrompt(
     {
       render() {
         if (this.state === 'submit') {
-          const selectedLabel = `${selected.length} selected`;
+          const selectedLabel = `${selected.length} of ${getTotal()} selected`;
           return `  ${green('✓')}  ${message} ${dim(selectedLabel)}`;
         }
         if (this.state === 'cancel') {
           return `  ${red('✗')}  ${message}`;
         }
 
-        const atCap = selected.length >= MULTISELECT_MAX_SELECTED;
-        const hint = atCap
-          ? dim(
-              `(${MULTISELECT_MAX_SELECTED}/${MULTISELECT_MAX_SELECTED} - deselect to choose others)`,
-            )
-          : dim('(Space to toggle, Enter to confirm, q to quit)');
+        const atCap = selected.length >= maxSelected;
+        const countLabel = `${selected.length}/${getTotal()} selected`;
+        const hint = buildSelectHint(countLabel, atCap, selectAll !== undefined);
 
-        const total = options.length;
+        const loadMoreRowVisible = hasMore();
+        const total = options.length + (loadMoreRowVisible ? 1 : 0);
         const { start, end } = calculateViewport(cursor, total, MULTISELECT_VIEWPORT_SIZE);
 
         const lines = [`  ${cyan('?')}  ${message}  ${hint}`];
@@ -204,14 +311,16 @@ export async function multiSelectPrompt<T>(
         }
 
         for (let i = start; i < end; i++) {
-          const opt = options[i];
           const isCursor = i === cursor;
+
+          if (loadMoreRowVisible && i === options.length) {
+            lines.push(renderLoadMoreRow(isCursor));
+            continue;
+          }
+
+          const opt = options[i];
           const isSelected = selected.includes(opt.value);
-          const unavailable = atCap && !isSelected;
-          const checkbox = checkboxComponent(isSelected, unavailable);
-          const arrow = isCursor ? cyan('❯') : ' ';
-          const label = isCursor && !unavailable ? opt.label : dim(opt.label);
-          lines.push(`    ${arrow} ${checkbox}  ${label}`);
+          lines.push(renderOptionRow(opt.label, isCursor, isSelected, atCap));
         }
 
         const more = `↓ ${total - end} more`;
@@ -224,21 +333,34 @@ export async function multiSelectPrompt<T>(
   );
 
   prompt.on('cursor', (dir) => {
+    const total = options.length + (hasMore() ? 1 : 0);
     if (dir === 'up') cursor = Math.max(0, cursor - 1);
-    else if (dir === 'down') cursor = Math.min(options.length - 1, cursor + 1);
+    else if (dir === 'down') cursor = Math.min(total - 1, cursor + 1);
     else if (dir === 'space') {
       const val = options[cursor]?.value;
       if (val !== undefined) {
-        toggleSelected(selected, val, MULTISELECT_MAX_SELECTED);
+        toggleSelected(selected, val, maxSelected);
       }
     }
   });
 
   prompt.on('key', (_key, s) => {
     if (s.name === 'return') {
+      pendingLoadMoreSubmitBlock = isOnLoadMoreRow() && onLoadMore !== undefined;
+      if (pendingLoadMoreSubmitBlock && onLoadMore) {
+        options = onLoadMore();
+        return;
+      }
       prompt.value = [...selected];
     } else if (s.name === 'q') {
       prompt.state = 'cancel';
+    } else if (s.name === 'a' && selectAll) {
+      const allOptions = selectAll();
+      options = allOptions;
+      const next = computeSelectAllToggle(allOptions, selected, maxSelected);
+      selected.length = 0;
+      selected.push(...next);
+      cursor = Math.min(cursor, options.length + (hasMore() ? 1 : 0) - 1);
     }
   });
 

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -24,7 +24,11 @@ export { bold, dim, stripAnsi, visibleLength } from './colors.js';
 export { note } from './components/note.js';
 export type { PhaseItem, StepStatus } from './components/phase.js';
 export { phase, phaseItem } from './components/phase.js';
-export type { MultiSelectOption, SelectOption } from './components/prompts.js';
+export type {
+  MultiSelectOption,
+  MultiSelectPromptOptions,
+  SelectOption,
+} from './components/prompts.js';
 export {
   confirmPrompt,
   multiSelectPrompt,

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -101,10 +101,21 @@ export class ProjectBuilder {
 export class FakeSonarQubeServer {
   private readonly server: ReturnType<typeof Bun.serve>;
   private readonly requests: RecordedRequest[];
+  private readonly provisionConcurrency: { current: number; peak: number };
 
-  constructor(server: ReturnType<typeof Bun.serve>, requests: RecordedRequest[]) {
+  constructor(
+    server: ReturnType<typeof Bun.serve>,
+    requests: RecordedRequest[],
+    provisionConcurrency: { current: number; peak: number },
+  ) {
     this.server = server;
     this.requests = requests;
+    this.provisionConcurrency = provisionConcurrency;
+  }
+
+  /** Peak number of concurrent `provision_projects` requests observed in flight. */
+  getPeakConcurrentProvisionRequests(): number {
+    return this.provisionConcurrency.peak;
   }
 
   baseUrl(): string {
@@ -160,6 +171,8 @@ export class FakeSonarQubeServerBuilder {
   private serverMode: 'MQR' | 'STANDARD' = 'STANDARD';
   private provisionProjectsStatusCode?: number;
   private provisionProjectsStatusBody?: string;
+  private provisionProjectsFailingInstallationKey?: string;
+  private provisionProjectsDelayMs?: number;
 
   withMode(mode: 'MQR' | 'STANDARD'): this {
     this.serverMode = mode;
@@ -321,10 +334,27 @@ export class FakeSonarQubeServerBuilder {
   /**
    * Force POST /api/alm_integration/provision_projects to fail with the given HTTP status
    * code, simulating a provisioning error (e.g. repo already imported, permission denied).
+   * When `onlyForInstallationKey` is set, only requests for that exact `installationKeys`
+   * value fail — every other request succeeds normally, simulating a mixed-outcome batch.
    */
-  withProvisionProjectsError(statusCode: number, body?: string): this {
+  withProvisionProjectsError(
+    statusCode: number,
+    body?: string,
+    opts?: { onlyForInstallationKey?: string },
+  ): this {
     this.provisionProjectsStatusCode = statusCode;
     this.provisionProjectsStatusBody = body;
+    this.provisionProjectsFailingInstallationKey = opts?.onlyForInstallationKey;
+    return this;
+  }
+
+  /**
+   * Add an artificial delay (ms) before responding to POST
+   * /api/alm_integration/provision_projects, so tests can observe genuinely concurrent
+   * in-flight requests via `getPeakConcurrentProvisionRequests()`.
+   */
+  withProvisionProjectsDelay(ms: number): this {
+    this.provisionProjectsDelayMs = ms;
     return this;
   }
 
@@ -381,9 +411,12 @@ export class FakeSonarQubeServerBuilder {
       organizationsSearchErrorCode,
       provisionProjectsStatusCode,
       provisionProjectsStatusBody,
+      provisionProjectsFailingInstallationKey,
+      provisionProjectsDelayMs,
     } = this;
     const memberOrganizationsTotal = rawMemberOrganizationsTotal ?? memberOrganizations.length;
     const requests: RecordedRequest[] = [];
+    const provisionConcurrency = { current: 0, peak: 0 };
 
     const server = Bun.serve({
       port: 0,
@@ -738,23 +771,45 @@ export class FakeSonarQubeServerBuilder {
         }
 
         if (path === '/api/alm_integration/provision_projects' && req.method === 'POST') {
-          if (provisionProjectsStatusCode !== undefined) {
-            return new Response(
-              provisionProjectsStatusBody ??
-                JSON.stringify({ errors: [{ msg: 'Provisioning failed' }] }),
-              {
-                status: provisionProjectsStatusCode,
-                headers: { 'Content-Type': 'application/json' },
-              },
+          provisionConcurrency.current++;
+          provisionConcurrency.peak = Math.max(
+            provisionConcurrency.peak,
+            provisionConcurrency.current,
+          );
+          try {
+            if (provisionProjectsDelayMs) {
+              await new Promise((resolve) => setTimeout(resolve, provisionProjectsDelayMs));
+            }
+
+            const params = new URLSearchParams(body ?? '');
+            const installationKeys = params.get('installationKeys') ?? '';
+            const shouldFail =
+              provisionProjectsStatusCode !== undefined &&
+              (provisionProjectsFailingInstallationKey === undefined ||
+                provisionProjectsFailingInstallationKey === installationKeys);
+
+            if (shouldFail) {
+              return new Response(
+                provisionProjectsStatusBody ??
+                  JSON.stringify({ errors: [{ msg: 'Provisioning failed' }] }),
+                {
+                  status: provisionProjectsStatusCode,
+                  headers: { 'Content-Type': 'application/json' },
+                },
+              );
+            }
+
+            const organization = params.get('organization') ?? '';
+            const projectKey = `${organization}_${installationKeys}`.replace(
+              /[^a-zA-Z0-9_-]/g,
+              '_',
             );
+            return new Response(JSON.stringify({ projects: [{ projectKey }] }), {
+              headers: { 'Content-Type': 'application/json' },
+            });
+          } finally {
+            provisionConcurrency.current--;
           }
-          const params = new URLSearchParams(body ?? '');
-          const organization = params.get('organization') ?? '';
-          const installationKeys = params.get('installationKeys') ?? '';
-          const projectKey = `${organization}_${installationKeys}`.replace(/[^a-zA-Z0-9_-]/g, '_');
-          return new Response(JSON.stringify({ projects: [{ projectKey }] }), {
-            headers: { 'Content-Type': 'application/json' },
-          });
         }
 
         if (path === '/api/settings/values' && req.method === 'GET') {
@@ -957,6 +1012,6 @@ export class FakeSonarQubeServerBuilder {
       },
     });
 
-    return Promise.resolve(new FakeSonarQubeServer(server, requests));
+    return Promise.resolve(new FakeSonarQubeServer(server, requests, provisionConcurrency));
   }
 }

--- a/tests/integration/specs/import/import.test.ts
+++ b/tests/integration/specs/import/import.test.ts
@@ -96,7 +96,7 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import', {
-          stdinChunks: ['\r', '\r'], // enter → selects the only org, enter → selects the only repo
+          stdinChunks: ['\r', ' \r'], // enter → selects the only org, space+enter → toggles and confirms the only repo
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -127,7 +127,7 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import', {
-          stdinChunks: ['\r', '\r'], // enter → selects the only eligible org, enter → selects the only repo
+          stdinChunks: ['\r', ' \r'], // enter → selects the only eligible org, space+enter → toggles and confirms the only repo
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -156,7 +156,7 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', '\r'], // down arrow + enter → selects second org, enter → selects the only repo
+          stdinChunks: ['\x1b[B\r', ' \r'], // down arrow + enter → selects second org, space+enter → toggles and confirms the only repo
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -290,7 +290,7 @@ describe('sonar import', () => {
 
         // navigate to "Load more...", select it, pick the 11th org, then select the only repo
         const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B'.repeat(10) + '\r', '\x1b[B'.repeat(10) + '\r', '\r'],
+          stdinChunks: ['\x1b[B'.repeat(10) + '\r', '\x1b[B'.repeat(10) + '\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -329,7 +329,7 @@ describe('sonar import', () => {
 
         // first visible option is the org whose key equals the internal sentinel string
         const result = await harness.run('import', {
-          stdinChunks: ['\r', '\r'], // enter → selects the sentinel-keyed org, enter → selects the only repo
+          stdinChunks: ['\r', ' \r'], // enter → selects the sentinel-keyed org, space+enter → toggles and confirms the only repo
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -386,6 +386,193 @@ describe('sonar import', () => {
     );
   });
 
+  describe('onboarding mode selection', () => {
+    it(
+      'offers Recommended, Manual, and Back, importing everything eligible when Recommended is chosen',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [
+            { id: 'repo-1', name: 'repo-1', slug: 'my-org/repo-1' },
+            { id: 'repo-2', name: 'repo-2', slug: 'my-org/repo-2' },
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --org my-org', {
+          stdin: '\r', // enter → Recommended (the default, first option)
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('How do you want to import repositories?');
+        expect(result.stdout).toContain(
+          'Recommended — import all eligible repositories automatically',
+        );
+        expect(result.stdout).toContain('Manual — choose repositories yourself');
+        expect(result.stdout).toContain('Imported 2 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(2);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'omits "← Back" when --org pins the organization',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [{ id: 'repo-1', name: 'repo-1', slug: 'my-org/repo-1' }])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --org my-org', {
+          stdin: '\r',
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).not.toContain('← Back');
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      '"← Back" returns to organization selection and re-resolves the newly chosen org',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withOrganizations([
+            { key: 'org-one', name: 'Organization One', alm: GITHUB_ALM, actions: ADMIN_ACTIONS },
+            { key: 'org-two', name: 'Organization Two', alm: GITHUB_ALM, actions: ADMIN_ACTIONS },
+          ])
+          .withDopRepositories('org-one', [
+            { id: 'repo-1', name: 'repo-one', slug: 'org-one/repo-one' },
+          ])
+          .withDopRepositories('org-two', [
+            { id: 'repo-2', name: 'repo-two', slug: 'org-two/repo-two' },
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // enter → picks org-one; down+down+enter → "← Back" (3rd option after
+        // Recommended/Manual); down+enter → picks org-two this time; enter → Recommended
+        // mode for org-two (its only repo is eligible either way).
+        const result = await harness.run('import', {
+          stdinChunks: ['\r', '\x1b[B\x1b[B\r', '\x1b[B\r', '\r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('org-two');
+        expect(result.stdout).toContain('org-two/repo-two');
+        expect(result.stdout).not.toContain('org-one/repo-one');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(1);
+        expect(new URLSearchParams(provisionRequests[0].body ?? '').get('installationKeys')).toBe(
+          'org-two/repo-two|repo-2',
+        );
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'offers to go back when the interactively-picked org has nothing eligible to import',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withOrganizations([
+            { key: 'org-one', name: 'Organization One', alm: GITHUB_ALM, actions: ADMIN_ACTIONS },
+            { key: 'org-two', name: 'Organization Two', alm: GITHUB_ALM, actions: ADMIN_ACTIONS },
+          ])
+          .withDopRepositories('org-one', [
+            {
+              id: 'repo-1',
+              name: 'repo-one',
+              slug: 'org-one/repo-one',
+              importedInCurrentOrg: true,
+            },
+          ])
+          .withDopRepositories('org-two', [
+            { id: 'repo-2', name: 'repo-two', slug: 'org-two/repo-two' },
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // enter → picks org-one (nothing eligible); enter → accepts the default "Yes, go
+        // back"; down+enter → picks org-two this time; enter → Recommended mode for org-two.
+        const result = await harness.run('import', {
+          stdinChunks: ['\r', '\r', '\x1b[B\r', '\r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain(
+          'All repositories for the selected organization have already been imported into SonarQube.',
+        );
+        expect(output).toContain('Go back and choose a different organization?');
+        expect(result.stdout).toContain('org-two/repo-two');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(1);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits with code 1 when declining to go back after nothing is eligible',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withOrganizations([
+            { key: 'org-one', name: 'Organization One', alm: GITHUB_ALM, actions: ADMIN_ACTIONS },
+          ])
+          .withDopRepositories('org-one', [
+            {
+              id: 'repo-1',
+              name: 'repo-one',
+              slug: 'org-one/repo-one',
+              importedInCurrentOrg: true,
+            },
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // enter → picks the only org; 'n' → declines going back
+        const result = await harness.run('import', {
+          stdinChunks: ['\r', 'n'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain(
+          'All repositories for the selected organization have already been imported into SonarQube.',
+        );
+      },
+      { timeout: 15000 },
+    );
+  });
+
   describe('repository selection', () => {
     it(
       'prompts to select repo even when only one repo exists',
@@ -399,7 +586,7 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdin: '\r', // enter → selects the only repo
+          stdinChunks: ['\x1b[B\r', ' \r'], // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -424,7 +611,8 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdin: '\x1b[B\r', // down arrow then enter → selects second repo
+          // down arrow+enter → Manual mode, down arrow+space+enter → toggles and confirms second repo
+          stdinChunks: ['\x1b[B\r', '\x1b[B \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -462,7 +650,7 @@ describe('sonar import', () => {
     );
 
     it(
-      'exits with code 2 when --non-interactive is set without --repo',
+      'exits with code 2 when --non-interactive is set without --repo or --all',
       async () => {
         const server = await harness.newFakeServer().withAuthToken('test-token').start();
         const serverUrl = server.baseUrl();
@@ -474,7 +662,7 @@ describe('sonar import', () => {
 
         expect(result.exitCode).toBe(2);
         const output = result.stdout + result.stderr;
-        expect(output).toContain('--repo is required in non-interactive mode');
+        expect(output).toContain('--repo or --all is required in non-interactive mode');
       },
       { timeout: 15000 },
     );
@@ -512,7 +700,7 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdin: '\r',
+          stdinChunks: ['\x1b[B\r', ' \r'], // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -564,9 +752,12 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token');
 
-        // navigate to "Load more...", select it, then pick the 11th repo that appears
+        // down arrow+enter → Manual mode, then navigate to "Load more...", select it (cursor
+        // carries over onto the newly revealed 11th repo, since the multi-select prompt never
+        // resets its cursor), then toggle and confirm it. Repos are all fetched up front, so
+        // "Load more" is a synchronous local pagination step with no reload delay to account for.
         const result = await harness.run('import --org my-org', {
-          stdinChunks: ['\x1b[B'.repeat(10) + '\r', '\x1b[B'.repeat(10) + '\r'],
+          stdinChunks: ['\x1b[B\r', '\x1b[B'.repeat(10) + '\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -577,11 +768,11 @@ describe('sonar import', () => {
     );
 
     it(
-      'fetches only the first server page before showing the initial repo prompt',
+      'fetches every server page up front before showing the repo prompt',
       async () => {
-        // 60 repos exceeds the 50-item server page cap, so an eager fetch-all
-        // would need 2 requests; the lazy loader should only need 1 to fill
-        // the first local page (10 items) the user actually sees.
+        // 60 repos exceeds the 50-item server page cap, so fetching everything up front
+        // (mirroring org selection) needs exactly 2 requests, made before the prompt is
+        // ever shown — regardless of which repo the user ends up picking.
         const manyRepos = Array.from({ length: 60 }, (_, i) => ({
           id: `repo-${i + 1}`,
           name: `repo-${String(i + 1).padStart(2, '0')}`,
@@ -597,7 +788,8 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdin: '\r', // enter → selects the first repo without paging further
+          // down arrow+enter → Manual mode, space+enter → toggles and confirms the first repo
+          stdinChunks: ['\x1b[B\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -605,7 +797,57 @@ describe('sonar import', () => {
         expect(result.stdout).toContain('kevinmlsilva/repo-01');
         const recorded = server.getRecordedRequests();
         const repoRequests = recorded.filter((r) => r.path === '/dop-translation/dop-repositories');
-        expect(repoRequests).toHaveLength(1);
+        expect(repoRequests).toHaveLength(2);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'shows a full page of selectable repos in one go despite interleaved exclusions',
+      async () => {
+        // 15 raw repos; 5 of the first 10 are already imported. If filtering happened on
+        // a lazily-fetched 10-item window, the first page would show only 5 selectable
+        // repos (with "Load more" for the rest). Fetching everything up front and
+        // filtering before pagination shows a full page of 10 selectable repos instead.
+        const manyRepos = Array.from({ length: 15 }, (_, i) => ({
+          id: `repo-${i + 1}`,
+          name: `repo-${String(i + 1).padStart(2, '0')}`,
+          slug: `kevinmlsilva/repo-${String(i + 1).padStart(2, '0')}`,
+          importedInCurrentOrg: i < 10 && i % 2 === 0, // repo-01,03,05,07,09 excluded
+        }));
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', manyRepos)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --org my-org', {
+          // down arrow+enter → Manual mode, space+enter → toggles and confirms the first selectable repo
+          stdinChunks: ['\x1b[B\r', ' \r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        // Exactly the 10 selectable repos (02,04,06,08,10,11-15), no "Load more" needed.
+        for (const slug of [
+          'kevinmlsilva/repo-02',
+          'kevinmlsilva/repo-04',
+          'kevinmlsilva/repo-06',
+          'kevinmlsilva/repo-08',
+          'kevinmlsilva/repo-10',
+          'kevinmlsilva/repo-11',
+          'kevinmlsilva/repo-12',
+          'kevinmlsilva/repo-13',
+          'kevinmlsilva/repo-14',
+          'kevinmlsilva/repo-15',
+        ]) {
+          expect(result.stdout).toContain(slug);
+        }
+        expect(result.stdout).not.toContain('Load more');
+        expect(result.stdout).toContain('Imported 1 repository');
       },
       { timeout: 15000 },
     );
@@ -627,12 +869,14 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import', {
-          stdinChunks: ['\r', '\r'], // enter → selects the only org, enter → selects the only repo
+          // enter → selects the only org, down arrow+enter → Manual mode,
+          // space+enter → toggles and confirms the only repo
+          stdinChunks: ['\r', '\x1b[B\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('Project created:');
+        expect(result.stdout).toContain('Imported 1 repository');
         const recorded = server.getRecordedRequests();
         const provisionRequest = recorded.find(
           (r) => r.path === '/api/alm_integration/provision_projects',
@@ -660,7 +904,7 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import', {
-          stdinChunks: ['\r', '\r'],
+          stdinChunks: ['\r', '\x1b[B\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -690,7 +934,8 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdin: '\r', // enter → selects the only repo
+          // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
+          stdinChunks: ['\x1b[B\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -727,13 +972,13 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdin: '\r',
+          stdinChunks: ['\x1b[B\r', ' \r'], // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
         expect(result.exitCode).toBe(1);
         const output = result.stdout + result.stderr;
-        expect(output).toContain('Failed to create project');
+        expect(output).toContain('Failed to import 1 repository.');
       },
       { timeout: 15000 },
     );
@@ -825,7 +1070,7 @@ describe('sonar import', () => {
         });
 
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('Project created:');
+        expect(result.stdout).toContain('Imported 1 repository');
       },
       { timeout: 15000 },
     );
@@ -883,7 +1128,8 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdin: '\r', // enter → selects the only repo
+          // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
+          stdinChunks: ['\x1b[B\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -915,7 +1161,8 @@ describe('sonar import', () => {
         // No private-projects entitlement configured → org is public-only, so the private
         // repo must be dropped from the list rather than merely shown as disabled.
         const result = await harness.run('import --org my-org', {
-          stdin: '\r', // enter → selects the only remaining (public) repo
+          // down arrow+enter → Manual mode, space+enter → toggles and confirms the only remaining (public) repo
+          stdinChunks: ['\x1b[B\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
@@ -953,6 +1200,453 @@ describe('sonar import', () => {
         expect(output).toContain(
           "No repositories match this organization's project visibility settings.",
         );
+      },
+      { timeout: 15000 },
+    );
+  });
+
+  describe('batch import', () => {
+    const BATCH_REPOS = [
+      { id: 'repo-a-id', name: 'repo-a', slug: 'my-org/repo-a' },
+      { id: 'repo-b-id', name: 'repo-b', slug: 'my-org/repo-b' },
+      { id: 'repo-c-id', name: 'repo-c', slug: 'my-org/repo-c' },
+    ];
+
+    it(
+      'imports multiple repositories given repeated --repo flags',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-a --repo my-org/repo-b',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 2 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(2);
+        const installationKeys = provisionRequests.map((r) =>
+          new URLSearchParams(r.body ?? '').get('installationKeys'),
+        );
+        expect(installationKeys.sort()).toEqual(['repo-a-id', 'repo-b-id']);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'imports multiple repositories given a comma-separated --repo value',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-a,my-org/repo-b',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 2 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(2);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'dedupes repos given via a mix of repeated and comma-separated --repo flags',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-a,my-org/repo-b --repo my-org/repo-a',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 2 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(2);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'imports multiple repositories toggled interactively',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // down arrow+enter → Manual mode, space (toggle repo-a), down, down,
+        // space (toggle repo-c), enter (confirm)
+        const result = await harness.run('import --org my-org', {
+          stdinChunks: ['\x1b[B\r', ' \x1b[B\x1b[B \r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 2 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(2);
+        const installationKeys = provisionRequests.map((r) =>
+          new URLSearchParams(r.body ?? '').get('installationKeys'),
+        );
+        expect(installationKeys.sort()).toEqual(['repo-a-id', 'repo-c-id']);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      "selects every repo when pressing 'a' in the interactive picker",
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // down arrow+enter → Manual mode, 'a' → select all, enter → confirm
+        const result = await harness.run('import --org my-org', {
+          stdinChunks: ['\x1b[B\r', 'a\r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 3 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(3);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      "toggling 'a' twice clears the select-all, allowing a manual pick afterwards",
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // down arrow+enter → Manual mode, 'a' → select all, 'a' → deselect all,
+        // down, space (toggle repo-b), enter
+        const result = await harness.run('import --org my-org', {
+          stdinChunks: ['\x1b[B\r', 'aa\x1b[B \r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 1 repository');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(1);
+        expect(new URLSearchParams(provisionRequests[0].body ?? '').get('installationKeys')).toBe(
+          'repo-b-id',
+        );
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      "selecting all with 'a' is not capped at 20 repos",
+      async () => {
+        const manyRepos = Array.from({ length: 25 }, (_, i) => ({
+          id: `repo-${i + 1}`,
+          name: `repo-${i + 1}`,
+          slug: `my-org/repo-${i + 1}`,
+        }));
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', manyRepos)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --org my-org', {
+          // down arrow+enter → Manual mode, 'a' → select all, enter → confirm
+          stdinChunks: ['\x1b[B\r', 'a\r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+          timeoutMs: 20000,
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 25 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(25);
+      },
+      { timeout: 20000 },
+    );
+
+    it(
+      'reports a partial failure summary when some repos fail to provision',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .withProvisionProjectsError(
+            400,
+            JSON.stringify({ errors: [{ msg: 'Repository already imported' }] }),
+            { onlyForInstallationKey: 'repo-b-id' },
+          )
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-a,my-org/repo-b,my-org/repo-c',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('Imported 2 of 3 repositories (1 failed)');
+        expect(output).toContain('my-org/repo-a');
+        expect(output).toContain('my-org/repo-b');
+        expect(output).toContain('my-org/repo-c');
+        expect(output).toContain('Repository already imported');
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'fails fast without provisioning any repo when a --repo slug does not match',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', BATCH_REPOS)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-a,my-org/does-not-exist,my-org/repo-c',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain("not found in the selected organization's DevOps platform");
+        expect(output).toContain('my-org/does-not-exist');
+        expect(output).not.toContain('my-org/repo-a');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'caps concurrent provisioning requests at 10',
+      async () => {
+        const manyRepos = Array.from({ length: 15 }, (_, i) => ({
+          id: `repo-${i + 1}`,
+          name: `repo-${i + 1}`,
+          slug: `my-org/repo-${i + 1}`,
+        }));
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', manyRepos)
+          .withProvisionProjectsDelay(50)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const repoFlag = manyRepos.map((r) => r.slug).join(',');
+        const result = await harness.run(
+          `import --non-interactive --org my-org --repo ${repoFlag}`,
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl }, timeoutMs: 30000 },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 15 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(15);
+        expect(server.getPeakConcurrentProvisionRequests()).toBeLessThanOrEqual(10);
+        expect(server.getPeakConcurrentProvisionRequests()).toBeGreaterThanOrEqual(8);
+      },
+      { timeout: 30000 },
+    );
+  });
+
+  describe('bulk import (--all)', () => {
+    it(
+      'imports every eligible repo and reports skipped counts grouped by reason',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [
+            {
+              id: 'repo-1',
+              name: 'repo-1',
+              slug: 'my-org/already-imported',
+              importedInCurrentOrg: true,
+            },
+            {
+              id: 'repo-2',
+              name: 'repo-2',
+              slug: 'my-org/already-bound',
+              boundProjectIds: ['some-other-project'],
+            },
+            { id: 'repo-3', name: 'repo-3', slug: 'my-org/private-repo', private: true },
+            { id: 'repo-4', name: 'repo-4', slug: 'my-org/eligible-a' },
+            { id: 'repo-5', name: 'repo-5', slug: 'my-org/eligible-b' },
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --non-interactive --org my-org --all', {
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 2 repositories (3 skipped)');
+        expect(result.stdout).toContain('Repositories skipped: 3');
+        // Grouped by reason, not listed per repo: 2 already-imported (one flagged directly,
+        // one via a non-empty boundProjectIds) + 1 excluded by visibility settings.
+        expect(result.stdout).toContain('already imported: 2');
+        expect(result.stdout).toContain(
+          "private repos aren't allowed by this organization's project visibility settings: 1",
+        );
+        expect(result.stdout).not.toContain('my-org/already-imported');
+        expect(result.stdout).not.toContain('my-org/already-bound');
+        expect(result.stdout).not.toContain('my-org/private-repo');
+
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(2);
+        const installationKeys = provisionRequests.map((r) =>
+          new URLSearchParams(r.body ?? '').get('installationKeys'),
+        );
+        expect(installationKeys.sort()).toEqual(['repo-4', 'repo-5']);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits with code 2 when --all is combined with --repo',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [{ id: 'repo-1', name: 'repo-1', slug: 'my-org/repo-1' }])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --org my-org --all --repo my-org/repo-1', {
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(2);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('--all cannot be combined with --repo');
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'satisfies --non-interactive without needing --repo',
+      async () => {
+        const server = await harness.newFakeServer().withAuthToken('test-token').start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --non-interactive --org my-org --all', {
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        // No repos configured at all — fails for a different reason than the
+        // --repo-required validation, proving --all satisfied it.
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).not.toContain('is required in non-interactive mode');
+        expect(output).toContain('No repositories found for the selected organization.');
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'exits with code 1 when no repos are eligible for import',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [
+            { id: 'repo-1', name: 'repo-1', slug: 'my-org/repo-1', importedInCurrentOrg: true },
+            { id: 'repo-2', name: 'repo-2', slug: 'my-org/repo-2', private: true },
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --non-interactive --org my-org --all', {
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('No repositories are eligible for import');
       },
       { timeout: 15000 },
     );

--- a/tests/unit/ui/import-progress.test.ts
+++ b/tests/unit/ui/import-progress.test.ts
@@ -1,0 +1,184 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '../../../src/ui';
+import { ImportProgress } from '../../../src/ui/components/import-progress.js';
+
+const REPOS = ['my-org/api-gateway', 'my-org/auth-service', 'my-org/billing'];
+
+function captureStdout(fn: () => void): string {
+  const chunks: string[] = [];
+  const spy = spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  try {
+    fn();
+  } finally {
+    spy.mockRestore();
+  }
+  return chunks.join('');
+}
+
+describe('ImportProgress — non-TTY', () => {
+  it('writes nothing on start or during updates', () => {
+    const progress = new ImportProgress({ repos: REPOS, isTTY: false });
+    const start = captureStdout(() => progress.start());
+    expect(start).toBe('');
+
+    const update = captureStdout(() => progress.update(REPOS[0], 'running'));
+    expect(update).toBe('');
+  });
+
+  it('finish() delegates to the static phase() summary', () => {
+    const progress = new ImportProgress({ repos: REPOS, isTTY: false });
+    progress.start();
+    progress.update(REPOS[0], 'done', 'Project created', 'my-org_api-gateway');
+    progress.update(REPOS[1], 'done', 'Project created', 'my-org_auth-service');
+    progress.update(REPOS[2], 'failed', 'CI failed');
+
+    const output = captureStdout(() => {
+      const { succeeded, failed } = progress.finish();
+      expect(succeeded).toBe(2);
+      expect(failed).toBe(1);
+    });
+
+    expect(output).toContain('Import results');
+    expect(output).toContain('my-org/api-gateway');
+    expect(output).toContain('my-org/auth-service');
+    expect(output).toContain('my-org/billing');
+    expect(output).toContain('Project created');
+    expect(output).toContain('CI failed');
+  });
+
+  it('a repo never updated stays out of the succeeded/failed counts', () => {
+    const progress = new ImportProgress({ repos: REPOS, isTTY: false });
+    let succeeded = 0;
+    let failed = 0;
+    captureStdout(() => {
+      progress.start();
+      progress.update(REPOS[0], 'done', 'Project created', 'key');
+      ({ succeeded, failed } = progress.finish());
+    });
+    expect(succeeded).toBe(1);
+    expect(failed).toBe(0);
+  });
+});
+
+describe('ImportProgress — TTY', () => {
+  it('renders one row per repo plus a progress bar, updating in place', () => {
+    const progress = new ImportProgress({ repos: REPOS, isTTY: true });
+    const start = captureStdout(() => progress.start());
+    for (const repo of REPOS) {
+      expect(start).toContain(repo.split('/')[1]);
+    }
+    expect(start).toContain('0%');
+    expect(start).toContain('0/3');
+
+    const afterOne = captureStdout(() =>
+      progress.update(REPOS[0], 'done', 'Project created', 'my-org_api-gateway'),
+    );
+    expect(afterOne).toContain('Project created');
+    expect(afterOne).toContain('my-org_api-gateway');
+    expect(afterOne).toContain('33%');
+    expect(afterOne).toContain('1/3');
+  });
+
+  it('shows at most maxVisible rows, promoting the next queued repo on completion', () => {
+    const repos = ['org/repo-1', 'org/repo-2', 'org/repo-3', 'org/repo-4', 'org/repo-5'];
+    const progress = new ImportProgress({ repos, isTTY: true, maxVisible: 3 });
+
+    const start = captureStdout(() => progress.start());
+    expect(start).toContain('repo-1');
+    expect(start).toContain('repo-2');
+    expect(start).toContain('repo-3');
+    expect(start).not.toContain('repo-4');
+    expect(start).not.toContain('repo-5');
+
+    // repo-1 finishes → repo-4 (next queued) takes over its row.
+    const afterFirst = captureStdout(() =>
+      progress.update('org/repo-1', 'done', 'Project created'),
+    );
+    expect(afterFirst).not.toContain('repo-1');
+    expect(afterFirst).toContain('repo-2');
+    expect(afterFirst).toContain('repo-3');
+    expect(afterFirst).toContain('repo-4');
+    expect(afterFirst).not.toContain('repo-5');
+
+    // repo-2 finishes → repo-5 takes over; the queue is now empty.
+    const afterSecond = captureStdout(() => progress.update('org/repo-2', 'failed', 'CI failed'));
+    expect(afterSecond).not.toContain('repo-2');
+    expect(afterSecond).toContain('repo-5');
+
+    // repo-3 finishes with nothing left to promote — its row stays, showing "done".
+    const afterThird = captureStdout(() =>
+      progress.update('org/repo-3', 'done', 'Project created'),
+    );
+    expect(afterThird).toContain('repo-3');
+    expect(afterThird).toContain('repo-4');
+    expect(afterThird).toContain('repo-5');
+  });
+
+  it('finish() renders the final state and a Result section', () => {
+    const progress = new ImportProgress({ repos: REPOS, isTTY: true });
+    captureStdout(() => {
+      progress.start();
+      progress.update(REPOS[0], 'done', 'Project created', 'my-org_api-gateway');
+      progress.update(REPOS[1], 'done', 'Project created', 'my-org_auth-service');
+      progress.update(REPOS[2], 'failed', 'CI failed');
+    });
+
+    const finish = captureStdout(() => progress.finish());
+    expect(finish).toContain('100%');
+    expect(finish).toContain('3/3');
+    expect(finish).toContain('Result');
+    expect(finish).toContain('Succeeded: 2');
+    expect(finish).toContain('Failed: 1');
+  });
+});
+
+describe('ImportProgress — mock mode', () => {
+  beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
+  });
+  afterEach(() => setMockUi(false));
+
+  it('records method calls, writes nothing, and still tracks counts', () => {
+    const progress = new ImportProgress({ repos: REPOS });
+
+    const output = captureStdout(() => {
+      progress.start();
+      progress.update(REPOS[0], 'done', 'Project created', 'key-1');
+      progress.update(REPOS[1], 'failed', 'CI failed');
+    });
+    const { succeeded, failed } = progress.finish();
+
+    expect(output).toBe('');
+    expect(succeeded).toBe(1);
+    expect(failed).toBe(1);
+    const methods = getMockUiCalls().map((c) => c.method);
+    expect(methods).toContain('importProgress.start');
+    expect(methods).toContain('importProgress.update');
+    expect(methods).toContain('importProgress.finish');
+  });
+});


### PR DESCRIPTION
## Summary
- Provisions multiple repositories concurrently (max 10 in-flight) instead of one at a time, with a live per-repository progress display (`ImportProgress`) showing status, a windowed view (max 10 visible rows), and a final succeeded/failed summary.
- Adds a `--all` flag to bulk-import every eligible repository for the selected org, with eligibility filtering and a grouped skipped-repositories summary (count by reason).
- Adds an onboarding-mode prompt (Recommended / Manual / Back) before repository selection, and extends the interactive multi-select picker with select-all ('a' key), a live "N/total selected" counter, and load-more pagination.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:unit` (2023 pass)
- [x] `bun test tests/integration/specs/import/import.test.ts` (53 pass)
- [x] `bun test tests/unit/ui/import-progress.test.ts` (7 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)