### PR TITLE
CLI-902 Send telemetry events through the resolved network configuration

### DIFF
--- a/src/core/server/fetch-guarded.ts
+++ b/src/core/server/fetch-guarded.ts
@@ -23,12 +23,17 @@
 import { buildFetchNetworkOptions } from '@/core/host/connectivity/network-config.ts';
 import type { FetchNetworkOptions } from '@/core/host/connectivity/types.ts';
 
+/**
+ * `networkOptions` is required so a new call site cannot silently skip the resolved
+ * proxy/TLS configuration. Pass `buildFetchNetworkOptions(url)` for the URL being fetched.
+ * `body` stays positional but explicit: pass `undefined` for bodyless requests.
+ */
 export function buildFetchInit(
   method: string,
   headers: Record<string, string>,
   timeoutMs: number,
-  body?: string,
-  networkOptions?: FetchNetworkOptions,
+  body: string | undefined,
+  networkOptions: FetchNetworkOptions,
 ): RequestInit {
   return { method, headers, body, signal: AbortSignal.timeout(timeoutMs), ...networkOptions };
 }

--- a/src/core/telemetry/telemetry-events.ts
+++ b/src/core/telemetry/telemetry-events.ts
@@ -53,6 +53,13 @@ const TELEMETRY_EVENTS_FILENAME = 'telemetry-events.ndjson';
 const TELEMETRY_EVENTS_RETENTION_DAYS = 7;
 const TELEMETRY_EVENTS_RETENTION_MS = TELEMETRY_EVENTS_RETENTION_DAYS * 24 * 60 * 60 * 1000;
 
+/**
+ * Per-request ceiling for a telemetry POST. Without it a single unresponsive endpoint —
+ * typically a proxy that blackholes rather than rejects — consumes the whole flush deadline,
+ * leaving the detached worker alive for minutes and starving the rest of the batch.
+ */
+const TELEMETRY_REQUEST_TIMEOUT_MS = 20_000;
+
 function getTelemetryEventsPath(): string {
   return join(getTelemetryDir(), TELEMETRY_EVENTS_FILENAME);
 }
@@ -199,7 +206,8 @@ function parseValidEvents(content: string, now: number): StoredTelemetryEvent[] 
  * for the next flush attempt. The .sending file is deleted in all cases.
  *
  * Requests carry the resolved proxy/TLS configuration; when that configuration cannot be
