### PR TITLE
CLI-837 Add path alias for src directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,10 +22,10 @@
 
 // Main CLI entry point
 
-import { COMMAND_TREE } from './commands/command-tree.ts';
-import * as postUpdate from './lib/post-update';
-import { flushSentry } from './lib/sentry';
-import { setFormattedOutputMode } from './ui';
+import { COMMAND_TREE } from '@/commands/command-tree.ts';
+import * as postUpdate from '@/lib/post-update';
+import { flushSentry } from '@/lib/sentry';
+import { setFormattedOutputMode } from '@/ui';
 
 // Activate formatted output mode early so startup messages are collected
 // rather than printed to stdout when the command will produce JSON output.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
-    "types": ["node", "bun", "js-yaml"]
+    "types": ["node", "bun", "js-yaml"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
-  "include": [
-    "src/**/*",
-    "tests/**/*",
-    "build-scripts/**/*.ts"
-  ]
+  "include": ["src/**/*", "tests/**/*", "build-scripts/**/*.ts"]
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Configuration:**
    - Added `@/*` path alias to `tsconfig.json` to map imports to the `src` directory.
- **Refactor:**
    - Updated internal imports in `src/index.ts` to use the new `@` alias.

<sub>This will update automatically on new commits.</sub>