### PR TITLE
CLI-865 Mention env var auth fallback in keychain-unavailable error message

### DIFF
--- a/src/core/host/keychain.ts
+++ b/src/core/host/keychain.ts
@@ -40,7 +40,9 @@ const tokenCache = new Map<string, string | null>();
 
 const KEYCHAIN_UNAVAILABLE_MESSAGE = 'Failed to access the system keychain.';
 const KEYCHAIN_UNAVAILABLE_HINT =
-  "Make sure your system's keychain or credential manager is available and unlocked, then try again.";
+  "Make sure your system's keychain or credential manager is available and unlocked, then try again. " +
+  'Alternatively, authenticate via environment variables instead of the keychain: SONARQUBE_CLI_TOKEN ' +
+  'plus either SONARQUBE_CLI_SERVER (SonarQube Server) or SONARQUBE_CLI_ORG (SonarQube Cloud).';
 
 async function wrapBunSecrets<T>(operation: () => Promise<T>): Promise<T> {
   try {

--- a/tests/unit/core/host/keychain.test.ts
+++ b/tests/unit/core/host/keychain.test.ts
@@ -29,8 +29,9 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
+import { CommandFailedError } from '@/core/command-error.ts';
 import {
   clearTokenCache,
   deleteStaleTokens,
@@ -285,5 +286,45 @@ describe('file backend edge cases', () => {
     expect(await getToken('https://sonarcloud.io', 'org1')).toBe('tok-alt');
 
     rmSync(altDir, { recursive: true, force: true });
+  });
+});
+
+describe('OS keychain unavailable (Bun.secrets backend)', () => {
+  let savedKeychainFile: string | undefined;
+
+  beforeEach(() => {
+    savedKeychainFile = process.env.SONARQUBE_CLI_KEYCHAIN_FILE;
+    delete process.env.SONARQUBE_CLI_KEYCHAIN_FILE;
+    clearTokenCache();
+  });
+
+  afterEach(() => {
+    if (savedKeychainFile !== undefined) {
+      process.env.SONARQUBE_CLI_KEYCHAIN_FILE = savedKeychainFile;
+    }
+    clearTokenCache();
+  });
+
+  it('surfaces a remediation hint mentioning env var auth when the OS keychain is unreachable', async () => {
+    const getSpy = spyOn(Bun.secrets, 'get').mockRejectedValue(new Error('D-Bus not available'));
+
+    try {
+      let caught: unknown;
+      try {
+        await getToken('https://sonarcloud.io', 'my-org');
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(CommandFailedError);
+      const commandFailedError = caught as CommandFailedError;
+      expect(commandFailedError.message).toContain('Failed to access the system keychain.');
+      expect(commandFailedError.message).toContain('D-Bus not available');
+      expect(commandFailedError.remediationHint).toContain('SONARQUBE_CLI_TOKEN');
+      expect(commandFailedError.remediationHint).toContain('SONARQUBE_CLI_SERVER');
+      expect(commandFailedError.remediationHint).toContain('SONARQUBE_CLI_ORG');
+    } finally {
+      getSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
----
## Summary by Gitar

- **Error Handling:**
    - Updated keychain unavailable error message in `keychain.ts` to suggest environment variable authentication fallback.
- **Tests:**
    - Added unit tests in `keychain.test.ts` verifying the remediation hint includes environment variable instructions.

<sub>This will update automatically on new commits.</sub>