### PR TITLE
CLI-855 Remove beta label from `analyze dependency-risks` command help

### DIFF
--- a/src/cli/command-tree.ts
+++ b/src/cli/command-tree.ts
@@ -499,9 +499,7 @@ ${projectKeyExtraHelp}`;
 
 analyze
   .command('dependency-risks')
-  .description(
-    'Analyze project dependencies for security and license risks (beta: subject to change)',
-  )
+  .description('Analyze project dependencies for security and license risks')
   .option('-p, --project <project>', 'Project key (auto-detected when omitted)')
   .addOption(dependencyRisksFormatOption)
   .addOption(dependencyRisksStatusFilterOption)

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -48,7 +48,7 @@ function getExpectedRootHelp(): string {
     '  COMMANDS',
     '    analyze                                                  Analyze code for quality and security issues',
     '    analyze secrets                                          Scan files or stdin for hardcoded secrets',
-    '    analyze dependency-risks                                 Analyze project dependencies for security and license risks (beta: subject to change)',
+    '    analyze dependency-risks                                 Analyze project dependencies for security and license risks',
     '    analyze agentic                                          Run server-side agentic analysis (SonarQube Cloud only). Limitations apply.',
     '    remediate                                                Trigger AI agent remediation for eligible issues (SonarQube Cloud only)',
     '',


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Documentation updates:**
    - Removed '(beta: subject to change)' label from the `analyze dependency-risks` command description in `command-tree.ts`.
    - Updated the integration test expectation in `root-help.test.ts` to match the updated command description.

<sub>This will update automatically on new commits.</sub>