### PR TITLE
CLI-819 Change Apple Developer ID to SonarSource Sarl

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
             local binary="$1"
             local archive="/tmp/$(basename "$binary").zip"
 
-            codesign --sign "Developer ID Application: SonarSource SA ($APPLE_TEAM_ID)" --identifier sonarqube-cli --options runtime --timestamp "$binary"
+            codesign --sign "Developer ID Application: SonarSource Sarl ($APPLE_TEAM_ID)" --identifier sonarqube-cli --options runtime --timestamp "$binary"
             codesign --verify --verbose "$binary"
 
             zip "$archive" "$binary"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ To avoid this, install the SonarSource Developer ID certificate locally. Once in
    ```bash
    security import certificate.p12 -k ~/Library/Keychains/login.keychain-db
    ```
-4. In **Keychain Access**, find the private key named _Developer ID Application: SonarSource SA_, open **Get Info → Access Control**, and select **Allow all applications to access this item**.
+4. In **Keychain Access**, find the private key named _Developer ID Application: SonarSource Sarl_, open **Get Info → Access Control**, and select **Allow all applications to access this item**.
 
 After this, every build signs the binary automatically. On machines without the certificate or without `APPLE_TEAM_ID` set the step is silently skipped.
 

--- a/build-scripts/codesign-local.ts
+++ b/build-scripts/codesign-local.ts
@@ -31,7 +31,7 @@ if (!teamId) {
   process.exit(0);
 }
 
-const SIGN_IDENTITY = `Developer ID Application: SonarSource SA (${teamId})`;
+const SIGN_IDENTITY = `Developer ID Application: SonarSource Sarl (${teamId})`;
 
 const findIdentity = spawnSync('/usr/bin/security', ['find-identity', '-v', '-p', 'codesigning'], {
   encoding: 'utf8',
@@ -42,7 +42,7 @@ if (!findIdentity.stdout.includes(teamId)) {
   process.exit(0);
 }
 
-console.log(`Signing ${BINARY} with Developer ID Application: SonarSource SA...`);
+console.log(`Signing ${BINARY} with Developer ID Application: SonarSource Sarl...`);
 const result = spawnSync(
   '/usr/bin/codesign',
   ['--sign', SIGN_IDENTITY, '--force', '--options', 'runtime', BINARY],


### PR DESCRIPTION
----
## Summary by Gitar

- **Build configuration:**
  - Updated `SIGN_IDENTITY` in `codesign-local.ts` to reflect the change from `SonarSource SA` to `SonarSource Sarl`.
  - Updated `codesign` command in `build.yml` to use the new developer identity string.
- **Documentation:**
  - Updated `CONTRIBUTING.md` instructions to reference `SonarSource Sarl` when configuring local certificates in Keychain Access.

<sub>This will update automatically on new commits.</sub>