### PR TITLE
GROW-247 Paginate repository fetch in sonar import

### DIFF
--- a/src/cli/commands/import/_common/repository-collection.ts
+++ b/src/cli/commands/import/_common/repository-collection.ts
@@ -113,15 +113,16 @@ export async function* iterateRepoPages(
  * triggers a genuine network request.
  */
 export class RepositoryCollection {
-  private readonly iterator: AsyncGenerator<{ repositories: DopRepository[]; total: number }, void>;
+  private readonly fetchPage: FetchPage;
   private readonly onlyPrivateProjects: OnlyPrivateProjects;
   private readonly eligible: DopRepository[] = [];
   private readonly skipped: SkippedRepo[] = [];
   private exhausted = false;
   private serverTotal = 0;
+  private nextPageIndex = 1;
 
   private constructor(fetchPage: FetchPage, onlyPrivateProjects: OnlyPrivateProjects) {
-    this.iterator = iterateRepoPages(fetchPage);
+    this.fetchPage = fetchPage;
     this.onlyPrivateProjects = onlyPrivateProjects;
   }
 
@@ -165,22 +166,28 @@ export class RepositoryCollection {
    * Fetch exactly one more server page, categorize it, append to the running totals, and return
    * just this page's delta (callers tracking the running totals themselves, like the manual
    * picker, can ignore the return value).
+   *
+   * Calls `fetchPage` directly (rather than driving a shared `AsyncGenerator`) so a failed fetch
+   * can be retried: the page index is only advanced after a successful fetch, so a rejected call
+   * leaves the collection pointed at the same page and `exhausted` unset, and the next `loadMore`
+   * re-fetches it instead of silently behaving as if the org had no further pages (per-instance
+   * generators become permanently done once they throw, which would break retry).
    */
   async loadMore(): Promise<{ eligible: DopRepository[]; skipped: SkippedRepo[] }> {
     if (this.exhausted) return { eligible: [], skipped: [] };
 
-    const { value, done } = await this.iterator.next();
-    if (done) {
+    const page = await this.fetchPage(
+      this.nextPageIndex,
+      SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE,
+    );
+    this.nextPageIndex++;
+
+    this.serverTotal = page.total;
+    if (page.repositories.length < SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE) {
       this.exhausted = true;
-      return { eligible: [], skipped: [] };
     }
 
-    this.serverTotal = value.total;
-    if (value.repositories.length < SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE) {
-      this.exhausted = true;
-    }
-
-    const { eligible, skipped } = categorizeRepos(value.repositories, this.onlyPrivateProjects);
+    const { eligible, skipped } = categorizeRepos(page.repositories, this.onlyPrivateProjects);
     this.eligible.push(...eligible);
     this.skipped.push(...skipped);
     return { eligible, skipped };

--- a/src/cli/commands/import/_common/repository-collection.ts
+++ b/src/cli/commands/import/_common/repository-collection.ts
@@ -59,17 +59,21 @@ function isRepoSelectable(
 
 /**
  * Split repos into those eligible for import — not already imported (see `isAlreadyImported`)
- * and allowed by the org's project visibility settings — and those skipped, with a reason each.
+ * and allowed by the org's project visibility settings — those already imported (kept as full
+ * repos, not just a `SkippedRepo` reason, so the manual picker can list them), and those skipped
+ * for visibility reasons.
  */
 function categorizeRepos(
   repos: DopRepository[],
   onlyPrivateProjects: OnlyPrivateProjects,
-): { eligible: DopRepository[]; skipped: SkippedRepo[] } {
+): { eligible: DopRepository[]; alreadyImported: DopRepository[]; skipped: SkippedRepo[] } {
   const eligible: DopRepository[] = [];
+  const alreadyImported: DopRepository[] = [];
   const skipped: SkippedRepo[] = [];
 
   for (const repo of repos) {
     if (isAlreadyImported(repo)) {
+      alreadyImported.push(repo);
       skipped.push({ slug: repo.slug, reason: 'already imported' });
       continue;
     }
@@ -83,7 +87,7 @@ function categorizeRepos(
     eligible.push(repo);
   }
 
-  return { eligible, skipped };
+  return { eligible, alreadyImported, skipped };
 }
 
 /**
@@ -116,6 +120,7 @@ export class RepositoryCollection {
   private readonly fetchPage: FetchPage;
   private readonly onlyPrivateProjects: OnlyPrivateProjects;
   private readonly eligible: DopRepository[] = [];
+  private readonly alreadyImported: DopRepository[] = [];
   private readonly skipped: SkippedRepo[] = [];
   private exhausted = false;
   private serverTotal = 0;
@@ -147,6 +152,11 @@ export class RepositoryCollection {
     return this.eligible;
   }
 
+  /** Repos already imported (into this org or another) across every page fetched so far. */
+  get alreadyImportedRepos(): readonly DopRepository[] {
+    return this.alreadyImported;
+  }
+
   /** Repos found ineligible (with a reason) across every page fetched so far. */
   get skippedRepos(): readonly SkippedRepo[] {
     return this.skipped;
@@ -173,8 +183,12 @@ export class RepositoryCollection {
    * re-fetches it instead of silently behaving as if the org had no further pages (per-instance
    * generators become permanently done once they throw, which would break retry).
    */
-  async loadMore(): Promise<{ eligible: DopRepository[]; skipped: SkippedRepo[] }> {
-    if (this.exhausted) return { eligible: [], skipped: [] };
+  async loadMore(): Promise<{
+    eligible: DopRepository[];
+    alreadyImported: DopRepository[];
+    skipped: SkippedRepo[];
+  }> {
+    if (this.exhausted) return { eligible: [], alreadyImported: [], skipped: [] };
 
     const page = await this.fetchPage(
       this.nextPageIndex,
@@ -187,9 +201,13 @@ export class RepositoryCollection {
       this.exhausted = true;
     }
 
-    const { eligible, skipped } = categorizeRepos(page.repositories, this.onlyPrivateProjects);
+    const { eligible, alreadyImported, skipped } = categorizeRepos(
+      page.repositories,
+      this.onlyPrivateProjects,
+    );
     this.eligible.push(...eligible);
+    this.alreadyImported.push(...alreadyImported);
     this.skipped.push(...skipped);
-    return { eligible, skipped };
+    return { eligible, alreadyImported, skipped };
   }
 }

--- a/src/cli/commands/import/_common/repository-collection.ts
+++ b/src/cli/commands/import/_common/repository-collection.ts
@@ -20,12 +20,20 @@
 
 import { type DopRepository, SonarQubeClient } from '../../../../sonarqube/client';
 
-const REPOSITORY_LOCAL_PAGE_SIZE = 10;
-
-type FetchPage = (
+export type FetchPage = (
   pageIndex: number,
   pageSize: number,
 ) => Promise<{ repositories: DopRepository[]; total: number }>;
+
+export interface OnlyPrivateProjects {
+  enabled: boolean;
+  available: boolean;
+}
+
+export interface SkippedRepo {
+  slug: string;
+  reason: string;
+}
 
 /**
  * A repo is already imported if it's flagged for the current org, or already bound to a
@@ -36,64 +44,145 @@ export function isAlreadyImported(repo: DopRepository): boolean {
 }
 
 /**
- * Filters and locally paginates repositories for the `sonar import` select prompt, mirroring
- * `OrganizationCollection`. All repositories are fetched up front via `fetchAll` (across as
- * many server pages as needed) before any filtering or pagination happens: filtering a
- * lazily-loaded window instead would make the number of items shown per local page fluctuate
- * unpredictably depending on how many of that window's repos get excluded.
+ * Whether a repo's visibility is selectable under the org's `onlyPrivateProjects` setting.
+ * Unavailable means public-only, available+enabled means private-only, available+disabled
+ * allows both.
+ */
+function isRepoSelectable(
+  repo: { private: boolean },
+  onlyPrivateProjects: OnlyPrivateProjects,
+): boolean {
+  if (!onlyPrivateProjects.available) return !repo.private;
+  if (onlyPrivateProjects.enabled) return repo.private;
+  return true;
+}
+
+/**
+ * Split repos into those eligible for import — not already imported (see `isAlreadyImported`)
+ * and allowed by the org's project visibility settings — and those skipped, with a reason each.
+ */
+function categorizeRepos(
+  repos: DopRepository[],
+  onlyPrivateProjects: OnlyPrivateProjects,
+): { eligible: DopRepository[]; skipped: SkippedRepo[] } {
+  const eligible: DopRepository[] = [];
+  const skipped: SkippedRepo[] = [];
+
+  for (const repo of repos) {
+    if (isAlreadyImported(repo)) {
+      skipped.push({ slug: repo.slug, reason: 'already imported' });
+      continue;
+    }
+    if (!isRepoSelectable(repo, onlyPrivateProjects)) {
+      skipped.push({
+        slug: repo.slug,
+        reason: `${repo.private ? 'private' : 'public'} repos aren't allowed by this organization's project visibility settings`,
+      });
+      continue;
+    }
+    eligible.push(repo);
+  }
+
+  return { eligible, skipped };
+}
+
+/**
+ * Yield one server page of repositories at a time, stopping as soon as a short page comes back
+ * (rather than trusting the server-reported `total`, so a stale/inconsistent total can't cause
+ * an infinite loop).
+ */
+export async function* iterateRepoPages(
+  fetchPage: FetchPage,
+): AsyncGenerator<{ repositories: DopRepository[]; total: number }, void> {
+  let pageIndex = 1;
+  for (;;) {
+    const page = await fetchPage(pageIndex, SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE);
+    yield page;
+    if (page.repositories.length < SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE) {
+      return;
+    }
+    pageIndex++;
+  }
+}
+
+/**
+ * A live, paginated, categorizing view over an org's repositories for the `sonar import` repo
+ * prompt and bulk-import job: it fetches and categorizes one server page at a time instead of
+ * eagerly loading the whole org up front, so `--all`/"Recommended" can start importing a page's
+ * eligible repos while the next page is still unfetched, and the manual picker's "Load more"
+ * triggers a genuine network request.
  */
 export class RepositoryCollection {
-  private readonly repos: DopRepository[];
-  private readonly pageSize: number;
-  private page: number;
+  private readonly iterator: AsyncGenerator<{ repositories: DopRepository[]; total: number }, void>;
+  private readonly onlyPrivateProjects: OnlyPrivateProjects;
+  private readonly eligible: DopRepository[] = [];
+  private readonly skipped: SkippedRepo[] = [];
+  private exhausted = false;
+  private serverTotal = 0;
 
-  constructor(repos: DopRepository[], pageSize = REPOSITORY_LOCAL_PAGE_SIZE) {
-    this.repos = repos;
-    this.pageSize = pageSize;
-    this.page = 1;
+  private constructor(fetchPage: FetchPage, onlyPrivateProjects: OnlyPrivateProjects) {
+    this.iterator = iterateRepoPages(fetchPage);
+    this.onlyPrivateProjects = onlyPrivateProjects;
   }
 
-  /** Fetch every repository for an organization across all server pages. */
-  static async fetchAll(fetchPage: FetchPage): Promise<DopRepository[]> {
-    const repos: DopRepository[] = [];
-    let serverPageIndex = 1;
-    let total: number | null = null;
+  /**
+   * Fetch pages until at least one eligible repo is found or the org is exhausted — avoids ever
+   * showing a picker or starting a job with zero visible items when eligible repos exist a page
+   * or two in.
+   */
+  static async create(
+    fetchPage: FetchPage,
+    onlyPrivateProjects: OnlyPrivateProjects,
+  ): Promise<RepositoryCollection> {
+    const collection = new RepositoryCollection(fetchPage, onlyPrivateProjects);
+    while (collection.eligible.length === 0 && !collection.exhausted) {
+      await collection.loadMore();
+    }
+    return collection;
+  }
 
-    while (total === null || repos.length < total) {
-      const { repositories, total: reportedTotal } = await fetchPage(
-        serverPageIndex,
-        SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE,
-      );
-      repos.push(...repositories);
-      serverPageIndex++;
-      // Trust the loaded count once the server stops returning full pages, so a stale or
-      // inconsistent server-reported total can't cause an infinite loop.
-      if (repositories.length < SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE) {
-        break;
-      }
-      total = reportedTotal;
+  /** Repos found eligible for import across every page fetched so far. */
+  get eligibleRepos(): readonly DopRepository[] {
+    return this.eligible;
+  }
+
+  /** Repos found ineligible (with a reason) across every page fetched so far. */
+  get skippedRepos(): readonly SkippedRepo[] {
+    return this.skipped;
+  }
+
+  /** True while more server pages remain unfetched. */
+  get hasMore(): boolean {
+    return !this.exhausted;
+  }
+
+  /** Server-reported total repo count for the org, known from the first page fetched. */
+  get total(): number {
+    return this.serverTotal;
+  }
+
+  /**
+   * Fetch exactly one more server page, categorize it, append to the running totals, and return
+   * just this page's delta (callers tracking the running totals themselves, like the manual
+   * picker, can ignore the return value).
+   */
+  async loadMore(): Promise<{ eligible: DopRepository[]; skipped: SkippedRepo[] }> {
+    if (this.exhausted) return { eligible: [], skipped: [] };
+
+    const { value, done } = await this.iterator.next();
+    if (done) {
+      this.exhausted = true;
+      return { eligible: [], skipped: [] };
     }
 
-    return repos;
-  }
+    this.serverTotal = value.total;
+    if (value.repositories.length < SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE) {
+      this.exhausted = true;
+    }
 
-  /** Total number of repositories in this collection (unaffected by pagination). */
-  get length(): number {
-    return this.repos.length;
-  }
-
-  /** Repositories visible up to and including the current page. */
-  get visible(): DopRepository[] {
-    return this.repos.slice(0, this.page * this.pageSize);
-  }
-
-  /** True when there are more repositories beyond the current visible window. */
-  get hasMore(): boolean {
-    return this.page * this.pageSize < this.repos.length;
-  }
-
-  /** Advance the visible window by one page. */
-  loadMore(): void {
-    if (this.hasMore) this.page++;
+    const { eligible, skipped } = categorizeRepos(value.repositories, this.onlyPrivateProjects);
+    this.eligible.push(...eligible);
+    this.skipped.push(...skipped);
+    return { eligible, skipped };
   }
 }

--- a/src/cli/commands/import/_common/resolve-options.ts
+++ b/src/cli/commands/import/_common/resolve-options.ts
@@ -29,15 +29,17 @@ import {
 } from '../../../../ui';
 import { CommandFailedError, InvalidOptionError } from '../../_common/error';
 import { OrganizationCollection } from './organization-collection';
-import { isAlreadyImported, RepositoryCollection } from './repository-collection';
+import {
+  type FetchPage,
+  isAlreadyImported,
+  iterateRepoPages,
+  type OnlyPrivateProjects,
+  RepositoryCollection,
+  type SkippedRepo,
+} from './repository-collection';
 
 /** ALM key used by GitHub-bound organizations, per `Organization.alm.key`. */
 const GITHUB_ALM_KEY = 'github';
-
-export interface OnlyPrivateProjects {
-  enabled: boolean;
-  available: boolean;
-}
 
 export interface ResolvedOrg {
   key: string;
@@ -60,40 +62,27 @@ export interface ResolvedRepo {
   installationKey: string;
 }
 
-export interface SkippedRepo {
-  slug: string;
-  reason: string;
-}
-
-export interface ResolvedRepos {
-  repos: ResolvedRepo[];
-  /** Repos deliberately excluded by `--all`'s eligibility filtering, with a reason each. */
-  skipped: SkippedRepo[];
-}
+/**
+ * Outcome of resolving which repositories to import:
+ * - `streaming` — `--all`/"Recommended" hand back the live `RepositoryCollection` itself so the
+ *   caller can run the fetch-a-page/import-a-page job (see `runBulkImportJob` in `index.ts`)
+ *   instead of a fully materialized list.
+ * - `batch` — manual selection and `--repo` already know their (small, explicit) final list, so
+ *   they resolve to it directly and the caller runs one single-batch import.
+ */
+export type RepoResolution =
+  | { kind: 'streaming'; collection: RepositoryCollection }
+  | { kind: 'batch'; repos: ResolvedRepo[]; skipped: SkippedRepo[] };
 
 /**
  * Format a DOP repository's unique identifier the way `provision_projects` expects it:
  * `<slug>|<id>` for GitHub, plain `id` for every other DevOps platform.
  */
-function computeInstallationKey(
+export function computeInstallationKey(
   repo: { id: string; slug: string },
   almKey: string | undefined,
 ): string {
   return almKey === GITHUB_ALM_KEY ? `${repo.slug}|${repo.id}` : repo.id;
-}
-
-/**
- * Whether a repo's visibility is selectable under the org's `onlyPrivateProjects` setting.
- * Unavailable means public-only, available+enabled means private-only, available+disabled
- * allows both.
- */
-function isRepoSelectable(
-  repo: { private: boolean },
-  onlyPrivateProjects: OnlyPrivateProjects,
-): boolean {
-  if (!onlyPrivateProjects.available) return !repo.private;
-  if (onlyPrivateProjects.enabled) return repo.private;
-  return true;
 }
 
 /** e.g. `my-org/repo - private`. */
@@ -207,7 +196,7 @@ export async function resolveRepos(
   almKey: string | undefined,
   onlyPrivateProjects: OnlyPrivateProjects,
   opts: { org?: string; repo?: string[]; all?: boolean; nonInteractive?: boolean },
-): Promise<ResolvedRepos | typeof BACK> {
+): Promise<RepoResolution | typeof BACK> {
   if (opts.all && opts.repo?.length) {
     throw new InvalidOptionError(
       '--all cannot be combined with --repo',
@@ -230,7 +219,7 @@ export async function resolveRepos(
   }
 
   if (opts.all) {
-    return resolveAllRepos(client, organizationId, almKey, onlyPrivateProjects);
+    return resolveAllRepos(client, organizationId, onlyPrivateProjects);
   }
 
   if (opts.repo?.length) {
@@ -241,7 +230,7 @@ export async function resolveRepos(
       onlyPrivateProjects,
       opts.repo,
     );
-    return { repos, skipped: [] };
+    return { kind: 'batch', repos, skipped: [] };
   }
 
   // "← Back" only makes sense when the org itself was chosen interactively — an org pinned
@@ -252,13 +241,76 @@ export async function resolveRepos(
 }
 
 /**
+ * Load pages of an org's repositories (via `RepositoryCollection.create`, which stops once it
+ * finds at least one eligible repo or the org is exhausted) and throw a `CommandFailedError` on
+ * a fetch failure or an org with no repositories at all.
+ */
+async function createRepositoryCollectionOrThrow(
+  client: SonarQubeClient,
+  organizationId: string,
+  onlyPrivateProjects: OnlyPrivateProjects,
+): Promise<RepositoryCollection> {
+  let collection: RepositoryCollection;
+  try {
+    collection = await withSpinner('Loading repositories...', () =>
+      RepositoryCollection.create(
+        (pageIndex, pageSize) =>
+          client.fetchDopRepositoriesPage(organizationId, pageIndex, pageSize),
+        onlyPrivateProjects,
+      ),
+    );
+  } catch (err) {
+    throw new CommandFailedError(
+      `Failed to load repositories: ${err instanceof Error ? err.message : String(err)}`,
+      { remediationHint: 'Check your network connection and authentication, then retry.' },
+    );
+  }
+
+  if (collection.total === 0) {
+    throw new CommandFailedError('No repositories found for the selected organization.', {
+      remediationHint:
+        'The organization may have no repositories visible to its connected DevOps platform, or the platform connection may need to be reconfigured.',
+    });
+  }
+
+  return collection;
+}
+
+/**
+ * Throws with a specific reason when an org has nothing importable — offering to go back to
+ * organization selection first when that's a valid escape hatch (an org pinned via `--org` has
+ * nowhere to go back to). `RepositoryCollection.create` only stops early once it finds an
+ * eligible repo, so this is only called once every fetched page has been fully scanned.
+ */
+async function handleNoEligibleRepos(
+  collection: RepositoryCollection,
+  allowBack: boolean,
+): Promise<typeof BACK> {
+  const reason = collection.skippedRepos.every((repo) => repo.reason === 'already imported')
+    ? 'All repositories for the selected organization have already been imported into SonarQube.'
+    : "No repositories match this organization's project visibility settings.";
+
+  if (!allowBack) {
+    throw new CommandFailedError(reason);
+  }
+
+  warn(reason);
+  const goBack = await confirmPrompt('Go back and choose a different organization?', true);
+  if (!goBack) {
+    throw new CommandFailedError(reason);
+  }
+  return BACK;
+}
+
+/**
  * Ask how the user wants to pick repositories to import: bulk-import everything eligible
  * (mirrors `--all`), choose specific ones interactively, or go back to organization selection.
  *
- * Eligibility is computed once up front (before the prompt is even shown) so an org with
- * nothing importable fails immediately with a specific reason, the same way it always has —
- * asking "recommended or manual?" would be pointless (and both branches would hit the same
- * dead end) when there's nothing to import either way.
+ * The collection is loaded just far enough to know whether anything is eligible before the
+ * prompt is even shown, so an org with nothing importable fails immediately with a specific
+ * reason — asking "recommended or manual?" would be pointless (and both branches would hit the
+ * same dead end) when there's nothing to import either way. Whichever mode is chosen continues
+ * fetching from this same collection rather than starting over from page one.
  */
 async function resolveOnboardingMode(
   client: SonarQubeClient,
@@ -266,25 +318,15 @@ async function resolveOnboardingMode(
   almKey: string | undefined,
   onlyPrivateProjects: OnlyPrivateProjects,
   opts: { allowBack: boolean },
-): Promise<ResolvedRepos | typeof BACK> {
-  const allRepos = await fetchAllReposOrThrow(client, organizationId);
-  const { eligible, skipped } = categorizeRepos(allRepos, onlyPrivateProjects);
+): Promise<RepoResolution | typeof BACK> {
+  const collection = await createRepositoryCollectionOrThrow(
+    client,
+    organizationId,
+    onlyPrivateProjects,
+  );
 
-  if (eligible.length === 0) {
-    const reason = allRepos.every((repo) => isAlreadyImported(repo))
-      ? 'All repositories for the selected organization have already been imported into SonarQube.'
-      : "No repositories match this organization's project visibility settings.";
-
-    if (!opts.allowBack) {
-      throw new CommandFailedError(reason);
-    }
-
-    warn(reason);
-    const goBack = await confirmPrompt('Go back and choose a different organization?', true);
-    if (!goBack) {
-      throw new CommandFailedError(reason);
-    }
-    return BACK;
+  if (collection.eligibleRepos.length === 0) {
+    return handleNoEligibleRepos(collection, opts.allowBack);
   }
 
   const RECOMMENDED = Symbol('recommended');
@@ -299,26 +341,28 @@ async function resolveOnboardingMode(
     options.push({ value: BACK, label: '← Back' });
   }
 
-  const choice = await selectPrompt('How do you want to import repositories?', options);
+  // Cancelling the "Manual" picker (below) re-shows this same menu instead of ending the
+  // command, so the user can pick a different mode (or go back further) rather than starting
+  // `sonar import` over from scratch.
+  for (;;) {
+    const choice = await selectPrompt('How do you want to import repositories?', options);
 
-  if (choice === null) {
-    throw new CommandFailedError('Repository selection cancelled');
-  }
-  if (choice === BACK) {
-    return BACK;
-  }
-  if (choice === RECOMMENDED) {
-    return {
-      repos: eligible.map((repo) => ({
-        slug: repo.slug,
-        installationKey: computeInstallationKey(repo, almKey),
-      })),
-      skipped,
-    };
-  }
+    if (choice === null) {
+      throw new CommandFailedError('Repository selection cancelled');
+    }
+    if (choice === BACK) {
+      return BACK;
+    }
+    if (choice === RECOMMENDED) {
+      return { kind: 'streaming', collection };
+    }
 
-  const repos = await promptForReposFromCollection(new RepositoryCollection(eligible), almKey);
-  return { repos, skipped: [] };
+    const repos = await promptForReposFromCollection(collection, almKey);
+    if (repos === BACK) {
+      continue;
+    }
+    return { kind: 'batch', repos, skipped: [] };
+  }
 }
 
 async function resolveReposBySlug(
@@ -328,13 +372,32 @@ async function resolveReposBySlug(
   onlyPrivateProjects: OnlyPrivateProjects,
   slugs: string[],
 ): Promise<ResolvedRepo[]> {
-  const matches = await findReposBySlugs(client, organizationId, slugs);
+  const matches = await findReposBySlugs(
+    (pageIndex, pageSize) => client.fetchDopRepositoriesPage(organizationId, pageIndex, pageSize),
+    slugs,
+  );
 
   const notFound = slugs.filter((slug) => !matches.has(slug));
   if (notFound.length > 0) {
     throw new CommandFailedError(
       `Repositor${notFound.length === 1 ? 'y' : 'ies'} not found in the selected organization's DevOps platform: ${notFound.join(', ')}`,
       { remediationHint: 'Check that the repository slug(s) are correct and visible to the org.' },
+    );
+  }
+
+  const alreadyImported = slugs
+    .map((slug) => matches.get(slug))
+    .filter((repo): repo is DopRepository => repo !== undefined && isAlreadyImported(repo));
+  if (alreadyImported.length === 1) {
+    throw new CommandFailedError(
+      `Repository '${alreadyImported[0].slug}' has already been imported into SonarQube.`,
+    );
+  }
+  if (alreadyImported.length > 1) {
+    throw new CommandFailedError(
+      `Repositories have already been imported into SonarQube: ${alreadyImported
+        .map((repo) => repo.slug)
+        .join(', ')}`,
     );
   }
 
@@ -368,127 +431,81 @@ async function resolveReposBySlug(
 }
 
 /**
- * Fetch every repository for an org (across all server pages), throwing a `CommandFailedError`
- * on a fetch failure or an org with no repositories at all.
+ * Whether a repo's visibility is selectable under the org's `onlyPrivateProjects` setting.
+ * Unavailable means public-only, available+enabled means private-only, available+disabled
+ * allows both. Duplicated in spirit from `RepositoryCollection`'s internal categorization —
+ * `--repo` resolution needs this on a handful of explicitly-named repos, not on every page.
  */
-async function fetchAllReposOrThrow(
-  client: SonarQubeClient,
-  organizationId: string,
-): Promise<DopRepository[]> {
-  let allRepos: DopRepository[];
-  try {
-    allRepos = await withSpinner('Loading repositories...', () =>
-      RepositoryCollection.fetchAll((pageIndex, pageSize) =>
-        client.fetchDopRepositoriesPage(organizationId, pageIndex, pageSize),
-      ),
-    );
-  } catch (err) {
-    throw new CommandFailedError(
-      `Failed to load repositories: ${err instanceof Error ? err.message : String(err)}`,
-      { remediationHint: 'Check your network connection and authentication, then retry.' },
-    );
-  }
-
-  if (allRepos.length === 0) {
-    throw new CommandFailedError('No repositories found for the selected organization.', {
-      remediationHint:
-        'The organization may have no repositories visible to its connected DevOps platform, or the platform connection may need to be reconfigured.',
-    });
-  }
-
-  return allRepos;
-}
-
-/**
- * Split repos into those eligible for import — not already imported (see `isAlreadyImported`)
- * and allowed by the org's project visibility settings — and those skipped, with a reason each.
- */
-function categorizeRepos(
-  allRepos: DopRepository[],
+function isRepoSelectable(
+  repo: { private: boolean },
   onlyPrivateProjects: OnlyPrivateProjects,
-): { eligible: DopRepository[]; skipped: SkippedRepo[] } {
-  const eligible: DopRepository[] = [];
-  const skipped: SkippedRepo[] = [];
-
-  for (const repo of allRepos) {
-    if (isAlreadyImported(repo)) {
-      skipped.push({ slug: repo.slug, reason: 'already imported' });
-      continue;
-    }
-    if (!isRepoSelectable(repo, onlyPrivateProjects)) {
-      skipped.push({
-        slug: repo.slug,
-        reason: `${repo.private ? 'private' : 'public'} repos aren't allowed by this organization's project visibility settings`,
-      });
-      continue;
-    }
-    eligible.push(repo);
-  }
-
-  return { eligible, skipped };
+): boolean {
+  if (!onlyPrivateProjects.available) return !repo.private;
+  if (onlyPrivateProjects.enabled) return repo.private;
+  return true;
 }
 
 /**
- * Resolve every eligible repository in the org for `--all`. Ineligible repos are reported back
- * with a reason instead of causing the whole command to fail, since a mixed batch (some
- * eligible, some not) is the normal case for a whole-org import.
+ * Resolve every eligible repository in the org for `--all` as a live streaming job: the caller
+ * (`runBulkImportJob`) imports each page's eligible repos as soon as it's fetched instead of
+ * waiting for the whole org to be scanned first.
  */
 async function resolveAllRepos(
   client: SonarQubeClient,
   organizationId: string,
-  almKey: string | undefined,
   onlyPrivateProjects: OnlyPrivateProjects,
-): Promise<ResolvedRepos> {
-  const allRepos = await fetchAllReposOrThrow(client, organizationId);
-  const { eligible, skipped } = categorizeRepos(allRepos, onlyPrivateProjects);
+): Promise<RepoResolution> {
+  const collection = await createRepositoryCollectionOrThrow(
+    client,
+    organizationId,
+    onlyPrivateProjects,
+  );
 
-  if (eligible.length === 0) {
+  if (collection.eligibleRepos.length === 0) {
     throw new CommandFailedError(
-      `No repositories are eligible for import (${skipped.length} skipped: already imported, or excluded by project visibility settings).`,
+      `No repositories are eligible for import (${collection.skippedRepos.length} skipped: already imported, or excluded by project visibility settings).`,
     );
   }
 
-  return {
-    repos: eligible.map((repo) => ({
-      slug: repo.slug,
-      installationKey: computeInstallationKey(repo, almKey),
-    })),
-    skipped,
-  };
+  return { kind: 'streaming', collection };
 }
 
 /**
- * Fetch every repository for an org (across all server pages) and resolve a set of slugs
- * against it in one pass — avoids N full scans for N `--repo` flags.
+ * Fetch an org's repositories page by page, stopping as soon as every requested slug has been
+ * matched instead of always scanning the whole org.
  */
 async function findReposBySlugs(
-  client: SonarQubeClient,
-  organizationId: string,
+  fetchPage: FetchPage,
   slugs: string[],
 ): Promise<Map<string, DopRepository>> {
   const remaining = new Set(slugs);
   const found = new Map<string, DopRepository>();
 
-  const allRepos = await RepositoryCollection.fetchAll((pageIndex, pageSize) =>
-    client.fetchDopRepositoriesPage(organizationId, pageIndex, pageSize),
-  );
-
-  for (const repo of allRepos) {
-    if (remaining.has(repo.slug)) found.set(repo.slug, repo);
+  for await (const { repositories } of iterateRepoPages(fetchPage)) {
+    for (const repo of repositories) {
+      if (remaining.has(repo.slug)) {
+        found.set(repo.slug, repo);
+        remaining.delete(repo.slug);
+      }
+    }
+    if (remaining.size === 0) break;
   }
 
   return found;
 }
 
+/** Max number of repos selectable at once in the "Manual" picker. */
+const MANUAL_SELECT_MAX_REPOS = 25;
+
 /**
- * Interactive multi-select over an already-fetched, already-filtered collection of eligible
- * repos (see `resolveOnboardingMode`, which computes eligibility once up front for both the
- * "Recommended" and "Manual" branches).
+ * Interactive multi-select over a live, lazily-paginated `RepositoryCollection`: "Load more"
+ * fetches and categorizes the next server page on demand. There's no "select all" here — the
+ * full set is never known up front, so there is nothing safe to bulk-select.
  */
 async function promptForReposFromCollection(
-  repos: RepositoryCollection,
+  collection: RepositoryCollection,
   almKey: string | undefined,
-): Promise<ResolvedRepo[]> {
+): Promise<ResolvedRepo[] | typeof BACK> {
   // `multiSelectPrompt` tracks selections by `===` identity, so the same `DopRepository`
   // must always map to the same `ResolvedRepo` object across a "Load more" reload, or
   // previously toggled selections would be silently dropped.
@@ -504,29 +521,24 @@ async function promptForReposFromCollection(
 
   const result = await multiSelectPrompt(
     'Select repositories to import',
-    repos.visible.map(toOption),
+    collection.eligibleRepos.map(toOption),
     {
-      hasMore: () => repos.hasMore,
-      onLoadMore: () => {
-        repos.loadMore();
-        return repos.visible.map(toOption);
+      hasMore: () => collection.hasMore,
+      onLoadMore: async () => {
+        await collection.loadMore();
+        return collection.eligibleRepos.map(toOption);
       },
-      // 'a' bulk-selects every eligible repo, not just the currently-paged-in ones — reveal
-      // every remaining page first so the rendered list and the selection stay consistent.
-      selectAll: () => {
-        while (repos.hasMore) repos.loadMore();
-        return repos.visible.map(toOption);
-      },
-      // No business reason to cap a repo import batch (unlike `sonar remediate`'s
-      // MULTISELECT_MAX_SELECTED default, which mirrors a remediation-agent capacity limit).
-      maxSelected: Number.POSITIVE_INFINITY,
-      // The true eligible count, not just what's paginated into view yet.
-      total: () => repos.length,
+      maxSelected: MANUAL_SELECT_MAX_REPOS,
+      // Only what's been paginated into view so far — the true total isn't known until every
+      // page has been fetched, which is exactly why there's no "select all" for this picker.
+      total: () => collection.eligibleRepos.length,
     },
   );
 
+  // Cancelling (q / Ctrl+C) goes back to the Recommended/Manual/← Back menu that led here,
+  // rather than ending the whole command — the caller (`resolveOnboardingMode`) re-shows it.
   if (result === null) {
-    throw new CommandFailedError('Repository selection cancelled');
+    return BACK;
   }
   if (result.length === 0) {
     throw new CommandFailedError('No repositories selected.');

--- a/src/cli/commands/import/_common/resolve-options.ts
+++ b/src/cli/commands/import/_common/resolve-options.ts
@@ -85,10 +85,14 @@ export function computeInstallationKey(
   return almKey === GITHUB_ALM_KEY ? `${repo.slug}|${repo.id}` : repo.id;
 }
 
-/** e.g. `my-org/repo - private`. */
-function formatRepoLabel(repo: { slug: string; private: boolean }): string {
+/** e.g. `my-org/repo - private`, or `my-org/repo - private (already imported)`. */
+function formatRepoLabel(
+  repo: { slug: string; private: boolean },
+  alreadyImported = false,
+): string {
   const visibility = repo.private ? 'private' : 'public';
-  return `${repo.slug} - ${visibility}`;
+  const suffix = alreadyImported ? ' (already imported)' : '';
+  return `${repo.slug} - ${visibility}${suffix}`;
 }
 
 export async function resolveOrg(
@@ -507,31 +511,40 @@ async function promptForReposFromCollection(
   // must always map to the same `ResolvedRepo` object across a "Load more" reload, or
   // previously toggled selections would be silently dropped.
   const resolvedByRepo = new WeakMap<DopRepository, ResolvedRepo>();
-  const toOption = (repo: DopRepository): MultiSelectOption<ResolvedRepo> => {
+  const toOption = (
+    repo: DopRepository,
+    alreadyImported = false,
+  ): MultiSelectOption<ResolvedRepo> => {
     let resolved = resolvedByRepo.get(repo);
     if (!resolved) {
       resolved = { slug: repo.slug, installationKey: computeInstallationKey(repo, almKey) };
       resolvedByRepo.set(repo, resolved);
     }
-    return { value: resolved, label: formatRepoLabel(repo) };
+    return {
+      value: resolved,
+      label: formatRepoLabel(repo, alreadyImported),
+      disabled: alreadyImported,
+    };
   };
+  // Already-imported repos are listed too (dimmed, non-toggleable) so the picker shows every
+  // repo the org has, not just the ones still importable.
+  const buildOptions = (): MultiSelectOption<ResolvedRepo>[] => [
+    ...collection.eligibleRepos.map((repo) => toOption(repo)),
+    ...collection.alreadyImportedRepos.map((repo) => toOption(repo, true)),
+  ];
 
-  const result = await multiSelectPrompt(
-    'Select repositories to import',
-    collection.eligibleRepos.map(toOption),
-    {
-      hasMore: () => collection.hasMore,
-      onLoadMore: async () => {
-        await collection.loadMore();
-        return collection.eligibleRepos.map(toOption);
-      },
-      // No cap on Manual selection — every eligible repo paginated into view can be selected.
-      maxSelected: Infinity,
-      // Only what's been paginated into view so far — the true total isn't known until every
-      // page has been fetched, which is exactly why there's no "select all" for this picker.
-      total: () => collection.eligibleRepos.length,
+  const result = await multiSelectPrompt('Select repositories to import', buildOptions(), {
+    hasMore: () => collection.hasMore,
+    onLoadMore: async () => {
+      await collection.loadMore();
+      return buildOptions();
     },
-  );
+    // No cap on Manual selection — every eligible repo paginated into view can be selected.
+    maxSelected: Infinity,
+    // Only what's been paginated into view so far — the true total isn't known until every
+    // page has been fetched, which is exactly why there's no "select all" for this picker.
+    total: () => collection.eligibleRepos.length,
+  });
 
   // Cancelling (q / Ctrl+C) goes back to the Recommended/Manual/← Back menu that led here,
   // rather than ending the whole command — the caller (`resolveOnboardingMode`) re-shows it.

--- a/src/cli/commands/import/_common/resolve-options.ts
+++ b/src/cli/commands/import/_common/resolve-options.ts
@@ -494,9 +494,6 @@ async function findReposBySlugs(
   return found;
 }
 
-/** Max number of repos selectable at once in the "Manual" picker. */
-const MANUAL_SELECT_MAX_REPOS = 25;
-
 /**
  * Interactive multi-select over a live, lazily-paginated `RepositoryCollection`: "Load more"
  * fetches and categorizes the next server page on demand. There's no "select all" here — the
@@ -528,7 +525,8 @@ async function promptForReposFromCollection(
         await collection.loadMore();
         return collection.eligibleRepos.map(toOption);
       },
-      maxSelected: MANUAL_SELECT_MAX_REPOS,
+      // No cap on Manual selection — every eligible repo paginated into view can be selected.
+      maxSelected: Infinity,
       // Only what's been paginated into view so far — the true total isn't known until every
       // page has been fetched, which is exactly why there's no "select all" for this picker.
       total: () => collection.eligibleRepos.length,

--- a/src/cli/commands/import/index.ts
+++ b/src/cli/commands/import/index.ts
@@ -145,7 +145,18 @@ async function runBulkImportJob(
   await importPage(collection.eligibleRepos);
 
   while (collection.hasMore) {
-    const page = await collection.loadMore();
+    let page;
+    try {
+      page = await collection.loadMore();
+    } catch (err) {
+      // A later page's fetch failure still leaves earlier pages' provisioning results behind —
+      // finish the display so they're reported, same as any other partial-failure exit.
+      progress.finish();
+      throw new CommandFailedError(
+        `Failed to load repositories: ${err instanceof Error ? err.message : String(err)}`,
+        { remediationHint: 'Check your network connection and authentication, then retry.' },
+      );
+    }
     progress.recordSkipped(page.skipped.length);
     await importPage(page.eligible);
   }

--- a/src/cli/commands/import/index.ts
+++ b/src/cli/commands/import/index.ts
@@ -20,15 +20,24 @@
 
 import type { ResolvedAuth } from '../../../lib/auth-resolver';
 import { runWithConcurrencyLimit } from '../../../lib/concurrency-pool';
-import { SonarQubeClient } from '../../../sonarqube/client';
+import {
+  type DopRepository,
+  type ProvisionedProject,
+  SonarQubeClient,
+} from '../../../sonarqube/client';
 import { info, intro, outro } from '../../../ui';
 import { ImportProgress } from '../../../ui/components/import-progress.js';
 import { CommandFailedError } from '../_common/error';
+import type {
+  OnlyPrivateProjects,
+  RepositoryCollection,
+  SkippedRepo,
+} from './_common/repository-collection';
 import {
   BACK,
-  type OnlyPrivateProjects,
+  computeInstallationKey,
+  type RepoResolution,
   type ResolvedRepo,
-  type ResolvedRepos,
   resolveOrg,
   resolveRepos,
 } from './_common/resolve-options';
@@ -47,7 +56,7 @@ const IMPORT_PROVISION_CONCURRENCY_LIMIT = 10;
 async function resolveOrgAndRepos(
   client: SonarQubeClient,
   options: ImportOptions,
-): Promise<{ orgKey: string } & ResolvedRepos> {
+): Promise<{ orgKey: string; almKey: string | undefined } & RepoResolution> {
   for (;;) {
     const {
       key: orgKey,
@@ -71,67 +80,101 @@ async function resolveOrgAndRepos(
       continue;
     }
 
-    return { orgKey, ...outcome };
+    return { orgKey, almKey, ...outcome };
   }
 }
 
-export async function importHandler(options: ImportOptions, auth: ResolvedAuth): Promise<void> {
-  const client = new SonarQubeClient(auth.serverUrl, auth.token);
-
-  intro('Import repositories', 'SonarQube');
-
-  const { orgKey, repos, skipped } = await resolveOrgAndRepos(client, options);
-
-  info(`Repositories to import: ${repos.length}`);
-  if (skipped.length > 0) {
-    info(`Repositories skipped: ${skipped.length}`);
-    const countsByReason = new Map<string, number>();
-    for (const s of skipped) {
-      countsByReason.set(s.reason, (countsByReason.get(s.reason) ?? 0) + 1);
+/** Builds the `runWithConcurrencyLimit` task that provisions one repo and updates `progress`. */
+function createProvisionTask(
+  client: SonarQubeClient,
+  orgKey: string,
+  progress: ImportProgress,
+): (repo: ResolvedRepo) => Promise<ProvisionedProject> {
+  return async (repo) => {
+    progress.update(repo.slug, 'running');
+    try {
+      const result = await client.provisionProject(orgKey, repo.installationKey);
+      if (result.projects.length === 0) {
+        throw new Error(
+          'provision_projects returned no project — the repository may already be bound, or ' +
+            'the installation key was rejected by the server.',
+        );
+      }
+      const project = result.projects[0];
+      progress.update(repo.slug, 'done', 'Project created', project.projectKey);
+      return project;
+    } catch (err) {
+      progress.update(repo.slug, 'failed', err instanceof Error ? err.message : String(err));
+      throw err;
     }
-    for (const [reason, count] of countsByReason) {
-      info(`  - ${reason}: ${count}`);
-    }
-  }
+  };
+}
 
-  const progress = new ImportProgress({
-    repos: repos.map((repo) => repo.slug),
-    maxVisible: IMPORT_PROVISION_CONCURRENCY_LIMIT,
-  });
+/**
+ * Runs `--all`/"Recommended" as a streaming job: import each server page's eligible repos as
+ * soon as it's fetched, then fetch the next page — rather than resolving the whole org's repo
+ * list before provisioning anything.
+ */
+async function runBulkImportJob(
+  client: SonarQubeClient,
+  orgKey: string,
+  almKey: string | undefined,
+  collection: RepositoryCollection,
+): Promise<{ succeeded: number; failed: number; skipped: readonly SkippedRepo[] }> {
+  const progress = new ImportProgress({ maxVisible: IMPORT_PROVISION_CONCURRENCY_LIMIT });
+  progress.setTotal(collection.total);
   progress.start();
 
-  await runWithConcurrencyLimit(
-    repos,
-    IMPORT_PROVISION_CONCURRENCY_LIMIT,
-    async (repo: ResolvedRepo) => {
-      progress.update(repo.slug, 'running');
-      try {
-        const result = await client.provisionProject(orgKey, repo.installationKey);
-        if (result.projects.length === 0) {
-          throw new Error(
-            'provision_projects returned no project — the repository may already be bound, or ' +
-              'the installation key was rejected by the server.',
-          );
-        }
-        const project = result.projects[0];
-        progress.update(repo.slug, 'done', 'Project created', project.projectKey);
-        return project;
-      } catch (err) {
-        progress.update(repo.slug, 'failed', err instanceof Error ? err.message : String(err));
-        throw err;
-      }
-    },
-  );
+  const importPage = async (eligible: readonly DopRepository[]): Promise<void> => {
+    if (eligible.length === 0) return;
+    const repos: ResolvedRepo[] = eligible.map((repo) => ({
+      slug: repo.slug,
+      installationKey: computeInstallationKey(repo, almKey),
+    }));
+    progress.addRepos(repos.map((repo) => repo.slug));
+    await runWithConcurrencyLimit(
+      repos,
+      IMPORT_PROVISION_CONCURRENCY_LIMIT,
+      createProvisionTask(client, orgKey, progress),
+    );
+  };
+
+  // `RepositoryCollection.create` already loaded the first eligible-or-exhausted window before
+  // handing the collection here — import it before fetching any further pages.
+  progress.recordSkipped(collection.skippedRepos.length);
+  await importPage(collection.eligibleRepos);
+
+  while (collection.hasMore) {
+    const page = await collection.loadMore();
+    progress.recordSkipped(page.skipped.length);
+    await importPage(page.eligible);
+  }
 
   const { succeeded, failed } = progress.finish();
-  const skippedSuffix = skipped.length > 0 ? ` (${skipped.length} skipped)` : '';
+  return { succeeded, failed, skipped: collection.skippedRepos };
+}
+
+function reportSkipped(skipped: readonly SkippedRepo[]): void {
+  if (skipped.length === 0) return;
+  info(`Repositories skipped: ${skipped.length}`);
+  const countsByReason = new Map<string, number>();
+  for (const s of skipped) {
+    countsByReason.set(s.reason, (countsByReason.get(s.reason) ?? 0) + 1);
+  }
+  for (const [reason, count] of countsByReason) {
+    info(`  - ${reason}: ${count}`);
+  }
+}
+
+function reportOutcome(succeeded: number, failed: number, skippedCount: number): void {
+  const skippedSuffix = skippedCount > 0 ? ` (${skippedCount} skipped)` : '';
 
   if (failed > 0) {
     const failedNoun = failed === 1 ? 'repository' : 'repositories';
     const message =
       succeeded === 0
         ? `Failed to import ${failed} ${failedNoun}.`
-        : `Imported ${succeeded} of ${repos.length} repositories (${failed} failed)${skippedSuffix}.`;
+        : `Imported ${succeeded} of ${succeeded + failed} repositories (${failed} failed)${skippedSuffix}.`;
     throw new CommandFailedError(message, {
       remediationHint: 'See the per-repository errors above for details.',
     });
@@ -139,4 +182,43 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
 
   const succeededNoun = succeeded === 1 ? 'repository' : 'repositories';
   outro(`Imported ${succeeded} ${succeededNoun}${skippedSuffix}`, 'success');
+}
+
+export async function importHandler(options: ImportOptions, auth: ResolvedAuth): Promise<void> {
+  const client = new SonarQubeClient(auth.serverUrl, auth.token);
+
+  intro('Import repositories', 'SonarQube');
+
+  const resolution = await resolveOrgAndRepos(client, options);
+
+  if (resolution.kind === 'streaming') {
+    const { succeeded, failed, skipped } = await runBulkImportJob(
+      client,
+      resolution.orgKey,
+      resolution.almKey,
+      resolution.collection,
+    );
+    reportSkipped(skipped);
+    reportOutcome(succeeded, failed, skipped.length);
+    return;
+  }
+
+  const { repos, skipped } = resolution;
+
+  info(`Repositories to import: ${repos.length}`);
+  reportSkipped(skipped);
+
+  const progress = new ImportProgress({ maxVisible: IMPORT_PROVISION_CONCURRENCY_LIMIT });
+  progress.setTotal(repos.length);
+  progress.addRepos(repos.map((repo) => repo.slug));
+  progress.start();
+
+  await runWithConcurrencyLimit(
+    repos,
+    IMPORT_PROVISION_CONCURRENCY_LIMIT,
+    createProvisionTask(client, resolution.orgKey, progress),
+  );
+
+  const { succeeded, failed } = progress.finish();
+  reportOutcome(succeeded, failed, skipped.length);
 }

--- a/src/cli/commands/import/index.ts
+++ b/src/cli/commands/import/index.ts
@@ -101,7 +101,7 @@ function createProvisionTask(
         );
       }
       const project = result.projects[0];
-      progress.update(repo.slug, 'done', 'Project created', project.projectKey);
+      progress.update(repo.slug, 'done');
       return project;
     } catch (err) {
       progress.update(repo.slug, 'failed', err instanceof Error ? err.message : String(err));

--- a/src/ui/components/import-progress.ts
+++ b/src/ui/components/import-progress.ts
@@ -232,8 +232,11 @@ export class ImportProgress {
     const resolved =
       [...this.repos.values()].filter((s) => s.status === 'done' || s.status === 'failed').length +
       this.skippedResolved;
-    const pct = total === 0 ? 100 : Math.round((resolved / total) * 100);
-    const filled = Math.round((pct / 100) * BAR_WIDTH);
+    // Clamped because `total` is the server-reported count, which loop termination
+    // deliberately distrusts (see `iterateRepoPages`) and so can be stale/inconsistent with
+    // the number of repos actually resolved.
+    const pct = total === 0 ? 100 : Math.min(100, Math.round((resolved / total) * 100));
+    const filled = Math.min(BAR_WIDTH, Math.round((pct / 100) * BAR_WIDTH));
     const bar = green(BAR_FILLED.repeat(filled)) + dim(BAR_EMPTY.repeat(BAR_WIDTH - filled));
     const pctLabel = bold(`${pct}%`);
     const fractionLabel = dim(`${resolved}/${total}`);

--- a/src/ui/components/import-progress.ts
+++ b/src/ui/components/import-progress.ts
@@ -87,11 +87,7 @@ export class ImportProgress {
     for (const slug of slugs) {
       this.repos.set(slug, { status: 'pending' });
       this.order.push(slug);
-      if (this.visible.length < this.maxVisible) {
-        this.visible.push(slug);
-      } else {
-        this.queue.push(slug);
-      }
+      this.admit(slug);
     }
     if (isMockActive()) {
       recordCall('importProgress.addRepos', slugs);
@@ -151,6 +147,31 @@ export class ImportProgress {
     if (next !== undefined) {
       this.visible[slot] = next;
     }
+  }
+
+  /**
+   * Places a newly discovered repo into the first available row: an empty slot if `visible`
+   * hasn't filled up yet, otherwise a slot already showing a finished (done/failed) repo from an
+   * earlier batch — that row's own completion already fired `promoteNext`, so nothing will ever
+   * swap it out again on its own. Falls back to the queue only when every visible slot is still
+   * pending/running, to be promoted later via `promoteNext`.
+   */
+  private admit(slug: string): void {
+    if (this.visible.length < this.maxVisible) {
+      this.visible.push(slug);
+      return;
+    }
+    const staleSlot = this.visible.findIndex((visibleSlug) => this.isTerminal(visibleSlug));
+    if (staleSlot !== -1) {
+      this.visible[staleSlot] = slug;
+      return;
+    }
+    this.queue.push(slug);
+  }
+
+  private isTerminal(slug: string): boolean {
+    const status = this.repos.get(slug)?.status;
+    return status === 'done' || status === 'failed';
   }
 
   /** Finalizes the display and returns aggregate counts. */

--- a/src/ui/components/import-progress.ts
+++ b/src/ui/components/import-progress.ts
@@ -62,20 +62,61 @@ function toPhaseStatus(status: ImportRepoStatus | undefined): 'done' | 'failed' 
  * queue at all, so every repo simply stays visible throughout).
  */
 export class ImportProgress {
-  private readonly order: string[];
-  private readonly repos: Map<string, RepoState>;
+  private readonly order: string[] = [];
+  private readonly repos = new Map<string, RepoState>();
   private readonly isTTY: boolean;
-  private readonly visible: string[];
-  private readonly queue: string[];
+  private readonly visible: string[] = [];
+  private readonly queue: string[] = [];
+  private readonly maxVisible: number;
+  private total = 0;
+  private skippedResolved = 0;
   private linesRendered = 0;
 
-  constructor(opts: { repos: string[]; isTTY?: boolean; maxVisible?: number }) {
-    this.order = opts.repos;
-    this.repos = new Map(opts.repos.map((slug) => [slug, { status: 'pending' as const }]));
+  constructor(opts: { isTTY?: boolean; maxVisible?: number }) {
     this.isTTY = opts.isTTY ?? process.stdout.isTTY;
-    const maxVisible = opts.maxVisible ?? DEFAULT_MAX_VISIBLE;
-    this.visible = opts.repos.slice(0, maxVisible);
-    this.queue = opts.repos.slice(maxVisible);
+    this.maxVisible = opts.maxVisible ?? DEFAULT_MAX_VISIBLE;
+  }
+
+  /** Sets the progress bar's denominator. Call once, before `start()`. */
+  setTotal(total: number): void {
+    this.total = total;
+  }
+
+  /** Registers newly discovered repos to track/render, appending to the visible or queued set. */
+  addRepos(slugs: string[]): void {
+    for (const slug of slugs) {
+      this.repos.set(slug, { status: 'pending' });
+      this.order.push(slug);
+      if (this.visible.length < this.maxVisible) {
+        this.visible.push(slug);
+      } else {
+        this.queue.push(slug);
+      }
+    }
+    if (isMockActive()) {
+      recordCall('importProgress.addRepos', slugs);
+      return;
+    }
+    if (this.isTTY) {
+      this.render();
+    }
+  }
+
+  /**
+   * Advances the progress bar for repos resolved without a provisioning call (e.g. already
+   * imported) — no row is added for them, they only count toward the bar's resolved fraction, or
+   * a streaming job's bar could never reach 100% while skipped repos keep turning up.
+   */
+  recordSkipped(count: number): void {
+    if (count <= 0) return;
+    this.skippedResolved += count;
+    if (isMockActive()) {
+      recordCall('importProgress.recordSkipped', count);
+      return;
+    }
+    if (this.isTTY) {
+      this.render();
+    }
   }
 
   start(): void {
@@ -162,7 +203,8 @@ export class ImportProgress {
     // Computed from every repo (not just the currently visible ones) so column alignment
     // stays stable as rows are swapped out — otherwise the bar/label columns would jitter
     // depending on which slugs happen to be in the window at a given moment.
-    const maxLabelWidth = Math.max(...this.order.map((slug) => visibleLength(slug)));
+    const maxLabelWidth =
+      this.order.length === 0 ? 0 : Math.max(...this.order.map((slug) => visibleLength(slug)));
     const rows = this.visible.map((slug) => this.formatRow(slug, maxLabelWidth));
     return [...rows, '', this.formatBar()];
   }
@@ -186,10 +228,10 @@ export class ImportProgress {
   }
 
   private formatBar(): string {
-    const total = this.order.length;
-    const resolved = [...this.repos.values()].filter(
-      (s) => s.status === 'done' || s.status === 'failed',
-    ).length;
+    const total = this.total;
+    const resolved =
+      [...this.repos.values()].filter((s) => s.status === 'done' || s.status === 'failed').length +
+      this.skippedResolved;
     const pct = total === 0 ? 100 : Math.round((resolved / total) * 100);
     const filled = Math.round((pct / 100) * BAR_WIDTH);
     const bar = green(BAR_FILLED.repeat(filled)) + dim(BAR_EMPTY.repeat(BAR_WIDTH - filled));

--- a/src/ui/components/prompts.ts
+++ b/src/ui/components/prompts.ts
@@ -191,7 +191,11 @@ function renderLoadMoreRow(isCursor: boolean, loading: boolean, error: string | 
     return `    ${dim('…')}    ${dim('Loading...')}`;
   }
   const arrow = isCursor ? cyan('❯') : ' ';
-  const label = error ? `Load more... ${dim(`(${error} - press enter to retry)`)}` : 'Load more...';
+  let label = 'Load more...';
+  if (error) {
+    const retryHint = dim(`(${error} - press enter to retry)`);
+    label = `Load more... ${retryHint}`;
+  }
   return `    ${arrow}    ${isCursor ? label : dim(label)}`;
 }
 

--- a/src/ui/components/prompts.ts
+++ b/src/ui/components/prompts.ts
@@ -186,12 +186,12 @@ function buildSelectHint(countLabel: string, atCap: boolean): string {
   return dim(`(${countLabel} - space to toggle, enter to confirm, q to quit)`);
 }
 
-function renderLoadMoreRow(isCursor: boolean, loading: boolean): string {
+function renderLoadMoreRow(isCursor: boolean, loading: boolean, error: string | null): string {
   if (loading) {
     return `    ${dim('…')}    ${dim('Loading...')}`;
   }
   const arrow = isCursor ? cyan('❯') : ' ';
-  const label = 'Load more...';
+  const label = error ? `Load more... ${dim(`(${error} - press enter to retry)`)}` : 'Load more...';
   return `    ${arrow}    ${isCursor ? label : dim(label)}`;
 }
 
@@ -236,6 +236,7 @@ export async function multiSelectPrompt<T>(
   const selected: T[] = [];
   let cursor = 0;
   let loadingMore = false;
+  let loadMoreError: string | null = null;
   const maxSelected = loadMoreOpts?.maxSelected ?? MULTISELECT_MAX_SELECTED;
 
   const onLoadMore = loadMoreOpts?.onLoadMore;
@@ -295,7 +296,7 @@ export async function multiSelectPrompt<T>(
           const isCursor = i === cursor;
 
           if (loadMoreRowVisible && i === options.length) {
-            lines.push(renderLoadMoreRow(isCursor, loadingMore));
+            lines.push(renderLoadMoreRow(isCursor, loadingMore, loadMoreError));
             continue;
           }
 
@@ -336,11 +337,19 @@ export async function multiSelectPrompt<T>(
       if (isOnLoadMoreRow() && onLoadMore) {
         pendingLoadMoreSubmitBlock = true;
         loadingMore = true;
-        void Promise.resolve(onLoadMore()).then((loaded) => {
-          options = loaded;
-          loadingMore = false;
-          prompt.refresh();
-        });
+        loadMoreError = null;
+        void Promise.resolve(onLoadMore())
+          .then((loaded) => {
+            options = loaded;
+          })
+          .catch((err: unknown) => {
+            // Leave `options`/`hasMore()` untouched so the row reappears and Enter retries.
+            loadMoreError = err instanceof Error ? err.message : String(err);
+          })
+          .finally(() => {
+            loadingMore = false;
+            prompt.refresh();
+          });
         return;
       }
       pendingLoadMoreSubmitBlock = false;

--- a/src/ui/components/prompts.ts
+++ b/src/ui/components/prompts.ts
@@ -136,20 +136,12 @@ export interface MultiSelectPromptOptions<T> {
   /** True while more options can be revealed (e.g. a paginated collection's `hasMore`). */
   hasMore?: () => boolean;
   /**
-   * Reveal more options, returning the full updated list (existing options plus newly
-   * revealed ones). Synchronous by design: options are expected to already be fully loaded
-   * locally (see `RepositoryCollection`/`OrganizationCollection`), so paging never needs to
-   * make a network call — keeping this synchronous also avoids having to reconcile prompt
-   * state against an in-flight async load.
+   * Reveal more options, returning (or resolving to) the full updated list (existing options
+   * plus newly revealed ones). May return a `Promise` when revealing more requires a network
+   * call (e.g. `RepositoryCollection.loadMore`) — the "Load more" row shows a loading indicator
+   * while it's in flight.
    */
-  onLoadMore?: () => MultiSelectOption<T>[];
-  /**
-   * Enables the 'a' keybinding to select/deselect every option at once. Called lazily (only
-   * when 'a' is pressed) so callers paginating lazily can reveal every remaining page first
-   * (e.g. via `onLoadMore`'s underlying collection) before returning the complete option list.
-   * Pressing 'a' again when everything is already selected clears the selection.
-   */
-  selectAll?: () => MultiSelectOption<T>[];
+  onLoadMore?: () => MultiSelectOption<T>[] | Promise<MultiSelectOption<T>[]>;
   /** Max number of selections. Defaults to 20; pass `Infinity` for no cap. */
   maxSelected?: number;
   /**
@@ -187,15 +179,17 @@ export function toggleSelected<T>(selected: T[], val: T, max: number): void {
 }
 
 /** Selection hint line shown while the multi-select prompt is active (not submitted/cancelled). */
-function buildSelectHint(countLabel: string, atCap: boolean, selectAllEnabled: boolean): string {
+function buildSelectHint(countLabel: string, atCap: boolean): string {
   if (atCap) {
     return dim(`(${countLabel} - at max, deselect to choose others)`);
   }
-  const selectAllHint = selectAllEnabled ? ', a to select all' : '';
-  return dim(`(${countLabel} - space to toggle, enter to confirm${selectAllHint}, q to quit)`);
+  return dim(`(${countLabel} - space to toggle, enter to confirm, q to quit)`);
 }
 
-function renderLoadMoreRow(isCursor: boolean): string {
+function renderLoadMoreRow(isCursor: boolean, loading: boolean): string {
+  if (loading) {
+    return `    ${dim('…')}    ${dim('Loading...')}`;
+  }
   const arrow = isCursor ? cyan('❯') : ' ';
   const label = 'Load more...';
   return `    ${arrow}    ${isCursor ? label : dim(label)}`;
@@ -215,27 +209,6 @@ function renderOptionRow(
 }
 
 /**
- * 'a' (select-all) toggle result: everything `selectAll()` returned, or nothing if every
- * selectable slot (capped by `maxSelected`) is already selected.
- */
-function computeSelectAllToggle<T>(
-  allOptions: MultiSelectOption<T>[],
-  currentlySelected: T[],
-  maxSelected: number,
-): T[] {
-  const selectableCount = Math.min(allOptions.length, maxSelected);
-  const allSelected = selectableCount > 0 && currentlySelected.length >= selectableCount;
-  if (allSelected) return [];
-
-  const next: T[] = [];
-  for (const opt of allOptions) {
-    if (next.length >= maxSelected) break;
-    next.push(opt.value);
-  }
-  return next;
-}
-
-/**
  * Multi-select prompt. Space to toggle, Enter to confirm. Max 20 selections by default
  * (override via `loadMoreOpts.maxSelected`).
  * Returns the selected values array (may be empty) or null if cancelled (Ctrl+C or q).
@@ -245,10 +218,8 @@ function computeSelectAllToggle<T>(
  * `hasMore()` is true; pressing Enter on that row calls `onLoadMore()` instead of submitting.
  * Selections are preserved across a load-more because they're tracked by value identity
  * (`===`) rather than by index — callers must return `===`-stable values for options that
- * were already present before the reload.
- *
- * When `loadMoreOpts.selectAll` is given, pressing 'a' selects every option it returns (or
- * clears the selection if everything is already selected).
+ * were already present before the reload. When `onLoadMore` returns a `Promise`, the row shows
+ * a loading indicator until it resolves; Enter is ignored on every other row while it's pending.
  */
 export async function multiSelectPrompt<T>(
   message: string,
@@ -264,10 +235,10 @@ export async function multiSelectPrompt<T>(
   let options = initialOptions;
   const selected: T[] = [];
   let cursor = 0;
+  let loadingMore = false;
   const maxSelected = loadMoreOpts?.maxSelected ?? MULTISELECT_MAX_SELECTED;
 
   const onLoadMore = loadMoreOpts?.onLoadMore;
-  const selectAll = loadMoreOpts?.selectAll;
   const hasMore = (): boolean => onLoadMore !== undefined && (loadMoreOpts?.hasMore?.() ?? false);
   const isOnLoadMoreRow = (): boolean => hasMore() && cursor === options.length;
   const getTotal = (): number => loadMoreOpts?.total?.() ?? options.length;
@@ -281,6 +252,16 @@ export async function multiSelectPrompt<T>(
   class MultiSelectLoadMorePrompt extends Prompt<T[]> {
     protected override _shouldSubmit(): boolean {
       return !pendingLoadMoreSubmitBlock;
+    }
+
+    /**
+     * Forces a redraw outside of a keypress (needed once an async `onLoadMore()` resolves).
+     * `render` is private on the base class, but `output` is protected and the base
+     * constructor already wires `output.on('resize', this.render)` for terminal resizes —
+     * reusing that plumbing to trigger a render is simpler than re-implementing it.
+     */
+    refresh(): void {
+      this.output.emit('resize');
     }
   }
 
@@ -297,9 +278,9 @@ export async function multiSelectPrompt<T>(
 
         const atCap = selected.length >= maxSelected;
         const countLabel = `${selected.length}/${getTotal()} selected`;
-        const hint = buildSelectHint(countLabel, atCap, selectAll !== undefined);
+        const hint = buildSelectHint(countLabel, atCap);
 
-        const loadMoreRowVisible = hasMore();
+        const loadMoreRowVisible = hasMore() || loadingMore;
         const total = options.length + (loadMoreRowVisible ? 1 : 0);
         const { start, end } = calculateViewport(cursor, total, MULTISELECT_VIEWPORT_SIZE);
 
@@ -314,7 +295,7 @@ export async function multiSelectPrompt<T>(
           const isCursor = i === cursor;
 
           if (loadMoreRowVisible && i === options.length) {
-            lines.push(renderLoadMoreRow(isCursor));
+            lines.push(renderLoadMoreRow(isCursor, loadingMore));
             continue;
           }
 
@@ -346,21 +327,26 @@ export async function multiSelectPrompt<T>(
 
   prompt.on('key', (_key, s) => {
     if (s.name === 'return') {
-      pendingLoadMoreSubmitBlock = isOnLoadMoreRow() && onLoadMore !== undefined;
-      if (pendingLoadMoreSubmitBlock && onLoadMore) {
-        options = onLoadMore();
+      if (loadingMore) {
+        // A load is already in flight — ignore Enter entirely rather than letting it submit
+        // (or start a second overlapping load) while `options` is about to be replaced.
+        pendingLoadMoreSubmitBlock = true;
         return;
       }
+      if (isOnLoadMoreRow() && onLoadMore) {
+        pendingLoadMoreSubmitBlock = true;
+        loadingMore = true;
+        void Promise.resolve(onLoadMore()).then((loaded) => {
+          options = loaded;
+          loadingMore = false;
+          prompt.refresh();
+        });
+        return;
+      }
+      pendingLoadMoreSubmitBlock = false;
       prompt.value = [...selected];
     } else if (s.name === 'q') {
       prompt.state = 'cancel';
-    } else if (s.name === 'a' && selectAll) {
-      const allOptions = selectAll();
-      options = allOptions;
-      const next = computeSelectAllToggle(allOptions, selected, maxSelected);
-      selected.length = 0;
-      selected.push(...next);
-      cursor = Math.min(cursor, options.length + (hasMore() ? 1 : 0) - 1);
     }
   });
 

--- a/src/ui/components/prompts.ts
+++ b/src/ui/components/prompts.ts
@@ -130,6 +130,8 @@ export async function selectPrompt<T>(
 export interface MultiSelectOption<T> {
   value: T;
   label: string;
+  /** Shown but not toggleable (e.g. a repo that's already imported) — rendered like an at-cap row. */
+  disabled?: boolean;
 }
 
 export interface MultiSelectPromptOptions<T> {
@@ -204,8 +206,9 @@ function renderOptionRow(
   isCursor: boolean,
   isSelected: boolean,
   atCap: boolean,
+  disabled: boolean,
 ): string {
-  const unavailable = atCap && !isSelected;
+  const unavailable = disabled || (atCap && !isSelected);
   const checkbox = checkboxComponent(isSelected, unavailable);
   const arrow = isCursor ? cyan('❯') : ' ';
   const displayLabel = isCursor && !unavailable ? label : dim(label);
@@ -214,7 +217,8 @@ function renderOptionRow(
 
 /**
  * Multi-select prompt. Space to toggle, Enter to confirm. Max 20 selections by default
- * (override via `loadMoreOpts.maxSelected`).
+ * (override via `loadMoreOpts.maxSelected`). Options with `disabled: true` are shown (dimmed,
+ * like an at-cap row) but the cursor can't toggle them.
  * Returns the selected values array (may be empty) or null if cancelled (Ctrl+C or q).
  * Renders a scrolling viewport when the option list exceeds MULTISELECT_VIEWPORT_SIZE.
  *
@@ -306,7 +310,9 @@ export async function multiSelectPrompt<T>(
 
           const opt = options[i];
           const isSelected = selected.includes(opt.value);
-          lines.push(renderOptionRow(opt.label, isCursor, isSelected, atCap));
+          lines.push(
+            renderOptionRow(opt.label, isCursor, isSelected, atCap, opt.disabled ?? false),
+          );
         }
 
         const more = `↓ ${total - end} more`;
@@ -324,7 +330,7 @@ export async function multiSelectPrompt<T>(
     else if (dir === 'down') cursor = Math.min(total - 1, cursor + 1);
     else if (dir === 'space') {
       const val = options[cursor]?.value;
-      if (val !== undefined) {
+      if (val !== undefined && !options[cursor]?.disabled) {
         toggleSelected(selected, val, maxSelected);
       }
     }

--- a/tests/integration/specs/import/import.test.ts
+++ b/tests/integration/specs/import/import.test.ts
@@ -758,7 +758,7 @@ describe('sonar import', () => {
     );
 
     it(
-      'excludes repos already imported into the current org from the select list',
+      'lists repos already imported into the current org as non-toggleable in the select list',
       async () => {
         const server = await harness
           .newFakeServer()
@@ -772,13 +772,29 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         const result = await harness.run('import --org my-org', {
-          stdinChunks: ['\x1b[B\r', ' \r'], // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
+          stdinChunks: [
+            '\x1b[B\r', // down arrow+enter → Manual mode
+            // toggle the eligible repo (cursor starts on it), move down to the already-imported
+            // row, attempt to toggle it too (must be a no-op), then confirm.
+            ' \x1b[B \r',
+          ],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
 
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).not.toContain('kevinmlsilva/repo -');
+        // The already-imported repo is listed (dimmed/non-toggleable), not hidden.
+        expect(result.stdout).toContain('kevinmlsilva/repo - public (already imported)');
         expect(result.stdout).toContain('kevinmlsilva/other-repo - public');
+        expect(result.stdout).toContain('1 of 1 selected');
+        expect(result.stdout).toContain('Imported 1 repository');
+
+        const provisionRequests = server
+          .getRecordedRequests()
+          .filter((r) => r.path === '/api/alm_integration/provision_projects');
+        expect(provisionRequests).toHaveLength(1);
+        expect(new URLSearchParams(provisionRequests[0].body ?? '').get('installationKeys')).toBe(
+          'repo-2',
+        );
       },
       { timeout: 15000 },
     );
@@ -881,16 +897,17 @@ describe('sonar import', () => {
     );
 
     it(
-      'shows every selectable repo from a single server page despite interleaved exclusions',
+      'shows every selectable repo from a single server page alongside interleaved already-imported ones',
       async () => {
         // 15 raw repos easily fit in one 50-item server page; 5 of the first 10 are already
         // imported. Filtering happens per fetched page, so all 10 selectable repos from this
-        // one page show up together, with no "Load more" needed.
+        // one page show up together, with no "Load more" needed. The already-imported ones are
+        // still listed (non-toggleable), not hidden.
         const manyRepos = Array.from({ length: 15 }, (_, i) => ({
           id: `repo-${i + 1}`,
           name: `repo-${String(i + 1).padStart(2, '0')}`,
           slug: `kevinmlsilva/repo-${String(i + 1).padStart(2, '0')}`,
-          importedInCurrentOrg: i < 10 && i % 2 === 0, // repo-01,03,05,07,09 excluded
+          importedInCurrentOrg: i < 10 && i % 2 === 0, // repo-01,03,05,07,09 already imported
         }));
 
         const server = await harness
@@ -923,6 +940,7 @@ describe('sonar import', () => {
         ]) {
           expect(result.stdout).toContain(slug);
         }
+        expect(result.stdout).toContain('kevinmlsilva/repo-01 - public (already imported)');
         expect(result.stdout).not.toContain('Load more');
         expect(result.stdout).toContain('Imported 1 repository');
       },

--- a/tests/integration/specs/import/import.test.ts
+++ b/tests/integration/specs/import/import.test.ts
@@ -489,6 +489,44 @@ describe('sonar import', () => {
     );
 
     it(
+      'cancelling the Manual picker returns to the Recommended/Manual/Back menu',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [
+            { id: 'repo-1', name: 'repo-1', slug: 'my-org/repo-1' },
+            { id: 'repo-2', name: 'repo-2', slug: 'my-org/repo-2' },
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // down+enter → Manual mode; 'q' → cancel the picker, back to the mode menu; enter →
+        // Recommended this time (the re-shown menu's default, first option).
+        const result = await harness.run('import --org my-org', {
+          stdinChunks: ['\x1b[B\r', 'q', '\r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+        });
+
+        expect(result.exitCode).toBe(0);
+        // The picker is cancelled (not treated as an error) and the mode menu re-appears,
+        // this time resolving to Recommended instead of Manual.
+        expect(result.stdout).toContain('✗  Select repositories to import');
+        expect(result.stdout).toContain(
+          '✓  How do you want to import repositories? Recommended — import all eligible repositories automatically',
+        );
+        expect(result.stdout).toContain('Imported 2 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(2);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
       'offers to go back when the interactively-picked org has nothing eligible to import',
       async () => {
         const server = await harness
@@ -650,6 +688,40 @@ describe('sonar import', () => {
     );
 
     it(
+      'paginates --repo resolution until every slug is found, across multiple server pages',
+      async () => {
+        // 60 repos exceeds the 50-item server page cap: repo-1 is on the first page, repo-51
+        // only appears on the second — resolving both requires exactly 2 pages, proving
+        // pagination continues until every requested slug is matched.
+        const manyRepos = Array.from({ length: 60 }, (_, i) => ({
+          id: `repo-${i + 1}`,
+          name: `repo-${i + 1}`,
+          slug: `my-org/repo-${i + 1}`,
+        }));
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', manyRepos)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-1,my-org/repo-51',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 2 repositories');
+        const recorded = server.getRecordedRequests();
+        const repoRequests = recorded.filter((r) => r.path === '/dop-translation/dop-repositories');
+        expect(repoRequests).toHaveLength(2);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
       'exits with code 2 when --non-interactive is set without --repo or --all',
       async () => {
         const server = await harness.newFakeServer().withAuthToken('test-token').start();
@@ -736,9 +808,12 @@ describe('sonar import', () => {
     );
 
     it(
-      'shows a "Load more..." option when more than 10 repos exist and advances when selected',
+      'shows a "Load more..." option after a full first page and fetches the next page when selected',
       async () => {
-        const manyRepos = Array.from({ length: 11 }, (_, i) => ({
+        // 51 repos exceeds the 50-item server page cap, so the first page is fetched (and
+        // shown) without ever touching the 51st repo — "Load more" only fetches page two when
+        // actually selected.
+        const manyRepos = Array.from({ length: 51 }, (_, i) => ({
           id: `repo-${i + 1}`,
           name: `repo-${String(i + 1).padStart(2, '0')}`,
           slug: `kevinmlsilva/repo-${String(i + 1).padStart(2, '0')}`,
@@ -752,27 +827,30 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token');
 
-        // down arrow+enter → Manual mode, then navigate to "Load more...", select it (cursor
-        // carries over onto the newly revealed 11th repo, since the multi-select prompt never
-        // resets its cursor), then toggle and confirm it. Repos are all fetched up front, so
-        // "Load more" is a synchronous local pagination step with no reload delay to account for.
+        // down arrow+enter → Manual mode, then navigate to "Load more..." (50 repos precede it
+        // on the first page), select it — which fetches page two — then toggle and confirm the
+        // newly revealed 51st repo (cursor carries over onto it, since the multi-select prompt
+        // never resets its cursor).
         const result = await harness.run('import --org my-org', {
-          stdinChunks: ['\x1b[B\r', '\x1b[B'.repeat(10) + '\r', ' \r'],
+          stdinChunks: ['\x1b[B\r', '\x1b[B'.repeat(50) + '\r', ' \r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+          timeoutMs: 20000,
         });
 
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('kevinmlsilva/repo-11');
+        expect(result.stdout).toContain('kevinmlsilva/repo-51');
+        const recorded = server.getRecordedRequests();
+        const repoRequests = recorded.filter((r) => r.path === '/dop-translation/dop-repositories');
+        expect(repoRequests).toHaveLength(2);
       },
-      { timeout: 15000 },
+      { timeout: 20000 },
     );
 
     it(
-      'fetches every server page up front before showing the repo prompt',
+      'does not fetch further server pages until "Load more" is actually selected',
       async () => {
-        // 60 repos exceeds the 50-item server page cap, so fetching everything up front
-        // (mirroring org selection) needs exactly 2 requests, made before the prompt is
-        // ever shown — regardless of which repo the user ends up picking.
+        // 60 repos exceeds the 50-item server page cap, but picking a repo from the first page
+        // should never trigger a second page fetch.
         const manyRepos = Array.from({ length: 60 }, (_, i) => ({
           id: `repo-${i + 1}`,
           name: `repo-${String(i + 1).padStart(2, '0')}`,
@@ -797,18 +875,17 @@ describe('sonar import', () => {
         expect(result.stdout).toContain('kevinmlsilva/repo-01');
         const recorded = server.getRecordedRequests();
         const repoRequests = recorded.filter((r) => r.path === '/dop-translation/dop-repositories');
-        expect(repoRequests).toHaveLength(2);
+        expect(repoRequests).toHaveLength(1);
       },
       { timeout: 15000 },
     );
 
     it(
-      'shows a full page of selectable repos in one go despite interleaved exclusions',
+      'shows every selectable repo from a single server page despite interleaved exclusions',
       async () => {
-        // 15 raw repos; 5 of the first 10 are already imported. If filtering happened on
-        // a lazily-fetched 10-item window, the first page would show only 5 selectable
-        // repos (with "Load more" for the rest). Fetching everything up front and
-        // filtering before pagination shows a full page of 10 selectable repos instead.
+        // 15 raw repos easily fit in one 50-item server page; 5 of the first 10 are already
+        // imported. Filtering happens per fetched page, so all 10 selectable repos from this
+        // one page show up together, with no "Load more" needed.
         const manyRepos = Array.from({ length: 15 }, (_, i) => ({
           id: `repo-${i + 1}`,
           name: `repo-${String(i + 1).padStart(2, '0')}`,
@@ -850,6 +927,48 @@ describe('sonar import', () => {
         expect(result.stdout).toContain('Imported 1 repository');
       },
       { timeout: 15000 },
+    );
+
+    it(
+      'caps Manual selection at 25 repos',
+      async () => {
+        const manyRepos = Array.from({ length: 26 }, (_, i) => ({
+          id: `repo-${i + 1}`,
+          name: `repo-${i + 1}`,
+          slug: `my-org/repo-${i + 1}`,
+        }));
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', manyRepos)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        // down arrow+enter → Manual mode; toggle the first repo, then (down+toggle) 25 more
+        // times — 26 toggle attempts across 26 repos. The 26th is rejected since selection is
+        // capped at 25, so only the first 25 end up selected.
+        const result = await harness.run('import --org my-org', {
+          stdinChunks: ['\x1b[B\r', ' ' + '\x1b[B '.repeat(25) + '\r'],
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+          timeoutMs: 20000,
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('25 of 26 selected');
+        expect(result.stdout).toContain('Imported 25 repositories');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(25);
+        const installationKeys = provisionRequests.map((r) =>
+          new URLSearchParams(r.body ?? '').get('installationKeys'),
+        );
+        expect(installationKeys).not.toContain('repo-26');
+      },
+      { timeout: 20000 },
     );
   });
 
@@ -1331,101 +1450,6 @@ describe('sonar import', () => {
     );
 
     it(
-      "selects every repo when pressing 'a' in the interactive picker",
-      async () => {
-        const server = await harness
-          .newFakeServer()
-          .withAuthToken('test-token')
-          .withDopRepositories('my-org', BATCH_REPOS)
-          .start();
-        const serverUrl = server.baseUrl();
-        harness.withAuth(serverUrl, 'test-token');
-
-        // down arrow+enter → Manual mode, 'a' → select all, enter → confirm
-        const result = await harness.run('import --org my-org', {
-          stdinChunks: ['\x1b[B\r', 'a\r'],
-          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
-        });
-
-        expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('Imported 3 repositories');
-        const recorded = server.getRecordedRequests();
-        const provisionRequests = recorded.filter(
-          (r) => r.path === '/api/alm_integration/provision_projects',
-        );
-        expect(provisionRequests).toHaveLength(3);
-      },
-      { timeout: 15000 },
-    );
-
-    it(
-      "toggling 'a' twice clears the select-all, allowing a manual pick afterwards",
-      async () => {
-        const server = await harness
-          .newFakeServer()
-          .withAuthToken('test-token')
-          .withDopRepositories('my-org', BATCH_REPOS)
-          .start();
-        const serverUrl = server.baseUrl();
-        harness.withAuth(serverUrl, 'test-token');
-
-        // down arrow+enter → Manual mode, 'a' → select all, 'a' → deselect all,
-        // down, space (toggle repo-b), enter
-        const result = await harness.run('import --org my-org', {
-          stdinChunks: ['\x1b[B\r', 'aa\x1b[B \r'],
-          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
-        });
-
-        expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('Imported 1 repository');
-        const recorded = server.getRecordedRequests();
-        const provisionRequests = recorded.filter(
-          (r) => r.path === '/api/alm_integration/provision_projects',
-        );
-        expect(provisionRequests).toHaveLength(1);
-        expect(new URLSearchParams(provisionRequests[0].body ?? '').get('installationKeys')).toBe(
-          'repo-b-id',
-        );
-      },
-      { timeout: 15000 },
-    );
-
-    it(
-      "selecting all with 'a' is not capped at 20 repos",
-      async () => {
-        const manyRepos = Array.from({ length: 25 }, (_, i) => ({
-          id: `repo-${i + 1}`,
-          name: `repo-${i + 1}`,
-          slug: `my-org/repo-${i + 1}`,
-        }));
-
-        const server = await harness
-          .newFakeServer()
-          .withAuthToken('test-token')
-          .withDopRepositories('my-org', manyRepos)
-          .start();
-        const serverUrl = server.baseUrl();
-        harness.withAuth(serverUrl, 'test-token');
-
-        const result = await harness.run('import --org my-org', {
-          // down arrow+enter → Manual mode, 'a' → select all, enter → confirm
-          stdinChunks: ['\x1b[B\r', 'a\r'],
-          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
-          timeoutMs: 20000,
-        });
-
-        expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('Imported 25 repositories');
-        const recorded = server.getRecordedRequests();
-        const provisionRequests = recorded.filter(
-          (r) => r.path === '/api/alm_integration/provision_projects',
-        );
-        expect(provisionRequests).toHaveLength(25);
-      },
-      { timeout: 20000 },
-    );
-
-    it(
       'reports a partial failure summary when some repos fail to provision',
       async () => {
         const server = await harness
@@ -1488,6 +1512,75 @@ describe('sonar import', () => {
     );
 
     it(
+      'fails fast without provisioning any repo when a single --repo slug is already imported',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [
+            ...BATCH_REPOS.map((repo) =>
+              repo.slug === 'my-org/repo-a' ? { ...repo, importedInCurrentOrg: true } : repo,
+            ),
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-a,my-org/repo-b',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('my-org/repo-a');
+        expect(output).toContain('has already been imported into SonarQube');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
+      'fails fast listing every already-imported repo when multiple --repo slugs are already imported',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', [
+            ...BATCH_REPOS.map((repo) =>
+              repo.slug === 'my-org/repo-a' || repo.slug === 'my-org/repo-b'
+                ? { ...repo, importedInCurrentOrg: true }
+                : repo,
+            ),
+          ])
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run(
+          'import --non-interactive --org my-org --repo my-org/repo-a,my-org/repo-b,my-org/repo-c',
+          { extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl } },
+        );
+
+        expect(result.exitCode).toBe(1);
+        const output = result.stdout + result.stderr;
+        expect(output).toContain('Repositories have already been imported into SonarQube');
+        expect(output).toContain('my-org/repo-a');
+        expect(output).toContain('my-org/repo-b');
+        const recorded = server.getRecordedRequests();
+        const provisionRequests = recorded.filter(
+          (r) => r.path === '/api/alm_integration/provision_projects',
+        );
+        expect(provisionRequests).toHaveLength(0);
+      },
+      { timeout: 15000 },
+    );
+
+    it(
       'caps concurrent provisioning requests at 10',
       async () => {
         const manyRepos = Array.from({ length: 15 }, (_, i) => ({
@@ -1526,6 +1619,51 @@ describe('sonar import', () => {
   });
 
   describe('bulk import (--all)', () => {
+    it(
+      'imports each server page as it is fetched instead of resolving the whole org first',
+      async () => {
+        // 60 repos exceeds the 50-item server page cap, so `--all` must fetch page one (50
+        // repos), import all of them, then fetch page two (10 repos) and import those too.
+        const manyRepos = Array.from({ length: 60 }, (_, i) => ({
+          id: `repo-${i + 1}`,
+          name: `repo-${i + 1}`,
+          slug: `my-org/repo-${i + 1}`,
+        }));
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withDopRepositories('my-org', manyRepos)
+          .start();
+        const serverUrl = server.baseUrl();
+        harness.withAuth(serverUrl, 'test-token');
+
+        const result = await harness.run('import --non-interactive --org my-org --all', {
+          extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
+          timeoutMs: 30000,
+        });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain('Imported 60 repositories');
+
+        const recorded = server.getRecordedRequests();
+        const repoPageRequests = recorded.filter(
+          (r) => r.path === '/dop-translation/dop-repositories',
+        );
+        expect(repoPageRequests).toHaveLength(2);
+
+        // Every repo from page one must have been provisioned before page two was ever
+        // fetched — proving the job streams page-by-page rather than fetching everything
+        // up front and importing it all at the end.
+        const secondPageIndex = recorded.indexOf(repoPageRequests[1]);
+        const provisionsBeforeSecondPage = recorded
+          .slice(0, secondPageIndex)
+          .filter((r) => r.path === '/api/alm_integration/provision_projects').length;
+        expect(provisionsBeforeSecondPage).toBe(50);
+      },
+      { timeout: 30000 },
+    );
+
     it(
       'imports every eligible repo and reports skipped counts grouped by reason',
       async () => {

--- a/tests/integration/specs/import/import.test.ts
+++ b/tests/integration/specs/import/import.test.ts
@@ -930,7 +930,7 @@ describe('sonar import', () => {
     );
 
     it(
-      'caps Manual selection at 25 repos',
+      'does not cap Manual selection — every eligible repo on the page can be selected',
       async () => {
         const manyRepos = Array.from({ length: 26 }, (_, i) => ({
           id: `repo-${i + 1}`,
@@ -947,8 +947,7 @@ describe('sonar import', () => {
         harness.withAuth(serverUrl, 'test-token');
 
         // down arrow+enter → Manual mode; toggle the first repo, then (down+toggle) 25 more
-        // times — 26 toggle attempts across 26 repos. The 26th is rejected since selection is
-        // capped at 25, so only the first 25 end up selected.
+        // times — 26 toggle attempts across all 26 repos, all of which must be accepted.
         const result = await harness.run('import --org my-org', {
           stdinChunks: ['\x1b[B\r', ' ' + '\x1b[B '.repeat(25) + '\r'],
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
@@ -956,17 +955,17 @@ describe('sonar import', () => {
         });
 
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain('25 of 26 selected');
-        expect(result.stdout).toContain('Imported 25 repositories');
+        expect(result.stdout).toContain('26 of 26 selected');
+        expect(result.stdout).toContain('Imported 26 repositories');
         const recorded = server.getRecordedRequests();
         const provisionRequests = recorded.filter(
           (r) => r.path === '/api/alm_integration/provision_projects',
         );
-        expect(provisionRequests).toHaveLength(25);
+        expect(provisionRequests).toHaveLength(26);
         const installationKeys = provisionRequests.map((r) =>
           new URLSearchParams(r.body ?? '').get('installationKeys'),
         );
-        expect(installationKeys).not.toContain('repo-26');
+        expect(installationKeys).toContain('repo-26');
       },
       { timeout: 20000 },
     );

--- a/tests/unit/cli/commands/import/_common/repository-collection.test.ts
+++ b/tests/unit/cli/commands/import/_common/repository-collection.test.ts
@@ -1,0 +1,77 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { RepositoryCollection } from '../../../../../../src/cli/commands/import/_common/repository-collection.ts';
+import type { DopRepository } from '../../../../../../src/sonarqube/client.ts';
+import { SonarQubeClient } from '../../../../../../src/sonarqube/client.ts';
+
+const ONLY_PRIVATE_PROJECTS = { enabled: false, available: false };
+
+function makeRepos(count: number, prefix: string): DopRepository[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i}`,
+    name: `${prefix}-${i}`,
+    slug: `${prefix}-${i}`,
+    private: false,
+    archived: false,
+    boundProjectIds: [],
+    importedInCurrentOrg: false,
+  }));
+}
+
+describe('RepositoryCollection.loadMore', () => {
+  it('retries a failed page fetch on the next call instead of treating the collection as exhausted', async () => {
+    const firstPage = makeRepos(SonarQubeClient.DOP_REPOSITORIES_MAX_PAGE_SIZE, 'page1');
+    const secondPage = makeRepos(1, 'page2');
+    const callsPerPage = new Map<number, number>();
+
+    const fetchPage = (
+      pageIndex: number,
+      _pageSize: number,
+    ): Promise<{ repositories: DopRepository[]; total: number }> => {
+      callsPerPage.set(pageIndex, (callsPerPage.get(pageIndex) ?? 0) + 1);
+
+      if (pageIndex === 2 && callsPerPage.get(pageIndex) === 1) {
+        return Promise.reject(new Error('transient network error'));
+      }
+
+      const repositories = pageIndex === 1 ? firstPage : secondPage;
+      return Promise.resolve({ repositories, total: firstPage.length + secondPage.length });
+    };
+
+    const collection = await RepositoryCollection.create(fetchPage, ONLY_PRIVATE_PROJECTS);
+    expect(collection.eligibleRepos).toHaveLength(firstPage.length);
+    expect(collection.hasMore).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable
+    await expect(collection.loadMore()).rejects.toThrow('transient network error');
+    // The failed attempt must not consume the page or mark the collection exhausted.
+    expect(collection.hasMore).toBe(true);
+    expect(collection.eligibleRepos).toHaveLength(firstPage.length);
+
+    const retryResult = await collection.loadMore();
+    expect(retryResult.eligible.map((r) => r.slug)).toEqual(secondPage.map((r) => r.slug));
+    expect(collection.eligibleRepos).toHaveLength(firstPage.length + secondPage.length);
+    expect(collection.hasMore).toBe(false);
+    expect(callsPerPage.get(2)).toBe(2);
+  });
+});

--- a/tests/unit/ui/import-progress.test.ts
+++ b/tests/unit/ui/import-progress.test.ts
@@ -39,9 +39,17 @@ function captureStdout(fn: () => void): string {
   return chunks.join('');
 }
 
+/** Mirrors the pre-streaming single-batch construction: total and rows known up front. */
+function newProgress(repos: string[], opts: { isTTY?: boolean; maxVisible?: number } = {}) {
+  const progress = new ImportProgress(opts);
+  progress.setTotal(repos.length);
+  progress.addRepos(repos);
+  return progress;
+}
+
 describe('ImportProgress — non-TTY', () => {
   it('writes nothing on start or during updates', () => {
-    const progress = new ImportProgress({ repos: REPOS, isTTY: false });
+    const progress = newProgress(REPOS, { isTTY: false });
     const start = captureStdout(() => progress.start());
     expect(start).toBe('');
 
@@ -50,7 +58,7 @@ describe('ImportProgress — non-TTY', () => {
   });
 
   it('finish() delegates to the static phase() summary', () => {
-    const progress = new ImportProgress({ repos: REPOS, isTTY: false });
+    const progress = newProgress(REPOS, { isTTY: false });
     progress.start();
     progress.update(REPOS[0], 'done', 'Project created', 'my-org_api-gateway');
     progress.update(REPOS[1], 'done', 'Project created', 'my-org_auth-service');
@@ -71,7 +79,7 @@ describe('ImportProgress — non-TTY', () => {
   });
 
   it('a repo never updated stays out of the succeeded/failed counts', () => {
-    const progress = new ImportProgress({ repos: REPOS, isTTY: false });
+    const progress = newProgress(REPOS, { isTTY: false });
     let succeeded = 0;
     let failed = 0;
     captureStdout(() => {
@@ -86,7 +94,7 @@ describe('ImportProgress — non-TTY', () => {
 
 describe('ImportProgress — TTY', () => {
   it('renders one row per repo plus a progress bar, updating in place', () => {
-    const progress = new ImportProgress({ repos: REPOS, isTTY: true });
+    const progress = newProgress(REPOS, { isTTY: true });
     const start = captureStdout(() => progress.start());
     for (const repo of REPOS) {
       expect(start).toContain(repo.split('/')[1]);
@@ -105,7 +113,7 @@ describe('ImportProgress — TTY', () => {
 
   it('shows at most maxVisible rows, promoting the next queued repo on completion', () => {
     const repos = ['org/repo-1', 'org/repo-2', 'org/repo-3', 'org/repo-4', 'org/repo-5'];
-    const progress = new ImportProgress({ repos, isTTY: true, maxVisible: 3 });
+    const progress = newProgress(repos, { isTTY: true, maxVisible: 3 });
 
     const start = captureStdout(() => progress.start());
     expect(start).toContain('repo-1');
@@ -139,7 +147,7 @@ describe('ImportProgress — TTY', () => {
   });
 
   it('finish() renders the final state and a Result section', () => {
-    const progress = new ImportProgress({ repos: REPOS, isTTY: true });
+    const progress = newProgress(REPOS, { isTTY: true });
     captureStdout(() => {
       progress.start();
       progress.update(REPOS[0], 'done', 'Project created', 'my-org_api-gateway');
@@ -154,6 +162,50 @@ describe('ImportProgress — TTY', () => {
     expect(finish).toContain('Succeeded: 2');
     expect(finish).toContain('Failed: 1');
   });
+
+  it('setTotal fixes the bar denominator independently of addRepos, for a streaming job', () => {
+    // The server-reported total (5) is known before any page's eligible repos are added.
+    const progress = new ImportProgress({ isTTY: true });
+    progress.setTotal(5);
+
+    const start = captureStdout(() => progress.start());
+    expect(start).toContain('0/5');
+
+    // First page: 2 eligible repos added and both provisioned.
+    const afterPage1 = captureStdout(() => {
+      progress.addRepos(['org/repo-1', 'org/repo-2']);
+      progress.update('org/repo-1', 'done', 'Project created');
+      progress.update('org/repo-2', 'done', 'Project created');
+    });
+    expect(afterPage1).toContain('40%');
+    expect(afterPage1).toContain('2/5');
+
+    // Second page: 3 more eligible repos discovered and added.
+    const afterPage2 = captureStdout(() =>
+      progress.addRepos(['org/repo-3', 'org/repo-4', 'org/repo-5']),
+    );
+    expect(afterPage2).toContain('repo-3');
+    expect(afterPage2).toContain('repo-4');
+    expect(afterPage2).toContain('repo-5');
+  });
+
+  it('recordSkipped advances the bar without adding a row', () => {
+    const progress = new ImportProgress({ isTTY: true });
+    progress.setTotal(3);
+    progress.start();
+
+    const afterSkip = captureStdout(() => progress.recordSkipped(2));
+    expect(afterSkip).toContain('67%');
+    expect(afterSkip).toContain('2/3');
+    expect(afterSkip).not.toContain('repo');
+
+    const afterAdd = captureStdout(() => {
+      progress.addRepos(['org/only-eligible-repo']);
+      progress.update('org/only-eligible-repo', 'done', 'Project created');
+    });
+    expect(afterAdd).toContain('100%');
+    expect(afterAdd).toContain('3/3');
+  });
 });
 
 describe('ImportProgress — mock mode', () => {
@@ -164,12 +216,13 @@ describe('ImportProgress — mock mode', () => {
   afterEach(() => setMockUi(false));
 
   it('records method calls, writes nothing, and still tracks counts', () => {
-    const progress = new ImportProgress({ repos: REPOS });
+    const progress = newProgress(REPOS);
 
     const output = captureStdout(() => {
       progress.start();
       progress.update(REPOS[0], 'done', 'Project created', 'key-1');
       progress.update(REPOS[1], 'failed', 'CI failed');
+      progress.recordSkipped(1);
     });
     const { succeeded, failed } = progress.finish();
 
@@ -179,6 +232,7 @@ describe('ImportProgress — mock mode', () => {
     const methods = getMockUiCalls().map((c) => c.method);
     expect(methods).toContain('importProgress.start');
     expect(methods).toContain('importProgress.update');
+    expect(methods).toContain('importProgress.recordSkipped');
     expect(methods).toContain('importProgress.finish');
   });
 });

--- a/tests/unit/ui/import-progress.test.ts
+++ b/tests/unit/ui/import-progress.test.ts
@@ -189,6 +189,36 @@ describe('ImportProgress — TTY', () => {
     expect(afterPage2).toContain('repo-5');
   });
 
+  it('a later page takes over rows already finished by an earlier page, instead of stalling in the queue', () => {
+    // maxVisible (mirrors the real IMPORT_PROVISION_CONCURRENCY_LIMIT) is smaller than a page,
+    // so page 1 fills every visible row and finishes all of them before page 2 is fetched —
+    // exactly the streaming `--all` shape (page size 50, maxVisible 10).
+    const progress = new ImportProgress({ isTTY: true, maxVisible: 2 });
+    progress.setTotal(4);
+    progress.start();
+
+    captureStdout(() => {
+      progress.addRepos(['org/repo-1', 'org/repo-2']);
+      progress.update('org/repo-1', 'done', 'Project created');
+      progress.update('org/repo-2', 'done', 'Project created');
+    });
+
+    // Page 2 arrives after page 1's rows are already terminal — repo-3/4 must take over those
+    // rows immediately rather than sitting in the queue forever (nothing will ever finish again
+    // to trigger `promoteNext`).
+    const afterPage2 = captureStdout(() => progress.addRepos(['org/repo-3', 'org/repo-4']));
+    expect(afterPage2).toContain('repo-3');
+    expect(afterPage2).toContain('repo-4');
+    expect(afterPage2).not.toContain('repo-1');
+    expect(afterPage2).not.toContain('repo-2');
+    expect(afterPage2).not.toContain('Project created');
+
+    const afterThird = captureStdout(() =>
+      progress.update('org/repo-3', 'done', 'Project created'),
+    );
+    expect(afterThird).toContain('Project created');
+  });
+
   it('recordSkipped advances the bar without adding a row', () => {
     const progress = new ImportProgress({ isTTY: true });
     progress.setTotal(3);


### PR DESCRIPTION
## Summary
- Streams the org's repositories page by page instead of loading the whole list upfront, so `--all`/"Recommended" can start provisioning a page's eligible repos while later pages are still being fetched.
- The manual repo picker's "Load more" now triggers a real paginated network request instead of just revealing an already-loaded local list (dropped the select-all shortcut, which relied on everything being loaded upfront).
- Updated the live import progress bar to support a dynamic total/repo set as pages stream in, and updated tests accordingly.

## Test plan
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run test:unit`
- [ ] `bun run test:integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)