### PR TITLE
CLI-837 fix update notification logic architecture

### DIFF
--- a/src/commands/_common/sonar-command.ts
+++ b/src/commands/_common/sonar-command.ts
@@ -20,6 +20,7 @@
 
 // SonarCommand — Commander Command subclass with built-in error handling and auth support
 
+import type { CommandOptions } from 'commander';
 import { Command } from 'commander';
 
 import { CliError, CommandFailedError, remediationHintFor } from '@/core/command-error.ts';
@@ -80,7 +81,7 @@ export class SonarCommand extends Command {
    * this tree's createCommand(), bypassing the shared per-tree state it sets up.
    * Use .command() instead.
    */
-  addCommand(): this {
+  addCommand(_cmd: Command, _opts?: CommandOptions): this {
     throw new Error('addCommand() is disallowed; use .command() instead');
   }
 

--- a/src/commands/_common/sonar-command.ts
+++ b/src/commands/_common/sonar-command.ts
@@ -25,6 +25,10 @@ import { Command } from 'commander';
 import { CliError, CommandFailedError, remediationHintFor } from '@/core/command-error.ts';
 import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
 import { resolveAuth } from '@/core/host/auth-resolver.ts';
+import {
+  registerUpdateNotification,
+  type UpdateNotificationCondition,
+} from '@/core/host/update/notification.ts';
 import logger from '@/core/observability/logger.ts';
 import { blank, error, print } from '@/core/ui';
 
@@ -37,8 +41,7 @@ export interface RootHelpMetadata {
   label?: string;
 }
 
-/** When to show the post-command update notice for a opted-in command. */
-export type UpdateNotificationCondition = (opts: Record<string, unknown>) => boolean;
+export type { UpdateNotificationCondition };
 
 type CommandArgs = unknown[];
 type CommandResult = void | Promise<void>;
@@ -58,7 +61,6 @@ type CommandResult = void | Promise<void>;
 export class SonarCommand extends Command {
   private _requiresAuth = false;
   private _rootHelp: RootHelpMetadata = {};
-  private _showUpdateNotification?: true | UpdateNotificationCondition;
 
   /** Ensures subcommands created via .command() are also SonarCommand instances. */
   createCommand(name?: string): SonarCommand {
@@ -81,7 +83,7 @@ export class SonarCommand extends Command {
    * merged action-command options (parsed by Commander).
    */
   showUpdateNotification(when?: UpdateNotificationCondition): this {
-    this._showUpdateNotification = when ?? true;
+    registerUpdateNotification(this, when);
     return this;
   }
 
@@ -165,11 +167,6 @@ export class SonarCommand extends Command {
   /** Metadata used by the custom root help menu. */
   get rootHelpMetadata(): RootHelpMetadata {
     return this._rootHelp;
-  }
-
-  /** Update-notification opt-in and optional show condition for this command. */
-  get showUpdateNotificationWhen(): true | UpdateNotificationCondition | undefined {
-    return this._showUpdateNotification;
   }
 
   async runCommand(fn: () => Promise<void>): Promise<void> {

--- a/src/commands/_common/sonar-command.ts
+++ b/src/commands/_common/sonar-command.ts
@@ -26,8 +26,8 @@ import { CliError, CommandFailedError, remediationHintFor } from '@/core/command
 import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
 import { resolveAuth } from '@/core/host/auth-resolver.ts';
 import {
-  registerUpdateNotification,
   type UpdateNotificationCondition,
+  UpdateNotifier,
 } from '@/core/host/update/notification.ts';
 import logger from '@/core/observability/logger.ts';
 import { blank, error, print } from '@/core/ui';
@@ -61,10 +61,33 @@ type CommandResult = void | Promise<void>;
 export class SonarCommand extends Command {
   private _requiresAuth = false;
   private _rootHelp: RootHelpMetadata = {};
+  private readonly _updateNotifier: UpdateNotifier;
+
+  /**
+   * `updateNotifier` defaults to a fresh instance so the root command (the only
+   * place `new SonarCommand()` is called without it) owns the one instance the
+   * whole tree shares; every subcommand inherits it via createCommand() below
+   * instead of reading a module-level singleton.
+   */
+  constructor(name?: string, updateNotifier: UpdateNotifier = new UpdateNotifier()) {
+    super(name);
+    this._updateNotifier = updateNotifier;
+  }
 
   /** Ensures subcommands created via .command() are also SonarCommand instances. */
   createCommand(name?: string): SonarCommand {
-    return new SonarCommand(name);
+    return new SonarCommand(name, this._updateNotifier);
+  }
+
+  /**
+   * The update-notification registry shared by this command and its whole subtree.
+   * command-tree.ts builds the whole tree as top-level side effects when the
+   * module loads, registering every .showUpdateNotification() call into this
+   * instance in the process. External code (the postAction hook, unit tests)
+   * reads that already-populated instance via this getter on the root command.
+   */
+  get updateNotifier(): UpdateNotifier {
+    return this._updateNotifier;
   }
 
   /**
@@ -83,7 +106,7 @@ export class SonarCommand extends Command {
    * merged action-command options (parsed by Commander).
    */
   showUpdateNotification(when?: UpdateNotificationCondition): this {
-    registerUpdateNotification(this, when);
+    this._updateNotifier.register(this, when);
     return this;
   }
 

--- a/src/commands/_common/sonar-command.ts
+++ b/src/commands/_common/sonar-command.ts
@@ -25,10 +25,8 @@ import { Command } from 'commander';
 import { CliError, CommandFailedError, remediationHintFor } from '@/core/command-error.ts';
 import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
 import { resolveAuth } from '@/core/host/auth-resolver.ts';
-import {
-  type UpdateNotificationCondition,
-  UpdateNotifier,
-} from '@/core/host/update/notification.ts';
+import type { UpdateNotificationCondition } from '@/core/host/update/notification.ts';
+import { UpdateNotifier } from '@/core/host/update/notification.ts';
 import logger from '@/core/observability/logger.ts';
 import { blank, error, print } from '@/core/ui';
 
@@ -40,8 +38,6 @@ export interface RootHelpMetadata {
   expandSubcommands?: boolean;
   label?: string;
 }
-
-export type { UpdateNotificationCondition };
 
 type CommandArgs = unknown[];
 type CommandResult = void | Promise<void>;
@@ -77,6 +73,15 @@ export class SonarCommand extends Command {
   /** Ensures subcommands created via .command() are also SonarCommand instances. */
   createCommand(name?: string): SonarCommand {
     return new SonarCommand(name, this._updateNotifier);
+  }
+
+  /**
+   * Disallowed: addCommand() attaches a command constructed independently of
+   * this tree's createCommand(), bypassing the shared per-tree state it sets up.
+   * Use .command() instead.
+   */
+  addCommand(): this {
+    throw new Error('addCommand() is disallowed; use .command() instead');
   }
 
   /**

--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -22,7 +22,7 @@ import { type Command, Help, InvalidArgumentError, Option } from 'commander';
 
 import { CommandFailedError } from '@/core/command-error.ts';
 import { CURRENT_DISTRIBUTION } from '@/core/host/distribution.ts';
-import { maybeNotifyUpdateAvailable } from '@/core/host/update-notification.ts';
+import { maybeNotifyUpdateAvailable } from '@/core/host/update/notification.ts';
 import { initSentry } from '@/core/observability/sentry.ts';
 import { GENERIC_HTTP_METHODS } from '@/core/server/client.ts';
 import { MAX_PAGE_SIZE } from '@/core/server/projects.ts';

--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -22,7 +22,6 @@ import { type Command, Help, InvalidArgumentError, Option } from 'commander';
 
 import { CommandFailedError } from '@/core/command-error.ts';
 import { CURRENT_DISTRIBUTION } from '@/core/host/distribution.ts';
-import { maybeNotifyUpdateAvailable } from '@/core/host/update/notification.ts';
 import { initSentry } from '@/core/observability/sentry.ts';
 import { GENERIC_HTTP_METHODS } from '@/core/server/client.ts';
 import { MAX_PAGE_SIZE } from '@/core/server/projects.ts';
@@ -734,5 +733,5 @@ COMMAND_TREE.hook('preAction', () => {
 // Collect a telemetry event after every command action.
 COMMAND_TREE.hook('postAction', async (_thisCommand, actionCommand) => {
   await storeEvent(actionCommand, (process.exitCode ?? 0) === 0);
-  await maybeNotifyUpdateAvailable(actionCommand);
+  await COMMAND_TREE.updateNotifier.maybeNotify(actionCommand);
 });

--- a/src/commands/update/update-check.ts
+++ b/src/commands/update/update-check.ts
@@ -25,21 +25,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { CommandFailedError } from '@/core/command-error.ts';
-import {
-  CLI_STABLE_VERSION_PATH,
-  SONARSOURCE_BINARIES_URL,
-  UPDATE_SCRIPT_BASE_URL,
-} from '@/core/config-constants.ts';
-import { buildFetchNetworkOptions } from '@/core/host/connectivity/network-config.ts';
+import { UPDATE_SCRIPT_BASE_URL } from '@/core/config-constants.ts';
 import { isWindows } from '@/core/host/platform-detector.ts';
+import { fetchLatestVersion, fetchText } from '@/core/host/update/check.ts';
 import { Version } from '@/core/version.ts';
 
 import { version as CURRENT_VERSION } from '../../../package.json';
 
-const UPDATE_CHECK_TIMEOUT_MS = 5000;
-/** Best-effort background fetch after eligible commands — fail fast to avoid blocking UX. */
-export const BACKGROUND_UPDATE_CHECK_TIMEOUT_MS = 1500;
-const STABLE_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
 const TEMP_SCRIPT_PREFIX = 'sonar-update-';
 const TEMP_SCRIPT_CREATE_ATTEMPTS = 5;
 
@@ -165,43 +157,6 @@ export interface UpdateCheckResult {
   currentVersion: Version;
   latest: Update;
   upToDate: boolean;
-}
-
-async function fetchText(
-  url: string,
-  description: string,
-  timeoutMs = UPDATE_CHECK_TIMEOUT_MS,
-): Promise<string> {
-  const response = await fetch(url, {
-    signal: AbortSignal.timeout(timeoutMs),
-    ...buildFetchNetworkOptions(url),
-  });
-  if (!response.ok) {
-    throw new CommandFailedError(`Failed to fetch ${description}: HTTP ${response.status}`, {
-      remediationHint: 'Check network access and retry.',
-    });
-  }
-  return response.text();
-}
-
-function parseStableVersion(raw: string): string | null {
-  const latestVersion = raw.trim();
-  return STABLE_VERSION_PATTERN.test(latestVersion) ? latestVersion : null;
-}
-
-/**
- * Reads the published stable.version string from binaries.sonarsource.com.
- */
-export async function fetchLatestVersion(timeoutMs = UPDATE_CHECK_TIMEOUT_MS): Promise<string> {
-  const stableVersionUrl = `${SONARSOURCE_BINARIES_URL}/${CLI_STABLE_VERSION_PATH}`;
-  const body = await fetchText(stableVersionUrl, 'stable version', timeoutMs);
-  const version = parseStableVersion(body);
-  if (!version) {
-    throw new CommandFailedError('Could not determine the latest version.', {
-      remediationHint: 'Retry later or update manually using the installer script.',
-    });
-  }
-  return version;
 }
 
 /**

--- a/src/core/host/update/check.ts
+++ b/src/core/host/update/check.ts
@@ -1,0 +1,70 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Reads the published stable CLI version from binaries.sonarsource.com. Used by
+// both `sonar update` (commands/update/update-check.ts, for the foreground
+// version check) and the background update-notification check in
+// core/host/update/notification.ts.
+
+import { CommandFailedError } from '../../command-error.ts';
+import { CLI_STABLE_VERSION_PATH, SONARSOURCE_BINARIES_URL } from '../../config-constants.ts';
+import { buildFetchNetworkOptions } from '../connectivity/network-config.ts';
+
+const UPDATE_CHECK_TIMEOUT_MS = 5000;
+/** Best-effort background fetch after eligible commands — fail fast to avoid blocking UX. */
+export const BACKGROUND_UPDATE_CHECK_TIMEOUT_MS = 1500;
+const STABLE_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:\.\d+)?$/;
+
+export async function fetchText(
+  url: string,
+  description: string,
+  timeoutMs = UPDATE_CHECK_TIMEOUT_MS,
+): Promise<string> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(timeoutMs),
+    ...buildFetchNetworkOptions(url),
+  });
+  if (!response.ok) {
+    throw new CommandFailedError(`Failed to fetch ${description}: HTTP ${response.status}`, {
+      remediationHint: 'Check network access and retry.',
+    });
+  }
+  return response.text();
+}
+
+function parseStableVersion(raw: string): string | null {
+  const latestVersion = raw.trim();
+  return STABLE_VERSION_PATTERN.test(latestVersion) ? latestVersion : null;
+}
+
+/**
+ * Reads the published stable.version string from binaries.sonarsource.com.
+ */
+export async function fetchLatestVersion(timeoutMs = UPDATE_CHECK_TIMEOUT_MS): Promise<string> {
+  const stableVersionUrl = `${SONARSOURCE_BINARIES_URL}/${CLI_STABLE_VERSION_PATH}`;
+  const body = await fetchText(stableVersionUrl, 'stable version', timeoutMs);
+  const version = parseStableVersion(body);
+  if (!version) {
+    throw new CommandFailedError('Could not determine the latest version.', {
+      remediationHint: 'Retry later or update manually using the installer script.',
+    });
+  }
+  return version;
+}

--- a/src/core/host/update/check.ts
+++ b/src/core/host/update/check.ts
@@ -23,9 +23,9 @@
 // version check) and the background update-notification check in
 // core/host/update/notification.ts.
 
-import { CommandFailedError } from '../../command-error.ts';
-import { CLI_STABLE_VERSION_PATH, SONARSOURCE_BINARIES_URL } from '../../config-constants.ts';
-import { buildFetchNetworkOptions } from '../connectivity/network-config.ts';
+import { CommandFailedError } from '@/core/command-error.ts';
+import { CLI_STABLE_VERSION_PATH, SONARSOURCE_BINARIES_URL } from '@/core/config-constants.ts';
+import { buildFetchNetworkOptions } from '@/core/host/connectivity/network-config.ts';
 
 const UPDATE_CHECK_TIMEOUT_MS = 5000;
 /** Best-effort background fetch after eligible commands — fail fast to avoid blocking UX. */

--- a/src/core/host/update/notification.ts
+++ b/src/core/host/update/notification.ts
@@ -20,24 +20,37 @@
 
 import type { Command } from 'commander';
 
-import {
-  SonarCommand,
-  type UpdateNotificationCondition,
-} from '@/commands/_common/sonar-command.ts';
-import {
-  BACKGROUND_UPDATE_CHECK_TIMEOUT_MS,
-  fetchLatestVersion,
-} from '@/commands/update/update-check.ts';
 import { TELEMETRY_FLUSH_MODE_ENV } from '@/core/telemetry';
 import { isFormattedOutputMode, text } from '@/core/ui';
 import { cyan } from '@/core/ui/colors.ts';
 import { Version } from '@/core/version.ts';
 
-import { version as CURRENT_VERSION } from '../../../package.json';
-import type { CliUpdateCheckState } from '../state/state.ts';
-import { loadState, saveState } from '../state/state-manager.ts';
+import { version as CURRENT_VERSION } from '../../../../package.json';
+import type { CliUpdateCheckState } from '../../state/state.ts';
+import { loadState, saveState } from '../../state/state-manager.ts';
+import { BACKGROUND_UPDATE_CHECK_TIMEOUT_MS, fetchLatestVersion } from './check.ts';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+/** When to show the post-command update notice for an opted-in command. */
+export type UpdateNotificationCondition = (opts: Record<string, unknown>) => boolean;
+
+// Per-command opt-in registry, keyed by Commander Command instance. Populated by
+// SonarCommand.showUpdateNotification() (commands/_common/sonar-command.ts) via
+// registerUpdateNotification() below, so this module owns both the write side
+// (opt-in) and the read side (eligibility check) without depending on that class.
+const updateNotificationRegistry = new WeakMap<Command, true | UpdateNotificationCondition>();
+
+/**
+ * Opt a command into the post-command "new version available" stderr notice.
+ * Called by SonarCommand.showUpdateNotification().
+ */
+export function registerUpdateNotification(
+  command: Command,
+  when?: UpdateNotificationCondition,
+): void {
+  updateNotificationRegistry.set(command, when ?? true);
+}
 
 function collectCommandOpts(command: Command): Record<string, unknown> {
   const names: Command[] = [];
@@ -59,11 +72,9 @@ function resolveUpdateNotification(
 ): true | UpdateNotificationCondition | undefined {
   let current: Command | null = command;
   while (current !== null) {
-    if (current instanceof SonarCommand) {
-      const when = current.showUpdateNotificationWhen;
-      if (when !== undefined) {
-        return when;
-      }
+    const when = updateNotificationRegistry.get(current);
+    if (when !== undefined) {
+      return when;
     }
     current = current.parent;
   }

--- a/src/core/host/update/notification.ts
+++ b/src/core/host/update/notification.ts
@@ -35,164 +35,162 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 /** When to show the post-command update notice for an opted-in command. */
 export type UpdateNotificationCondition = (opts: Record<string, unknown>) => boolean;
 
-// Per-command opt-in registry, keyed by Commander Command instance. Populated by
-// SonarCommand.showUpdateNotification() (commands/_common/sonar-command.ts) via
-// registerUpdateNotification() below, so this module owns both the write side
-// (opt-in) and the read side (eligibility check) without depending on that class.
-const updateNotificationRegistry = new WeakMap<Command, true | UpdateNotificationCondition>();
-
 /**
- * Opt a command into the post-command "new version available" stderr notice.
- * Called by SonarCommand.showUpdateNotification().
+ * Owns the per-command opt-in registry for the post-command "new version
+ * available" stderr notice, plus the eligibility/suppression checks and the
+ * actual throttled version check. There is no shared singleton here: the root
+ * `SonarCommand` (commands/_common/sonar-command.ts) owns one instance and
+ * propagates it to every subcommand, so `showUpdateNotification()` can call
+ * `register()` on it without this module depending on that class.
  */
-export function registerUpdateNotification(
-  command: Command,
-  when?: UpdateNotificationCondition,
-): void {
-  updateNotificationRegistry.set(command, when ?? true);
-}
+export class UpdateNotifier {
+  private readonly registry = new WeakMap<Command, true | UpdateNotificationCondition>();
 
-function collectCommandOpts(command: Command): Record<string, unknown> {
-  const names: Command[] = [];
-  let current: Command | null = command;
-  while (current.parent !== null) {
-    names.unshift(current);
-    current = current.parent;
+  /** Opt a command into the post-command "new version available" stderr notice. */
+  register(command: Command, when?: UpdateNotificationCondition): void {
+    this.registry.set(command, when ?? true);
   }
 
-  const merged: Record<string, unknown> = {};
-  for (const cmd of names) {
-    Object.assign(merged, cmd.opts());
+  isEligible(command: Command): boolean {
+    return this.resolve(command) !== undefined;
   }
-  return merged;
-}
 
-function resolveUpdateNotification(
-  command: Command,
-): true | UpdateNotificationCondition | undefined {
-  let current: Command | null = command;
-  while (current !== null) {
-    const when = updateNotificationRegistry.get(current);
-    if (when !== undefined) {
-      return when;
+  shouldSuppress(command: Command): boolean {
+    if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {
+      return true;
     }
-    current = current.parent;
-  }
-  return undefined;
-}
+    if (process.env.CI === 'true') {
+      return true;
+    }
+    if (!process.env.SONARQUBE_CLI_MOCK_TTY && (!process.stderr.isTTY || !process.stdout.isTTY)) {
+      return true;
+    }
+    if (isFormattedOutputMode()) {
+      return true;
+    }
 
-export function isUpdateNotificationEligible(command: Command): boolean {
-  return resolveUpdateNotification(command) !== undefined;
-}
+    const when = this.resolve(command);
+    if (typeof when === 'function' && !when(this.collectOpts(command))) {
+      return true;
+    }
 
-export function shouldSuppressUpdateNotification(command: Command): boolean {
-  if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {
-    return true;
-  }
-  if (process.env.CI === 'true') {
-    return true;
-  }
-  if (!process.env.SONARQUBE_CLI_MOCK_TTY && (!process.stderr.isTTY || !process.stdout.isTTY)) {
-    return true;
-  }
-  if (isFormattedOutputMode()) {
-    return true;
-  }
-
-  const when = resolveUpdateNotification(command);
-  if (typeof when === 'function' && !when(collectCommandOpts(command))) {
-    return true;
-  }
-
-  return false;
-}
-
-function isWithinCooldown(isoTimestamp: string | undefined, cooldownMs: number): boolean {
-  if (!isoTimestamp) {
     return false;
   }
-  const elapsed = Date.now() - Date.parse(isoTimestamp);
-  return Number.isFinite(elapsed) && elapsed >= 0 && elapsed < cooldownMs;
-}
 
-async function resolveLatestVersion(
-  updateCheck: CliUpdateCheckState | undefined,
-): Promise<{ latestVersion: string | undefined; updateCheck: CliUpdateCheckState }> {
-  if (isWithinCooldown(updateCheck?.lastCheckedAt, ONE_DAY_MS)) {
-    // Checked within the last day: reuse the cached result (which is undefined
-    // when the previous check failed) instead of hitting the network again.
-    return {
-      latestVersion: updateCheck?.latestVersion,
-      updateCheck: { ...updateCheck },
-    };
-  }
-
-  const lastCheckedAt = new Date().toISOString();
-  try {
-    const latestVersion = await fetchLatestVersion(BACKGROUND_UPDATE_CHECK_TIMEOUT_MS);
-    return {
-      latestVersion,
-      updateCheck: { ...updateCheck, lastCheckedAt, latestVersion },
-    };
-  } catch {
-    // Record the attempt so a failing check does not re-hit the network — and
-    // stall the command for up to the fetch timeout — on every invocation.
-    // Any previously cached version is preserved so we can still notify from it.
-    return {
-      latestVersion: updateCheck?.latestVersion,
-      updateCheck: { ...updateCheck, lastCheckedAt },
-    };
-  }
-}
-
-function renderUpdateNotification(currentNoBuild: string, latestNoBuild: string): void {
-  // Keep the whole notice on stderr so it never contaminates a command's stdout.
-  text('', undefined, 'stderr');
-  text(
-    `  ${cyan('ℹ')}  A new version of SonarQube CLI is available: ${currentNoBuild} → ${latestNoBuild}`,
-    undefined,
-    'stderr',
-  );
-  text(`   → Run \`sonar update\` to update to v${latestNoBuild}`, undefined, 'stderr');
-}
-
-/**
- * After eligible interactive commands, fetch binaries.sonarsource.com at most once
- * per day and print a stderr notice when a newer stable version exists.
- */
-export async function maybeNotifyUpdateAvailable(command: Command): Promise<void> {
-  if ((process.exitCode ?? 0) !== 0) {
-    return;
-  }
-  if (shouldSuppressUpdateNotification(command) || !isUpdateNotificationEligible(command)) {
-    return;
-  }
-
-  try {
-    const state = loadState();
-    const currentVersion = new Version(CURRENT_VERSION);
-    const currentNoBuild = currentVersion.noBuild.text;
-
-    const resolved = await resolveLatestVersion(state.config.updateCheck);
-
-    // Persist the fetch timestamp on every attempt (success or failure) so the
-    // remote version check stays throttled to once per day.
-    state.config.updateCheck = resolved.updateCheck;
-    saveState(state);
-
-    if (!resolved.latestVersion) {
+  /**
+   * After eligible interactive commands, fetch binaries.sonarsource.com at most once
+   * per day and print a stderr notice when a newer stable version exists.
+   */
+  async maybeNotify(command: Command): Promise<void> {
+    if ((process.exitCode ?? 0) !== 0) {
+      return;
+    }
+    if (this.shouldSuppress(command) || !this.isEligible(command)) {
       return;
     }
 
-    const latestVersion = new Version(resolved.latestVersion);
-    const latestNoBuild = latestVersion.noBuild.text;
+    try {
+      const state = loadState();
+      const currentVersion = new Version(CURRENT_VERSION);
+      const currentNoBuild = currentVersion.noBuild.text;
 
-    if (!latestVersion.noBuild.isNewerThan(currentVersion)) {
-      return;
+      const resolved = await this.resolveLatestVersion(state.config.updateCheck);
+
+      // Persist the fetch timestamp on every attempt (success or failure) so the
+      // remote version check stays throttled to once per day.
+      state.config.updateCheck = resolved.updateCheck;
+      saveState(state);
+
+      if (!resolved.latestVersion) {
+        return;
+      }
+
+      const latestVersion = new Version(resolved.latestVersion);
+      const latestNoBuild = latestVersion.noBuild.text;
+
+      if (!latestVersion.noBuild.isNewerThan(currentVersion)) {
+        return;
+      }
+
+      this.renderNotification(currentNoBuild, latestNoBuild);
+    } catch {
+      // Best-effort only — never fail the user's command because of update metadata.
+    }
+  }
+
+  private resolve(command: Command): true | UpdateNotificationCondition | undefined {
+    let current: Command | null = command;
+    while (current !== null) {
+      const when = this.registry.get(current);
+      if (when !== undefined) {
+        return when;
+      }
+      current = current.parent;
+    }
+    return undefined;
+  }
+
+  private collectOpts(command: Command): Record<string, unknown> {
+    const names: Command[] = [];
+    let current: Command | null = command;
+    while (current.parent !== null) {
+      names.unshift(current);
+      current = current.parent;
     }
 
-    renderUpdateNotification(currentNoBuild, latestNoBuild);
-  } catch {
-    // Best-effort only — never fail the user's command because of update metadata.
+    const merged: Record<string, unknown> = {};
+    for (const cmd of names) {
+      Object.assign(merged, cmd.opts());
+    }
+    return merged;
+  }
+
+  private isWithinCooldown(isoTimestamp: string | undefined, cooldownMs: number): boolean {
+    if (!isoTimestamp) {
+      return false;
+    }
+    const elapsed = Date.now() - Date.parse(isoTimestamp);
+    return Number.isFinite(elapsed) && elapsed >= 0 && elapsed < cooldownMs;
+  }
+
+  private async resolveLatestVersion(
+    updateCheck: CliUpdateCheckState | undefined,
+  ): Promise<{ latestVersion: string | undefined; updateCheck: CliUpdateCheckState }> {
+    if (this.isWithinCooldown(updateCheck?.lastCheckedAt, ONE_DAY_MS)) {
+      // Checked within the last day: reuse the cached result (which is undefined
+      // when the previous check failed) instead of hitting the network again.
+      return {
+        latestVersion: updateCheck?.latestVersion,
+        updateCheck: { ...updateCheck },
+      };
+    }
+
+    const lastCheckedAt = new Date().toISOString();
+    try {
+      const latestVersion = await fetchLatestVersion(BACKGROUND_UPDATE_CHECK_TIMEOUT_MS);
+      return {
+        latestVersion,
+        updateCheck: { ...updateCheck, lastCheckedAt, latestVersion },
+      };
+    } catch {
+      // Record the attempt so a failing check does not re-hit the network — and
+      // stall the command for up to the fetch timeout — on every invocation.
+      // Any previously cached version is preserved so we can still notify from it.
+      return {
+        latestVersion: updateCheck?.latestVersion,
+        updateCheck: { ...updateCheck, lastCheckedAt },
+      };
+    }
+  }
+
+  private renderNotification(currentNoBuild: string, latestNoBuild: string): void {
+    // Keep the whole notice on stderr so it never contaminates a command's stdout.
+    text('', undefined, 'stderr');
+    text(
+      `  ${cyan('ℹ')}  A new version of SonarQube CLI is available: ${currentNoBuild} → ${latestNoBuild}`,
+      undefined,
+      'stderr',
+    );
+    text(`   → Run \`sonar update\` to update to v${latestNoBuild}`, undefined, 'stderr');
   }
 }

--- a/src/core/host/update/notification.ts
+++ b/src/core/host/update/notification.ts
@@ -20,14 +20,14 @@
 
 import type { Command } from 'commander';
 
+import type { CliUpdateCheckState } from '@/core/state/state.ts';
+import { loadState, saveState } from '@/core/state/state-manager.ts';
 import { TELEMETRY_FLUSH_MODE_ENV } from '@/core/telemetry';
 import { isFormattedOutputMode, text } from '@/core/ui';
 import { cyan } from '@/core/ui/colors.ts';
 import { Version } from '@/core/version.ts';
 
 import { version as CURRENT_VERSION } from '../../../../package.json';
-import type { CliUpdateCheckState } from '../../state/state.ts';
-import { loadState, saveState } from '../../state/state-manager.ts';
 import { BACKGROUND_UPDATE_CHECK_TIMEOUT_MS, fetchLatestVersion } from './check.ts';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;

--- a/src/core/host/update/notification.ts
+++ b/src/core/host/update/notification.ts
@@ -92,7 +92,7 @@ export function shouldSuppressUpdateNotification(command: Command): boolean {
   if (process.env.CI === 'true') {
     return true;
   }
-  if (!process.stderr.isTTY || !process.stdout.isTTY) {
+  if (!process.env.SONARQUBE_CLI_MOCK_TTY && (!process.stderr.isTTY || !process.stdout.isTTY)) {
     return true;
   }
   if (isFormattedOutputMode()) {

--- a/tests/integration/specs/update/notification.test.ts
+++ b/tests/integration/specs/update/notification.test.ts
@@ -1,0 +1,134 @@
+﻿/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integration tests for the background "new version available" stderr notice
+// (core/host/update/notification.ts). The harness always spawns the CLI with
+// piped stdio (never a real TTY) and defaults CI=true for determinism, so
+// these tests explicitly clear CI and set SONARQUBE_CLI_MOCK_TTY to reach the
+// code path that would otherwise only run for an interactive human user.
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { version as CURRENT_VERSION } from '../../../../package.json';
+import { TestHarness } from '../../harness';
+
+const INTERACTIVE_ENV = { CI: '', SONARQUBE_CLI_MOCK_TTY: '1' };
+const NOTICE_TEXT = 'A new version of SonarQube CLI is available';
+
+describe('update notification', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'prints the notice on stderr (never stdout) for an eligible command when a newer version exists',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('test-token').start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+      await harness.newFakeBinariesServer().withStableVersion('99.0.0').start();
+
+      const result = await harness.run('auth status', { extraEnv: INTERACTIVE_ENV });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain(NOTICE_TEXT);
+      expect(result.stderr).toContain('Run `sonar update` to update to v99.0.0');
+      expect(result.stdout).not.toContain(NOTICE_TEXT);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not print the notice when already on the latest version',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('test-token').start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+      await harness.newFakeBinariesServer().withStableVersion(CURRENT_VERSION).start();
+
+      const result = await harness.run('auth status', { extraEnv: INTERACTIVE_ENV });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain(NOTICE_TEXT);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not print the notice for a command that never opted in',
+    async () => {
+      await harness.newFakeBinariesServer().withStableVersion('99.0.0').start();
+
+      const result = await harness.run('config telemetry --disabled', {
+        extraEnv: INTERACTIVE_ENV,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain(NOTICE_TEXT);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'suppresses the notice for list issues in its default (JSON) format',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project')
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+      await harness.newFakeBinariesServer().withStableVersion('99.0.0').start();
+
+      const result = await harness.run('list issues --project my-project', {
+        extraEnv: INTERACTIVE_ENV,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).not.toContain(NOTICE_TEXT);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'shows the notice for list issues when --format table is requested',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project')
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+      await harness.newFakeBinariesServer().withStableVersion('99.0.0').start();
+
+      const result = await harness.run('list issues --project my-project --format table', {
+        extraEnv: INTERACTIVE_ENV,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain(NOTICE_TEXT);
+    },
+    { timeout: 15000 },
+  );
+});

--- a/tests/integration/specs/update/notification.test.ts
+++ b/tests/integration/specs/update/notification.test.ts
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * SonarQube CLI
  * Copyright (C) SonarSource Sàrl
  * mailto:info AT sonarsource DOT com

--- a/tests/unit/commands/_common/sonar-command.test.ts
+++ b/tests/unit/commands/_common/sonar-command.test.ts
@@ -64,6 +64,18 @@ describe('SonarCommand', () => {
     });
   });
 
+  // ─── addCommand() ────────────────────────────────────────────────────────
+
+  describe('addCommand()', () => {
+    it('throws to enforce use of .command() instead', () => {
+      const cmd = new SonarCommand();
+      const sub = new SonarCommand('sub');
+      expect(() => cmd.addCommand(sub)).toThrow(
+        'addCommand() is disallowed; use .command() instead',
+      );
+    });
+  });
+
   // ─── runCommand() ─────────────────────────────────────────────────────────
 
   describe('runCommand()', () => {

--- a/tests/unit/commands/update/update-version.test.ts
+++ b/tests/unit/commands/update/update-version.test.ts
@@ -63,7 +63,8 @@ void mock.module('@/core/host/platform-detector.js', () => ({
   isWindows: isWindowsMock,
 }));
 
-const { checkForUpdate, fetchLatestVersion } = await import('@/commands/update/update-check.ts');
+const { checkForUpdate } = await import('@/commands/update/update-check.ts');
+const { fetchLatestVersion } = await import('@/core/host/update/check.ts');
 const { updateVersion } = await import('@/commands/update');
 
 function stableVersionResponse(version: string) {

--- a/tests/unit/core/host/update/notification.test.ts
+++ b/tests/unit/core/host/update/notification.test.ts
@@ -35,11 +35,10 @@ const originalEnvForNotify = { ...process.env };
 const tempHome = mkdtempSync(join(tmpdir(), 'sonar-update-notify-'));
 process.env.SONAR_USER_HOME = tempHome;
 
-const {
-  isUpdateNotificationEligible,
-  maybeNotifyUpdateAvailable,
-  shouldSuppressUpdateNotification,
-} = await import('@/core/host/update/notification.ts');
+// Importing command-tree.ts already ran every .showUpdateNotification() call
+// as a top-level side effect, registering into COMMAND_TREE's UpdateNotifier —
+// reuse that same instance here rather than constructing a fresh one.
+const updateNotifier = COMMAND_TREE.updateNotifier;
 
 function resolveCommand(path: string[]): Command {
   let current: Command = COMMAND_TREE;
@@ -55,28 +54,28 @@ function resolveCommand(path: string[]): Command {
 
 describe('update notification eligibility', () => {
   it('allows auth commands', () => {
-    expect(isUpdateNotificationEligible(resolveCommand(['auth', 'status']))).toBe(true);
+    expect(updateNotifier.isEligible(resolveCommand(['auth', 'status']))).toBe(true);
   });
 
   it('allows analyze and list data commands', () => {
-    expect(isUpdateNotificationEligible(resolveCommand(['analyze', 'agentic']))).toBe(true);
-    expect(isUpdateNotificationEligible(resolveCommand(['list', 'issues']))).toBe(true);
-    expect(isUpdateNotificationEligible(resolveCommand(['list', 'projects']))).toBe(true);
+    expect(updateNotifier.isEligible(resolveCommand(['analyze', 'agentic']))).toBe(true);
+    expect(updateNotifier.isEligible(resolveCommand(['list', 'issues']))).toBe(true);
+    expect(updateNotifier.isEligible(resolveCommand(['list', 'projects']))).toBe(true);
   });
 
   it('blocks integrate when non-interactive', () => {
     const command = resolveCommand(['integrate', 'claude']);
     command.setOptionValue('nonInteractive', true);
-    expect(shouldSuppressUpdateNotification(command)).toBe(true);
-    expect(isUpdateNotificationEligible(command)).toBe(true);
+    expect(updateNotifier.shouldSuppress(command)).toBe(true);
+    expect(updateNotifier.isEligible(command)).toBe(true);
   });
 
   it('blocks api, context, and hook commands', () => {
-    expect(isUpdateNotificationEligible(resolveCommand(['api']))).toBe(false);
-    expect(isUpdateNotificationEligible(resolveCommand(['context']))).toBe(false);
-    expect(isUpdateNotificationEligible(resolveCommand(['hook', 'git-pre-commit']))).toBe(false);
-    expect(isUpdateNotificationEligible(resolveCommand(['config', 'telemetry']))).toBe(false);
-    expect(isUpdateNotificationEligible(resolveCommand(['system', 'reset']))).toBe(false);
+    expect(updateNotifier.isEligible(resolveCommand(['api']))).toBe(false);
+    expect(updateNotifier.isEligible(resolveCommand(['context']))).toBe(false);
+    expect(updateNotifier.isEligible(resolveCommand(['hook', 'git-pre-commit']))).toBe(false);
+    expect(updateNotifier.isEligible(resolveCommand(['config', 'telemetry']))).toBe(false);
+    expect(updateNotifier.isEligible(resolveCommand(['system', 'reset']))).toBe(false);
   });
 });
 
@@ -109,25 +108,25 @@ describe('update notification suppression', () => {
   it('suppresses in CI and machine-readable modes', () => {
     const command = resolveCommand(['auth', 'status']);
     process.env.CI = 'true';
-    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+    expect(updateNotifier.shouldSuppress(command)).toBe(true);
 
     delete process.env.CI;
     setFormattedOutputMode(true);
-    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+    expect(updateNotifier.shouldSuppress(command)).toBe(true);
   });
 
   it('suppresses list issues when format is json', () => {
     const command = resolveCommand(['list', 'issues']);
-    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+    expect(updateNotifier.shouldSuppress(command)).toBe(true);
 
     command.setOptionValue('format', 'table');
-    expect(shouldSuppressUpdateNotification(command)).toBe(false);
+    expect(updateNotifier.shouldSuppress(command)).toBe(false);
   });
 
   it('suppresses system status when --json is set', () => {
     const command = resolveCommand(['system', 'status']);
     command.setOptionValue('json', true);
-    expect(shouldSuppressUpdateNotification(command)).toBe(true);
+    expect(updateNotifier.shouldSuppress(command)).toBe(true);
   });
 });
 
@@ -141,7 +140,7 @@ function fetchUrlString(url: string | URL | Request): string {
   return url.url;
 }
 
-describe('maybeNotifyUpdateAvailable', () => {
+describe('updateNotifier.maybeNotify', () => {
   let stdoutSpy: ReturnType<typeof spyOn>;
   let stderrSpy: ReturnType<typeof spyOn>;
   let fetchSpy: ReturnType<typeof spyOn>;
@@ -183,7 +182,7 @@ describe('maybeNotifyUpdateAvailable', () => {
   }
 
   it('prints a stderr notice when a newer version is available', async () => {
-    await maybeNotifyUpdateAvailable(resolveCommand(['auth', 'status']));
+    await updateNotifier.maybeNotify(resolveCommand(['auth', 'status']));
 
     const output = notificationOutput();
     const [major, minor, patch] = CURRENT_VERSION.split('.');
@@ -194,7 +193,7 @@ describe('maybeNotifyUpdateAvailable', () => {
   });
 
   it('persists fetch metadata in state', async () => {
-    await maybeNotifyUpdateAvailable(resolveCommand(['auth', 'status']));
+    await updateNotifier.maybeNotify(resolveCommand(['auth', 'status']));
 
     const state = JSON.parse(
       readFileSync(join(tempHome, 'sonarqube-cli', 'state.json'), 'utf8'),
@@ -213,10 +212,10 @@ describe('maybeNotifyUpdateAvailable', () => {
   it('notifies on every eligible command when an update is available', async () => {
     const command = resolveCommand(['auth', 'status']);
 
-    await maybeNotifyUpdateAvailable(command);
+    await updateNotifier.maybeNotify(command);
     stdoutSpy.mockClear();
     stderrSpy.mockClear();
-    await maybeNotifyUpdateAvailable(command);
+    await updateNotifier.maybeNotify(command);
 
     const output = notificationOutput();
     expect(output).toContain('A new version of SonarQube CLI is available');
@@ -227,12 +226,12 @@ describe('maybeNotifyUpdateAvailable', () => {
     const command = resolveCommand(['auth', 'status']);
     fetchSpy.mockImplementation(() => Promise.reject(new Error('offline')));
 
-    await maybeNotifyUpdateAvailable(command);
+    await updateNotifier.maybeNotify(command);
     expect(fetchSpy.mock.calls).toHaveLength(1);
 
     // The failed attempt is recorded, so the next command must not hit the
     // network again (which would stall on the fetch timeout).
-    await maybeNotifyUpdateAvailable(command);
+    await updateNotifier.maybeNotify(command);
     expect(fetchSpy.mock.calls).toHaveLength(1);
   });
 });

--- a/tests/unit/core/host/update/notification.test.ts
+++ b/tests/unit/core/host/update/notification.test.ts
@@ -29,7 +29,7 @@ import { COMMAND_TREE } from '@/commands/command-tree.ts';
 import { TELEMETRY_FLUSH_MODE_ENV } from '@/core/telemetry';
 import { setFormattedOutputMode } from '@/core/ui';
 
-import { version as CURRENT_VERSION } from '../../../../package.json';
+import { version as CURRENT_VERSION } from '../../../../../package.json';
 
 const originalEnvForNotify = { ...process.env };
 const tempHome = mkdtempSync(join(tmpdir(), 'sonar-update-notify-'));
@@ -39,7 +39,7 @@ const {
   isUpdateNotificationEligible,
   maybeNotifyUpdateAvailable,
   shouldSuppressUpdateNotification,
-} = await import('@/core/host/update-notification.ts');
+} = await import('@/core/host/update/notification.ts');
 
 function resolveCommand(path: string[]): Command {
   let current: Command = COMMAND_TREE;


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactoring:**
    - Extracted update notification logic into new `UpdateNotifier` class and version fetching utilities
    - Shared a single `UpdateNotifier` instance across command trees via `SonarCommand`
- **Testing:**
    - Added integration tests for update notifications and updated unit tests

<sub>This will update automatically on new commits.</sub>