### PR TITLE
CLI-659 Print agent-friendly syntax hints before interactive prompts

### DIFF
--- a/src/cli/commands/_common/agent-prompt-hint.ts
+++ b/src/cli/commands/_common/agent-prompt-hint.ts
@@ -1,0 +1,41 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { type CallerAgent, detectCallerAgent } from '../../../lib/agent-detector';
+import { info, print } from '../../../ui';
+
+const AGENT_DISPLAY_NAMES: Record<CallerAgent, string> = {
+  claude: 'Claude Code',
+  cursor: 'Cursor',
+  copilot: 'Copilot CLI',
+  codex: 'Codex',
+  antigravity: 'Antigravity',
+};
+
+export function printAgentNonInteractiveAlternativeHint(...nonInteractiveExamples: string[]): void {
+  const agent = detectCallerAgent();
+  if (agent === null) {
+    return;
+  }
+  info(`[${AGENT_DISPLAY_NAMES[agent]}] To run non-interactively:`);
+  for (const example of nonInteractiveExamples) {
+    print(`   → ${example}`);
+  }
+}

--- a/src/cli/commands/_common/agent-prompt-hint.ts
+++ b/src/cli/commands/_common/agent-prompt-hint.ts
@@ -18,23 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { type CallerAgent, detectCallerAgent } from '../../../lib/agent-detector';
+import { detectCallerAgent } from '../../../lib/agent-detector';
 import { info, print } from '../../../ui';
 