- * resolved the whole batch is requeued rather than sent without it.
+ * resolved the whole batch is requeued rather than sent without it. Each request is capped at
+ * TELEMETRY_REQUEST_TIMEOUT_MS, independently of how much of the deadline is left.
  */
 export async function flushTelemetryEvents(deadline: number): Promise<void> {
   const eventsPath = getTelemetryEventsPath();
@@ -235,13 +243,14 @@ export async function flushTelemetryEvents(deadline: number): Promise<void> {
     for (let i = 0; i < events.length; i++) {
       const remainingTime = deadline - Date.now();
       if (remainingTime <= 0) break;
+      const requestTimeout = Math.min(remainingTime, TELEMETRY_REQUEST_TIMEOUT_MS);
       try {
         await fetchGuarded(
           TELEMETRY_ENDPOINT,
           buildFetchInit(
             'POST',
             { 'Content-Type': 'application/json', 'x-api-key': TELEMETRY_API_KEY },
-            remainingTime,
+            requestTimeout,
             JSON.stringify(events[i], (_key, value) => (value === null ? undefined : value)),
             networkOptions,
           ),

--- a/src/core/telemetry/telemetry-events.ts
+++ b/src/core/telemetry/telemetry-events.ts
@@ -24,6 +24,8 @@ import { join } from 'node:path';
 
 import { detectCallerAgent } from '@/core/host/agent-detector.ts';
 import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
+import { buildFetchNetworkOptions } from '@/core/host/connectivity/network-config.ts';
+import type { FetchNetworkOptions } from '@/core/host/connectivity/types.ts';
 import { buildFetchInit, fetchGuarded } from '@/core/server/fetch-guarded.ts';
 import { INVOCATION_ID } from '@/core/telemetry/invocation-id.ts';
 
@@ -195,6 +197,9 @@ function parseValidEvents(content: string, now: number): StoredTelemetryEvent[] 
  * events older than 7 days, then POSTs each remaining event to the telemetry backend.
  * Unsent events (deadline reached or send error) are re-appended to telemetry-events.ndjson
  * for the next flush attempt. The .sending file is deleted in all cases.
+ *
+ * Requests carry the resolved proxy/TLS configuration; when that configuration cannot be
+ * resolved the whole batch is requeued rather than sent without it.
  */
 export async function flushTelemetryEvents(deadline: number): Promise<void> {
   const eventsPath = getTelemetryEventsPath();
@@ -216,6 +221,17 @@ export async function flushTelemetryEvents(deadline: number): Promise<void> {
     const events = parseValidEvents(readFileSync(sendingPath, 'utf-8'), Date.now());
     const sentIndices = new Set<number>();
 
+    // Resolved once: every event targets the same endpoint, and buildFetchNetworkOptions
+    // copies the root certificate list on each call when a custom CA is configured.
+    let networkOptions: FetchNetworkOptions;
+    try {
+      networkOptions = buildFetchNetworkOptions(TELEMETRY_ENDPOINT);
+    } catch {
+      // Unusable proxy/TLS config: requeue everything rather than bypassing it.
+      unsent.push(...events);
+      return;
+    }
+
     for (let i = 0; i < events.length; i++) {
       const remainingTime = deadline - Date.now();
       if (remainingTime <= 0) break;
@@ -227,6 +243,7 @@ export async function flushTelemetryEvents(deadline: number): Promise<void> {
             { 'Content-Type': 'application/json', 'x-api-key': TELEMETRY_API_KEY },
             remainingTime,
             JSON.stringify(events[i], (_key, value) => (value === null ? undefined : value)),
+            networkOptions,
           ),
         );
         sentIndices.add(i);

--- a/tests/unit/core/telemetry/telemetry-events.test.ts
+++ b/tests/unit/core/telemetry/telemetry-events.test.ts
@@ -38,6 +38,7 @@ import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
 import * as networkConfig from '@/core/host/connectivity/network-config.ts';
 import { DISTRIBUTION } from '@/core/host/distribution.ts';
 import type { SpawnResult } from '@/core/process/process.ts';
+import * as fetchGuardedModule from '@/core/server/fetch-guarded.ts';
 import type {
   AnalysisCompletedEventPayload,
   StoredAnalysisCompletedEvent,
@@ -626,6 +627,38 @@ describe('flushTelemetryEvents()', () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+
+  describe('per-request timeout', () => {
+    it('caps each request at 20s even when the flush deadline is far away', async () => {
+      writeTelemetryEvent(testSonarUserHome, makeStoredCompletedEvent());
+
+      const initSpy = spyOn(fetchGuardedModule, 'buildFetchInit');
+      const fetchSpy = mockFetch();
+      try {
+        await flushTelemetryEvents(Date.now() + 60_000);
+        expect(initSpy.mock.calls[0][2]).toBe(20_000);
+      } finally {
+        fetchSpy.mockRestore();
+        initSpy.mockRestore();
+      }
+    });
+
+    it('uses the remaining deadline when it is shorter than the cap', async () => {
+      writeTelemetryEvent(testSonarUserHome, makeStoredCompletedEvent());
+
+      const initSpy = spyOn(fetchGuardedModule, 'buildFetchInit');
+      const fetchSpy = mockFetch();
+      try {
+        await flushTelemetryEvents(Date.now() + 2_000);
+        const timeout = initSpy.mock.calls[0][2];
+        expect(timeout).toBeGreaterThan(0);
+        expect(timeout).toBeLessThanOrEqual(2_000);
+      } finally {
+        fetchSpy.mockRestore();
+        initSpy.mockRestore();
+      }
+    });
   });
 
   describe('network configuration', () => {

--- a/tests/unit/core/telemetry/telemetry-events.test.ts
+++ b/tests/unit/core/telemetry/telemetry-events.test.ts
@@ -32,9 +32,10 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { scanAndEmitSecrets } from '@/commands/analyze/secrets.ts';
-import { ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
+import { ENV_SONAR_USER_HOME, TELEMETRY_ENDPOINT } from '@/core/config-constants.ts';
 import * as agentDetector from '@/core/host/agent-detector.ts';
 import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
+import * as networkConfig from '@/core/host/connectivity/network-config.ts';
 import { DISTRIBUTION } from '@/core/host/distribution.ts';
 import type { SpawnResult } from '@/core/process/process.ts';
 import type {
@@ -625,6 +626,59 @@ describe('flushTelemetryEvents()', () => {
     } finally {
       fetchSpy.mockRestore();
     }
+  });
+
+  describe('network configuration', () => {
+    it('sends through the resolved proxy and TLS options', async () => {
+      writeTelemetryEvent(testSonarUserHome, makeStoredCompletedEvent());
+
+      const networkSpy = spyOn(networkConfig, 'buildFetchNetworkOptions').mockReturnValue({
+        proxy: 'http://proxy.internal:3128',
+      });
+      const fetchSpy = mockFetch();
+      try {
+        await flushTelemetryEvents(Date.now() + 60_000);
+        expect(networkSpy).toHaveBeenCalledWith(TELEMETRY_ENDPOINT);
+        const init = fetchSpy.mock.calls[0][1] as RequestInit & { proxy?: string };
+        expect(init.proxy).toBe('http://proxy.internal:3128');
+      } finally {
+        fetchSpy.mockRestore();
+        networkSpy.mockRestore();
+      }
+    });
+
+    it('resolves the network options once for the whole batch', async () => {
+      writeTelemetryEvent(testSonarUserHome, makeStoredCompletedEvent({ analysis_id: 'run-a' }));
+      writeTelemetryEvent(testSonarUserHome, makeStoredCompletedEvent({ analysis_id: 'run-b' }));
+
+      const networkSpy = spyOn(networkConfig, 'buildFetchNetworkOptions').mockReturnValue({});
+      const fetchSpy = mockFetch();
+      try {
+        await flushTelemetryEvents(Date.now() + 60_000);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(networkSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        fetchSpy.mockRestore();
+        networkSpy.mockRestore();
+      }
+    });
+
+    it('requeues events instead of bypassing an unusable network config', async () => {
+      writeTelemetryEvent(testSonarUserHome, makeStoredCompletedEvent({ analysis_id: 'run-a' }));
+
+      const networkSpy = spyOn(networkConfig, 'buildFetchNetworkOptions').mockImplementation(() => {
+        throw new Error('unreadable client certificate');
+      });
+      const fetchSpy = mockFetch();
+      try {
+        await flushTelemetryEvents(Date.now() + 60_000);
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(readAnalysisEvents(testSonarUserHome)).toHaveLength(1);
+      } finally {
+        fetchSpy.mockRestore();
+        networkSpy.mockRestore();
+      }
+    });
   });
 });
 


### PR DESCRIPTION
The telemetry flush was the only fetch in the CLI that did not pass `buildFetchNetworkOptions`, so it ignored the proxy, custom CA, and client certificate settings every other request honors. Behind an enforced corporate proxy it failed for every event, so those installations reported no telemetry at all; where direct egress happened to be open it succeeded by bypassing the configured policy.

The options are now resolved once per batch, the batch is requeued rather than sent when they cannot be resolved, and each request is capped at 20s so one stalled request no longer consumes the whole flush deadline.

Verified end to end with a proxy pointed at a closed port:

| | `telemetry-events.ndjson` after flush |
|---|---|
| before | absent — drained, so the POST succeeded despite the unreachable proxy |
| after | present, 1 event queued — proxy honored, nothing sent |

Three unit tests added, each verified to fail without the corresponding source change.