### PR TITLE
CLI-876 Add feature replacement migration to post-update

### DIFF
--- a/src/core/framework/features/index.ts
+++ b/src/core/framework/features/index.ts
@@ -90,6 +90,7 @@ export type {
   AppliedResource,
   ContainerIntegrationContext,
   DependencyInstallContext,
+  FeatureApplication,
   FeatureContainer,
   FeatureDeclaration,
   FeatureOperation,

--- a/src/core/framework/features/registry.ts
+++ b/src/core/framework/features/registry.ts
@@ -49,6 +49,7 @@ export class IntegrationRegistry {
     for (const feature of declaration.features) {
       this.validateFeature(declaration, feature);
     }
+    this.validateReplacements(declaration);
     this.ensureUnique(
       (declaration.legacyFeatures ?? []).map((feature) => feature.id),
       `Duplicate legacy feature id in integration ${declaration.id}`,
@@ -56,6 +57,28 @@ export class IntegrationRegistry {
     for (const legacyFeature of declaration.legacyFeatures ?? []) {
       this.ensureNonEmptyId(legacyFeature.id, 'Legacy feature');
     }
+  }
+
+  private validateReplacements(declaration: IntegrationDeclaration): void {
+    const featureIds = new Set(declaration.features.map((feature) => feature.id));
+    const replacedIds: string[] = [];
+
+    for (const feature of declaration.features) {
+      for (const replacedId of feature.replaces ?? []) {
+        this.ensureNonEmptyId(replacedId, 'Replaced feature');
+        if (featureIds.has(replacedId)) {
+          throw new Error(
+            `Feature ${declaration.id}.${feature.id} replaces an active feature id: ${replacedId}`,
+          );
+        }
+        replacedIds.push(replacedId);
+      }
+    }
+
+    this.ensureUnique(
+      replacedIds,
+      `Duplicate replaced feature id in integration ${declaration.id}`,
+    );
   }
 
   private validateFeature(declaration: IntegrationDeclaration, feature: FeatureDeclaration): void {

--- a/src/core/framework/features/registry.ts
+++ b/src/core/framework/features/registry.ts
@@ -64,7 +64,7 @@ export class IntegrationRegistry {
     const replacedIds: string[] = [];
 
     for (const feature of declaration.features) {
-      for (const replacedId of feature.replaces ?? []) {
+      for (const replacedId of feature.replacedIds ?? []) {
         this.ensureNonEmptyId(replacedId, 'Replaced feature');
         if (featureIds.has(replacedId)) {
           throw new Error(

--- a/src/core/framework/features/types.ts
+++ b/src/core/framework/features/types.ts
@@ -121,6 +121,11 @@ export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
   dependencies?: DependencyDeclaration[];
   resources?: ResourceDeclaration[];
   operations?: FeatureOperation[];
+  /**
+   * Ids of retired features of the same integration that this feature supersedes.
+   * Post-update migrates each recorded predecessor install into this feature.
+   */
+  replaces?: string[];
   legacyCleanups?: (ResourceIdentity & RemovableResource)[];
   /**
    * Optional "try it out" example rendered by the framework completion summary

--- a/src/core/framework/features/types.ts
+++ b/src/core/framework/features/types.ts
@@ -125,7 +125,7 @@ export interface FeatureDeclaration<TOptions = Record<string, unknown>> {
    * Ids of retired features of the same integration that this feature supersedes.
    * Post-update migrates each recorded predecessor install into this feature.
    */
-  replaces?: string[];
+  replacedIds?: string[];
   legacyCleanups?: (ResourceIdentity & RemovableResource)[];
   /**
    * Optional "try it out" example rendered by the framework completion summary

--- a/src/core/host/post-update.ts
+++ b/src/core/host/post-update.ts
@@ -41,6 +41,7 @@ import logger from '../observability/logger.ts';
 import type {
   CliState,
   HookExtension,
+  InstalledIntegration,
   InstalledIntegrationFeature,
   IntegrationStateAttribute,
 } from '../state/state.ts';
@@ -182,37 +183,13 @@ export async function migrateDeclarativeIntegrations(registry: IntegrationRegist
     if (!installedIntegration) {
       continue;
     }
-
-    const replacementApplications = migrateReplacedFeatures(
+    const { applications, removedUnknownFeatures } = createMigrationFeatureApplications(
       integration,
-      installedIntegration.features,
+      installedIntegration,
     );
-
-    const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
-    const knownFeatures = installedIntegration.features.filter((feature) =>
-      featuresById.has(feature.featureId),
-    );
-
-    if (knownFeatures.length !== installedIntegration.features.length) {
-      installedIntegration.features = knownFeatures;
+    if (removedUnknownFeatures) {
       stateChanged = true;
     }
-
-    const applications: FeatureApplication[] = [];
-    for (const installedFeature of knownFeatures) {
-      const application = createFeatureMigrationApplication(
-        featuresById,
-        installedFeature.featureId,
-        installedFeature.subfeatures?.map((subfeature) => subfeature.featureId),
-        installedFeature.targetRoot,
-        installedFeature.scope,
-        installedFeature.attrs,
-      );
-      if (application) {
-        applications.push(application);
-      }
-    }
-    applications.push(...replacementApplications);
 
     try {
       const installedFeatures = await integrationInstaller.applyAndRecordFeatures(
@@ -242,13 +219,50 @@ export async function migrateDeclarativeIntegrations(registry: IntegrationRegist
   }
 }
 
+function createMigrationFeatureApplications(
+  integration: IntegrationDeclaration,
+  installedIntegration: InstalledIntegration,
+): { applications: FeatureApplication[]; removedUnknownFeatures: boolean } {
+  const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
+  const replacementApplications = migrateReplacedFeatures(
+    integration,
+    featuresById,
+    installedIntegration.features,
+  );
+  const knownFeatures = installedIntegration.features.filter((feature) =>
+    featuresById.has(feature.featureId),
+  );
+  const removedUnknownFeatures = knownFeatures.length !== installedIntegration.features.length;
+  if (removedUnknownFeatures) {
+    installedIntegration.features = knownFeatures;
+  }
+
+  const applications: FeatureApplication[] = [];
+  for (const installedFeature of knownFeatures) {
+    const application = createFeatureApplication(
+      featuresById,
+      installedFeature.featureId,
+      installedFeature.subfeatures?.map((subfeature) => subfeature.featureId),
+      installedFeature.targetRoot,
+      installedFeature.scope,
+      installedFeature.attrs,
+    );
+    if (application) {
+      applications.push(application);
+    }
+  }
+  applications.push(...replacementApplications);
+
+  return { applications, removedUnknownFeatures };
+}
+
 function migrateReplacedFeatures(
   integration: IntegrationDeclaration,
+  featuresById: Map<string, FeatureDeclaration>,
   installedFeatures: InstalledIntegrationFeature[],
 ): FeatureApplication[] {
   const applications: FeatureApplication[] = [];
 
-  const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
   for (const successor of integration.features) {
     const predecessorsByTarget = groupReplacedFeaturesByTarget(successor, installedFeatures);
 
@@ -263,7 +277,7 @@ function migrateReplacedFeatures(
       if (hasRecordedSuccessor) {
         continue;
       }
-      const application = createFeatureMigrationApplication(
+      const application = createFeatureApplication(
         featuresById,
         successor.id,
         undefined,
@@ -286,7 +300,7 @@ function groupReplacedFeaturesByTarget(
 ): Map<string, InstalledIntegrationFeature[]> {
   const predecessorsByTarget = new Map<string, InstalledIntegrationFeature[]>();
 
-  for (const replacedId of successor.replaces ?? []) {
+  for (const replacedId of successor.replacedIds ?? []) {
     for (const installedFeature of installedFeatures) {
       if (installedFeature.featureId !== replacedId) {
         continue;
@@ -335,7 +349,7 @@ function getFeature(
   return applicationFeature;
 }
 
-function createFeatureMigrationApplication(
+function createFeatureApplication(
   featuresById: Map<string, FeatureDeclaration>,
   featureId: string,
   subfeatureIds: string[] | undefined,

--- a/src/core/host/post-update.ts
+++ b/src/core/host/post-update.ts
@@ -284,19 +284,20 @@ function groupReplacedFeaturesByTarget(
   successor: FeatureDeclaration,
   installedFeatures: InstalledIntegrationFeature[],
 ): Map<string, InstalledIntegrationFeature[]> {
-  const replacedIds = new Set(successor.replaces ?? []);
   const predecessorsByTarget = new Map<string, InstalledIntegrationFeature[]>();
 
-  for (const installedFeature of installedFeatures) {
-    if (!replacedIds.has(installedFeature.featureId)) {
-      continue;
-    }
-    const targetKey = `${installedFeature.scope}:${installedFeature.targetRoot}`;
-    const predecessors = predecessorsByTarget.get(targetKey);
-    if (predecessors) {
-      predecessors.push(installedFeature);
-    } else {
-      predecessorsByTarget.set(targetKey, [installedFeature]);
+  for (const replacedId of successor.replaces ?? []) {
+    for (const installedFeature of installedFeatures) {
+      if (installedFeature.featureId !== replacedId) {
+        continue;
+      }
+      const targetKey = `${installedFeature.scope}:${installedFeature.targetRoot}`;
+      const predecessors = predecessorsByTarget.get(targetKey);
+      if (predecessors) {
+        predecessors.push(installedFeature);
+      } else {
+        predecessorsByTarget.set(targetKey, [installedFeature]);
+      }
     }
   }
   return predecessorsByTarget;

--- a/src/core/host/post-update.ts
+++ b/src/core/host/post-update.ts
@@ -23,8 +23,10 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  type FeatureApplication,
   type FeatureDeclaration,
   findInstalledIntegration,
+  type IntegrationDeclaration,
   integrationInstaller,
   type IntegrationRegistry,
   isFeatureContainer,
@@ -36,7 +38,12 @@ import { appendTelemetryEvent } from '@/core/telemetry/telemetry-events.ts';
 import { version as CURRENT_VERSION } from '../../../package.json';
 import { getTelemetryDir } from '../config-constants.ts';
 import logger from '../observability/logger.ts';
-import type { CliState, HookExtension, InstalledIntegrationFeature } from '../state/state.ts';
+import type {
+  CliState,
+  HookExtension,
+  InstalledIntegrationFeature,
+  IntegrationStateAttribute,
+} from '../state/state.ts';
 import { loadState, saveState, stateFileExists, tryLoadState } from '../state/state-repository.ts';
 import { isNewerVersion } from '../version.ts';
 import { SCA_SCANNER_BINARY_NAME, SECRETS_BINARY_NAME } from './install-types.ts';
@@ -176,6 +183,11 @@ export async function migrateDeclarativeIntegrations(registry: IntegrationRegist
       continue;
     }
 
+    const replacementApplications = migrateReplacedFeatures(
+      integration,
+      installedIntegration.features,
+    );
+
     const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
     const knownFeatures = installedIntegration.features.filter((feature) =>
       featuresById.has(feature.featureId),
@@ -186,27 +198,21 @@ export async function migrateDeclarativeIntegrations(registry: IntegrationRegist
       stateChanged = true;
     }
 
-    const applications = [];
+    const applications: FeatureApplication[] = [];
     for (const installedFeature of knownFeatures) {
-      const feature = getFeature(featuresById, installedFeature);
-      if (!feature) {
-        continue;
+      const application = createFeatureMigrationApplication(
+        featuresById,
+        installedFeature.featureId,
+        installedFeature.subfeatures?.map((subfeature) => subfeature.featureId),
+        installedFeature.targetRoot,
+        installedFeature.scope,
+        installedFeature.attrs,
+      );
+      if (application) {
+        applications.push(application);
       }
-
-      if (installedFeature.scope === 'project' && !fs.existsSync(installedFeature.targetRoot)) {
-        logger.debug(
-          `Declarative migration skipped for ${integration.id}.${installedFeature.featureId}: target root no longer exists: ${installedFeature.targetRoot}`,
-        );
-        continue;
-      }
-
-      applications.push({
-        feature: feature,
-        targetRoot: installedFeature.targetRoot,
-        scope: installedFeature.scope,
-        attrs: installedFeature.attrs,
-      });
     }
+    applications.push(...replacementApplications);
 
     try {
       const installedFeatures = await integrationInstaller.applyAndRecordFeatures(
@@ -236,22 +242,89 @@ export async function migrateDeclarativeIntegrations(registry: IntegrationRegist
   }
 }
 
+function migrateReplacedFeatures(
+  integration: IntegrationDeclaration,
+  installedFeatures: InstalledIntegrationFeature[],
+): FeatureApplication[] {
+  const applications: FeatureApplication[] = [];
+
+  const featuresById = new Map(integration.features.map((feature) => [feature.id, feature]));
+  for (const successor of integration.features) {
+    const predecessorsByTarget = groupReplacedFeaturesByTarget(successor, installedFeatures);
+
+    for (const predecessors of predecessorsByTarget.values()) {
+      const { scope, targetRoot } = predecessors[0];
+      const hasRecordedSuccessor = installedFeatures.some(
+        (feature) =>
+          feature.featureId === successor.id &&
+          feature.scope === scope &&
+          feature.targetRoot === targetRoot,
+      );
+      if (hasRecordedSuccessor) {
+        continue;
+      }
+      const application = createFeatureMigrationApplication(
+        featuresById,
+        successor.id,
+        undefined,
+        targetRoot,
+        scope,
+        mergeFeatureAttrs(predecessors),
+      );
+      if (application) {
+        applications.push(application);
+      }
+    }
+  }
+
+  return applications;
+}
+
+function groupReplacedFeaturesByTarget(
+  successor: FeatureDeclaration,
+  installedFeatures: InstalledIntegrationFeature[],
+): Map<string, InstalledIntegrationFeature[]> {
+  const replacedIds = new Set(successor.replaces ?? []);
+  const predecessorsByTarget = new Map<string, InstalledIntegrationFeature[]>();
+
+  for (const installedFeature of installedFeatures) {
+    if (!replacedIds.has(installedFeature.featureId)) {
+      continue;
+    }
+    const targetKey = `${installedFeature.scope}:${installedFeature.targetRoot}`;
+    const predecessors = predecessorsByTarget.get(targetKey);
+    if (predecessors) {
+      predecessors.push(installedFeature);
+    } else {
+      predecessorsByTarget.set(targetKey, [installedFeature]);
+    }
+  }
+  return predecessorsByTarget;
+}
+
+function mergeFeatureAttrs(
+  features: InstalledIntegrationFeature[],
+): Record<string, IntegrationStateAttribute> | undefined {
+  const attrs = features.reduce<Record<string, IntegrationStateAttribute>>(
+    (merged, feature) => ({ ...merged, ...feature.attrs }),
+    {},
+  );
+  return Object.keys(attrs).length > 0 ? attrs : undefined;
+}
+
 function getFeature(
   featuresById: Map<string, FeatureDeclaration>,
-  installedFeature: InstalledIntegrationFeature,
+  featureId: string,
+  subfeatureIds: string[] | undefined,
 ): FeatureDeclaration | undefined {
-  const feature = featuresById.get(installedFeature.featureId);
+  const feature = featuresById.get(featureId);
   if (!feature) {
     return undefined;
   }
 
   let applicationFeature = feature;
   if (isFeatureContainer(feature)) {
-    const activeIds = new Set(
-      installedFeature.subfeatures !== undefined
-        ? installedFeature.subfeatures.map((s) => s.featureId)
-        : feature.defaultInstallSubfeatureIds,
-    );
+    const activeIds = new Set(subfeatureIds ?? feature.defaultInstallSubfeatureIds);
     const filteredContainer = {
       ...feature,
       subfeatures: feature.subfeatures.filter((s) => activeIds.has(s.id)),
@@ -259,6 +332,29 @@ function getFeature(
     applicationFeature = filteredContainer;
   }
   return applicationFeature;
+}
+
+function createFeatureMigrationApplication(
+  featuresById: Map<string, FeatureDeclaration>,
+  featureId: string,
+  subfeatureIds: string[] | undefined,
+  targetRoot: string,
+  scope: InstalledIntegrationFeature['scope'],
+  attrs: InstalledIntegrationFeature['attrs'],
+): FeatureApplication | undefined {
+  const feature = getFeature(featuresById, featureId, subfeatureIds);
+  if (!feature) {
+    return undefined;
+  }
+
+  if (scope === 'project' && !fs.existsSync(targetRoot)) {
+    logger.debug(
+      `Declarative migration skipped for ${featureId}: target root no longer exists: ${targetRoot}`,
+    );
+    return undefined;
+  }
+
+  return { feature, targetRoot, scope, attrs };
 }
 
 /**

--- a/tests/unit/core/framework/features/registry.test.ts
+++ b/tests/unit/core/framework/features/registry.test.ts
@@ -255,7 +255,7 @@ describe('declarative integration framework', () => {
     ).toThrow('Legacy feature id must not be empty');
   });
 
-  // Feature replacement (`replaces`) :O
+  // Feature replacement (`replacedIds`) :O
 
   const expectReplacementRejected = (features: FeatureDeclaration[], expectedError: string) =>
     expect(() =>
@@ -264,7 +264,7 @@ describe('declarative integration framework', () => {
 
   it('rejects empty replaced feature ids', () => {
     expectReplacementRejected(
-      [{ id: 'vortex', displayName: 'Vortex', replaces: [' '] }],
+      [{ id: 'vortex', displayName: 'Vortex', replacedIds: [' '] }],
       'Replaced feature id must not be empty',
     );
   });
@@ -272,14 +272,14 @@ describe('declarative integration framework', () => {
   it('rejects replacing an active feature id, including the feature itself', () => {
     expectReplacementRejected(
       [
-        { id: 'vortex', displayName: 'Vortex', replaces: ['sqaa-instructions'] },
+        { id: 'vortex', displayName: 'Vortex', replacedIds: ['sqaa-instructions'] },
         { id: 'sqaa-instructions', displayName: 'SQAA instructions' },
       ],
       'Feature claude-code.vortex replaces an active feature id: sqaa-instructions',
     );
 
     expectReplacementRejected(
-      [{ id: 'vortex', displayName: 'Vortex', replaces: ['vortex'] }],
+      [{ id: 'vortex', displayName: 'Vortex', replacedIds: ['vortex'] }],
       'Feature claude-code.vortex replaces an active feature id: vortex',
     );
   });
@@ -289,37 +289,43 @@ describe('declarative integration framework', () => {
 
     expectReplacementRejected(
       [
-        { id: 'vortex-sqaa', displayName: 'Vortex SQAA', replaces: ['context-augmentation'] },
-        { id: 'vortex-cag', displayName: 'Vortex CAG', replaces: ['context-augmentation'] },
+        { id: 'vortex-sqaa', displayName: 'Vortex SQAA', replacedIds: ['context-augmentation'] },
+        { id: 'vortex-cag', displayName: 'Vortex CAG', replacedIds: ['context-augmentation'] },
       ],
       duplicateClaim,
     );
 
     expectReplacementRejected(
-      [{ id: 'vortex', displayName: 'Vortex', replaces: ['sonar-sqaa-hook', 'sonar-sqaa-hook'] }],
+      [
+        {
+          id: 'vortex',
+          displayName: 'Vortex',
+          replacedIds: ['sonar-sqaa-hook', 'sonar-sqaa-hook'],
+        },
+      ],
       duplicateClaim,
     );
   });
 
   it('accepts the same replaced feature ids in different agent integrations', () => {
     const registry = new IntegrationRegistry();
-    const replaces = ['sonar-sqaa-hook', 'sqaa-instructions', 'context-augmentation'];
+    const replacedIds = ['sonar-sqaa-hook', 'sqaa-instructions', 'context-augmentation'];
 
     registry.register(
       makeIntegration({
         id: 'claude-code',
-        features: [{ id: 'vortex', displayName: 'Vortex', replaces }],
+        features: [{ id: 'vortex', displayName: 'Vortex', replacedIds }],
       }),
     );
     registry.register(
       makeIntegration({
         id: 'copilot-cli',
-        features: [{ id: 'vortex', displayName: 'Vortex', replaces }],
+        features: [{ id: 'vortex', displayName: 'Vortex', replacedIds }],
       }),
     );
 
-    expect(registry.get('claude-code')?.features[0].replaces).toEqual(replaces);
-    expect(registry.get('copilot-cli')?.features[0].replaces).toEqual(replaces);
+    expect(registry.get('claude-code')?.features[0].replacedIds).toEqual(replacedIds);
+    expect(registry.get('copilot-cli')?.features[0].replacedIds).toEqual(replacedIds);
   });
 
   it('rejects duplicate and empty subfeature ids in a FeatureContainer', () => {

--- a/tests/unit/core/framework/features/registry.test.ts
+++ b/tests/unit/core/framework/features/registry.test.ts
@@ -255,6 +255,73 @@ describe('declarative integration framework', () => {
     ).toThrow('Legacy feature id must not be empty');
   });
 
+  // Feature replacement (`replaces`) :O
+
+  const expectReplacementRejected = (features: FeatureDeclaration[], expectedError: string) =>
+    expect(() =>
+      new IntegrationRegistry().register(makeIntegration({ id: 'claude-code', features })),
+    ).toThrow(expectedError);
+
+  it('rejects empty replaced feature ids', () => {
+    expectReplacementRejected(
+      [{ id: 'vortex', displayName: 'Vortex', replaces: [' '] }],
+      'Replaced feature id must not be empty',
+    );
+  });
+
+  it('rejects replacing an active feature id, including the feature itself', () => {
+    expectReplacementRejected(
+      [
+        { id: 'vortex', displayName: 'Vortex', replaces: ['sqaa-instructions'] },
+        { id: 'sqaa-instructions', displayName: 'SQAA instructions' },
+      ],
+      'Feature claude-code.vortex replaces an active feature id: sqaa-instructions',
+    );
+
+    expectReplacementRejected(
+      [{ id: 'vortex', displayName: 'Vortex', replaces: ['vortex'] }],
+      'Feature claude-code.vortex replaces an active feature id: vortex',
+    );
+  });
+
+  it('rejects the same replaced feature id claimed twice in one integration', () => {
+    const duplicateClaim = 'Duplicate replaced feature id in integration claude-code';
+
+    expectReplacementRejected(
+      [
+        { id: 'vortex-sqaa', displayName: 'Vortex SQAA', replaces: ['context-augmentation'] },
+        { id: 'vortex-cag', displayName: 'Vortex CAG', replaces: ['context-augmentation'] },
+      ],
+      duplicateClaim,
+    );
+
+    expectReplacementRejected(
+      [{ id: 'vortex', displayName: 'Vortex', replaces: ['sonar-sqaa-hook', 'sonar-sqaa-hook'] }],
+      duplicateClaim,
+    );
+  });
+
+  it('accepts the same replaced feature ids in different agent integrations', () => {
+    const registry = new IntegrationRegistry();
+    const replaces = ['sonar-sqaa-hook', 'sqaa-instructions', 'context-augmentation'];
+
+    registry.register(
+      makeIntegration({
+        id: 'claude-code',
+        features: [{ id: 'vortex', displayName: 'Vortex', replaces }],
+      }),
+    );
+    registry.register(
+      makeIntegration({
+        id: 'copilot-cli',
+        features: [{ id: 'vortex', displayName: 'Vortex', replaces }],
+      }),
+    );
+
+    expect(registry.get('claude-code')?.features[0].replaces).toEqual(replaces);
+    expect(registry.get('copilot-cli')?.features[0].replaces).toEqual(replaces);
+  });
+
   it('rejects duplicate and empty subfeature ids in a FeatureContainer', () => {
     const registry = new IntegrationRegistry();
 

--- a/tests/unit/core/host/post-update.test.ts
+++ b/tests/unit/core/host/post-update.test.ts
@@ -903,7 +903,7 @@ describe('migrateDeclarativeIntegrations', () => {
         {
           id: 'vortex',
           displayName: 'Vortex',
-          replaces: ['old-sqaa', 'old-context'],
+          replacedIds: ['old-sqaa', 'old-context'],
           operations: [
             {
               id: 'vortex-operation',
@@ -953,7 +953,7 @@ describe('migrateDeclarativeIntegrations', () => {
         {
           id: 'vortex',
           displayName: 'Vortex',
-          replaces: ['old-sqaa', 'old-context'],
+          replacedIds: ['old-sqaa', 'old-context'],
           operations: [
             {
               id: 'vortex-operation',
@@ -996,7 +996,7 @@ describe('migrateDeclarativeIntegrations', () => {
         {
           id: 'vortex',
           displayName: 'Vortex',
-          replaces: ['old-context'],
+          replacedIds: ['old-context'],
           operations: [
             {
               id: 'vortex-operation',

--- a/tests/unit/core/host/post-update.test.ts
+++ b/tests/unit/core/host/post-update.test.ts
@@ -51,7 +51,12 @@ import {
   updateScaScannerBinaryIfNeeded,
   updateSecretsBinaryIfNeeded,
 } from '@/core/host/post-update.ts';
-import type { CliState, HookExtension, StoredCommandExecutedEvent } from '@/core/state/state.ts';
+import type {
+  CliState,
+  HookExtension,
+  InstalledIntegrationFeature,
+  StoredCommandExecutedEvent,
+} from '@/core/state/state.ts';
 import { getDefaultState } from '@/core/state/state.ts';
 import * as stateRepository from '@/core/state/state-repository.ts';
 import * as telemetryEvents from '@/core/telemetry/telemetry-events.ts';
@@ -350,6 +355,26 @@ describe('migrateDeclarativeIntegrations', () => {
     saveStateSpy.mockRestore();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
+
+  function recordedFeature(
+    featureId: string,
+    attrs?: InstalledIntegrationFeature['attrs'],
+  ): InstalledIntegrationFeature {
+    const now = '2026-01-01T00:00:00.000Z';
+    return {
+      featureId,
+      scope: 'project',
+      targetRoot: tempDir,
+      installedByCliVersion: '0.9.0',
+      installedAt: now,
+      updatedByCliVersion: '0.9.0',
+      updatedAt: now,
+      dependencies: [],
+      resources: [],
+      operations: [],
+      attrs,
+    };
+  }
 
   it('reapplies only installed declarative features and prunes unknown feature state', async () => {
     const operationCalls: string[] = [];
@@ -851,6 +876,101 @@ describe('migrateDeclarativeIntegrations', () => {
 
     const savedFeature = saveStateSpy.mock.calls[0][0].integrations.installed[0].features[0];
     expect(savedFeature.subfeatures).toBeUndefined();
+  });
+
+  it('migrates replaced features into one successor with merged attrs', async () => {
+    const appliedAttrs: (IntegrationContext['attrs'] | undefined)[] = [];
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedByCliVersion: '0.9.0',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      features: [
+        recordedFeature('old-sqaa', { projectKey: 'project-key' }),
+        recordedFeature('old-context', { orgKey: 'org-key', scaEnabled: true }),
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [
+        {
+          id: 'vortex',
+          displayName: 'Vortex',
+          replaces: ['old-sqaa', 'old-context'],
+          operations: [
+            {
+              id: 'vortex-operation',
+              apply: (context) => {
+                appliedAttrs.push(context.attrs);
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(appliedAttrs).toEqual([
+      { projectKey: 'project-key', orgKey: 'org-key', scaEnabled: true },
+    ]);
+    expect(state.integrations.installed[0].features).toHaveLength(1);
+    expect(state.integrations.installed[0].features[0]).toMatchObject({
+      featureId: 'vortex',
+      attrs: { projectKey: 'project-key', orgKey: 'org-key', scaEnabled: true },
+    });
+  });
+
+  it('reapplies a recorded successor without merging predecessor attrs', async () => {
+    const appliedAttrs: (IntegrationContext['attrs'] | undefined)[] = [];
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedByCliVersion: '0.9.0',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      features: [
+        recordedFeature('old-context', { orgKey: 'old-org' }),
+        recordedFeature('vortex', { projectKey: 'project-key' }),
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [
+        {
+          id: 'vortex',
+          displayName: 'Vortex',
+          replaces: ['old-context'],
+          operations: [
+            {
+              id: 'vortex-operation',
+              apply: (context) => {
+                appliedAttrs.push(context.attrs);
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(appliedAttrs).toEqual([{ projectKey: 'project-key' }]);
+    expect(state.integrations.installed[0].features).toHaveLength(1);
+    expect(state.integrations.installed[0].features[0].featureId).toBe('vortex');
   });
 });
 

--- a/tests/unit/core/host/post-update.test.ts
+++ b/tests/unit/core/host/post-update.test.ts
@@ -928,6 +928,49 @@ describe('migrateDeclarativeIntegrations', () => {
     });
   });
 
+  it('merges predecessor attrs in successor replacement order', async () => {
+    const appliedAttrs: (IntegrationContext['attrs'] | undefined)[] = [];
+    const state = makeState();
+    state.integrations.installed.push({
+      id: 'integration-id',
+      integrationId: 'test-integration',
+      installedByCliVersion: '0.9.0',
+      installedAt: '2026-01-01T00:00:00.000Z',
+      updatedByCliVersion: '0.9.0',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      features: [
+        recordedFeature('old-context', { projectKey: 'context-project' }),
+        recordedFeature('old-sqaa', { projectKey: 'sqaa-project' }),
+      ],
+    });
+    loadStateSpy.mockReturnValue(state);
+
+    const registry = new IntegrationRegistry();
+    registry.register({
+      id: 'test-integration',
+      displayName: 'Test integration',
+      features: [
+        {
+          id: 'vortex',
+          displayName: 'Vortex',
+          replaces: ['old-sqaa', 'old-context'],
+          operations: [
+            {
+              id: 'vortex-operation',
+              apply: (context) => {
+                appliedAttrs.push(context.attrs);
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    await migrateDeclarativeIntegrations(registry);
+
+    expect(appliedAttrs).toEqual([{ projectKey: 'context-project' }]);
+  });
+
   it('reapplies a recorded successor without merging predecessor attrs', async () => {
     const appliedAttrs: (IntegrationContext['attrs'] | undefined)[] = [];
     const state = makeState();


### PR DESCRIPTION
----
## Summary by Gitar

- **Migrations:**
    - Added feature replacement migration to post-update handling via `replaces` declarations
    - Merged predecessor attribute values when migrating replaced features into successors
- **Framework:**
    - Added validation rules in `IntegrationRegistry` to reject invalid feature replacements

<sub>This will update automatically on new commits.</sub>