-const AGENT_DISPLAY_NAMES: Record<CallerAgent, string> = {
-  claude: 'Claude Code',
-  cursor: 'Cursor',
-  copilot: 'Copilot CLI',
-  codex: 'Codex',
-  antigravity: 'Antigravity',
-};
-
 export function printAgentNonInteractiveAlternativeHint(...nonInteractiveExamples: string[]): void {
-  const agent = detectCallerAgent();
-  if (agent === null) {
+  if (detectCallerAgent() === null) {
     return;
   }
-  info(`[${AGENT_DISPLAY_NAMES[agent]}] To run non-interactively:`);
+  info('Agent environment detected. To run non-interactively:');
   for (const example of nonInteractiveExamples) {
     print(`   → ${example}`);
   }

--- a/src/cli/commands/analyze/sqaa-auth.ts
+++ b/src/cli/commands/analyze/sqaa-auth.ts
@@ -28,6 +28,7 @@ import { spawnProcess } from '../../../lib/process';
 import { loadState } from '../../../lib/repository/state-repository';
 import { canonicalProjectRoot } from '../../../lib/state-manager';
 import { blank, confirmPrompt, text, warn } from '../../../ui';
+import { printAgentNonInteractiveAlternativeHint } from '../_common/agent-prompt-hint';
 import { CommandFailedError } from '../_common/error.js';
 import { SQAA_HOOK_FEATURE_ID } from '../integrate/_common/sqaa-entitlement';
 import { CLAUDE_INTEGRATION_ID } from '../integrate/claude/declaration';
@@ -174,11 +175,12 @@ export async function confirmLargeChangeset(fileCount: number): Promise<boolean>
     `You are about to analyze a large number of files (${fileCount}). This may take longer to process.\n${LARGE_CHANGESET_HINT}`,
   );
 
-  if (!process.stdin.isTTY) {
+  if (!process.stdin.isTTY && !process.env.SONARQUBE_CLI_MOCK_TTY) {
     return true;
   }
 
   blank();
+  printAgentNonInteractiveAlternativeHint('sonar analyze --force');
   const confirmed = await confirmPrompt('Do you wish to proceed?', true);
   if (!confirmed) {
     blank();

--- a/src/cli/commands/integrate/antigravity/index.ts
+++ b/src/cli/commands/integrate/antigravity/index.ts
@@ -21,6 +21,7 @@
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import type { IntegrationStateAttribute } from '../../../../lib/state';
 import { info } from '../../../../ui';
+import { printAgentNonInteractiveAlternativeHint } from '../../_common/agent-prompt-hint';
 import { displayAgentIntegratePrelude } from '../_common/agent-integrate-prelude';
 import {
   buildContextAugmentationAttrs,
@@ -38,6 +39,13 @@ export async function integrateAntigravity(
   options: IntegrateAgentOptions,
   auth: ResolvedAuth,
 ): Promise<void> {
+  if (!options.nonInteractive) {
+    printAgentNonInteractiveAlternativeHint(
+      'sonar integrate antigravity -p <project-key>',
+      'sonar integrate antigravity -g',
+    );
+  }
+
   const ctx = await displayAgentIntegratePrelude('Antigravity', 'antigravity', options, auth);
 
   if (options.skipContext) {

--- a/src/cli/commands/integrate/antigravity/index.ts
+++ b/src/cli/commands/integrate/antigravity/index.ts
@@ -41,7 +41,7 @@ export async function integrateAntigravity(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate antigravity --non-interactive -p <project-key>',
+      'sonar integrate antigravity --non-interactive',
       'sonar integrate antigravity --non-interactive -g',
     );
   }

--- a/src/cli/commands/integrate/antigravity/index.ts
+++ b/src/cli/commands/integrate/antigravity/index.ts
@@ -41,8 +41,8 @@ export async function integrateAntigravity(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate antigravity -p <project-key>',
-      'sonar integrate antigravity -g',
+      'sonar integrate antigravity --non-interactive -p <project-key>',
+      'sonar integrate antigravity --non-interactive -g',
     );
   }
 

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -57,8 +57,8 @@ export async function integrateClaude(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate claude -p <project-key>',
-      'sonar integrate claude -g',
+      'sonar integrate claude --non-interactive -p <project-key>',
+      'sonar integrate claude --non-interactive -g',
     );
   }
 

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -57,7 +57,7 @@ export async function integrateClaude(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate claude --non-interactive -p <project-key>',
+      'sonar integrate claude --non-interactive',
       'sonar integrate claude --non-interactive -g',
     );
   }

--- a/src/cli/commands/integrate/claude/index.ts
+++ b/src/cli/commands/integrate/claude/index.ts
@@ -25,6 +25,7 @@ import { homedir } from 'node:os';
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { OBSOLETE_A3S_MARKER, removeObsoleteHookArtifacts } from '../../../../lib/migration';
 import type { IntegrationStateAttribute } from '../../../../lib/state';
+import { printAgentNonInteractiveAlternativeHint } from '../../_common/agent-prompt-hint';
 import {
   displayAgentIntegratePrelude,
   resolveIntegrateInstallTarget,
@@ -54,6 +55,13 @@ export async function integrateClaude(
   options: IntegrateAgentOptions,
   auth: ResolvedAuth,
 ): Promise<void> {
+  if (!options.nonInteractive) {
+    printAgentNonInteractiveAlternativeHint(
+      'sonar integrate claude -p <project-key>',
+      'sonar integrate claude -g',
+    );
+  }
+
   const ctx = await displayAgentIntegratePrelude('Claude Code', 'claude', options, auth);
 
   const config = toConfigurationData(ctx);

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -21,6 +21,7 @@
 // Integrate command — setup SonarQube integration for Codex.
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
+import { printAgentNonInteractiveAlternativeHint } from '../../_common/agent-prompt-hint';
 import { finalizeAgentInstall } from '../_common/agent-integrate-postlude';
 import { displayAgentIntegratePrelude } from '../_common/agent-integrate-prelude';
 import { resolveSqaaSetup } from '../_common/sqaa-entitlement';
@@ -31,6 +32,13 @@ export async function integrateCodex(
   options: IntegrateAgentOptions,
   auth: ResolvedAuth,
 ): Promise<void> {
+  if (!options.nonInteractive) {
+    printAgentNonInteractiveAlternativeHint(
+      'sonar integrate codex -p <project-key>',
+      'sonar integrate codex -g',
+    );
+  }
+
   const ctx = await displayAgentIntegratePrelude('Codex', 'codex', options, auth);
 
   // SQAA is always project-scoped. resolveSqaaSetup returns false (and surfaces

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -34,7 +34,7 @@ export async function integrateCodex(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate codex --non-interactive -p <project-key>',
+      'sonar integrate codex --non-interactive',
       'sonar integrate codex --non-interactive -g',
     );
   }

--- a/src/cli/commands/integrate/codex/index.ts
+++ b/src/cli/commands/integrate/codex/index.ts
@@ -34,8 +34,8 @@ export async function integrateCodex(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate codex -p <project-key>',
-      'sonar integrate codex -g',
+      'sonar integrate codex --non-interactive -p <project-key>',
+      'sonar integrate codex --non-interactive -g',
     );
   }
 

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -19,6 +19,7 @@
  */
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
+import { printAgentNonInteractiveAlternativeHint } from '../../_common/agent-prompt-hint';
 import { finalizeAgentInstall } from '../_common/agent-integrate-postlude';
 import { displayAgentIntegratePrelude } from '../_common/agent-integrate-prelude';
 import { resolveSqaaSetup } from '../_common/sqaa-entitlement';
@@ -27,6 +28,13 @@ import { COPILOT_INTEGRATION_ID, type CopilotIntegrationOptions } from './declar
 import { detectGlobalSecretsHook } from './hooks';
 
 export async function integrateCopilot(options: IntegrateAgentOptions, auth: ResolvedAuth) {
+  if (!options.nonInteractive) {
+    printAgentNonInteractiveAlternativeHint(
+      'sonar integrate copilot -p <project-key>',
+      'sonar integrate copilot -g',
+    );
+  }
+
   const ctx = await displayAgentIntegratePrelude('Copilot', 'copilot', options, auth);
 
   // SQAA is always project-scoped. resolveSqaaSetup owns the user-facing

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -30,8 +30,8 @@ import { detectGlobalSecretsHook } from './hooks';
 export async function integrateCopilot(options: IntegrateAgentOptions, auth: ResolvedAuth) {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate copilot -p <project-key>',
-      'sonar integrate copilot -g',
+      'sonar integrate copilot --non-interactive -p <project-key>',
+      'sonar integrate copilot --non-interactive -g',
     );
   }
 

--- a/src/cli/commands/integrate/copilot/index.ts
+++ b/src/cli/commands/integrate/copilot/index.ts
@@ -30,7 +30,7 @@ import { detectGlobalSecretsHook } from './hooks';
 export async function integrateCopilot(options: IntegrateAgentOptions, auth: ResolvedAuth) {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate copilot --non-interactive -p <project-key>',
+      'sonar integrate copilot --non-interactive',
       'sonar integrate copilot --non-interactive -g',
     );
   }

--- a/src/cli/commands/integrate/cursor/index.ts
+++ b/src/cli/commands/integrate/cursor/index.ts
@@ -35,8 +35,8 @@ export async function integrateCursor(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate cursor -p <project-key>',
-      'sonar integrate cursor -g',
+      'sonar integrate cursor --non-interactive -p <project-key>',
+      'sonar integrate cursor --non-interactive -g',
     );
   }
 

--- a/src/cli/commands/integrate/cursor/index.ts
+++ b/src/cli/commands/integrate/cursor/index.ts
@@ -22,6 +22,7 @@
 
 import type { ResolvedAuth } from '../../../../lib/auth-resolver';
 import { warn } from '../../../../ui';
+import { printAgentNonInteractiveAlternativeHint } from '../../_common/agent-prompt-hint';
 import { finalizeAgentInstall } from '../_common/agent-integrate-postlude';
 import { displayAgentIntegratePrelude } from '../_common/agent-integrate-prelude';
 import { resolveSqaaSetup } from '../_common/sqaa-entitlement';
@@ -32,6 +33,13 @@ export async function integrateCursor(
   options: IntegrateAgentOptions,
   auth: ResolvedAuth,
 ): Promise<void> {
+  if (!options.nonInteractive) {
+    printAgentNonInteractiveAlternativeHint(
+      'sonar integrate cursor -p <project-key>',
+      'sonar integrate cursor -g',
+    );
+  }
+
   const ctx = await displayAgentIntegratePrelude('Cursor', 'cursor', options, auth);
 
   if (ctx.isGlobal) {

--- a/src/cli/commands/integrate/cursor/index.ts
+++ b/src/cli/commands/integrate/cursor/index.ts
@@ -35,7 +35,7 @@ export async function integrateCursor(
 ): Promise<void> {
   if (!options.nonInteractive) {
     printAgentNonInteractiveAlternativeHint(
-      'sonar integrate cursor --non-interactive -p <project-key>',
+      'sonar integrate cursor --non-interactive',
       'sonar integrate cursor --non-interactive -g',
     );
   }

--- a/src/cli/commands/integrate/git/index.ts
+++ b/src/cli/commands/integrate/git/index.ts
@@ -29,6 +29,7 @@ import { normalizePath } from '../../../../lib/fs-utils';
 import { discoverProject, findGitRoot } from '../../../../lib/project-workspace';
 import { blank, confirmPrompt, info, intro, phase, phaseItem, text, warn } from '../../../../ui';
 import { yellow } from '../../../../ui/colors.js';
+import { printAgentNonInteractiveAlternativeHint } from '../../_common/agent-prompt-hint';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { GitRepo, resolveGitHooksDir } from '../../_common/git-repo';
 import { resolveIntegrateScope } from '../_common/integrate-scope';
@@ -143,6 +144,10 @@ export async function integrateGit(
 
   if (options.global && (options.dependencyRisks || options.project)) {
     throw new InvalidOptionError('--dependency-risks and -p are not supported with --global.');
+  }
+
+  if (!options.nonInteractive) {
+    printAgentNonInteractiveAlternativeHint('sonar integrate git --non-interactive');
   }
 
   intro('SonarQube Git Integration (source code scanning)');

--- a/src/cli/commands/remediate/index.ts
+++ b/src/cli/commands/remediate/index.ts
@@ -62,7 +62,7 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
     options.issues === undefined ? undefined : parseIssueKeys(options.issues);
 
   if (suppliedIssueKeys === undefined) {
-    printAgentNonInteractiveAlternativeHint('sonar remediate --issues PROJ-1,PROJ-2');
+    printAgentNonInteractiveAlternativeHint('sonar remediate --issues <issue-key-1>,<issue-key-2>');
   }
 
   assertCloudConnection(auth);

--- a/src/cli/commands/remediate/index.ts
+++ b/src/cli/commands/remediate/index.ts
@@ -34,6 +34,7 @@ import { IssuesClient } from '../../../sonarqube/issues';
 import { MAX_PAGE_SIZE } from '../../../sonarqube/projects';
 import { blank, info, multiSelectPrompt, print, success, withSpinner } from '../../../ui';
 import { cyan, dim, red, yellow } from '../../../ui/colors';
+import { printAgentNonInteractiveAlternativeHint } from '../_common/agent-prompt-hint';
 import { CommandFailedError, InvalidOptionError } from '../_common/error';
 
 export interface RemediateOptions {
@@ -60,42 +61,66 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
   const suppliedIssueKeys =
     options.issues === undefined ? undefined : parseIssueKeys(options.issues);
 
-  if (auth.connectionType !== 'cloud') {
-    throw new CommandFailedError('sonar remediate requires a SonarQube Cloud connection.', {
-      remediationHint: "Authenticate against SonarQube Cloud with 'sonar auth login' and retry.",
-    });
+  if (suppliedIssueKeys === undefined) {
+    printAgentNonInteractiveAlternativeHint('sonar remediate --issues PROJ-1,PROJ-2');
   }
 
-  if (
-    !process.stdin.isTTY &&
-    !process.env.SONARQUBE_CLI_MOCK_TTY &&
-    suppliedIssueKeys === undefined
-  ) {
-    throw new CommandFailedError('Non-interactive mode requires --issues <issueIds>.', {
-      remediationHint:
-        "Run 'sonar list issues --project <key>' to find issue keys, then pass them with --issues.",
-    });
-  }
+  assertCloudConnection(auth);
+  assertInteractiveOrIssuesSupplied(suppliedIssueKeys);
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
-
   // resolveAuth guarantees orgKey is set for cloud connections (see auth-resolver.ts);
   // narrow once and reuse throughout this function.
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const orgKey = auth.orgKey!;
 
+  if (!(await confirmEntitlement(client, orgKey))) return;
+
+  const projectKey = await resolveProjectKey(options, auth);
+  const selectedKeys =
+    suppliedIssueKeys ?? (await selectIssuesInteractively(client, orgKey, projectKey));
+  if (selectedKeys === null) return;
+
+  const projectId = await resolveProjectId(client, projectKey);
+  const taskId = await submitRemediationJob(client, projectId, selectedKeys, orgKey);
+  reportSubmissionSuccess(auth, projectKey, selectedKeys, taskId);
+}
+
+function assertCloudConnection(auth: ResolvedAuth): void {
+  if (auth.connectionType !== 'cloud') {
+    throw new CommandFailedError('sonar remediate requires a SonarQube Cloud connection.', {
+      remediationHint: "Authenticate against SonarQube Cloud with 'sonar auth login' and retry.",
+    });
+  }
+}
+
+function assertInteractiveOrIssuesSupplied(suppliedIssueKeys: string[] | undefined): void {
+  const canPrompt = process.stdin.isTTY || Boolean(process.env.SONARQUBE_CLI_MOCK_TTY);
+  if (!canPrompt && suppliedIssueKeys === undefined) {
+    throw new CommandFailedError('Non-interactive mode requires --issues <issueIds>.', {
+      remediationHint:
+        "Run 'sonar list issues --project <key>' to find issue keys, then pass them with --issues.",
+    });
+  }
+}
+
+/**
+ * Prints the applicable message and returns false when remediation is not
+ * available for this organisation. Throws when entitlement could not be verified.
+ */
+async function confirmEntitlement(client: SonarQubeClient, orgKey: string): Promise<boolean> {
   const { status: entitlement } = await client.checkAiRemediationEntitlement(orgKey);
   if (entitlement === 'not_eligible') {
     blank();
     info(`The Remediation Agent is not available for your organisation. See ${AGENTIC_PACK_URL}`);
-    return;
+    return false;
   }
   if (entitlement === 'not_enabled') {
     blank();
     info(
       `The Remediation Agent is not enabled for your organisation. Contact your admin to enable it.`,
     );
-    return;
+    return false;
   }
   if (entitlement === 'unknown') {
     throw new CommandFailedError('Remediation Agent unavailable.', {
@@ -103,41 +128,43 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
         'Could not verify Remediation Agent entitlement. Retry later, and report to https://github.com/SonarSource/sonarqube-cli/issues if the problem persists.',
     });
   }
+  return true;
+}
 
-  let projectKey = options.project;
-  if (!projectKey) {
-    const discovered = await discoverProject(process.cwd(), false, { auth });
-    projectKey = discovered.projectKey;
+async function resolveProjectKey(options: RemediateOptions, auth: ResolvedAuth): Promise<string> {
+  if (options.project) {
+    return options.project;
   }
-  if (!projectKey) {
+  const discovered = await discoverProject(process.cwd(), false, { auth });
+  if (!discovered.projectKey) {
     throw new CommandFailedError('Could not determine project key.', {
       remediationHint: 'Use --project <key> to specify it.',
     });
   }
+  return discovered.projectKey;
+}
 
-  let selectedKeys: string[];
-  if (suppliedIssueKeys === undefined) {
-    const interactive = await selectIssuesInteractively(client, orgKey, projectKey);
-    if (interactive === null) return;
-    selectedKeys = interactive;
-  } else {
-    selectedKeys = suppliedIssueKeys;
-  }
-
-  // The AI agent API requires the project's legacy component ID, not its key.
+// The AI agent API requires the project's legacy component ID, not its key.
+async function resolveProjectId(client: SonarQubeClient, projectKey: string): Promise<string> {
   const resolvedId = await client.getComponentId(projectKey);
   logger.debug(`getComponentId(${projectKey}) => ${resolvedId ?? 'null (falling back to key)'}`);
-  const projectId = resolvedId ?? projectKey;
+  return resolvedId ?? projectKey;
+}
 
+async function submitRemediationJob(
+  client: SonarQubeClient,
+  projectId: string,
+  issueKeys: string[],
+  orgKey: string,
+): Promise<string> {
   blank();
-  const jobRequest = { projectId, issueKeys: selectedKeys, triggerSource: 'CLI' as const };
+  const jobRequest = { projectId, issueKeys, triggerSource: 'CLI' as const };
   logger.debug(`scheduleAgentJob request: ${JSON.stringify(jobRequest)}`);
-  let taskId: string;
   try {
     const response = await withSpinner('Submitting remediation job', () =>
       client.scheduleAgentJob(jobRequest),
     );
-    taskId = response.taskId;
+    return response.taskId;
   } catch (err) {
     logger.error(`scheduleAgentJob failed: ${(err as Error).message}`);
     throw new CommandFailedError('Remediation job submission failed.', {
@@ -145,7 +172,14 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
       remediationHint: mapSubmissionFailureHint((err as Error).message, orgKey),
     });
   }
+}
 
+function reportSubmissionSuccess(
+  auth: ResolvedAuth,
+  projectKey: string,
+  selectedKeys: string[],
+  taskId: string,
+): void {
   const issueWord = selectedKeys.length === 1 ? 'issue' : 'issues';
   blank();
   success(`Submitted ${selectedKeys.length} ${issueWord} for remediation\nJob: job/${taskId}`);

--- a/src/cli/commands/system/reset.ts
+++ b/src/cli/commands/system/reset.ts
@@ -23,6 +23,7 @@ import { loadState, saveState } from '../../../lib/repository/state-repository';
 import { type CliState, getDefaultState, type InstalledIntegration } from '../../../lib/state';
 import type { PhaseItem } from '../../../ui';
 import { info, phase, print, success, text, textPrompt, warn } from '../../../ui';
+import { printAgentNonInteractiveAlternativeHint } from '../_common/agent-prompt-hint';
 import { supportedIntegrations } from '../integrate';
 import { purgeAuth } from './reset-auth';
 import { removeBinaries } from './reset-binaries';
@@ -69,8 +70,11 @@ function mergeCleanedFields(fields: CleanedFields[]): CleanedFields {
  * and cached files. Telemetry settings are preserved.
  */
 export async function systemReset(options: SystemResetOptions): Promise<void> {
-  if (!(options.force || (await confirmDestructiveAction()))) {
-    return;
+  if (!options.force) {
+    printAgentNonInteractiveAlternativeHint('sonar system reset --force');
+    if (!(await confirmDestructiveAction())) {
+      return;
+    }
   }
 
   info('Cleaning up SonarQube CLI environment...');

--- a/tests/_common/agent-hint-assertions.ts
+++ b/tests/_common/agent-hint-assertions.ts
@@ -1,0 +1,43 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Shared assertions for `printAgentNonInteractiveAlternativeHint` output
+// (src/cli/commands/_common/agent-prompt-hint.ts). Callers only supply the
+// agent display name and the non-interactive example(s), mirroring the real
+// function's own signature.
+
+import { expect } from 'bun:test';
+
+/** Asserts the hint was printed for `displayName`, with one line per example. */
+export function expectAgentPromptHint(
+  output: string,
+  displayName: string,
+  ...examples: string[]
+): void {
+  expect(output).toContain(`[${displayName}] To run non-interactively:`);
+  for (const example of examples) {
+    expect(output).toContain(`   → ${example}`);
+  }
+}
+
+/** Asserts the hint was not printed at all (e.g. human/non-agent caller). */
+export function expectNoAgentPromptHint(output: string): void {
+  expect(output).not.toContain('To run non-interactively');
+}

--- a/tests/_common/agent-hint-assertions.ts
+++ b/tests/_common/agent-hint-assertions.ts
@@ -20,18 +20,13 @@
 
 // Shared assertions for `printAgentNonInteractiveAlternativeHint` output
 // (src/cli/commands/_common/agent-prompt-hint.ts). Callers only supply the
-// agent display name and the non-interactive example(s), mirroring the real
-// function's own signature.
+// non-interactive example(s), mirroring the real function's own signature.
 
 import { expect } from 'bun:test';
 
-/** Asserts the hint was printed for `displayName`, with one line per example. */
-export function expectAgentPromptHint(
-  output: string,
-  displayName: string,
-  ...examples: string[]
-): void {
-  expect(output).toContain(`[${displayName}] To run non-interactively:`);
+/** Asserts the hint was printed, with one line per example. */
+export function expectAgentPromptHint(output: string, ...examples: string[]): void {
+  expect(output).toContain('Agent environment detected. To run non-interactively:');
   for (const example of examples) {
     expect(output).toContain(`   → ${example}`);
   }

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -1363,7 +1363,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {
-        expectAgentPromptHint(result.stdout, 'Claude Code', 'sonar analyze --force');
+        expectAgentPromptHint(result.stdout, 'sonar analyze --force');
       } else {
         expectNoAgentPromptHint(result.stdout);
       }

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -32,6 +32,10 @@ import {
   SQAA_ANALYZE_AGENTIC_CALLER_COMMAND,
   SQAA_ANALYZE_CALLER_COMMAND,
 } from '../../../../src/telemetry/sqaa-analysis-telemetry.js';
+import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
 import { readAnalysisEvents } from '../../../_common/telemetry-helpers';
 import { TestHarness } from '../../harness';
 import { commitFile, git, initGitRepo, stageFile } from '../hook/git-test-helpers';
@@ -1322,6 +1326,72 @@ describe('analyze agentic — change-set mode (no --file)', () => {
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
       expect(totalSqaaFilesSent(sqaaCalls)).toBe(51);
+    },
+    { timeout: 30000 },
+  );
+
+  it.each([
+    [true, true, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, false],
+  ])(
+    'prints a non-interactive hint before the large change set confirmation only for a detected AI agent without --force (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+    async (isAgent, isInteractive, expectedShownPrompt) => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+      harness
+        .state()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaFeature(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      commitFile(harness.cwd.path, 'README.md', 'hello');
+      for (let i = 1; i <= 51; i++) {
+        harness.cwd.writeFile(`file${i}.ts`, `const x${i} = ${i};`);
+      }
+
+      const result = await harness.run(`analyze agentic${isInteractive ? '' : ' --force'}`, {
+        ...(isInteractive ? { stdinChunks: ['\r'] } : {}),
+        extraEnv: {
+          SONARQUBE_CLI_MOCK_TTY: '1',
+          ...(isAgent ? { CLAUDECODE: '1' } : {}),
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      if (expectedShownPrompt) {
+        expectAgentPromptHint(result.stdout, 'Claude Code', 'sonar analyze --force');
+      } else {
+        expectNoAgentPromptHint(result.stdout);
+      }
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'does not print a non-interactive hint for a detected AI agent when the change set is below the large-set threshold',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+      harness
+        .state()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaFeature(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      commitFile(harness.cwd.path, 'README.md', 'hello');
+
+      const result = await harness.run('analyze agentic', {
+        extraEnv: { SONARQUBE_CLI_MOCK_TTY: '1', CLAUDECODE: '1' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expectNoAgentPromptHint(result.stdout);
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -210,8 +210,7 @@ describe('integrate antigravity', () => {
         if (expectedShownPrompt) {
           expectAgentPromptHint(
             result.stdout,
-            'Antigravity',
-            'sonar integrate antigravity --non-interactive -p <project-key>',
+            'sonar integrate antigravity --non-interactive',
             'sonar integrate antigravity --non-interactive -g',
           );
         } else {

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -211,8 +211,8 @@ describe('integrate antigravity', () => {
           expectAgentPromptHint(
             result.stdout,
             'Antigravity',
-            'sonar integrate antigravity -p <project-key>',
-            'sonar integrate antigravity -g',
+            'sonar integrate antigravity --non-interactive -p <project-key>',
+            'sonar integrate antigravity --non-interactive -g',
           );
         } else {
           expectNoAgentPromptHint(result.stdout);

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -26,6 +26,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { SQAA_GLOBAL_SKIP_MESSAGE } from '../../../../src/cli/commands/integrate/_common/sqaa-entitlement';
 import { CLI_COMMAND } from '../../../../src/lib/config-constants';
+import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
 import { IS_WINDOWS, normalizePath, TestHarness } from '../../harness';
 import {
   type AntigravityHooksJson,
@@ -178,6 +182,41 @@ describe('integrate antigravity', () => {
         expect(result.stdout + result.stderr).toContain(
           'Skipping Vortex context augmentation (--skip-context)',
         );
+      },
+      { timeout: 30000 },
+    );
+
+    it.each([
+      [true, true, true],
+      [true, false, false],
+      [false, true, false],
+      [false, false, false],
+    ])(
+      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      async (isAgent, isInteractive, expectedShownPrompt) => {
+        // -p skips the scope prompt; three features ask by default (secrets
+        // hooks, MCP server, prompt-secrets project rules) — SQAA is skipped
+        // silently (not entitled) and prompt-secrets global rules are
+        // skipped (project scope). --non-interactive skips those asks too.
+        const result = await harness.run(
+          `integrate antigravity --project ${TEST_PROJECT}${isInteractive ? '' : ' --non-interactive'}`,
+          {
+            ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r'] } : {}),
+            extraEnv: isAgent ? { ANTIGRAVITY_AGENT: '1' } : {},
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+        if (expectedShownPrompt) {
+          expectAgentPromptHint(
+            result.stdout,
+            'Antigravity',
+            'sonar integrate antigravity -p <project-key>',
+            'sonar integrate antigravity -g',
+          );
+        } else {
+          expectNoAgentPromptHint(result.stdout);
+        }
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -192,7 +192,7 @@ describe('integrate antigravity', () => {
       [false, true, false],
       [false, false, false],
     ])(
-      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      'prints a non-interactive hint with --non-interactive plus -p/-g examples only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
       async (isAgent, isInteractive, expectedShownPrompt) => {
         // -p skips the scope prompt; three features ask by default (secrets
         // hooks, MCP server, prompt-secrets project rules) — SQAA is skipped

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -29,6 +29,10 @@ import { buildLocalBinaryName } from '../../../../src/cli/commands/_common/insta
 import { claudeIntegration } from '../../../../src/cli/commands/integrate/claude/declaration.js';
 import { detectPlatform } from '../../../../src/lib/platform-detector.js';
 import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
+import {
   hookScriptName,
   hookScriptPath,
   IS_WINDOWS,
@@ -1871,6 +1875,45 @@ describe('integrate claude — interactive feature selection', () => {
       expect(findClaudeFeature(harness, 'sonar-secrets-hooks')).toBeDefined();
       expect(findClaudeFeature(harness, 'mcp-server')).toBeDefined();
       expect(findClaudeFeature(harness, 'sonar-sqaa-hook')).toBeUndefined();
+    },
+    { timeout: 30000 },
+  );
+
+  it.each([
+    [true, true, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, false],
+  ])(
+    'prints a non-interactive hint using the CLI subcommand (not the claude-code registry id) only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+    async (isAgent, isInteractive, expectedShownPrompt) => {
+      const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
+      harness.withAuth(server.baseUrl(), 'tok');
+      harness.cwd.writeFile(
+        'sonar-project.properties',
+        [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
+      );
+
+      const result = await harness.run(
+        `integrate claude${isInteractive ? '' : ' --non-interactive'}`,
+        {
+          ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r'] } : {}),
+          extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      if (expectedShownPrompt) {
+        expectAgentPromptHint(
+          result.stdout,
+          'Claude Code',
+          'sonar integrate claude -p <project-key>',
+          'sonar integrate claude -g',
+        );
+        expect(result.stdout).not.toContain('sonar integrate claude-code');
+      } else {
+        expectNoAgentPromptHint(result.stdout);
+      }
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -1907,8 +1907,8 @@ describe('integrate claude — interactive feature selection', () => {
         expectAgentPromptHint(
           result.stdout,
           'Claude Code',
-          'sonar integrate claude -p <project-key>',
-          'sonar integrate claude -g',
+          'sonar integrate claude --non-interactive -p <project-key>',
+          'sonar integrate claude --non-interactive -g',
         );
         expect(result.stdout).not.toContain('sonar integrate claude-code');
       } else {

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -1885,7 +1885,7 @@ describe('integrate claude — interactive feature selection', () => {
     [false, true, false],
     [false, false, false],
   ])(
-    'prints a non-interactive hint using the CLI subcommand (not the claude-code registry id) only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+    'prints a non-interactive hint with --non-interactive plus -p/-g examples, using the CLI subcommand (not the claude-code registry id), only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
     async (isAgent, isInteractive, expectedShownPrompt) => {
       const server = await harness.newFakeServer().withAuthToken('tok').withProject('proj').start();
       harness.withAuth(server.baseUrl(), 'tok');

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -1906,8 +1906,7 @@ describe('integrate claude — interactive feature selection', () => {
       if (expectedShownPrompt) {
         expectAgentPromptHint(
           result.stdout,
-          'Claude Code',
-          'sonar integrate claude --non-interactive -p <project-key>',
+          'sonar integrate claude --non-interactive',
           'sonar integrate claude --non-interactive -g',
         );
         expect(result.stdout).not.toContain('sonar integrate claude-code');

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -710,8 +710,8 @@ describe('integrate codex', () => {
           expectAgentPromptHint(
             result.stdout,
             'Codex',
-            'sonar integrate codex -p <project-key>',
-            'sonar integrate codex -g',
+            'sonar integrate codex --non-interactive -p <project-key>',
+            'sonar integrate codex --non-interactive -g',
           );
         } else {
           expectNoAgentPromptHint(result.stdout);

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -695,7 +695,7 @@ describe('integrate codex', () => {
       [false, true, false],
       [false, false, false],
     ])(
-      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      'prints a non-interactive hint with --non-interactive plus -p/-g examples only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
       async (isAgent, isInteractive, expectedShownPrompt) => {
         const result = await harness.run(
           `integrate codex${isInteractive ? '' : ' --non-interactive'}`,

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -29,6 +29,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { codexIntegration } from '../../../../src/cli/commands/integrate/codex/declaration';
 import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
+import {
   hookScriptName,
   hookScriptPath,
   IS_WINDOWS,
@@ -681,6 +685,37 @@ describe('integrate codex', () => {
         expect(findCodexFeature(harness, 'secrets-instructions')).toBeDefined();
         expect(findCodexFeature(harness, 'mcp-server')).toBeDefined();
         expect(findCodexFeature(harness, 'sonar-sqaa-hook')).toBeUndefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it.each([
+      [true, true, true],
+      [true, false, false],
+      [false, true, false],
+      [false, false, false],
+    ])(
+      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      async (isAgent, isInteractive, expectedShownPrompt) => {
+        const result = await harness.run(
+          `integrate codex${isInteractive ? '' : ' --non-interactive'}`,
+          {
+            ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r', '\r'] } : {}),
+            extraEnv: isAgent ? { CODEX_SANDBOX_NETWORK_DISABLED: '1' } : {},
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+        if (expectedShownPrompt) {
+          expectAgentPromptHint(
+            result.stdout,
+            'Codex',
+            'sonar integrate codex -p <project-key>',
+            'sonar integrate codex -g',
+          );
+        } else {
+          expectNoAgentPromptHint(result.stdout);
+        }
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -709,8 +709,7 @@ describe('integrate codex', () => {
         if (expectedShownPrompt) {
           expectAgentPromptHint(
             result.stdout,
-            'Codex',
-            'sonar integrate codex --non-interactive -p <project-key>',
+            'sonar integrate codex --non-interactive',
             'sonar integrate codex --non-interactive -g',
           );
         } else {

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -898,8 +898,7 @@ describe('integrate copilot', () => {
         if (expectedShownPrompt) {
           expectAgentPromptHint(
             result.stdout,
-            'Copilot CLI',
-            'sonar integrate copilot --non-interactive -p <project-key>',
+            'sonar integrate copilot --non-interactive',
             'sonar integrate copilot --non-interactive -g',
           );
           expect(result.stdout).not.toContain('sonar integrate copilot-cli');

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -884,7 +884,7 @@ describe('integrate copilot', () => {
       [false, true, false],
       [false, false, false],
     ])(
-      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      'prints a non-interactive hint with --non-interactive plus -p/-g examples only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
       async (isAgent, isInteractive, expectedShownPrompt) => {
         const result = await harness.run(
           `integrate copilot${isInteractive ? '' : ' --non-interactive'}`,

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -899,8 +899,8 @@ describe('integrate copilot', () => {
           expectAgentPromptHint(
             result.stdout,
             'Copilot CLI',
-            'sonar integrate copilot -p <project-key>',
-            'sonar integrate copilot -g',
+            'sonar integrate copilot --non-interactive -p <project-key>',
+            'sonar integrate copilot --non-interactive -g',
           );
           expect(result.stdout).not.toContain('sonar integrate copilot-cli');
         } else {

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -23,6 +23,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { CLI_COMMAND } from '../../../../src/lib/config-constants.js';
+import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
 import { normalizePath, TestHarness } from '../../harness';
 import {
   CopilotHookEntry,
@@ -870,6 +874,38 @@ describe('integrate copilot', () => {
         expect(findCopilotFeature(harness, 'prompt-secrets-instructions')).toBeDefined();
         expect(findCopilotFeature(harness, 'mcp-server')).toBeDefined();
         expect(findCopilotFeature(harness, 'sqaa-instructions')).toBeUndefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it.each([
+      [true, true, true],
+      [true, false, false],
+      [false, true, false],
+      [false, false, false],
+    ])(
+      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      async (isAgent, isInteractive, expectedShownPrompt) => {
+        const result = await harness.run(
+          `integrate copilot${isInteractive ? '' : ' --non-interactive'}`,
+          {
+            ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r', '\r'] } : {}),
+            extraEnv: isAgent ? { COPILOT_CLI: '1' } : {},
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+        if (expectedShownPrompt) {
+          expectAgentPromptHint(
+            result.stdout,
+            'Copilot CLI',
+            'sonar integrate copilot -p <project-key>',
+            'sonar integrate copilot -g',
+          );
+          expect(result.stdout).not.toContain('sonar integrate copilot-cli');
+        } else {
+          expectNoAgentPromptHint(result.stdout);
+        }
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -568,8 +568,8 @@ describe('integrate cursor', () => {
           expectAgentPromptHint(
             result.stdout,
             'Cursor',
-            'sonar integrate cursor -p <project-key>',
-            'sonar integrate cursor -g',
+            'sonar integrate cursor --non-interactive -p <project-key>',
+            'sonar integrate cursor --non-interactive -g',
           );
         } else {
           expectNoAgentPromptHint(result.stdout);

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -28,6 +28,10 @@ import { isAbsolute } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { cursorIntegration } from '../../../../src/cli/commands/integrate/cursor/declaration';
+import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
 import { hookScriptName, hookScriptPath, normalizePath, TestHarness } from '../../harness';
 import { findInstalledFeature, getInstalledIntegration } from './state-helpers';
 
@@ -537,6 +541,39 @@ describe('integrate cursor', () => {
         expect(
           findInstalledFeature(harness, 'cursor', 'sqaa-instructions', 'project'),
         ).toBeDefined();
+      },
+      { timeout: 30000 },
+    );
+
+    it.each([
+      [true, true, true],
+      [true, false, false],
+      [false, true, false],
+      [false, false, false],
+    ])(
+      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      async (isAgent, isInteractive, expectedShownPrompt) => {
+        const { extraEnv } = await setupCloudWithEntitlement();
+
+        const result = await harness.run(
+          `integrate cursor --project ${TEST_PROJECT}${isInteractive ? '' : ' --non-interactive'}`,
+          {
+            extraEnv: isAgent ? { ...extraEnv, CURSOR_AGENT: '1' } : extraEnv,
+            ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r'] } : {}),
+          },
+        );
+
+        expect(result.exitCode).toBe(0);
+        if (expectedShownPrompt) {
+          expectAgentPromptHint(
+            result.stdout,
+            'Cursor',
+            'sonar integrate cursor -p <project-key>',
+            'sonar integrate cursor -g',
+          );
+        } else {
+          expectNoAgentPromptHint(result.stdout);
+        }
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -551,7 +551,7 @@ describe('integrate cursor', () => {
       [false, true, false],
       [false, false, false],
     ])(
-      'prints a non-interactive hint using -p/-g only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+      'prints a non-interactive hint with --non-interactive plus -p/-g examples only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
       async (isAgent, isInteractive, expectedShownPrompt) => {
         const { extraEnv } = await setupCloudWithEntitlement();
 

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -567,8 +567,7 @@ describe('integrate cursor', () => {
         if (expectedShownPrompt) {
           expectAgentPromptHint(
             result.stdout,
-            'Cursor',
-            'sonar integrate cursor --non-interactive -p <project-key>',
+            'sonar integrate cursor --non-interactive',
             'sonar integrate cursor --non-interactive -g',
           );
         } else {

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -26,6 +26,10 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import * as yaml from 'js-yaml';
 
+import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
 import { ISOLATED_CLI_SPAWN_ENV } from '../../../_common/isolated-cli-env.js';
 import { TestHarness } from '../../harness';
 import { getCliBinaryPath } from '../../harness/cli-runner.js';
@@ -432,6 +436,44 @@ describe('integrate git (native hooks)', () => {
     { timeout: 15000 },
   );
 
+  it.each([
+    [true, true, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, false],
+  ])(
+    'prints a non-interactive hint before scope and feature prompts only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+    async (isAgent, isInteractive, expectedShownPrompt) => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+      initGitRepo(harness);
+
+      const result = await harness.run(
+        `integrate git${isInteractive ? '' : ' --non-interactive'}`,
+        {
+          ...(isInteractive
+            ? { stdinChunks: ['\r', '\r', 'n'], stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS }
+            : {}),
+          extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      if (expectedShownPrompt) {
+        expectAgentPromptHint(
+          result.stdout,
+          'Claude Code',
+          'sonar integrate git --non-interactive',
+        );
+        // Must use the CLI subcommand "git", not the internal registry
+        // integrationId (native-git/husky/pre-commit).
+        expect(result.stdout).not.toContain('sonar integrate native-git');
+      } else {
+        expectNoAgentPromptHint(result.stdout);
+      }
+    },
+    { timeout: 15000 },
+  );
+
   it(
     'installs all hooks when --non-interactive is used without --hook',
     async () => {
@@ -750,6 +792,38 @@ describe('integrate git (native hooks)', () => {
       expect(result.stdout + result.stderr).toContain('✓  pre-commit code scanning hook');
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-commit')).toBe(true);
       expect(harness.userHome.exists('.sonar', 'sonarqube-cli', 'hooks', 'pre-push')).toBe(false);
+    },
+    { timeout: 15000 },
+  );
+
+  it.each([
+    [true, true, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, false],
+  ])(
+    'prints a non-interactive hint before the global-install confirmation only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+    async (isAgent, isInteractive, expectedShownPrompt) => {
+      await setupAuthenticated(harness, { withSecretsBinary: true });
+
+      const result = await harness.run(
+        `integrate git --global${isInteractive ? '' : ' --non-interactive'}`,
+        {
+          ...(isInteractive ? { stdinChunks: ['\r', '\r', 'n'] } : {}),
+          extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      if (expectedShownPrompt) {
+        expectAgentPromptHint(
+          result.stdout,
+          'Claude Code',
+          'sonar integrate git --non-interactive',
+        );
+      } else {
+        expectNoAgentPromptHint(result.stdout);
+      }
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -459,11 +459,7 @@ describe('integrate git (native hooks)', () => {
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {
-        expectAgentPromptHint(
-          result.stdout,
-          'Claude Code',
-          'sonar integrate git --non-interactive',
-        );
+        expectAgentPromptHint(result.stdout, 'sonar integrate git --non-interactive');
         // Must use the CLI subcommand "git", not the internal registry
         // integrationId (native-git/husky/pre-commit).
         expect(result.stdout).not.toContain('sonar integrate native-git');
@@ -816,11 +812,7 @@ describe('integrate git (native hooks)', () => {
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {
-        expectAgentPromptHint(
-          result.stdout,
-          'Claude Code',
-          'sonar integrate git --non-interactive',
-        );
+        expectAgentPromptHint(result.stdout, 'sonar integrate git --non-interactive');
       } else {
         expectNoAgentPromptHint(result.stdout);
       }

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -287,7 +287,7 @@ describe('sonar remediate', () => {
         expectAgentPromptHint(
           result.stdout,
           'Claude Code',
-          'sonar remediate --issues PROJ-1,PROJ-2',
+          'sonar remediate --issues <issue-key-1>,<issue-key-2>',
         );
       } else {
         expectNoAgentPromptHint(result.stdout);

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -22,6 +22,10 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
+import {
+  expectAgentPromptHint,
+  expectNoAgentPromptHint,
+} from '../../../_common/agent-hint-assertions.js';
 import { TestHarness } from '../../harness';
 
 const VALID_TOKEN = 'integration-test-token';
@@ -249,6 +253,45 @@ describe('sonar remediate', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('No issues selected');
+    },
+    { timeout: 15000 },
+  );
+
+  it.each([
+    [true, true, true],
+    [true, false, false],
+    [false, true, false],
+    [false, false, false],
+  ])(
+    'prints a non-interactive hint before the issue-selection prompt only for a detected AI agent without --issues (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
+    async (isAgent, isInteractive, expectedShownPrompt) => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withProject(TEST_PROJECT, (p) => {
+          p.withIssue({ ruleKey: 'java:S100', message: 'Fixable issue', fixableByAgent: true });
+        })
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      const command = isInteractive
+        ? `remediate --project ${TEST_PROJECT}`
+        : `remediate --project ${TEST_PROJECT} --issues PROJ-1,PROJ-2`;
+      const result = await harness.run(command, {
+        ...(isInteractive ? { stdinChunks: ['\r'] } : {}),
+        extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      if (expectedShownPrompt) {
+        expectAgentPromptHint(
+          result.stdout,
+          'Claude Code',
+          'sonar remediate --issues PROJ-1,PROJ-2',
+        );
+      } else {
+        expectNoAgentPromptHint(result.stdout);
+      }
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -286,7 +286,6 @@ describe('sonar remediate', () => {
       if (expectedShownPrompt) {
         expectAgentPromptHint(
           result.stdout,
-          'Claude Code',
           'sonar remediate --issues <issue-key-1>,<issue-key-2>',
         );
       } else {


### PR DESCRIPTION
----
## Summary by Gitar

- **New utility:**
  - Added `printAgentNonInteractiveAlternativeHint` in `src/cli/commands/_common/agent-prompt-hint.ts` to suggest CLI commands for AI agents.
- **Logic updates:**
  - Integrated agent-friendly hints into `sqaa-auth.ts` and `remediate/index.ts` to guide users toward non-interactive alternatives.
  - Refactored `remediate/index.ts` to improve project key resolution, submission handling, and non-interactive mode assertions.
  - Updated interaction checks in `sqaa-auth.ts` to respect `SONARQUBE_CLI_MOCK_TTY` for improved testing reliability.
- **Testing enhancements:**
  - Added `tests/_common/agent-hint-assertions.ts` for consistent validation of hint output.
  - Implemented new integration tests in `analyze-sqaa.test.ts` covering various AI agent and TTY scenarios.

<sub>This will update automatically on new commits.</sub>