### PR TITLE
CLI-859 Add project_uuid to CLI telemetry events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,15 @@ All telemetry events (`CliCommandExecuted` from `storeEvent`, `CliAnalysisComple
 
 **Caching rules** — disk entries are written only when the API call succeeded (`response.ok`). Non-null values and confirmed-absent nulls are persisted; failed/transient responses are omitted so the next run retries. The `'fieldName' in entry` check in `planFieldsToFetch()` distinguishes “not yet tried” from “confirmed absent”.
 
+**`project_uuid`** — `string | null`, on `CommandExecutedEventPayload` **only**. Despite the name it is **not** an RFC-4122 UUID: it's SonarQube's legacy internal `projects.uuid`, fetched via `GET /api/navigation/component` (the same value `SonarQubeClient.getComponentId()` returns), and works identically on SQC and SQS. `CliAnalysisCompleted` and `CliIntegrationConfigured` deliberately do **not** carry it — they join to the command event on `invocation_id`.
+
+`src/core/telemetry/project-uuid.ts` owns both halves:
+
+- **Resolver** — `resolveProjectUuid(auth, projectKey)`: cache-then-API, never rejects, short-circuits when telemetry is disabled. Permanent disk cache (`project-uuid-cache.json`) keyed by `` `${serverUrl}::${projectKey}` `` — deliberately *not* by auth fingerprint, since the legacy id is a property of the project, not the caller. Resolved-but-empty is cached as `null` (stop retrying); transient failures are not cached (retry next call).
+- **Ambient context** — the project is a *per-invocation* fact held in a module-level slot rather than threaded through call signatures. `noteProject(auth, projectKey)` records it (synchronous, no I/O, no-ops on a missing key); `currentProjectUuid()` resolves it, memoized to at most one API call per process; `storeEvent` is the only consumer. Tests **must** call `resetProjectUuidContextForTests()` in `beforeEach` — module state outlives individual tests in a file.
+
+Call `noteProject` wherever a project key resolves and auth is in hand: `resolveCloudAuthAndProject` (`analyze/sqaa-auth.ts` — the choke point for bare `sonar analyze`, `analyze agentic`, and `verify`), `analyze/dependency-risks.ts`, `remediate/index.ts`, the three `hook/` handlers (`agent-post-tool-use`, `codex-post-tool-use`, `git-pre-commit`), and `framework/features/install-integration.ts` (project scope only, from the first non-empty `attrs.projectKey` — so a secrets-only `integrate git` and `--global` report `null`). `sonar run mcp` deliberately does not note it: it starts a long-running server, so its `CliCommandExecuted` may never fire.
+
 ## Error handling
 
 Please use the exception types defined in `src/core/command-error.ts` for production code. If you need to throw an error from a mock in test code, it's fine to use the generic `Error` type.

--- a/src/commands/analyze/dependency-risks.ts
+++ b/src/commands/analyze/dependency-risks.ts
@@ -24,6 +24,7 @@ import { DefaultScaScannerInstaller } from '@/core/host/install/sca-scanner.ts';
 import { DefaultSecretsInstaller } from '@/core/host/install/secrets.ts';
 import { discoverProject } from '@/core/project-info.ts';
 import { SonarQubeClient } from '@/core/server/client.ts';
+import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import {
   emitScaAnalysisTelemetry,
   SCA_CALLER_COMMANDS,
@@ -69,6 +70,7 @@ export async function analyzeDependencyRisks(
   }
 
   const projectKey = await resolveProjectKey(options.project, auth);
+  noteProject(auth, projectKey);
 
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
   const orchestrator = new ScaScanOrchestrator(

--- a/src/commands/analyze/sqaa-auth.ts
+++ b/src/commands/analyze/sqaa-auth.ts
@@ -27,6 +27,7 @@ import { selectRecordedFeatureForDir } from '@/core/host/recorded-feature-resolv
 import logger from '@/core/observability/logger.ts';
 import type { InstalledIntegrationFeature, IntegrationStateAttribute } from '@/core/state/state.ts';
 import { loadState } from '@/core/state/state-repository.ts';
+import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import { blank, confirmPrompt, text, warn } from '@/core/ui';
 
 import { SQAA_HOOK_FEATURE_ID } from '../integrate/_common/sqaa-entitlement.ts';
@@ -77,9 +78,13 @@ export type SqaaAuthResolution =
   | { kind: 'no-project' };
 
 /**
- * Combines cloud-auth validation and project-key resolution. Pure with respect to
- * the missing-project case: it never throws or warns for `no-project` — the caller
- * owns that decision (see `resolveSqaaContext` in sqaa.ts).
+ * Combines cloud-auth validation and project-key resolution. Never throws or warns for
+ * `no-project` — the caller owns that decision (see `resolveSqaaContext` in sqaa.ts).
+ *
+ * Not side-effect-free: on a successful resolution it publishes the project key for
+ * `project_uuid` telemetry (see `noteProject`). This is the single choke point for every SQAA
+ * entry point — bare `sonar analyze`, `analyze agentic`, and `verify` — so noting here covers
+ * all of them instead of at each of the five downstream call sites.
  */
 export async function resolveCloudAuthAndProject(
   auth: ResolvedAuth,
@@ -92,6 +97,7 @@ export async function resolveCloudAuthAndProject(
   const projectKey = explicitProject ?? (await resolveSqaaProjectKey(projectRoot));
   if (!projectKey) return { kind: 'no-project' };
 
+  noteProject(auth, projectKey);
   return { kind: 'resolved', cloudAuth, projectKey };
 }
 

--- a/src/commands/hook/agent-post-tool-use.ts
+++ b/src/commands/hook/agent-post-tool-use.ts
@@ -29,6 +29,7 @@ import { canonicalizePath, toRelativePosixPath } from '@/core/io/fs-utils.ts';
 import logger from '@/core/observability/logger.ts';
 import { timed } from '@/core/observability/timed.ts';
 import { SqaaForbiddenError } from '@/core/server/errors.ts';
+import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import {
   emitSqaaHookFailureTelemetry,
   SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
@@ -76,6 +77,8 @@ export async function agentPostToolUse(options: AgentPostToolUseOptions): Promis
 
   const projectKey = options.project;
   if (!projectKey) return;
+
+  noteProject(auth, projectKey);
 
   const canonicalPath = canonicalizePath(filePath);
   const normalizedPath = toRelativePosixPath(canonicalPath);

--- a/src/commands/hook/codex-post-tool-use.ts
+++ b/src/commands/hook/codex-post-tool-use.ts
@@ -26,6 +26,7 @@ import { AGENTIC_PACK_URL } from '@/core/config-constants.ts';
 import { resolveAuth } from '@/core/host/auth-resolver.ts';
 import logger from '@/core/observability/logger.ts';
 import { SqaaForbiddenError } from '@/core/server/errors.ts';
+import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import {
   emitSqaaHookFailureTelemetry,
   SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
@@ -52,6 +53,8 @@ export async function codexPostToolUse(options: CodexPostToolUseOptions): Promis
 
   const auth = await resolveAuth().catch(() => null);
   if (auth?.connectionType !== 'cloud' || !auth.orgKey) return;
+
+  noteProject(auth, projectKey);
 
   const runStart = performance.now();
   let report: SqaaJsonReport | null;

--- a/src/commands/hook/git-pre-commit.ts
+++ b/src/commands/hook/git-pre-commit.ts
@@ -25,6 +25,7 @@
 import { InvalidOptionError } from '@/core/command-error.ts';
 import { resolveAuth } from '@/core/host/auth-resolver.ts';
 import { spawnProcess } from '@/core/process/process.ts';
+import { noteProject } from '@/core/telemetry/project-uuid.ts';
 
 import { runDepRisksStage } from './git-pre-commit-dependency-risks.ts';
 import { runCommitSecretsStage } from './git-pre-commit-secrets.ts';
@@ -50,6 +51,11 @@ export async function gitPreCommit(
   if (!auth) {
     throw new MissingDependenciesError(HOOK_INACTIVE_UNAUTHENTICATED);
   }
+
+  // Noted before the stages, not inside the dependency-risks one, so a `-p` passed without
+  // --dependency-risks is still reported. In practice integrate only bakes `-p` into the hook
+  // alongside --dependency-risks, so a secrets-only pre-commit correctly reports null.
+  noteProject(auth, options.project);
 
   await runCommitSecretsStage(stagedFiles, auth);
 

--- a/src/commands/remediate/index.ts
+++ b/src/commands/remediate/index.ts
@@ -33,6 +33,7 @@ import { SonarQubeClient } from '@/core/server/client.ts';
 import { IssuesClient } from '@/core/server/issues.ts';
 import { MAX_PAGE_SIZE } from '@/core/server/projects.ts';
 import type { SonarQubeIssue } from '@/core/server/types.ts';
+import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import { blank, info, multiSelectPrompt, print, success, withSpinner } from '@/core/ui';
 import { cyan, dim, red, yellow } from '@/core/ui/colors.ts';
 
@@ -78,6 +79,7 @@ export async function remediate(options: RemediateOptions, auth: ResolvedAuth): 
   if (!(await confirmEntitlement(client, orgKey))) return;
 
   const projectKey = await resolveProjectKey(options, auth);
+  noteProject(auth, projectKey);
   const selectedKeys =
     suppliedIssueKeys ?? (await selectIssuesInteractively(client, orgKey, projectKey));
   if (selectedKeys === null) return;

--- a/src/commands/run/mcp.ts
+++ b/src/commands/run/mcp.ts
@@ -66,6 +66,10 @@ export async function runMcp(
   const cwd = process.cwd();
   const cwdIsHomeDir = canonicalizePath(cwd) === canonicalizePath(homedir());
   const discovered = cwdIsHomeDir ? undefined : await discoverProject(cwd, true, { auth });
+  // Deliberately does NOT call `noteProject` (telemetry/project-uuid.ts), unlike the other
+  // commands that resolve a project key: this starts a long-running server, and
+  // CliCommandExecuted is only emitted from the postAction hook once it exits — or never, if
+  // the process is killed. Attaching project_uuid to an event that unreliable buys nothing.
   const projectKey = options.project || discovered?.projectKey;
   if (!projectKey) {
     warn(

--- a/src/core/framework/features/install-integration.ts
+++ b/src/core/framework/features/install-integration.ts
@@ -30,6 +30,7 @@ import type {
 } from '@/core/state/state.ts';
 import { loadState, saveState } from '@/core/state/state-repository.ts';
 import { emitIntegrationConfiguredTelemetry } from '@/core/telemetry/integrate-telemetry.ts';
+import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import { text, warn } from '@/core/ui';
 
 import { renderCompletionSummary } from './completion-summary.ts';
@@ -142,6 +143,12 @@ export async function installIntegration<TOptions>({
 
     renderCompletionSummary(integration, installedFeatures, removedFeatures);
 
+    // Publish the project for `project_uuid` on CliCommandExecuted. Project scope only:
+    // `--global` installs have no project key recorded, which is why they report null.
+    if (scope === 'project' && auth) {
+      noteProject(auth, findProjectKeyFromFeatures(installedFeatures));
+    }
+
     const stateSaved = saveInstalledFeatures(state);
     if (stateSaved) {
       await emitIntegrationConfiguredTelemetry({
@@ -185,6 +192,23 @@ export function makeContext(
     attrs,
     resolvedDependencies: new Map(),
   };
+}
+
+/**
+ * Project key for telemetry `project_uuid`: the first `attrs.projectKey` recorded on any
+ * installed feature, or undefined when none carries one.
+ *
+ * `integrate git` records `{ projectKey: options.project ?? null }`, and the agent
+ * integrations record the discovered key on their SQAA/CAG features — so the non-empty-string
+ * check is what makes a secrets-only git install (which records an explicit `null`) report
+ * `project_uuid: null` rather than a bogus value.
+ */
+function findProjectKeyFromFeatures(features: InstalledIntegrationFeature[]): string | undefined {
+  for (const feature of features) {
+    const value = feature.attrs?.projectKey;
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
 }
 
 /**

--- a/src/core/framework/features/install-integration.ts
+++ b/src/core/framework/features/install-integration.ts
@@ -146,7 +146,7 @@ export async function installIntegration<TOptions>({
     // Publish the project for `project_uuid` on CliCommandExecuted. Project scope only:
     // `--global` installs have no project key recorded, which is why they report null.
     if (scope === 'project' && auth) {
-      noteProject(auth, findProjectKeyFromFeatures(installedFeatures));
+      noteProject(auth, projectKeyFromAttrs(attrs));
     }
 
     const stateSaved = saveInstalledFeatures(state);
@@ -195,20 +195,16 @@ export function makeContext(
 }
 
 /**
- * Project key for telemetry `project_uuid`: the first `attrs.projectKey` recorded on any
- * installed feature, or undefined when none carries one.
- *
- * `integrate git` records `{ projectKey: options.project ?? null }`, and the agent
- * integrations record the discovered key on their SQAA/CAG features — so the non-empty-string
- * check is what makes a secrets-only git install (which records an explicit `null`) report
- * `project_uuid: null` rather than a bogus value.
+ * Project key for telemetry `project_uuid`. Read from the invocation attrs rather than the
+ * installed features — every application inherits these verbatim, so the value is the same,
+ * but it also survives a run that only removes features. The non-empty check is what makes a
+ * secrets-only `integrate git` (which records an explicit `null`) report no project.
  */
-function findProjectKeyFromFeatures(features: InstalledIntegrationFeature[]): string | undefined {
-  for (const feature of features) {
-    const value = feature.attrs?.projectKey;
-    if (typeof value === 'string' && value.length > 0) return value;
-  }
-  return undefined;
+function projectKeyFromAttrs(
+  attrs: Record<string, IntegrationStateAttribute> | undefined,
+): string | undefined {
+  const value = attrs?.projectKey;
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
 
 /**

--- a/src/core/server/client.ts
+++ b/src/core/server/client.ts
@@ -227,6 +227,7 @@ export class SonarQubeClient {
     endpoint: string,
     params?: Record<string, string | number | boolean>,
     baseUrl?: string,
+    timeoutMs: number = GET_REQUEST_TIMEOUT_MS,
   ): Promise<{ response: Response; value: TValue | undefined }> {
     const url = new URL(`${baseUrl ?? this.serverURL}${endpoint}`);
 
@@ -242,7 +243,7 @@ export class SonarQubeClient {
       buildFetchInit(
         'GET',
         this.commonHeaders(),
-        GET_REQUEST_TIMEOUT_MS,
+        timeoutMs,
         undefined,
         buildFetchNetworkOptions(urlString),
       ),

--- a/src/core/state/state.ts
+++ b/src/core/state/state.ts
@@ -542,6 +542,18 @@ export interface CommandExecutedEventPayload extends TelemetryEventIdentityPaylo
   result: 'success' | 'failure';
   /** Distribution channel of the running CLI binary. */
   distribution: Distribution;
+  /**
+   * SonarQube's legacy internal project identifier (`projects.uuid`, resolved via
+   * `GET /api/navigation/component`) — NOT a real RFC-4122 UUID.
+   *
+   * The only event carrying it: `CliAnalysisCompleted` and `CliIntegrationConfigured` are
+   * joined to this event on the shared `invocation_id`. Populated for every command that
+   * resolves a project key (see `noteProject` in telemetry/project-uuid.ts); `null` for
+   * commands that never resolve one, for `sonar integrate --global`, and when resolution
+   * failed or was skipped. Stripped from the wire by the existing null-stripping replacer,
+   * same as `user_uuid`/`organization_uuid_v4`.
+   */
+  project_uuid: string | null;
 }
 
 /** Full CliCommandExecuted event written to telemetry-events.ndjson. */

--- a/src/core/telemetry/index.ts
+++ b/src/core/telemetry/index.ts
@@ -23,6 +23,7 @@ import { type Command } from 'commander';
 import { DISTRIBUTION } from '../host/distribution.ts';
 import { tryLoadState } from '../state/state-manager.ts';
 import { isTelemetryEnabled } from './enabled.ts';
+import { currentProjectUuid } from './project-uuid.ts';
 import { emitCommandExecuted, flushTelemetryEvents } from './telemetry-events.ts';
 
 export const TELEMETRY_FLUSH_MODE_ENV = '__SQ_CLI_TELEMETRY_FLUSH__';
@@ -63,12 +64,15 @@ export async function storeEvent(command: Command, success: boolean): Promise<vo
   } else {
     subcommand = fallbackSubcommand;
   }
-
   await emitCommandExecuted({
     command: topCommand,
     subcommand,
     result: success ? 'success' : 'failure',
     distribution: DISTRIBUTION,
+    // Per-invocation, published by whichever command resolved a project key (see
+    // noteProject). `null` for commands that never resolve one; the other telemetry
+    // events recover it by joining on the shared invocation_id.
+    project_uuid: await currentProjectUuid(),
   });
 
   spawnFlushWorker();

--- a/src/core/telemetry/project-uuid.ts
+++ b/src/core/telemetry/project-uuid.ts
@@ -1,0 +1,241 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Resolves SonarQube's legacy internal project identifier (`projects.uuid` — NOT a real
+// RFC-4122 UUID) for the `project_uuid` telemetry field. Mirrors telemetry/identity.ts's
+// cache-then-API shape, but keyed by server + project key rather than by connection
+// fingerprint, since the legacy project id is a property of the project, not the caller.
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
+import { SonarQubeClient } from '@/core/server/client.ts';
+
+import { getTelemetryDir } from '../config-constants.ts';
+import { tryLoadState } from '../state/state-manager.ts';
+import { isTelemetryEnabled } from './enabled.ts';
+
+const CACHE_FILENAME = 'project-uuid-cache.json';
+
+/**
+ * Transport-level budget for the one resolution per process. Deliberately far below
+ * `getSafe`'s 30s default: this runs in the `postAction` hook, after the command has already
+ * printed its result, so a slow server would otherwise look like the CLI hanging at exit
+ * (worst for `hook git-pre-commit`, where it would stall a commit). Enforced via the fetch's
+ * own `AbortSignal` rather than a `Promise.race`, because racing only caps what we *await* —
+ * an open socket keeps the process alive regardless. Only ever bites on the first run for a
+ * given project; every later run hits the permanent disk cache.
+ */
+const RESOLVE_BUDGET_MS = 3_000;
+
+/**
+ * The cache file is user-writable JSON, so entry *values* are as untrusted as the envelope:
+ * `unknown`, not `string | null`. Typing them honestly is what forces {@link readCachedUuid}
+ * to narrow — a `Record<string, string | null>` would let a cast smuggle an arbitrary JSON
+ * value straight into the `project_uuid` column.
+ */
+interface ProjectUuidCacheFile {
+  entries: Record<string, unknown>;
+}
+
+function cacheKey(serverUrl: string, projectKey: string): string {
+  return `${serverUrl}::${projectKey}`;
+}
+
+function readDiskCache(): ProjectUuidCacheFile {
+  const path = join(getTelemetryDir(), CACHE_FILENAME);
+  if (!existsSync(path)) {
+    return { entries: {} };
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'));
+    if (parsed !== null && typeof parsed === 'object' && 'entries' in parsed) {
+      // `entries` is untyped at runtime: guard against `null` (typeof null ===
+      // 'object') and non-object values so callers can safely index into it.
+      const entries: unknown = parsed.entries;
+      if (entries !== null && typeof entries === 'object') {
+        return parsed as ProjectUuidCacheFile;
+      }
+    }
+  } catch {
+    return { entries: {} };
+  }
+  return { entries: {} };
+}
+
+/**
+ * Reads one cache entry, distinguishing three states:
+ * - `{ hit: true, value }` — a usable `string` (resolved) or `null` (confirmed absent; stop
+ *   retrying).
+ * - `{ hit: false }` — key missing (never attempted), or present with a value that is neither
+ *   a string nor `null`. A corrupt or hand-edited entry is therefore treated as "not yet
+ *   attempted" and re-fetched, which also overwrites it with a valid value.
+ */
+function readCachedUuid(
+  entries: Record<string, unknown>,
+  entryKey: string,
+): { hit: true; value: string | null } | { hit: false } {
+  const cached = entries[entryKey];
+  if (cached === null || typeof cached === 'string') {
+    return { hit: true, value: cached };
+  }
+  return { hit: false };
+}
+
+function writeDiskCache(cache: ProjectUuidCacheFile): void {
+  try {
+    mkdirSync(getTelemetryDir(), { recursive: true });
+    writeFileSync(join(getTelemetryDir(), CACHE_FILENAME), JSON.stringify(cache));
+  } catch {
+    // Best-effort — read-only or ephemeral filesystems skip persistence.
+  }
+}
+
+/**
+ * Fetches the legacy project id from `/api/navigation/component`, end-to-end non-throwing.
+ * Distinguishes a resolved-but-empty response (cache `null`, stop retrying) from a
+ * transient/network failure (do not cache, retry next call) via the `ok` return flag.
+ *
+ * Deliberately does not reuse `SonarQubeClient.getComponentId()`: that helper collapses both
+ * outcomes to `null`, which would defeat the cache's retry semantics.
+ */
+async function fetchProjectUuid(
+  client: SonarQubeClient,
+  projectKey: string,
+): Promise<{ value: string | null; ok: boolean }> {
+  try {
+    const { response, value } = await client.getSafe<{ id: string }>(
+      '/api/navigation/component',
+      { component: projectKey },
+      undefined,
+      RESOLVE_BUDGET_MS,
+    );
+    if (!response.ok) {
+      return { value: null, ok: false };
+    }
+    return { value: value?.id ?? null, ok: true };
+  } catch {
+    return { value: null, ok: false };
+  }
+}
+
+/**
+ * Resolves SonarQube's legacy internal project identifier for `projectKey`, caching the
+ * result permanently under `{SONAR_USER_HOME}/sonarqube-cli/telemetry/project-uuid-cache.json`.
+ *
+ * Never rejects — always resolves to `string | null`. Skips entirely (no cache lookup, no API
+ * call) when telemetry is disabled.
+ */
+export async function resolveProjectUuid(
+  auth: ResolvedAuth,
+  projectKey: string,
+): Promise<string | null> {
+  try {
+    const state = tryLoadState();
+    if (!state || !isTelemetryEnabled(state)) return null;
+
+    const entryKey = cacheKey(auth.serverUrl, projectKey);
+    const diskCache = readDiskCache();
+    const cached = readCachedUuid(diskCache.entries, entryKey);
+    if (cached.hit) {
+      return cached.value;
+    }
+
+    const client = new SonarQubeClient(auth.serverUrl, auth.token);
+    const { value, ok } = await fetchProjectUuid(client, projectKey);
+    if (ok) {
+      diskCache.entries[entryKey] = value;
+      writeDiskCache(diskCache);
+    }
+    // Transient failures are deliberately not cached, so the next command retries. Each
+    // attempt is bounded by RESOLVE_BUDGET_MS, so a persistently hanging server costs that
+    // budget once per project-resolving command rather than once ever. Accepted rather than
+    // adding a negative TTL: every noteProject site sits on a path that already makes its own
+    // server calls under the 30s GET budget (SQAA, SCA, entitlement checks), so in any state
+    // where this hangs the command is already paying an order of magnitude more. A TTL would
+    // trade telemetry completeness — null for the whole TTL after the network recovers — for a
+    // latency win that is noise next to that. Revisit if it shows up in practice.
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+// --- Ambient per-invocation project context -----------------------------------------------
+//
+// `project_uuid` is reported on `CliCommandExecuted` only; the other events are joined to it
+// on the shared `invocation_id` that `buildIdentityBase` stamps on every event. That makes the
+// project a per-process fact, so it is held here rather than threaded through call signatures
+// (which previously required forwarding the Commander `Command` down ~12 function signatures
+// purely to key a map that only ever held one entry). Same shape as `INVOCATION_ID` in
+// invocation-id.ts: one value per CLI process.
+//
+// Commands that resolve a project key call `noteProject`; `storeEvent` calls
+// `currentProjectUuid` once at `postAction`. Writes are synchronous and do no I/O, so noting
+// never adds latency to the command's own work.
+
+interface NotedProject {
+  auth: ResolvedAuth;
+  projectKey: string;
+}
+
+let notedProject: NotedProject | null = null;
+let pendingResolution: Promise<string | null> | null = null;
+
+/**
+ * Record the project this invocation is about, for `project_uuid` on `CliCommandExecuted`.
+ *
+ * Synchronous and I/O-free — the API call happens later, once, in {@link currentProjectUuid}.
+ * Call it at the point where both a project key and {@link ResolvedAuth} are known (auth is
+ * needed for the server URL, and in the anonymous hook commands it is resolved inside the
+ * handler, not before it). No-ops for a missing or empty key, so callers can pass an
+ * unresolved value directly — that leaves `project_uuid: null`, which is the correct report
+ * for `--global` installs and project-less commands.
+ */
+export function noteProject(auth: ResolvedAuth, projectKey: string | null | undefined): void {
+  if (!projectKey) return;
+  notedProject = { auth, projectKey };
+  // Drop any memo from an earlier note so a superseding project key is not shadowed by it.
+  pendingResolution = null;
+}
+
+/**
+ * The `project_uuid` for this invocation, or `null` when no project was noted.
+ *
+ * Memoized: at most one resolution (and therefore at most one API call and one disk-cache
+ * read) per process, however many times this is called.
+ */
+export function currentProjectUuid(): Promise<string | null> {
+  const project = notedProject;
+  if (!project) return Promise.resolve(null);
+  pendingResolution ??= resolveProjectUuid(project.auth, project.projectKey);
+  return pendingResolution;
+}
+
+/**
+ * Clear the ambient context. Tests **must** call this in `beforeEach`: module state outlives
+ * individual tests in the same file, so a leaked project from an earlier test would otherwise
+ * make a later assertion pass for the wrong reason.
+ */
+export function resetProjectUuidContextForTests(): void {
+  notedProject = null;
+  pendingResolution = null;
+}

--- a/src/core/telemetry/sqaa-analysis-telemetry.ts
+++ b/src/core/telemetry/sqaa-analysis-telemetry.ts
@@ -138,6 +138,11 @@ export function tallyFromSqaaJsonReport(report: SqaaJsonReport): RunTally {
  *
  * `errors_count` is {@link RunTally.totalErrors} only (API `errors[]` on successful analyses).
  * `failures_count` is {@link RunTally.totalFailures} (per-file analysis failures).
+ *
+ * The body is fully guarded, matching {@link emitScaAnalysisTelemetry}: this was the only
+ * `emit*` path with no exception handling anywhere in its call chain, so a throw from identity
+ * resolution or the event file write could turn a successful SQAA analysis into a reported
+ * command failure. Telemetry is strictly fire-and-forget.
  */
 export async function emitSqaaAnalysisTelemetry(
   callerCommand: SqaaTelemetryCallerCommand,
@@ -146,20 +151,24 @@ export async function emitSqaaAnalysisTelemetry(
   durationMs: number,
   exitCode?: number | null,
 ): Promise<void> {
-  const analysisId = randomUUID();
-  const findingsCount = tally.totalIssues;
-  const details =
-    findingsCount > 0 ? JSON.stringify(collectRuleCounts(collectIssuesFromTally(tally))) : '';
+  try {
+    const analysisId = randomUUID();
+    const findingsCount = tally.totalIssues;
+    const details =
+      findingsCount > 0 ? JSON.stringify(collectRuleCounts(collectIssuesFromTally(tally))) : '';
 
-  await emitAnalysisCompleted(auth, {
-    caller_command: callerCommand,
-    analyzer: 'sqaa',
-    analysis_id: analysisId,
-    findings_count: findingsCount,
-    exit_code: exitCode ?? null,
-    errors_count: tally.totalErrors,
-    failures_count: tally.totalFailures,
-    scan_duration_ms: durationMs,
-    details,
-  });
+    await emitAnalysisCompleted(auth, {
+      caller_command: callerCommand,
+      analyzer: 'sqaa',
+      analysis_id: analysisId,
+      findings_count: findingsCount,
+      exit_code: exitCode ?? null,
+      errors_count: tally.totalErrors,
+      failures_count: tally.totalFailures,
+      scan_duration_ms: durationMs,
+      details,
+    });
+  } catch {
+    // Telemetry is strictly fire-and-forget; never surface to the command handler.
+  }
 }

--- a/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
+++ b/tests/integration/specs/analyze/analyze-dependency-risks.test.ts
@@ -29,6 +29,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { buildLocalBinaryName } from '@/core/host/install/sca-scanner.ts';
 import { detectPlatform } from '@/core/host/platform-detector.ts';
 
+import { readCommandEvents } from '../../../_common/telemetry-helpers';
 import { TestHarness } from '../../harness';
 
 const VALID_TOKEN = 'integration-test-token';
@@ -377,4 +378,62 @@ describe('analyze dependency-risks', () => {
     expect(result.stderr).toContain('Using project key: demo');
     expect(result.stderr).not.toContain('Using auto-detected project key');
   });
+});
+
+describe('analyze dependency-risks — project_uuid telemetry', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'resolves and records a non-null project_uuid on CliCommandExecuted',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withScaEnabled(true)
+        .withProject('demo')
+        .withProjectSettings('demo', [])
+        .start();
+      // Deliberately do NOT set TELEMETRY_FLUSH_MODE_ENV here: that flag makes storeEvent()
+      // (which owns CliCommandExecuted) no-op, since it also doubles as the guard that stops
+      // the detached flush worker from recursively emitting its own CliCommandExecuted event.
+      harness.state().withTelemetryEnabled();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      // The scan itself still fails against the fake server (no SCA backend — the manifest
+      // discovery/secrets pre-scan step fails first, before the SCA analyzer's own telemetry
+      // try/catch is even reached; see sca-scan-orchestrator.ts), but the project key is
+      // resolved (and project_uuid recorded on the command) before any of that runs.
+      const result = await harness.run('analyze dependency-risks --project demo --format json', {
+        timeoutMs: 30_000,
+      });
+
+      expect(result.exitCode).toBe(1);
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.command).toBe('analyze');
+      expect(commandEvent.event_payload.project_uuid).toBe('AYdemolegacy');
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'leaves project_uuid null on CliCommandExecuted for commands with no project context',
+    async () => {
+      harness.state().withTelemetryEnabled();
+
+      const result = await harness.run('system status --json');
+
+      expect(result.exitCode).toBe(0);
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.project_uuid).toBeNull();
+    },
+    { timeout: 15000 },
+  );
 });

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -38,7 +38,7 @@ import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
-import { readAnalysisEvents } from '../../../_common/telemetry-helpers';
+import { readAnalysisEvents, readCommandEvents } from '../../../_common/telemetry-helpers';
 import { TestHarness } from '../../harness';
 import { commitFile, git, initGitRepo, stageFile } from '../hook/git-test-helpers';
 import {
@@ -1172,6 +1172,45 @@ describe('analyze agentic — analysis telemetry', () => {
     },
     { timeout: 15000 },
   );
+
+  it(
+    'resolves and records a non-null project_uuid on CliCommandExecuted',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .withProject(TEST_PROJECT)
+        .start();
+
+      // Deliberately do NOT set TELEMETRY_FLUSH_MODE_ENV: it makes storeEvent() (which owns
+      // CliCommandExecuted) no-op, since it also doubles as the guard that stops the detached
+      // flush worker from recursively emitting its own CliCommandExecuted event.
+      harness
+        .state()
+        .withTelemetryEnabled()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaFeature(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      harness.cwd.writeFile('src/index.ts', 'const x = 1;');
+
+      const result = await harness.run('analyze agentic --file src/index.ts');
+
+      expect(result.exitCode).toBe(0);
+      const [analysisEvent] = readAnalysisEvents(harness.sonarUserHome.path);
+      expect(analysisEvent.event_payload.analyzer).toBe('sqaa');
+
+      // project_uuid lives only on CliCommandExecuted; the analysis event above is joined to
+      // it on the shared invocation_id.
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.command).toBe('analyze');
+      expect(commandEvent.event_payload.invocation_id).toBe(
+        analysisEvent.event_payload.invocation_id,
+      );
+      expect(commandEvent.event_payload.project_uuid).toBe(`AY${TEST_PROJECT}legacy`);
+    },
+    { timeout: 15000 },
+  );
 });
 
 describe('sonar analyze — analysis telemetry', () => {
@@ -1259,6 +1298,71 @@ describe('sonar analyze — analysis telemetry', () => {
       expect(sqaaEvents).toHaveLength(1);
       expect(secretsEvents[0].event_payload.caller_command).toBe(SECRETS_CALLER_COMMANDS.analyze);
       expect(sqaaEvents[0].event_payload.caller_command).toBe(SQAA_ANALYZE_CALLER_COMMAND);
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'records a non-null project_uuid on CliCommandExecuted for bare analyze --file (text)',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .withProject(TEST_PROJECT)
+        .start();
+
+      // Do NOT enable flush mode: TELEMETRY_FLUSH_MODE_ENV no-ops storeEvent(), which owns
+      // CliCommandExecuted, so the command event would never be written.
+      harness
+        .state()
+        .withTelemetryEnabled()
+        .withSecretsBinaryInstalled()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaFeature(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      harness.cwd.writeFile('src/index.ts', 'const x = 1;');
+
+      const result = await harness.run('analyze --file src/index.ts');
+
+      expect(result.exitCode).toBe(0);
+      const [analysisEvent] = readCompletedEventsForAnalyzer('sqaa');
+
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.invocation_id).toBe(
+        analysisEvent.event_payload.invocation_id,
+      );
+      expect(commandEvent.event_payload.command).toBe('analyze');
+      expect(commandEvent.event_payload.project_uuid).toBe(`AY${TEST_PROJECT}legacy`);
+    },
+    { timeout: 30000 },
+  );
+
+  it(
+    'records a non-null project_uuid on CliCommandExecuted for bare analyze --format json --file',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .withProject(TEST_PROJECT)
+        .start();
+
+      harness
+        .state()
+        .withTelemetryEnabled()
+        .withSecretsBinaryInstalled()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaFeature(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      harness.cwd.writeFile('src/index.ts', 'const x = 1;');
+
+      const result = await harness.run('analyze --format json --file src/index.ts');
+
+      expect(result.exitCode).toBe(0);
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.command).toBe('analyze');
+      expect(commandEvent.event_payload.project_uuid).toBe(`AY${TEST_PROJECT}legacy`);
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
@@ -24,6 +24,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
+import { readAnalysisEvents, readCommandEvents } from '../../../_common/telemetry-helpers';
 import { TestHarness } from '../../harness';
 import { parseSqaaRequestBody, sqaaRequestFirstFilePath } from '../analyze/sqaa-request-helpers';
 
@@ -174,6 +175,43 @@ describe('sonar hook claude-post-tool-use', () => {
       expect(body.files).toHaveLength(1);
       expect(body.files?.[0]?.content).toContain('const x');
       expect(body.analysisDepth).toBeUndefined();
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'resolves and records a non-null project_uuid on CliCommandExecuted',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .withProject(TEST_PROJECT)
+        .start();
+      // Deliberately do NOT set TELEMETRY_FLUSH_MODE_ENV: it makes storeEvent() (which owns
+      // CliCommandExecuted) no-op, since it also doubles as the guard that stops the detached
+      // flush worker from recursively emitting its own CliCommandExecuted event.
+      harness.state().withTelemetryEnabled();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+      harness.cwd.writeFile('src/main.ts', 'const x = 1;');
+      const filePath = join(harness.cwd.path, 'src/main.ts');
+
+      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
+        stdin: postToolUseStdin(filePath),
+      });
+
+      expect(result.exitCode).toBe(0);
+      const [analysisEvent] = readAnalysisEvents(harness.sonarUserHome.path);
+      expect(analysisEvent.event_payload.analyzer).toBe('sqaa');
+
+      // project_uuid lives only on CliCommandExecuted; the analysis event above is joined to
+      // it on the shared invocation_id.
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.command).toBe('hook');
+      expect(commandEvent.event_payload.invocation_id).toBe(
+        analysisEvent.event_payload.invocation_id,
+      );
+      expect(commandEvent.event_payload.project_uuid).toBe(`AY${TEST_PROJECT}legacy`);
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-codex-post-tool-use.test.ts
@@ -22,6 +22,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
+import { readAnalysisEvents, readCommandEvents } from '../../../_common/telemetry-helpers';
 import { TestHarness } from '../../harness';
 import {
   allSqaaRequestsUseDeep,
@@ -153,6 +154,40 @@ describe('sonar hook codex-post-tool-use', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'resolves and records a non-null project_uuid on CliCommandExecuted',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .withProject(TEST_PROJECT)
+        .start();
+      // Deliberately do NOT set TELEMETRY_FLUSH_MODE_ENV: it makes storeEvent() (which owns
+      // CliCommandExecuted) no-op, since it also doubles as the guard that stops the detached
+      // flush worker from recursively emitting its own CliCommandExecuted event.
+      harness.state().withTelemetryEnabled();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+      harness.cwd.writeFile('src/main.ts', 'const x = 1;');
+
+      const result = await harness.run(`hook codex-post-tool-use --project ${TEST_PROJECT}`);
+
+      expect(result.exitCode).toBe(0);
+      const [analysisEvent] = readAnalysisEvents(harness.sonarUserHome.path);
+      expect(analysisEvent.event_payload.analyzer).toBe('sqaa');
+
+      // project_uuid lives only on CliCommandExecuted; the analysis event above is joined to
+      // it on the shared invocation_id.
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.command).toBe('hook');
+      expect(commandEvent.event_payload.invocation_id).toBe(
+        analysisEvent.event_payload.invocation_id,
+      );
+      expect(commandEvent.event_payload.project_uuid).toBe(`AY${TEST_PROJECT}legacy`);
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/hook/hook-git-pre-commit.test.ts
+++ b/tests/integration/specs/hook/hook-git-pre-commit.test.ts
@@ -32,6 +32,7 @@ import {
 import { buildLocalBinaryName } from '@/core/host/install/secrets.ts';
 import { detectPlatform } from '@/core/host/platform-detector.ts';
 
+import { readCommandEvents } from '../../../_common/telemetry-helpers.ts';
 import { TestHarness } from '../../harness';
 import { initGitRepo, stageFile } from './git-test-helpers';
 
@@ -197,6 +198,34 @@ describe('sonar hook git-pre-commit', () => {
     { timeout: 15000 },
   );
 
+  it(
+    'reports project_uuid null for a secrets-only pre-commit (no -p passed)',
+    async () => {
+      initGitRepo(harness.cwd.path);
+      stageFile(harness.cwd.path, 'index.ts', CLEAN_CONTENT);
+
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withProject('demo')
+        .start();
+
+      harness.state().withTelemetryEnabled();
+      harness.state().withSecretsBinaryInstalled();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      const result = await harness.run('hook git-pre-commit');
+
+      expect(result.exitCode).toBe(0);
+      // integrate only bakes `-p` into the hook alongside --dependency-risks, so a
+      // secrets-only hook knows no project and must report null rather than guessing.
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.subcommand).toBe('git-pre-commit');
+      expect(commandEvent.event_payload.project_uuid).toBeNull();
+    },
+    { timeout: 30000 },
+  );
+
   describe('with --dependency-risks', () => {
     it(
       'exits 1 with the unauthenticated message when not authenticated (fails closed)',
@@ -242,6 +271,38 @@ describe('sonar hook git-pre-commit', () => {
         expect(result.stdout + result.stderr).toContain(
           'No dependency manifests changed in this commit',
         );
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'records a non-null project_uuid on CliCommandExecuted',
+      async () => {
+        initGitRepo(harness.cwd.path);
+        stageFile(harness.cwd.path, 'index.ts', CLEAN_CONTENT);
+
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken(VALID_TOKEN)
+          .withScaEnabled(true)
+          .withProject('demo')
+          .withProjectSettings('demo', [])
+          .start();
+
+        // Do NOT enable flush mode: TELEMETRY_FLUSH_MODE_ENV no-ops storeEvent(), which owns
+        // CliCommandExecuted, so the command event would never be written.
+        harness.state().withTelemetryEnabled();
+        harness.state().withSecretsBinaryInstalled();
+        harness.state().withScaScannerBinaryInstalled();
+        harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+        const result = await harness.run('hook git-pre-commit -p demo --dependency-risks');
+
+        expect(result.exitCode).toBe(0);
+        const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+        expect(commandEvent.event_payload.command).toBe('hook');
+        expect(commandEvent.event_payload.subcommand).toBe('git-pre-commit');
+        expect(commandEvent.event_payload.project_uuid).toBe('AYdemolegacy');
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -31,6 +31,7 @@ import {
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
 import { ISOLATED_CLI_SPAWN_ENV } from '../../../_common/isolated-cli-env.js';
+import { readCommandEvents } from '../../../_common/telemetry-helpers.ts';
 import { TestHarness } from '../../harness';
 import { getCliBinaryPath } from '../../harness/cli-runner.js';
 import { buildHomeEnv, IS_WINDOWS } from '../../harness/platform';
@@ -613,6 +614,37 @@ describe('integrate git (native hooks)', () => {
       expect(feature.attrs).toMatchObject({ projectKey: 'my-project' });
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectSubfeatureHasDependency(feature, 'pre-commit-dependency-risks', 'sca-scanner-cli');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'records project_uuid on CliCommandExecuted for a project-scoped install',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(INTEGRATION_TEST_TOKEN)
+        .withProject('my-project')
+        .start();
+      // Do NOT enable flush mode: TELEMETRY_FLUSH_MODE_ENV no-ops storeEvent(), which owns
+      // CliCommandExecuted, so the command event would never be written.
+      harness
+        .state()
+        .withActiveConnection(server.baseUrl())
+        .withKeychainToken(server.baseUrl(), INTEGRATION_TEST_TOKEN)
+        .withSecretsBinaryInstalled()
+        .withTelemetryEnabled();
+      initGitRepo(harness);
+
+      const result = await harness.run(
+        'integrate git --hook pre-commit -p my-project --non-interactive',
+      );
+
+      expect(result.exitCode).toBe(0);
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.command).toBe('integrate');
+      expect(commandEvent.event_payload.subcommand).toBe('git');
+      expect(commandEvent.event_payload.project_uuid).toBe('AYmy-projectlegacy');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -26,6 +26,7 @@ import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
+import { readCommandEvents } from '../../../_common/telemetry-helpers';
 import { TestHarness } from '../../harness';
 
 const VALID_TOKEN = 'integration-test-token';
@@ -973,4 +974,45 @@ describe('sonar remediate', () => {
       { timeout: 15000 },
     );
   });
+
+  it(
+    'resolves and records a non-null project_uuid on CliCommandExecuted',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withProject(TEST_PROJECT)
+        .start();
+      // Deliberately do NOT set TELEMETRY_FLUSH_MODE_ENV: it makes storeEvent() (which owns
+      // CliCommandExecuted) no-op, since it also doubles as the guard that stops the detached
+      // flush worker from recursively emitting its own CliCommandExecuted event.
+      harness.state().withTelemetryEnabled();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      const result = await harness.run(`remediate --project ${TEST_PROJECT} --issues k1,k2`, {
+        extraEnv: { SONARQUBE_CLI_MOCK_TTY: '' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.command).toBe('remediate');
+      expect(commandEvent.event_payload.project_uuid).toBe(`AY${TEST_PROJECT}legacy`);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'leaves project_uuid null on CliCommandExecuted when the command fails before resolving a project',
+    async () => {
+      harness.state().withTelemetryEnabled();
+
+      const result = await harness.run('remediate --issues k1,k2');
+
+      expect(result.exitCode).toBe(1);
+      const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+      expect(commandEvent.event_payload.result).toBe('failure');
+      expect(commandEvent.event_payload.project_uuid).toBeNull();
+    },
+    { timeout: 15000 },
+  );
 });

--- a/tests/unit/core/telemetry/project-uuid-api-mock.ts
+++ b/tests/unit/core/telemetry/project-uuid-api-mock.ts
@@ -1,0 +1,72 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { spyOn } from 'bun:test';
+
+import { SonarQubeClient } from '@/core/server/client.ts';
+
+interface ApiStep {
+  ok: boolean;
+  id?: string;
+  /** When true, getSafe() itself throws (network error/timeout) instead of resolving. */
+  throws?: boolean;
+}
+
+interface ProjectUuidApiMockOptions {
+  component?: ApiStep[];
+}
+
+function shiftStep(queue: ApiStep[] | undefined, fallback: ApiStep): ApiStep {
+  return queue?.shift() ?? fallback;
+}
+
+/** Mock SonarQubeClient.getSafe for telemetry project-uuid resolver tests. */
+export function mockProjectUuidGetSafe(
+  options: ProjectUuidApiMockOptions = {},
+): ReturnType<typeof spyOn> {
+  const prototype = SonarQubeClient.prototype as {
+    getSafe?: ReturnType<typeof spyOn>;
+  };
+  prototype.getSafe?.mockRestore?.();
+
+  const componentSteps = options.component ? [...options.component] : undefined;
+
+  return spyOn(SonarQubeClient.prototype, 'getSafe').mockImplementation(
+    <TValue>(
+      endpoint: string,
+      _params?: Record<string, string | number | boolean>,
+      _baseUrl?: string,
+    ): Promise<{ response: Response; value: TValue | undefined }> => {
+      if (endpoint === '/api/navigation/component') {
+        const step = shiftStep(componentSteps, { ok: true });
+        if (step.throws) {
+          return Promise.reject(new Error('network error'));
+        }
+        return Promise.resolve({
+          response: { ok: step.ok } as Response,
+          value: (step.id ? { id: step.id } : {}) as TValue,
+        });
+      }
+      return Promise.reject(
+        new Error(`Unexpected getSafe endpoint in project-uuid test: ${endpoint}`),
+      );
+    },
+  );
+}

--- a/tests/unit/core/telemetry/project-uuid.test.ts
+++ b/tests/unit/core/telemetry/project-uuid.test.ts
@@ -1,0 +1,390 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * Unit tests for telemetry/project-uuid.ts: the cache-then-API resolver for the
+ * `project_uuid` telemetry field. Every test uses a unique project key and an
+ * isolated SONAR_USER_HOME to avoid cross-test disk-cache hits.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { ENV_SONAR_USER_HOME, getTelemetryDir } from '@/core/config-constants.ts';
+import type { ResolvedAuth } from '@/core/host/auth-resolver.ts';
+import { getDefaultState } from '@/core/state/state.ts';
+import * as stateRepository from '@/core/state/state-repository.ts';
+import {
+  currentProjectUuid,
+  noteProject,
+  resetProjectUuidContextForTests,
+  resolveProjectUuid,
+} from '@/core/telemetry/project-uuid.ts';
+
+import { mockProjectUuidGetSafe } from './project-uuid-api-mock.ts';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function auth(overrides: Partial<ResolvedAuth> = {}): ResolvedAuth {
+  return {
+    token: 't',
+    serverUrl: 'https://sonarcloud.io',
+    orgKey: 'my-org',
+    connectionType: 'cloud',
+    ...overrides,
+  };
+}
+
+/** Replicates project-uuid.ts#cacheKey so tests can seed the disk cache directly. */
+function cacheKey(serverUrl: string, projectKey: string): string {
+  return `${serverUrl}::${projectKey}`;
+}
+
+function seedDiskCache(serverUrl: string, projectKey: string, value: string | null): void {
+  mkdirSync(getTelemetryDir(), { recursive: true });
+  writeFileSync(
+    join(getTelemetryDir(), 'project-uuid-cache.json'),
+    JSON.stringify({ entries: { [cacheKey(serverUrl, projectKey)]: value } }),
+  );
+}
+
+function writeRawCache(contents: string): void {
+  mkdirSync(getTelemetryDir(), { recursive: true });
+  writeFileSync(join(getTelemetryDir(), 'project-uuid-cache.json'), contents);
+}
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+let testDir: string;
+let loadStateSpy: ReturnType<typeof spyOn>;
+let savedDoNotTrack: string | undefined;
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'project-uuid-test-'));
+  process.env[ENV_SONAR_USER_HOME] = testDir;
+
+  // The test preload opts every test out of telemetry via DO_NOT_TRACK=1 by default
+  // (tests/_common/preload-isolated-env.ts) — clear it here to exercise the
+  // telemetry-enabled path, matching telemetry-events.test.ts's convention.
+  savedDoNotTrack = process.env.DO_NOT_TRACK;
+  delete process.env.DO_NOT_TRACK;
+
+  loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
+
+  // Mandatory: the ambient slot is module state, so it outlives individual tests in this
+  // file. Without this a project noted by an earlier test would leak into a later one and
+  // make its assertion pass for the wrong reason.
+  resetProjectUuidContextForTests();
+});
+
+afterEach(() => {
+  delete process.env[ENV_SONAR_USER_HOME];
+  rmSync(testDir, { recursive: true, force: true });
+
+  if (savedDoNotTrack !== undefined) {
+    process.env.DO_NOT_TRACK = savedDoNotTrack;
+  } else {
+    delete process.env.DO_NOT_TRACK;
+  }
+
+  loadStateSpy.mockRestore();
+});
+
+// ─── resolveProjectUuid ─────────────────────────────────────────────────────
+
+describe('resolveProjectUuid()', () => {
+  it('serves a cached value from disk without hitting the API', async () => {
+    seedDiskCache('https://sonarcloud.io', 'proj-disk-cached', 'AV-disk-cached');
+    const getSafeSpy = mockProjectUuidGetSafe();
+
+    const result = await resolveProjectUuid(auth(), 'proj-disk-cached');
+
+    expect(result).toBe('AV-disk-cached');
+    expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('resolves from the API on a cache miss and caches the result', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true, id: 'AV-fresh' }],
+    });
+
+    const first = await resolveProjectUuid(auth(), 'proj-cache-miss');
+    const second = await resolveProjectUuid(auth(), 'proj-cache-miss');
+
+    expect(first).toBe('AV-fresh');
+    expect(second).toBe('AV-fresh');
+    expect(getSafeSpy).toHaveBeenCalledTimes(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('caches a confirmed-absent (resolved but empty) response as null and stops retrying', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true }],
+    });
+
+    const first = await resolveProjectUuid(auth(), 'proj-confirmed-absent');
+    const second = await resolveProjectUuid(auth(), 'proj-confirmed-absent');
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(getSafeSpy).toHaveBeenCalledTimes(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('does not cache a transient (non-ok) API failure and retries on the next call', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: false }, { ok: true, id: 'AV-after-retry' }],
+    });
+
+    const first = await resolveProjectUuid(auth(), 'proj-transient-failure');
+    const second = await resolveProjectUuid(auth(), 'proj-transient-failure');
+
+    expect(first).toBeNull();
+    expect(second).toBe('AV-after-retry');
+    expect(getSafeSpy).toHaveBeenCalledTimes(2);
+    getSafeSpy.mockRestore();
+  });
+
+  it('does not cache a network error (getSafe throws) and retries on the next call', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [
+        { ok: false, throws: true },
+        { ok: true, id: 'AV-after-network-retry' },
+      ],
+    });
+
+    const first = await resolveProjectUuid(auth(), 'proj-network-error');
+    const second = await resolveProjectUuid(auth(), 'proj-network-error');
+
+    expect(first).toBeNull();
+    expect(second).toBe('AV-after-network-retry');
+    expect(getSafeSpy).toHaveBeenCalledTimes(2);
+    getSafeSpy.mockRestore();
+  });
+
+  it('scopes the cache key by server URL, not just project key', async () => {
+    seedDiskCache('https://sq.example.com', 'shared-key', 'AV-server-a');
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true, id: 'AV-server-b' }],
+    });
+
+    const result = await resolveProjectUuid(
+      auth({ serverUrl: 'https://other-server.example.com', connectionType: 'on-premise' }),
+      'shared-key',
+    );
+
+    expect(result).toBe('AV-server-b');
+    expect(getSafeSpy).toHaveBeenCalledTimes(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('treats a malformed disk cache as empty and falls back to the API', async () => {
+    writeRawCache('{ not valid json');
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true, id: 'AV-after-malformed-cache' }],
+    });
+
+    const result = await resolveProjectUuid(auth(), 'proj-malformed-cache');
+
+    expect(result).toBe('AV-after-malformed-cache');
+    getSafeSpy.mockRestore();
+  });
+
+  it('treats a cache file without an entries object as empty', async () => {
+    writeRawCache(JSON.stringify({ unexpected: true }));
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true, id: 'AV-no-entries' }],
+    });
+
+    const result = await resolveProjectUuid(auth(), 'proj-no-entries');
+
+    expect(result).toBe('AV-no-entries');
+    getSafeSpy.mockRestore();
+  });
+
+  it('treats a cache file with a null entries value as empty', async () => {
+    // `typeof null === 'object'`, so a null `entries` must be rejected explicitly;
+    // otherwise indexing into it throws and degrades resolution to null forever.
+    writeRawCache(JSON.stringify({ entries: null }));
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true, id: 'AV-null-entries' }],
+    });
+
+    const result = await resolveProjectUuid(auth(), 'proj-null-entries');
+
+    expect(result).toBe('AV-null-entries');
+    getSafeSpy.mockRestore();
+  });
+
+  it.each([
+    ['an object', { a: 1 }],
+    ['a number', 42],
+    ['a boolean', true],
+    ['an array', ['x']],
+  ])('re-fetches when a cached entry value is %s rather than a string', async (_label, bad) => {
+    // Entry values are as untrusted as the envelope. Returning one unnarrowed would put a
+    // non-string into the project_uuid column silently, with nothing to notice it by.
+    const key = 'proj-corrupt-value';
+    writeRawCache(JSON.stringify({ entries: { [cacheKey('https://sonarcloud.io', key)]: bad } }));
+    const getSafeSpy = mockProjectUuidGetSafe({ component: [{ ok: true, id: 'AV-refetched' }] });
+
+    const result = await resolveProjectUuid(auth(), key);
+
+    // Corrupt entry treated as never-attempted: re-fetched, and the bad value overwritten.
+    expect(result).toBe('AV-refetched');
+    expect(getSafeSpy).toHaveBeenCalledTimes(1);
+    expect(await resolveProjectUuid(auth(), key)).toBe('AV-refetched');
+    expect(getSafeSpy).toHaveBeenCalledTimes(1);
+
+    getSafeSpy.mockRestore();
+  });
+
+  it('skips the cache lookup and the API call entirely when telemetry is disabled', async () => {
+    loadStateSpy.mockReturnValue({ ...getDefaultState('1.0.0'), telemetry: { enabled: false } });
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true, id: 'AV-should-not-be-fetched' }],
+    });
+
+    const result = await resolveProjectUuid(auth(), 'proj-telemetry-disabled');
+
+    expect(result).toBeNull();
+    expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('never throws when the disk cache write fails (strictly best-effort)', async () => {
+    const writeFileSyncSpy = spyOn(await import('node:fs'), 'writeFileSync').mockImplementation(
+      () => {
+        throw new Error('disk full');
+      },
+    );
+    const getSafeSpy = mockProjectUuidGetSafe({
+      component: [{ ok: true, id: 'AV-disk-full' }],
+    });
+
+    // Must resolve, not reject — a telemetry failure must never reach the command handler.
+    const result = await resolveProjectUuid(auth(), 'proj-disk-full');
+
+    expect(result).toBe('AV-disk-full');
+    writeFileSyncSpy.mockRestore();
+    getSafeSpy.mockRestore();
+  });
+
+  it('never throws when the API client itself throws unexpectedly', async () => {
+    const getSafeSpy = spyOn(
+      (await import('@/core/server/client.ts')).SonarQubeClient.prototype,
+      'getSafe',
+    ).mockImplementation(() => {
+      throw new Error('synchronous failure before fetch');
+    });
+
+    const result = await resolveProjectUuid(auth(), 'proj-synchronous-throw');
+
+    expect(result).toBeNull();
+    getSafeSpy.mockRestore();
+  });
+
+  it('never throws when loading state itself throws', async () => {
+    loadStateSpy.mockImplementation(() => {
+      throw new Error('state file corrupted');
+    });
+
+    const result = await resolveProjectUuid(auth(), 'proj-state-throws');
+
+    expect(result).toBeNull();
+  });
+});
+
+// ─── Ambient per-invocation context ─────────────────────────────────────────
+
+describe('noteProject() / currentProjectUuid()', () => {
+  it('resolves null when no project was noted', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe();
+
+    expect(await currentProjectUuid()).toBeNull();
+    expect(getSafeSpy).not.toHaveBeenCalled();
+
+    getSafeSpy.mockRestore();
+  });
+
+  it('resolves the noted project via the API', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe({ component: [{ ok: true, id: 'AV-noted' }] });
+
+    noteProject(auth(), 'proj-noted');
+
+    expect(await currentProjectUuid()).toBe('AV-noted');
+    getSafeSpy.mockRestore();
+  });
+
+  it('memoizes: repeated reads make at most one API call per process', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe({ component: [{ ok: true, id: 'AV-memo' }] });
+
+    noteProject(auth(), 'proj-memoized');
+
+    expect(await currentProjectUuid()).toBe('AV-memo');
+    expect(await currentProjectUuid()).toBe('AV-memo');
+    expect(await currentProjectUuid()).toBe('AV-memo');
+    expect(getSafeSpy).toHaveBeenCalledTimes(1);
+
+    getSafeSpy.mockRestore();
+  });
+
+  it('ignores an empty or missing project key, leaving the report null', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe();
+
+    noteProject(auth(), undefined);
+    noteProject(auth(), null);
+    noteProject(auth(), '');
+
+    expect(await currentProjectUuid()).toBeNull();
+    expect(getSafeSpy).not.toHaveBeenCalled();
+
+    getSafeSpy.mockRestore();
+  });
+
+  it('lets a later note supersede an earlier one instead of being shadowed by its memo', async () => {
+    const getSafeSpy = mockProjectUuidGetSafe({ component: [{ ok: true, id: 'AV-second' }] });
+
+    noteProject(auth(), 'proj-first');
+    noteProject(auth(), 'proj-second');
+
+    expect(await currentProjectUuid()).toBe('AV-second');
+    // Only the superseding key was ever fetched.
+    expect(getSafeSpy).toHaveBeenCalledTimes(1);
+
+    getSafeSpy.mockRestore();
+  });
+
+  it('never rejects when resolution fails, so storeEvent cannot be broken by it', async () => {
+    const getSafeSpy = spyOn(
+      (await import('@/core/server/client.ts')).SonarQubeClient.prototype,
+      'getSafe',
+    ).mockRejectedValue(new Error('network down'));
+
+    noteProject(auth(), 'proj-explodes');
+
+    expect(await currentProjectUuid()).toBeNull();
+    getSafeSpy.mockRestore();
+  });
+});

--- a/tests/unit/core/telemetry/sqaa-analysis-telemetry.test.ts
+++ b/tests/unit/core/telemetry/sqaa-analysis-telemetry.test.ts
@@ -323,4 +323,30 @@ describe('emitSqaaAnalysisTelemetry()', () => {
 
     expect(readAnalysisEvents(testSonarUserHome)).toHaveLength(0);
   });
+
+  it('never throws when identity resolution fails (strictly fire-and-forget)', async () => {
+    // getOrCreateUserId does mkdirSync/openSync and can throw on permission/disk errors.
+    // This is the bundled exception-safety fix: emitSqaaAnalysisTelemetry previously had no
+    // top-level try/catch anywhere in its call chain (see sca-analysis-telemetry.test.ts's
+    // equivalent test for the pattern this mirrors).
+    getUserIdSpy.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+    const tally = makeTally({
+      totalIssues: 1,
+      allResults: [
+        {
+          file: 'src/a.ts',
+          filePath: 'src/a.ts',
+          issues: [makeIssue('sqaa:S1234')],
+          errors: null,
+        },
+      ],
+    });
+
+    // Must resolve, not reject — a telemetry failure must never reach the command handler.
+    await emitSqaaAnalysisTelemetry(SQAA_ANALYZE_AGENTIC_CALLER_COMMAND, AUTH, tally, 100, 51);
+
+    expect(readAnalysisEvents(testSonarUserHome)).toHaveLength(0);
+  });
 });

--- a/tests/unit/core/telemetry/telemetry-events.test.ts
+++ b/tests/unit/core/telemetry/telemetry-events.test.ts
@@ -150,6 +150,7 @@ let loadStateSpy: ReturnType<typeof spyOn>;
 let getConnectionSpy: ReturnType<typeof spyOn>;
 let getUserIdSpy: ReturnType<typeof spyOn>;
 let detectAgentSpy: ReturnType<typeof spyOn>;
+let defaultFetchSpy: ReturnType<typeof spyOn>;
 let savedDoNotTrack: string | undefined;
 
 beforeEach(async () => {
@@ -163,6 +164,12 @@ beforeEach(async () => {
   getConnectionSpy = spyOn(stateManager, 'getActiveConnection').mockReturnValue(undefined);
   getUserIdSpy = spyOn(userModule, 'getOrCreateUserId').mockReturnValue('machine-id');
   detectAgentSpy = spyOn(agentDetector, 'detectCallerAgent').mockReturnValue(null);
+  // Emitting an event with a cloud/server auth but no seeded connection triggers
+  // identity enrichment, which otherwise hits the real network. Stub fetch by
+  // default so no test in this file depends on network reachability (a real call
+  // fails fast locally but hangs to a 5s timeout in CI). Tests that assert on the
+  // telemetry HTTP flush install their own fetch spy, which shadows this one.
+  defaultFetchSpy = mockFetch();
 });
 
 afterEach(async () => {
@@ -176,6 +183,7 @@ afterEach(async () => {
   getConnectionSpy.mockRestore();
   getUserIdSpy.mockRestore();
   detectAgentSpy.mockRestore();
+  defaultFetchSpy.mockRestore();
 
   await rm(testSonarUserHome, { recursive: true, force: true });
   if (previousSonarUserHome === undefined) {
@@ -335,6 +343,7 @@ describe('emitCommandExecuted()', () => {
       subcommand: 'login',
       result: 'success',
       distribution: DISTRIBUTION,
+      project_uuid: null,
     });
 
     const [event] = readCommandEvents(testSonarUserHome);
@@ -346,6 +355,21 @@ describe('emitCommandExecuted()', () => {
     // Identity base is merged in.
     expect(event.event_payload.cli_installation_id).toBe('install-id');
     expect(event.event_payload.machine_id).toBe('machine-id');
+    // No project resolved for this command.
+    expect(event.event_payload.project_uuid).toBeNull();
+  });
+
+  it('carries a resolved project_uuid through for opt-in commands', async () => {
+    await emitCommandExecuted({
+      command: 'analyze',
+      subcommand: 'dependency-risks',
+      result: 'success',
+      distribution: DISTRIBUTION,
+      project_uuid: 'AYmy-projectlegacy',
+    });
+
+    const [event] = readCommandEvents(testSonarUserHome);
+    expect(event.event_payload.project_uuid).toBe('AYmy-projectlegacy');
   });
 
   it('does not append when telemetry is disabled', async () => {
@@ -356,6 +380,7 @@ describe('emitCommandExecuted()', () => {
       subcommand: null,
       result: 'success',
       distribution: DISTRIBUTION,
+      project_uuid: null,
     });
 
     expect(readCommandEvents(testSonarUserHome)).toHaveLength(0);
@@ -371,6 +396,7 @@ describe('emitCommandExecuted()', () => {
       subcommand: null,
       result: 'success',
       distribution: DISTRIBUTION,
+      project_uuid: null,
     });
 
     expect(readCommandEvents(testSonarUserHome)).toHaveLength(0);

--- a/tests/unit/core/update/binary-refresh.test.ts
+++ b/tests/unit/core/update/binary-refresh.test.ts
@@ -81,10 +81,11 @@ describe('updateSecretsBinaryIfNeeded', () => {
     expect(installSecretsBinarySpy).toHaveBeenCalledTimes(1);
   });
 
-  it('propagates errors from installSecretsBinary to the caller', () => {
+  it('propagates errors from installSecretsBinary to the caller', async () => {
     installSecretsBinarySpy.mockRejectedValue(new Error('download failed'));
 
-    expect(updateSecretsBinaryIfNeeded()).rejects.toThrow('download failed');
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable
+    await expect(updateSecretsBinaryIfNeeded()).rejects.toThrow('download failed');
   });
 });
 
@@ -135,9 +136,10 @@ describe('updateScaScannerBinaryIfNeeded', () => {
     expect(installScaScannerBinarySpy).toHaveBeenCalledTimes(1);
   });
 
-  it('propagates errors from installScaScannerBinary to the caller', () => {
+  it('propagates errors from installScaScannerBinary to the caller', async () => {
     installScaScannerBinarySpy.mockRejectedValue(new Error('download failed'));
 
-    expect(updateScaScannerBinaryIfNeeded()).rejects.toThrow('download failed');
+    // eslint-disable-next-line @typescript-eslint/await-thenable -- Bun expect().rejects is awaitable at runtime; typings omit Thenable
+    await expect(updateScaScannerBinaryIfNeeded()).rejects.toThrow('download failed');
   });
 });

--- a/tests/unit/core/update/telemetry-migration.test.ts
+++ b/tests/unit/core/update/telemetry-migration.test.ts
@@ -60,6 +60,7 @@ function makeLegacyCommandEvent(command: string): StoredCommandExecutedEvent {
       subcommand: null,
       result: 'success',
       distribution: DISTRIBUTION,
+      project_uuid: null,
     },
   };
 }


### PR DESCRIPTION
## What

Reports `project_uuid` on the `CliCommandExecuted` telemetry event: SonarQube's legacy internal project id (`projects.uuid`, from `GET /api/navigation/component`). Despite the name it is **not** an RFC-4122 UUID. It behaves identically on SonarQube Cloud and Server.

`CliAnalysisCompleted` and `CliIntegrationConfigured` intentionally do **not** carry the field — every event already shares an `invocation_id`, so they join to the command event on it. One field, one write site.

`project_uuid` is `null` for commands that never resolve a project, for `integrate --global` and project-less integrations, and when resolution fails.

## How

`src/core/telemetry/project-uuid.ts` owns two halves:

- **`resolveProjectUuid(auth, projectKey)`** — cache-then-API. Permanent disk cache (`project-uuid-cache.json`) keyed by `serverUrl::projectKey` rather than by auth fingerprint, since the id belongs to the project, not the caller. A resolved-but-empty response is cached as `null`; transient failures are not cached, so the next run retries. Never rejects, and short-circuits when telemetry is disabled.
- **`noteProject()` / `currentProjectUuid()`** — the project is a per-invocation fact, so it lives in a module-level slot instead of being passed down call signatures. Writes are synchronous and do no I/O; resolution happens once per process, memoized, in the `postAction` hook — off the command's critical path.

`noteProject` is called wherever a project key resolves and auth is in hand (auth supplies the server URL, and the anonymous hook commands resolve it inside the handler):

| Site | Covers |
| --- | --- |
| `analyze/sqaa-auth.ts` — `resolveCloudAuthAndProject` | `analyze`, `analyze agentic`, `verify` |
| `analyze/dependency-risks.ts` | `analyze dependency-risks` |
| `remediate/index.ts` | `remediate` |
| `hook/agent-post-tool-use.ts`, `hook/codex-post-tool-use.ts`, `hook/git-pre-commit.ts` | the three project-bearing hooks |
| `framework/features/install-integration.ts` | every `integrate` subcommand (from the first non-empty `attrs.projectKey`) |

`sonar run mcp` deliberately opts out (comment in place): it starts a long-running server, so its `CliCommandExecuted` only fires at exit, if ever.

## Notes for reviewers

- **`SonarQubeClient.getSafe` gains an optional `timeoutMs`** (default unchanged). The resolver passes 3s instead of the 30s default because resolution runs in `postAction`, after the command has printed its result — a slow server would otherwise look like the CLI hanging at exit, worst in `hook git-pre-commit` where it would stall a commit. The cap is enforced by the fetch's own `AbortSignal`: bounding only the `await` would leave the socket open and keep the process alive anyway.
- **`emitSqaaAnalysisTelemetry` is now wrapped in try/catch**, mirroring `emitScaAnalysisTelemetry`. This is unrelated to `project_uuid` and is included because it is a small safety gap in the same code: it was the only `emit*` path with no exception guard anywhere in its call chain, so a telemetry failure could turn a successful SQAA analysis into a reported command failure.
- **The analysis→command join is 1→N.** Bare `sonar analyze` emits two `CliAnalysisCompleted` rows for one `CliCommandExecuted`, so per-project aggregates must count on the analysis side or `DISTINCT` on `invocation_id`.
- `project_uuid` is written on the last event of a run, so a hard `process.exit()` before `postAction` would lose it for the whole invocation. No current path does this with a project in scope.
- Tests must call `resetProjectUuidContextForTests()` in `beforeEach` — module state outlives individual tests in the same file.

## Testing

Unit tests cover the resolver (cache hit/miss, transient vs confirmed-absent caching, telemetry-disabled short-circuit) and the ambient context (memoization to one API call per process, a later note superseding an earlier one, never rejecting on failure).

Integration tests assert `project_uuid` on `CliCommandExecuted` — and `invocation_id` equality with the analysis event — across the analyze, hook, remediate and integrate paths, plus `null` for a secrets-only `git-pre-commit`.

Also verified manually against SonarQube Cloud on every note site except `remediate`, including auto-detection with no explicit `--project`.
