### PR TITLE
SC-52925 Use /org-entitlement to distinguish not-entitled from over-consumption

### DIFF
--- a/build-scripts/ux-report/generate-ux-report.ts
+++ b/build-scripts/ux-report/generate-ux-report.ts
@@ -433,7 +433,7 @@ uxDescribe('SonarQube Cloud — Happy Path', () => {
           severity: 'BLOCKER',
         });
       })
-      .withSqaaEntitlement(ORG, ORG_UUID, { eligible: true, enabled: true })
+      .withSqaaEntitlement(ORG, ORG_UUID, { allowed: true, hasEntitlement: true })
       .withSqaaResponse({
         issues: [{ rule: 'java:S100', message: 'Method name does not match regex', startLine: 3 }],
       })

--- a/src/cli/commands/integrate/_common/sqaa-entitlement.ts
+++ b/src/cli/commands/integrate/_common/sqaa-entitlement.ts
@@ -36,6 +36,14 @@ export const SQAA_GLOBAL_SKIP_MESSAGE =
  */
 export const SQAA_PROMOTION_MESSAGE = `Vortex agentic analysis is available on SonarQube Cloud. Learn more: ${AGENTIC_ANALYSIS_DOCS_URL}`;
 
+/**
+ * Shown when the organization is entitled to SonarQube Agentic Analysis but has
+ * reached its current usage limit. The integration is still installed so it works
+ * again once consumption resets.
+ */
+export const SQAA_OVER_CONSUMPTION_MESSAGE =
+  'Your organization has reached its Vortex agentic analysis usage limit. Installing it anyway — analysis will resume once your usage resets.';
+
 export interface ResolveSqaaSetupParams {
   serverURL: string;
   token: string;
@@ -68,7 +76,12 @@ export async function resolveSqaaSetup(params: ResolveSqaaSetupParams): Promise<
     warn(SQAA_GLOBAL_SKIP_MESSAGE);
     return false;
   }
+  // Entitled but over the current usage limit: still install so it works once
+  // consumption resets, and warn the user it cannot run right now.
+  if (status === 'over_consumption') {
+    warn(SQAA_OVER_CONSUMPTION_MESSAGE);
+  }
   // Explicit check so future statuses don't fall through to true.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  return status === 'enabled';
+  return status === 'enabled' || status === 'over_consumption';
 }

--- a/src/sonarqube/client.ts
+++ b/src/sonarqube/client.ts
@@ -59,7 +59,7 @@ export type HttpMethod = (typeof GENERIC_HTTP_METHODS)[number];
 
 export type CagEntitlementStatus = 'allowed' | 'not_allowed' | 'check_failed';
 
-export type SqaaEntitlementStatus = 'enabled' | 'not_enabled' | 'check_failed';
+export type SqaaEntitlementStatus = 'enabled' | 'over_consumption' | 'not_enabled' | 'check_failed';
 
 export interface Organization {
   key: string;
@@ -419,19 +419,28 @@ export class SonarQubeClient {
   }
 
   /**
-   * Check if an organization has SQAA entitlement.
-   * Returns `'enabled'` only when both eligible and enabled are true, `'not_enabled'`
-   * for a definitive negative answer, and `'check_failed'` when the API call errors out.
+   * Check if an organization has SQAA entitlement via `/a3s-analysis/org-entitlement/{id}`.
+   *
+   * The endpoint distinguishes two negative cases:
+   * - `allowed` — whether the org may use A3S right now (billing consumption check).
+   * - `hasEntitlement` — whether the org is entitled at all.
+   *
+   * Returns `'enabled'` when currently allowed, `'over_consumption'` when entitled but
+   * over its current usage limit, `'not_enabled'` when not entitled, and
+   * `'check_failed'` when the API call errors out.
    */
   async checkSqaaEntitlement(organizationUuid: string): Promise<SqaaEntitlementStatus> {
     try {
-      const endpoint = `/a3s-analysis/org-config/${organizationUuid}`;
-      const result = await this.get<{ id: string; enabled: boolean; eligible: boolean }>(
+      const endpoint = `/a3s-analysis/org-entitlement/${organizationUuid}`;
+      const result = await this.get<{ id: string; allowed: boolean; hasEntitlement: boolean }>(
         endpoint,
         undefined,
         resolveFromEndpoint(this.serverURL, endpoint),
       );
-      return result.eligible && result.enabled ? 'enabled' : 'not_enabled';
+      if (result.allowed) {
+        return 'enabled';
+      }
+      return result.hasEntitlement ? 'over_consumption' : 'not_enabled';
     } catch {
       return 'check_failed';
     }

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -130,7 +130,7 @@ export class FakeSonarQubeServerBuilder {
   private readonly systemStatus: 'UP' | 'DOWN' = 'UP';
   private readonly sqaaEntitlementOrgs: Map<
     string,
-    { uuid: string; eligible: boolean; enabled: boolean }
+    { uuid: string; allowed: boolean; hasEntitlement: boolean }
   > = new Map();
   private readonly cagEntitlementOrgs: Map<string, { uuid: string; allowed: boolean }> = new Map();
   /** Keyed by org UUID (`resourceId`), for `GET /billing/entitlements`. */
@@ -280,12 +280,14 @@ export class FakeSonarQubeServerBuilder {
   withSqaaEntitlement(
     orgKey: string,
     uuid: string,
-    options: { eligible?: boolean; enabled?: boolean } = {},
+    options: { allowed?: boolean; hasEntitlement?: boolean } = {},
   ): this {
+    const allowed = options.allowed ?? true;
     this.sqaaEntitlementOrgs.set(orgKey, {
       uuid,
-      eligible: options.eligible ?? true,
-      enabled: options.enabled ?? true,
+      allowed,
+      // An allowed org is necessarily entitled; default undefined to that.
+      hasEntitlement: options.hasEntitlement ?? allowed,
     });
     return this;
   }
@@ -783,9 +785,9 @@ export class FakeSonarQubeServerBuilder {
           });
         }
 
-        const orgConfigMatch = /^\/a3s-analysis\/org-config\/(.+)$/.exec(path);
-        if (orgConfigMatch) {
-          const uuid = orgConfigMatch[1];
+        const orgEntitlementMatch = /^\/a3s-analysis\/org-entitlement\/(.+)$/.exec(path);
+        if (orgEntitlementMatch) {
+          const uuid = orgEntitlementMatch[1];
           const entitlement = [...sqaaEntitlementOrgs.values()].find((e) => e.uuid === uuid);
           if (!entitlement) {
             return new Response(JSON.stringify({ errors: [{ msg: 'Not found' }] }), {
@@ -796,8 +798,8 @@ export class FakeSonarQubeServerBuilder {
           return new Response(
             JSON.stringify({
               id: uuid,
-              eligible: entitlement.eligible,
-              enabled: entitlement.enabled,
+              allowed: entitlement.allowed,
+              hasEntitlement: entitlement.hasEntitlement,
             }),
             { headers: { 'Content-Type': 'application/json' } },
           );

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -710,7 +710,7 @@ describe('integrate claude — SQAA entitlement guard', () => {
         .newFakeServer()
         .withAuthToken('cloud-token')
         .withOrganizations([{ key: 'my-org', name: 'My Org' }])
-        .withSqaaEntitlement('my-org', 'test-uuid-1234', { eligible: false, enabled: false })
+        .withSqaaEntitlement('my-org', 'test-uuid-1234', { allowed: false, hasEntitlement: false })
         .start();
 
       const serverUrl = server.baseUrl();
@@ -735,6 +735,49 @@ describe('integrate claude — SQAA entitlement guard', () => {
           hookScriptName('posttool-sqaa'),
         ),
       ).toBe(false);
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'installs the SQAA hook and warns when the org is entitled but over its usage limit',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('cloud-token')
+        .withOrganizations([{ key: 'my-org', name: 'My Org' }])
+        .withSqaaEntitlement('my-org', 'test-uuid-1234', {
+          allowed: false,
+          hasEntitlement: true,
+        })
+        .withProject('my-project')
+        .start();
+
+      const serverUrl = server.baseUrl();
+      harness.withAuth(serverUrl, 'cloud-token', 'my-org');
+
+      const result = await harness.run(`integrate claude --project my-project --non-interactive`, {
+        extraEnv: {
+          SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
+          SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(`${result.stdout}\n${result.stderr}`).toContain(
+        'Your organization has reached its Vortex agentic analysis usage limit',
+      );
+      const settings = harness.cwd.file('.claude', 'settings.json').asJson();
+      expect(settings.hooks?.PostToolUse).toBeDefined();
+      expect(
+        harness.cwd.exists(
+          '.claude',
+          'hooks',
+          'sonar-sqaa',
+          'build-scripts',
+          hookScriptName('posttool-sqaa'),
+        ),
+      ).toBe(true);
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -623,7 +623,7 @@ describe('integrate copilot', () => {
      * entitlement endpoint both resolve to the fake).
      */
     async function setupCloudWithEntitlement(
-      options: { eligible?: boolean; enabled?: boolean } = {},
+      options: { allowed?: boolean; hasEntitlement?: boolean } = {},
     ): Promise<{ extraEnv: Record<string, string> }> {
       const server = await harness
         .newFakeServer()
@@ -736,8 +736,8 @@ describe('integrate copilot', () => {
       'omits the SQAA section when the org is not entitled to SQAA',
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement({
-          eligible: false,
-          enabled: false,
+          allowed: false,
+          hasEntitlement: false,
         });
 
         const result = await harness.run(

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -473,7 +473,7 @@ describe('integrate cursor', () => {
     // org, swap the harness auth to a cloud connection, and return env vars that
     // point the CLI's hard-coded SonarCloud URL constants at the fake server.
     async function setupCloudWithEntitlement(
-      options: { eligible?: boolean; enabled?: boolean } = {},
+      options: { allowed?: boolean; hasEntitlement?: boolean } = {},
     ): Promise<{ extraEnv: Record<string, string> }> {
       const server = await harness
         .newFakeServer()
@@ -577,7 +577,10 @@ describe('integrate cursor', () => {
     it(
       'skips SQAA and shows the promotion message when the org is not entitled',
       async () => {
-        const { extraEnv } = await setupCloudWithEntitlement({ enabled: false });
+        const { extraEnv } = await setupCloudWithEntitlement({
+          allowed: false,
+          hasEntitlement: false,
+        });
 
         const result = await harness.run(
           `integrate cursor --project ${TEST_PROJECT} --non-interactive`,

--- a/tests/unit/sonarqube/client.test.ts
+++ b/tests/unit/sonarqube/client.test.ts
@@ -699,7 +699,7 @@ describe('SonarQubeClient', () => {
       expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('check_failed');
     });
 
-    it("returns 'enabled' when org UUID is resolved and entitlement is enabled and eligible", async () => {
+    it("returns 'enabled' when org UUID is resolved and entitlement is allowed", async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -709,13 +709,13 @@ describe('SonarQubeClient', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: true }),
+          json: () => Promise.resolve({ id: 'org-uuid', allowed: true, hasEntitlement: true }),
         } as Response);
 
       expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('enabled');
     });
 
-    it("returns 'not_enabled' when entitlement is enabled but not eligible", async () => {
+    it("returns 'not_enabled' when the org is not entitled at all", async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -725,13 +725,13 @@ describe('SonarQubeClient', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: false }),
+          json: () => Promise.resolve({ id: 'org-uuid', allowed: false, hasEntitlement: false }),
         } as Response);
 
       expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('not_enabled');
     });
 
-    it("returns 'not_enabled' when entitlement is eligible but not enabled", async () => {
+    it("returns 'over_consumption' when the org is entitled but over its usage limit", async () => {
       fetchSpy = spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
           ok: true,
@@ -741,10 +741,10 @@ describe('SonarQubeClient', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ id: 'org-uuid', enabled: false, eligible: true }),
+          json: () => Promise.resolve({ id: 'org-uuid', allowed: false, hasEntitlement: true }),
         } as Response);
 
-      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('not_enabled');
+      expect(await cloudClient.hasSqaaEntitlement('my-org')).toBe('over_consumption');
     });
 
     it("returns 'check_failed' when the entitlement check fails with an API error", async () => {
@@ -775,13 +775,13 @@ describe('SonarQubeClient', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ id: targetUuid, enabled: true, eligible: true }),
+          json: () => Promise.resolve({ id: targetUuid, allowed: true, hasEntitlement: true }),
         } as Response);
 
       await cloudClient.hasSqaaEntitlement('my-org');
 
       const entitlementUrl = new URL((fetchSpy.mock.calls[1][0] as URL).toString());
-      expect(entitlementUrl.pathname).toBe(`/a3s-analysis/org-config/${targetUuid}`);
+      expect(entitlementUrl.pathname).toBe(`/a3s-analysis/org-entitlement/${targetUuid}`);
     });
 
     it("returns 'enabled' for SonarQube Cloud US and hits US API", async () => {
@@ -795,7 +795,7 @@ describe('SonarQubeClient', () => {
         .mockResolvedValueOnce({
           ok: true,
           status: 200,
-          json: () => Promise.resolve({ id: 'org-uuid', enabled: true, eligible: true }),
+          json: () => Promise.resolve({ id: 'org-uuid', allowed: true, hasEntitlement: true }),
         } as Response);
 
       expect(await usClient.hasSqaaEntitlement('my-org')).toBe('enabled');


### PR DESCRIPTION
## What

Implements [SC-52925](https://sonarsource.atlassian.net/browse/SC-52925) — *Update SonarQube CLI to use `/org-entitlement/{id}`* (sub-task of [SC-52684](https://sonarsource.atlassian.net/browse/SC-52684), *Distinguish not-entitled from out of consumption*).

The CLI's SQAA (Vortex agentic analysis) entitlement check now uses the new endpoint created in [sonar-analysis-as-a-service#667](https://github.com/SonarSource/sonar-analysis-as-a-service/pull/667):

- **Before:** `GET /a3s-analysis/org-config/{id}` → `{ id, enabled, eligible }` (collapsed to enabled / not_enabled).
- **After:** `GET /a3s-analysis/org-entitlement/{id}` → `{ id, allowed, hasEntitlement }`, letting the CLI tell **not entitled at all** apart from **entitled but over the current usage limit**.

## Changes

- `SqaaEntitlementStatus` gains a fourth state: `'enabled' | 'over_consumption' | 'not_enabled' | 'check_failed'`.
- `SonarQubeClient.checkSqaaEntitlement()` hits the new endpoint and maps:
  - `allowed` → `enabled`
  - `!allowed && hasEntitlement` → `over_consumption`
  - `!allowed && !hasEntitlement` → `not_enabled`
  - error → `check_failed`
- `resolveSqaaSetup()`: on `over_consumption` the integration **still installs** (the org is entitled; the limit is transient) but emits a new `SQAA_OVER_CONSUMPTION_MESSAGE` warning. `not_enabled` keeps the promotion message and skips; `--global` skip still takes precedence.
- Test harness: `withSqaaEntitlement(options: { allowed?, hasEntitlement? })`, map + endpoint matcher updated to `/a3s-analysis/org-entitlement/`. Spec callers (claude/copilot/cursor) and the UX-report generator updated to the new option names.
- Added an integration test asserting the SQAA hook installs **and** the limit warning shows when the org is entitled but over-limit; unit tests updated with an `over_consumption` case.

## Testing

- `bun run format`, `eslint`, `bun run typecheck`: clean.
- Unit: `client.test.ts` + integrate unit tests pass.
- Integration: harness self-test + claude/copilot/cursor + codex/antigravity/reset specs pass.
- SonarQube advanced analysis: not run in this environment (MCP server not connected / no Cloud connection).

## ⚠️ Merge dependency

The `/org-entitlement/{id}` endpoint (sonar-analysis-as-a-service#667) is **not yet merged / deployed** (still on Dev11). This PR should land **after** that endpoint is available in the target environments.

## Out of scope

Removing `GET /org-config/{id}` and migrating other consumers (WebApp, FrontendContext) — later steps in SC-52684.


[SC-52925]: https://sonarsource.atlassian.net/browse/SC-52925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SC-52684]: https://sonarsource.atlassian.net/browse/SC-52684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