### PR TITLE
CLI-798 Rename CAG+SQAA consistently to Vortex

### DIFF
--- a/src/commands/analyze/sqaa-api.ts
+++ b/src/commands/analyze/sqaa-api.ts
@@ -213,7 +213,7 @@ async function with503Retry<T>(
     }
   }
   throw new CommandFailedError(
-    `SonarQube Agentic Analysis failed after ${MAX_503_RETRIES} retries. The service is still unavailable.`,
+    `Vortex analysis failed after ${MAX_503_RETRIES} retries. The service is still unavailable.`,
     { cause: lastServiceError },
   );
 }

--- a/src/commands/analyze/sqaa-auth.ts
+++ b/src/commands/analyze/sqaa-auth.ts
@@ -111,15 +111,12 @@ export function resolveCloudAuth(
 ): CloudAuth | null {
   if (auth.connectionType != 'cloud' || auth.orgKey == null) {
     if (explicitProject) {
-      throw new CommandFailedError(
-        'Vortex agentic analysis requires a SonarQube Cloud connection.',
-        {
-          remediationHint: "Run 'sonar auth login' and connect to SonarQube Cloud, then retry.",
-        },
-      );
+      throw new CommandFailedError('Vortex analysis requires a SonarQube Cloud connection.', {
+        remediationHint: "Run 'sonar auth login' and connect to SonarQube Cloud, then retry.",
+      });
     }
     warn(
-      'Vortex agentic analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
+      'Vortex analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
     );
     return null;
   }
@@ -153,13 +150,13 @@ export async function resolveSqaaProjectKey(projectRoot?: string): Promise<strin
 
     const projectKey = sqaaFeature?.attrs?.projectKey;
     if (typeof projectKey !== 'string' || projectKey.length === 0) {
-      logger.debug('Vortex agentic analysis skipped: no project key found in integration state');
+      logger.debug('Vortex analysis skipped: no project key found in integration state');
       return null;
     }
 
     return projectKey;
   } catch {
-    logger.debug('Vortex agentic analysis skipped: failed to resolve integration state');
+    logger.debug('Vortex analysis skipped: failed to resolve integration state');
     return null;
   }
 }

--- a/src/commands/analyze/sqaa-context.ts
+++ b/src/commands/analyze/sqaa-context.ts
@@ -63,7 +63,7 @@ export function resolveSqaaContext(
     case 'no-project':
       if (policy.requireProject) {
         throw new CommandFailedError(
-          'Vortex agentic analysis requires a project, but none is configured for this directory.',
+          'Vortex analysis requires a project, but none is configured for this directory.',
           {
             remediationHint:
               "Specify one with --project, or run 'sonar integrate' to configure this project.",
@@ -71,7 +71,7 @@ export function resolveSqaaContext(
         );
       }
       warn(
-        'Vortex agentic analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
+        'Vortex analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
       );
       return null;
   }

--- a/src/commands/analyze/sqaa-errors.ts
+++ b/src/commands/analyze/sqaa-errors.ts
@@ -27,7 +27,7 @@ const GENERIC_SQAA_FAILURE_HINT =
   'Check your SonarQube Cloud authentication, project key, and network connectivity, then retry.';
 
 /** Shown on command-level failures; stripped from per-file ✗ rows in sqaa-display. */
-export const SQAA_FAILURE_HEADING = 'SonarQube Agentic Analysis failed.';
+export const SQAA_FAILURE_HEADING = 'Vortex analysis failed.';
 
 export function sqaaFailureMessage(detail: string): string {
   return `${SQAA_FAILURE_HEADING} ${detail}`;

--- a/src/commands/analyze/sqaa.ts
+++ b/src/commands/analyze/sqaa.ts
@@ -199,13 +199,13 @@ async function analyzeSqaaChangeSet(params: {
   const resolvedBranch = await resolveSqaaBranchAtRepoRoot(branch, changeSet.repoRoot);
 
   if (changeSet.files.length === 0 && changeSet.ignored.length === 0) {
-    text('Vortex agentic analysis: no files in the change set to analyze.');
+    text('Vortex analysis: no files in the change set to analyze.');
     return;
   }
 
   if (changeSet.files.length === 0) {
     text(
-      'Vortex agentic analysis: no files to analyze — all change set files were excluded (binary or oversized).',
+      'Vortex analysis: no files to analyze — all change set files were excluded (binary or oversized).',
     );
     return;
   }

--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -305,7 +305,7 @@ Alternatively, add SonarQube for IDE shared binding JSON under .sonarlint/ (for 
 integrateCommand
   .command('claude')
   .description(
-    'Setup SonarQube integration for Claude Code. This will install secrets scanning hooks, configure Vortex agentic analysis and MCP Server.',
+    'Setup SonarQube integration for Claude Code. This will install secrets scanning hooks, configure Vortex analysis and MCP Server.',
   )
   .option('-p, --project <project>', 'Project key. Ignored when --global is used.')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
@@ -319,7 +319,7 @@ integrateCommand
 integrateCommand
   .command('copilot')
   .description(
-    'Setup SonarQube integration for GitHub Copilot CLI. This will install secrets scanning hooks, configure Vortex agentic analysis and MCP Server.',
+    'Setup SonarQube integration for GitHub Copilot CLI. This will install secrets scanning hooks, configure Vortex analysis and MCP Server.',
   )
   .option(
     '-g, --global',
@@ -382,7 +382,7 @@ integrateCommand
 integrateCommand
   .command('cursor')
   .description(
-    'Setup SonarQube integration for Cursor. This will configure the SonarQube MCP Server, install secrets scanning hooks, and configure Vortex agentic analysis.',
+    'Setup SonarQube integration for Cursor. This will configure the SonarQube MCP Server, install secrets scanning hooks, and configure Vortex analysis.',
   )
   .option('-p, --project <project>', 'Project key. Mutually exclusive with --global.')
   .option('--non-interactive', 'Non-interactive mode (no prompts)')
@@ -509,14 +509,14 @@ analyze
 applySqaaOptions(
   analyze
     .command('agentic')
-    .description('Run server-side agentic analysis (SonarQube Cloud only). Limitations apply.'),
+    .description('Run server-side Vortex analysis (SonarQube Cloud only). Limitations apply.'),
   { telemetryCallerCommand: SQAA_ANALYZE_AGENTIC_CALLER_COMMAND },
 );
 
 // `verify` is deprecated in favour of `sonar analyze`.
 const verifyCmd = applySqaaOptions(
   COMMAND_TREE.command('verify', { hidden: true }).description(
-    "Run server-side Vortex agentic analysis (deprecated — use 'sonar analyze' instead)",
+    "Run server-side Vortex analysis (deprecated — use 'sonar analyze' instead)",
   ),
   { telemetryCallerCommand: SQAA_VERIFY_CALLER_COMMAND },
 );
@@ -678,14 +678,14 @@ hookCommand
 
 hookCommand
   .command('claude-post-tool-use')
-  .description('PostToolUse handler: run agentic analysis after agent edits or writes a file')
+  .description('PostToolUse handler: run Vortex analysis after agent edits or writes a file')
   .requiredOption('--project <key>', 'SonarQube Cloud project key')
   .anonymousAction((options: AgentPostToolUseOptions) => agentPostToolUse(options));
 
 hookCommand
   .command('codex-post-tool-use')
   .description(
-    'PostToolUse handler for Codex: run agentic analysis on the git change set after apply_patch',
+    'PostToolUse handler for Codex: run Vortex analysis on the git change set after apply_patch',
   )
   .requiredOption('--project <key>', 'SonarQube Cloud project key')
   .anonymousAction((options: CodexPostToolUseOptions) => codexPostToolUse(options));

--- a/src/commands/hook/format-sqaa-hook-context.ts
+++ b/src/commands/hook/format-sqaa-hook-context.ts
@@ -96,7 +96,7 @@ function formatNoAnalyzedContent(report: SqaaJsonReport): string {
     lines.push(`Skipped ${report.skipped.length} file(s) (analysis not completed).`);
   } else if (report.ignored.length > 0 && report.files.length === 0) {
     lines.push(
-      'Agentic Analysis: no files to analyze — all change set files were excluded (binary or oversized).',
+      'Vortex analysis: no files to analyze — all change set files were excluded (binary or oversized).',
     );
   } else {
     lines.push(formatSqaaRunSummaryPlain(hookSummaryFromReport(report)));
@@ -151,7 +151,7 @@ export function formatSqaaJsonReportForHook(report: SqaaJsonReport): string | nu
   renderFileList(report, lines);
 
   if (report.failures.length > 0) {
-    lines.push('Agentic Analysis failures:');
+    lines.push('Vortex analysis failures:');
     report.failures.forEach((f) => lines.push(`  ✗  ${f.path}: ${f.message}`));
   }
 

--- a/src/commands/integrate/_common/features/context-augmentation-feature.ts
+++ b/src/commands/integrate/_common/features/context-augmentation-feature.ts
@@ -53,7 +53,7 @@ export function createContextAugmentationSubfeature<TOptions>(
     resources: [
       wholeFile({
         id: CONTEXT_AUGMENTATION_SKILL_RESOURCE_ID,
-        displayName: 'context augmentation skill file',
+        displayName: 'Vortex context augmentation skill file',
         version: SONAR_CONTEXT_AUGMENTATION_VERSION,
         targetPath: options.targetPath,
         content: async (context) =>
@@ -68,7 +68,7 @@ export function createContextAugmentationSubfeature<TOptions>(
     operations: [
       {
         id: CONTEXT_AUGMENTATION_TOOL_INTEGRATION_OPERATION_ID,
-        displayName: 'context augmentation tool integration',
+        displayName: 'Vortex context augmentation tool integration',
         shouldApply: (context) => context.executionMode === 'install',
         apply: async (context) =>
           runToolIntegrateCommand({

--- a/src/commands/integrate/_common/instructions-templates.ts
+++ b/src/commands/integrate/_common/instructions-templates.ts
@@ -46,13 +46,13 @@ export function sonarEndMarker(id: string): string {
 }
 
 export function buildSqaaSectionBody(projectKey: string): string {
-  return `# SonarQube Agentic Analysis protocol
+  return `# Vortex analysis protocol
 
-SonarQube Agentic Analysis is the final confirmation layer at the end of every turn in which you wrote to one or more files in the workspace (create, edit, patch, format — any tool call that changed file contents on disk).
+Vortex analysis is the final confirmation layer at the end of every turn in which you wrote to one or more files in the workspace (create, edit, patch, format — any tool call that changed file contents on disk).
 
 **Trigger:** the moment before you send your final reply for the turn.
 
-When the trigger fires, you **MUST** run SonarQube Agentic Analysis on the full set of files you modified this turn — **one command, not a per-file loop**.
+When the trigger fires, you **MUST** run Vortex analysis on the full set of files you modified this turn — **one command, not a per-file loop**.
 
 **Preferred:** pass every path you modified this turn in a single invocation (repeat \`--file\` for each path). Use paths **relative to the project root** (e.g. \`src/foo.ts\`). For end-of-turn analysis, **always** pass \`--depth DEEP\` — even when you changed only one file — so cross-file findings are included.
 
@@ -70,10 +70,10 @@ Per-edit hooks run faster STANDARD analysis. End-of-turn analysis must always us
 
 Non-negotiable rules:
 
-1. Mid-turn edits do **not** need SonarQube Agentic Analysis — only the final on-disk state matters. Skipping SonarQube Agentic Analysis at end-of-turn is a protocol violation.
-2. Run SonarQube Agentic Analysis **before** sending your final reply, marking the task done, or handing control back to the user.
-3. If SonarQube Agentic Analysis reports issues on lines you touched in this turn, fix them, then re-run SonarQube Agentic Analysis on the same scope (change set or explicit file list). Repeat until clean (or only pre-existing findings on lines you did not touch remain). Pre-existing findings on untouched lines are out of scope — do not "fix" them unless the user asked.
-4. If SonarQube Agentic Analysis is skipped (no SonarQube Cloud connection, or no project configured), state the skip reason to the user once and continue — do not retry.
-5. Do not suppress, summarize away, or omit SonarQube Agentic Analysis findings from your reply. Surface them verbatim.
+1. Mid-turn edits do **not** need Vortex analysis — only the final on-disk state matters. Skipping Vortex analysis at end-of-turn is a protocol violation.
+2. Run Vortex analysis **before** sending your final reply, marking the task done, or handing control back to the user.
+3. If Vortex analysis reports issues on lines you touched in this turn, fix them, then re-run Vortex analysis on the same scope (change set or explicit file list). Repeat until clean (or only pre-existing findings on lines you did not touch remain). Pre-existing findings on untouched lines are out of scope — do not "fix" them unless the user asked.
+4. If Vortex analysis is skipped (no SonarQube Cloud connection, or no project configured), state the skip reason to the user once and continue — do not retry.
+5. Do not suppress, summarize away, or omit Vortex analysis findings from your reply. Surface them verbatim.
 `;
 }

--- a/src/commands/integrate/antigravity/declaration.ts
+++ b/src/commands/integrate/antigravity/declaration.ts
@@ -76,7 +76,6 @@ import {
   PROMPT_SECRETS_RULE_MARKER,
   resolveLegacyGlobalInstructionsPath,
   resolveLegacyProjectInstructionsPath,
-  SQAA_RULE_MARKER,
 } from './rules.ts';
 
 export const ANTIGRAVITY_INTEGRATION_ID = 'antigravity';
@@ -129,7 +128,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
         createSqaaInstructionsSubfeature<AntigravityIntegrationOptions>([
           wholeFile({
             id: 'sqaa-rule-file',
-            displayName: 'Vortex agentic analysis rule for Antigravity',
+            displayName: 'Vortex analysis rule for Antigravity',
             targetPath: resolveSqaaRulePath,
             content: (context) =>
               buildAntigravityAlwaysOnRule(
@@ -137,7 +136,6 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
                   getRequiredStringAttr(context, 'projectKey', ANTIGRAVITY_DISPLAY_NAME),
                 ),
               ),
-            managedMarker: SQAA_RULE_MARKER,
           }),
         ]),
         createContextAugmentationSubfeature<AntigravityIntegrationOptions>({

--- a/src/commands/integrate/antigravity/rules.ts
+++ b/src/commands/integrate/antigravity/rules.ts
@@ -32,7 +32,6 @@ import { sonarBeginMarker } from '../_common/instructions-templates.ts';
 export { PROMPT_SECRETS_BODY } from '../copilot/instructions.ts';
 
 export const PROMPT_SECRETS_RULE_MARKER = '# SonarQube secrets scanning for prompts protocol';
-export const SQAA_RULE_MARKER = '# SonarQube Agentic Analysis protocol';
 
 /** Render an Antigravity workspace rule (`.agents/rules/*.md`) with always-on activation. */
 export function buildAntigravityAlwaysOnRule(body: string): string {

--- a/src/commands/integrate/claude/declaration.ts
+++ b/src/commands/integrate/claude/declaration.ts
@@ -178,7 +178,7 @@ function createSqaaHookSubfeature(): SubfeatureDeclaration<ClaudeIntegrationOpti
       }),
       jsonPatch({
         id: 'claude-settings-sqaa-hook',
-        displayName: 'Claude Vortex agentic analysis hook configuration',
+        displayName: 'Claude Vortex analysis hook configuration',
         targetPath: resolveClaudeSettingsPath,
         defaultValue: { hooks: {} },
         patch: (document, context) =>

--- a/src/commands/integrate/codex/declaration.ts
+++ b/src/commands/integrate/codex/declaration.ts
@@ -188,7 +188,7 @@ function createSqaaHookSubfeature(): SubfeatureDeclaration<CodexIntegrationOptio
       }),
       jsonPatch({
         id: 'codex-hooks-sqaa-hook',
-        displayName: 'Codex Vortex agentic analysis hook configuration',
+        displayName: 'Codex Vortex analysis hook configuration',
         targetPath: resolveCodexHooksPath,
         defaultValue: { hooks: {} },
         patch: (document, context) =>

--- a/src/commands/integrate/cursor/declaration.ts
+++ b/src/commands/integrate/cursor/declaration.ts
@@ -74,9 +74,6 @@ const SQAA_RULE_FILE = 'sonar-agentic-analysis.mdc';
 // Cursor-specific `.cursor/skills` to avoid a duplicate skill of the same name.
 const AGENTS_SKILLS_DIR = join('.agents', 'skills');
 const CAG_SKILL_NAME = 'sonar-context-augmentation';
-// Stable string always present in the rendered rule body — used by the
-// wholeFile remover so teardown only deletes the file we manage.
-const SQAA_RULE_MARKER = '# SonarQube Agentic Analysis protocol';
 
 export interface CursorIntegrationOptions extends IntegrateAgentOptions {
   globalSecretsHookExists?: boolean;
@@ -104,7 +101,7 @@ function resolveCursorSqaaRulePath(context: IntegrationContext): string {
 }
 
 /**
- * Render the Vortex agentic analysis rule as a Cursor `.mdc` file. The
+ * Render the Vortex analysis rule as a Cursor `.mdc` file. The
  * `alwaysApply: true` front-matter makes Cursor inject the protocol into every
  * session without the user attaching it manually.
  */
@@ -215,10 +212,9 @@ export const cursorIntegration: IntegrationDeclaration<CursorIntegrationOptions>
       createSqaaInstructionsSubfeature([
         wholeFile({
           id: 'sqaa-instructions-rule',
-          displayName: 'Cursor Vortex agentic analysis rule',
+          displayName: 'Cursor Vortex analysis rule',
           targetPath: resolveCursorSqaaRulePath,
           content: buildCursorSqaaRule,
-          managedMarker: SQAA_RULE_MARKER,
         }),
       ]),
       createContextAugmentationSubfeature<CursorIntegrationOptions>({

--- a/src/commands/system/status.ts
+++ b/src/commands/system/status.ts
@@ -86,7 +86,7 @@ const PINNED_VERSIONS: Partial<Record<string, string>> = {
 
 const BINARY_DISPLAY_NAMES: Record<string, string> = {
   'sonar-secrets': 'Secrets Detection',
-  'sonar-context-augmentation': 'Sonar Context Augmentation',
+  'sonar-context-augmentation': 'Vortex Context Augmentation',
   'sca-scanner-cli': 'Dependency Risks Scanner',
 };
 
@@ -734,7 +734,7 @@ function renderNetworkSection(network: ResolvedNetworkConfig): void {
   }
   text(
     '  Note: Not all CLI features currently support proxy and certificate configuration. ' +
-      'Secrets hook, Context Augmentation and Software Composition Analysis might currently not pick up the network configuration.',
+      'Secrets hook, Vortex context augmentation and Software Composition Analysis might currently not pick up the network configuration.',
   );
   if (network.proxy) {
     renderProxySubsection(network.proxy);

--- a/src/core/server/errors.ts
+++ b/src/core/server/errors.ts
@@ -65,7 +65,7 @@ export class ForbiddenApiError extends Error {
 /** Thrown when the SQAA analysis endpoint returns 403 — Agentic Pack entitlement revoked. */
 export class SqaaForbiddenError extends Error {
   constructor() {
-    super('Vortex agentic analysis is not available for this organization (403 Forbidden).');
+    super('Vortex analysis is not available for this organization (403 Forbidden).');
     this.name = 'SqaaForbiddenError';
   }
 }

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -301,7 +301,7 @@ describe('analyze (no subcommand)', () => {
       const output = result.stdout + result.stderr;
       expect(result.exitCode).toBe(0);
       expect(output).toContain('No issues found');
-      expect(output).toContain('Vortex agentic analysis skipped: no project configured');
+      expect(output).toContain('Vortex analysis skipped: no project configured');
       expect(output).not.toContain('Usage: sonar analyze');
       const sqaaCalls = server
         .getRecordedRequests()
@@ -579,7 +579,7 @@ describe('analyze agentic', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(
-        'Vortex agentic analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
+        'Vortex analysis skipped: a SonarQube Cloud connection is required. Run: sonar auth login (ensure you connect to SonarQube Cloud)',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -607,7 +607,7 @@ describe('analyze agentic', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        'Vortex agentic analysis requires a project, but none is configured for this directory.',
+        'Vortex analysis requires a project, but none is configured for this directory.',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -1839,7 +1839,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain(
-        'Vortex agentic analysis requires a project, but none is configured for this directory.',
+        'Vortex analysis requires a project, but none is configured for this directory.',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -1869,7 +1869,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(
-        'Vortex agentic analysis skipped: no project configured',
+        'Vortex analysis skipped: no project configured',
       );
       const sqaaCalls = server
         .getRecordedRequests()
@@ -2261,7 +2261,7 @@ describe('analyze agentic — API error codes', () => {
       // Issue details are on stdout.
       expect(result.stdout).toContain('TODO');
       // No Sonar error text should appear on stdout.
-      expect(result.stdout).not.toContain('❌ Vortex agentic analysis failed');
+      expect(result.stdout).not.toContain('❌ Vortex analysis failed');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -49,7 +49,7 @@ function getExpectedRootHelp(): string {
     '    analyze                                                  Analyze code for quality and security issues',
     '    analyze secrets                                          Scan files or stdin for hardcoded secrets',
     '    analyze dependency-risks                                 Analyze project dependencies for security and license risks',
-    '    analyze agentic                                          Run server-side agentic analysis (SonarQube Cloud only). Limitations apply.',
+    '    analyze agentic                                          Run server-side Vortex analysis (SonarQube Cloud only). Limitations apply.',
     '    remediate                                                Trigger AI agent remediation for eligible issues (SonarQube Cloud only)',
     '',
     '    list <issues|projects>                                   List issues and projects from SonarQube Cloud or Server',

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -498,7 +498,7 @@ describe('integrate antigravity', () => {
         );
         const sqaaRule = harness.cwd.file(...PROJECT_SQAA_RULE_PATH).asText();
         expectAntigravityAlwaysOnRule(sqaaRule);
-        expect(sqaaRule).toContain('# SonarQube Agentic Analysis protocol');
+        expect(sqaaRule).toContain('# Vortex analysis protocol');
         expect(sqaaRule).toContain(`sonar analyze agentic --project ${TEST_PROJECT} --depth DEEP`);
         const vortexFeature = findAntigravityFeature(harness, VORTEX_FEATURE_ID);
         expect(vortexFeature?.scope).toBe('project');
@@ -599,7 +599,7 @@ describe('integrate antigravity', () => {
         });
 
         const body = harness.cwd.file(...PROJECT_SQAA_RULE_PATH).asText();
-        expect(body.match(/# SonarQube Agentic Analysis protocol/g)?.length).toBe(1);
+        expect(body.match(/# Vortex analysis protocol/g)?.length).toBe(1);
       },
       { timeout: 60000 },
     );

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -676,9 +676,7 @@ describe('integrate claude — Vortex entitlement guard', () => {
           hookScriptName('posttool-sqaa'),
         ),
       ).toBe(true);
-      expect(harness.cwd.file('CLAUDE.md').asText()).toContain(
-        '# SonarQube Agentic Analysis protocol',
-      );
+      expect(harness.cwd.file('CLAUDE.md').asText()).toContain('# Vortex analysis protocol');
       expect(findClaudeFeature(harness, VORTEX_FEATURE_ID)?.scope).toBe('project');
     },
     { timeout: 30000 },
@@ -2042,9 +2040,7 @@ describe('integrate claude — interactive feature selection', () => {
         ),
       ).toBe(true);
       expect(findClaudeFeature(harness, VORTEX_FEATURE_ID)).toBeDefined();
-      expect(harness.cwd.file('CLAUDE.md').asText()).toContain(
-        '# SonarQube Agentic Analysis protocol',
-      );
+      expect(harness.cwd.file('CLAUDE.md').asText()).toContain('# Vortex analysis protocol');
       expect(
         findClaudeFeature(harness, VORTEX_FEATURE_ID)?.subfeatures?.map((s) => s.featureId),
       ).toContain(SQAA_INSTRUCTIONS_SUBFEATURE_ID);

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -53,7 +53,7 @@ const PROJECT_AGENTS_MD_DIRS = ['AGENTS.md'];
 const GLOBAL_AGENTS_MD_DIRS = ['.codex', 'AGENTS.md'];
 const CONFIG_TOML_DIRS = ['.codex', 'config.toml'];
 const SECRETS_HEADING = '# SonarQube secrets scanning for files protocol';
-const SQAA_HEADING = '# SonarQube Agentic Analysis protocol';
+const SQAA_HEADING = '# Vortex analysis protocol';
 
 interface CodexHooksFile {
   hooks?: {

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -662,7 +662,7 @@ describe('integrate copilot', () => {
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
-        expect(body).toContain('# SonarQube Agentic Analysis protocol');
+        expect(body).toContain('# Vortex analysis protocol');
         expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT}`);
         expect(body).toContain('--file');
 
@@ -688,7 +688,7 @@ describe('integrate copilot', () => {
         const output = result.stdout + result.stderr;
         expect(output).toContain('Install Vortex?');
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
-        expect(body).toContain('# SonarQube Agentic Analysis protocol');
+        expect(body).toContain('# Vortex analysis protocol');
         expect(findCopilotFeature(harness, 'vortex')?.scope).toBe('project');
       },
       { timeout: 30000 },
@@ -710,7 +710,7 @@ describe('integrate copilot', () => {
         // Global file holds prompt-secrets, NOT SQAA.
         const globalBody = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
         expect(globalBody).toContain('# SonarQube secrets scanning for prompts protocol');
-        expect(globalBody).not.toContain('# SonarQube Agentic Analysis');
+        expect(globalBody).not.toContain('# Vortex analysis');
 
         // SQAA is never written project-side on a global install.
         expect(harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).exists()).toBe(false);
@@ -732,7 +732,7 @@ describe('integrate copilot', () => {
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
-        expect(body).not.toContain('# SonarQube Agentic Analysis');
+        expect(body).not.toContain('# Vortex analysis');
       },
       { timeout: 30000 },
     );
@@ -755,7 +755,7 @@ describe('integrate copilot', () => {
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
-        expect(body).not.toContain('# SonarQube Agentic Analysis');
+        expect(body).not.toContain('# Vortex analysis');
       },
       { timeout: 30000 },
     );
@@ -773,7 +773,7 @@ describe('integrate copilot', () => {
         // and no project-level file is written.
         const body = harness.userHome.file(...GLOBAL_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
-        expect(body).not.toContain('# SonarQube Agentic Analysis');
+        expect(body).not.toContain('# Vortex analysis');
         expect(harness.cwd.exists(...PROJECT_INSTRUCTIONS_PATH)).toBe(false);
         expect(findCopilotFeature(harness, 'vortex')).toBeUndefined();
         // Vortex is project-scoped, so a --global install skips it with the central
@@ -798,7 +798,7 @@ describe('integrate copilot', () => {
         expect(result.exitCode).toBe(0);
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
-        expect(body).not.toContain('# SonarQube Agentic Analysis');
+        expect(body).not.toContain('# Vortex analysis');
       },
       { timeout: 30000 },
     );
@@ -830,7 +830,7 @@ describe('integrate copilot', () => {
         // Instructions file still written, but without the SQAA section.
         const body = harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText();
         expect(body).toContain('# SonarQube secrets scanning for prompts protocol');
-        expect(body).not.toContain('# SonarQube Agentic Analysis');
+        expect(body).not.toContain('# Vortex analysis');
       },
       { timeout: 30000 },
     );
@@ -867,7 +867,7 @@ describe('integrate copilot', () => {
         expect(harness.cwd.exists('.mcp.json')).toBe(true);
         // No SQAA marker block was written (org not entitled).
         expect(harness.cwd.file(...PROJECT_INSTRUCTIONS_PATH).asText()).not.toContain(
-          '# SonarQube Agentic Analysis',
+          '# Vortex analysis',
         );
         // Declarative state records only the accepted features.
         expect(findCopilotFeature(harness, 'pre-tool-use-hook')).toBeDefined();

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -514,7 +514,7 @@ describe('integrate cursor', () => {
         const body = harness.cwd.file(...SQAA_RULE_DIRS).asText();
         // Cursor auto-loads the rule in every session via the front-matter.
         expect(body).toContain('alwaysApply: true');
-        expect(body).toContain('# SonarQube Agentic Analysis protocol');
+        expect(body).toContain('# Vortex analysis protocol');
         expect(body).toContain(`sonar analyze agentic --project ${TEST_PROJECT}`);
         expect(body).toContain('--file');
 
@@ -538,7 +538,7 @@ describe('integrate cursor', () => {
         const output = result.stdout + result.stderr;
         expect(output).toContain('Install Vortex?');
         const body = harness.cwd.file(...SQAA_RULE_DIRS).asText();
-        expect(body).toContain('# SonarQube Agentic Analysis protocol');
+        expect(body).toContain('# Vortex analysis protocol');
         expect(findInstalledFeature(harness, 'cursor', 'vortex', 'project')).toBeDefined();
       },
       { timeout: 30000 },

--- a/tests/integration/specs/integrate/vortex.test.ts
+++ b/tests/integration/specs/integrate/vortex.test.ts
@@ -133,9 +133,7 @@ describe('integrate claude — Vortex entitlement', () => {
 
       expect(result.exitCode).toBe(0);
       expect(isVortexInstalled()).toBe(true);
-      expect(harness.cwd.file('CLAUDE.md').asText()).toContain(
-        '# SonarQube Agentic Analysis protocol',
-      );
+      expect(harness.cwd.file('CLAUDE.md').asText()).toContain('# Vortex analysis protocol');
     },
     { timeout: 30000 },
   );

--- a/tests/integration/specs/system/system-status.test.ts
+++ b/tests/integration/specs/system/system-status.test.ts
@@ -793,7 +793,7 @@ describe('system status', () => {
       expect(result.exitCode).toBe(0);
       const json = JSON.parse(result.stdout) as { binaries: Array<{ name: string }> };
       const names = json.binaries.map((b) => b.name);
-      expect(names).toContain('Sonar Context Augmentation');
+      expect(names).toContain('Vortex Context Augmentation');
       expect(names).toContain('Dependency Risks Scanner');
     },
     { timeout: 15000 },

--- a/tests/integration/specs/update/post-update.test.ts
+++ b/tests/integration/specs/update/post-update.test.ts
@@ -102,9 +102,7 @@ describe('post-update migration', () => {
       CONTEXT_AUGMENTATION_FEATURE_ID,
     ]);
     expect(harness.cwd.file('.claude', 'settings.json').asJson().hooks?.PostToolUse).toBeDefined();
-    expect(harness.cwd.file('CLAUDE.md').asText()).toContain(
-      '# SonarQube Agentic Analysis protocol',
-    );
+    expect(harness.cwd.file('CLAUDE.md').asText()).toContain('# Vortex analysis protocol');
     expect(
       harness.cwd.file('.claude', 'skills', 'sonar-context-augmentation', 'SKILL.md').exists(),
     ).toBe(true);
@@ -382,7 +380,7 @@ describe('post-update migration', () => {
       ]);
       expect(
         harness.cwd.file('.github', 'instructions', 'sonarqube.instructions.md').asText(),
-      ).toContain('# SonarQube Agentic Analysis protocol');
+      ).toContain('# Vortex analysis protocol');
       expect(
         harness.cwd.file('.github', 'skills', 'sonar-context-augmentation', 'SKILL.md').exists(),
       ).toBe(true);
@@ -412,7 +410,7 @@ describe('post-update migration', () => {
         CONTEXT_AUGMENTATION_FEATURE_ID,
       ]);
       expect(harness.cwd.file('.cursor', 'rules', 'sonar-agentic-analysis.mdc').asText()).toContain(
-        '# SonarQube Agentic Analysis protocol',
+        '# Vortex analysis protocol',
       );
       expect(
         harness.cwd.file('.agents', 'skills', 'sonar-context-augmentation', 'SKILL.md').exists(),
@@ -444,7 +442,7 @@ describe('post-update migration', () => {
         antigravity?.features[0].subfeatures?.map((subfeature) => subfeature.featureId),
       ).toEqual([SQAA_INSTRUCTIONS_SUBFEATURE_ID, CONTEXT_AUGMENTATION_FEATURE_ID]);
       expect(harness.cwd.file('.agents', 'rules', 'sonar-agentic-analysis.md').asText()).toContain(
-        '# SonarQube Agentic Analysis protocol',
+        '# Vortex analysis protocol',
       );
       expect(
         harness.cwd.file('.agents', 'skills', 'sonar-context-augmentation', 'SKILL.md').exists(),

--- a/tests/unit/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/commands/analyze/analyze-sqaa.test.ts
@@ -183,7 +183,7 @@ describe('analyzeSqaa: auth resolution', () => {
 
     expect(thrown).toBeInstanceOf(CommandFailedError);
     expect((thrown as Error).message).toContain(
-      'Vortex agentic analysis requires a project, but none is configured for this directory.',
+      'Vortex analysis requires a project, but none is configured for this directory.',
     );
     expect(createAnalysisSpy).not.toHaveBeenCalled();
   });
@@ -198,7 +198,7 @@ describe('analyzeSqaa: auth resolution', () => {
       .map((c) => String(c.args[0]))
       .join('\n');
     expect(output).toContain(
-      'Vortex agentic analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
+      'Vortex analysis skipped: no project configured. Specify one with --project or run: sonar integrate',
     );
   });
 });
@@ -315,7 +315,7 @@ describe('analyzeSqaa: API call and result display', () => {
       .map((c) => String(c.args[0]));
     expect(lines.some((line) => line.includes('src/index.ts'))).toBe(true);
     expect(lines.some((line) => line.includes('Network error'))).toBe(true);
-    expect(lines.some((line) => line.includes('SonarQube Agentic Analysis failed'))).toBe(false);
+    expect(lines.some((line) => line.includes('Vortex analysis failed'))).toBe(false);
     expect(lines.at(-1)).toContain('1 failure');
     expect(process.exitCode).toBe(1);
   });

--- a/tests/unit/commands/analyze/sqaa-display.test.ts
+++ b/tests/unit/commands/analyze/sqaa-display.test.ts
@@ -218,7 +218,7 @@ describe('printSqaaTextReport', () => {
     printSqaaTextReport({ tally, allPaths: ['b.ts'], analysisDepth: 'STANDARD' });
 
     const texts = getMockTextLines();
-    expect(texts.some((l) => l.includes('SonarQube Agentic Analysis failed'))).toBe(false);
+    expect(texts.some((l) => l.includes('Vortex analysis failed'))).toBe(false);
     expect(texts.some((l) => l.includes("File path must use forward slashes: 'b\\.ts'"))).toBe(
       true,
     );
@@ -230,7 +230,7 @@ describe('printSqaaTextReport', () => {
     clearMockUiCalls();
 
     const validationError = new CommandFailedError(
-      'SonarQube Agentic Analysis failed. File path must use forward slashes.',
+      'Vortex analysis failed. File path must use forward slashes.',
       { remediationHint: "Normalize paths to POSIX form (e.g. 'src/index.ts')." },
     );
     const tally: RunTally = {
@@ -255,7 +255,7 @@ describe('printSqaaTextReport', () => {
 describe('renderFailureDetailLines', () => {
   it('strips heading prefix from a single-line message', () => {
     const lines = renderFailureDetailLines(
-      new CommandFailedError('SonarQube Agentic Analysis failed. network error'),
+      new CommandFailedError('Vortex analysis failed. network error'),
       false,
     );
     expect(lines).toEqual(['     network error']);
@@ -263,7 +263,7 @@ describe('renderFailureDetailLines', () => {
 
   it('strips legacy multiline heading and indents each detail line', () => {
     const lines = renderFailureDetailLines(
-      new CommandFailedError('SonarQube Agentic Analysis failed.\n  network error'),
+      new CommandFailedError('Vortex analysis failed.\n  network error'),
       false,
     );
     expect(lines).toEqual(['     network error']);

--- a/tests/unit/commands/analyze/sqaa-errors.test.ts
+++ b/tests/unit/commands/analyze/sqaa-errors.test.ts
@@ -35,7 +35,7 @@ import {
 describe('sqaaFailureMessage', () => {
   it('keeps heading and detail on one line for command-level errors', () => {
     expect(sqaaFailureMessage('File path must use forward slashes.')).toBe(
-      'SonarQube Agentic Analysis failed. File path must use forward slashes.',
+      'Vortex analysis failed. File path must use forward slashes.',
     );
   });
 });

--- a/tests/unit/commands/hook/format-sqaa-hook-context.test.ts
+++ b/tests/unit/commands/hook/format-sqaa-hook-context.test.ts
@@ -96,4 +96,37 @@ describe('formatSqaaJsonReportForHook', () => {
     expect(text).toContain('large.bin');
     expect(text).toContain('oversized');
   });
+
+  it('lists change-set failures under the Vortex heading', () => {
+    const text = formatSqaaJsonReportForHook(
+      emptyReport({
+        failures: [{ path: 'src/broken.ts', message: 'analysis crashed' }],
+        summary: { totalIssues: 0, totalFailures: 1, totalSkipped: 0 },
+      }),
+    );
+
+    expect(text).toContain('Vortex analysis failures:');
+    expect(text).toContain('✗  src/broken.ts: analysis crashed');
+  });
+
+  it('lists skipped files alongside analyzed content', () => {
+    // A file with an error makes the report "analyzed content", so formatting
+    // reaches the skipped block instead of the no-analyzed-content early return.
+    const text = formatSqaaJsonReportForHook(
+      emptyReport({
+        files: [
+          {
+            path: 'src/analyzed.ts',
+            issues: [],
+            errors: [{ code: 'PARSE_ERROR', message: 'could not parse' }],
+          },
+        ],
+        skipped: ['src/skipped.ts'],
+        summary: { totalIssues: 0, totalFailures: 0, totalSkipped: 1 },
+      }),
+    );
+
+    expect(text).toContain('[SKIPPED]');
+    expect(text).toContain('src/skipped.ts');
+  });
 });

--- a/tests/unit/commands/integrate/_common/instructions-templates.test.ts
+++ b/tests/unit/commands/integrate/_common/instructions-templates.test.ts
@@ -38,7 +38,7 @@ describe('instructions-templates', () => {
   it('buildSqaaSectionBody renders the SQAA protocol body with the analyze command for the project', () => {
     const result = buildSqaaSectionBody('my-project');
 
-    expect(result).toContain('# SonarQube Agentic Analysis protocol');
+    expect(result).toContain('# Vortex analysis protocol');
     expect(result).toContain('sonar analyze agentic --project my-project');
     expect(result).toContain('--depth DEEP');
     expect(result).toContain('**Preferred:**');

--- a/tests/unit/core/framework/features/registry-remove.test.ts
+++ b/tests/unit/core/framework/features/registry-remove.test.ts
@@ -155,6 +155,27 @@ describe('declarative integration framework - remove and undo', () => {
       expect(await resource.remove(context)).toBeUndefined();
     });
 
+    it('whole-file: without a managedMarker, deletes the file even when its content differs', async () => {
+      const state = getDefaultState('test');
+      const context = makeContext(state, tempDir);
+      const filePath = join(tempDir, 'sonar-agentic-analysis.mdc');
+      const resource = wholeFile({
+        id: 'r',
+        targetPath: filePath,
+        content: '---\nalwaysApply: true\n---\n\n# Vortex analysis protocol\n',
+      });
+      // A rule file left by an older CLI carries the old heading; teardown must
+      // still remove it now that the SQAA rules declare no managedMarker.
+      await writeFile(
+        filePath,
+        '---\nalwaysApply: true\n---\n\n# SonarQube Agentic Analysis protocol\n',
+      );
+
+      await resource.remove(context);
+
+      expect(existsSync(filePath)).toBe(false);
+    });
+
     it('json-patch: removes keys added by removePatch', async () => {
       const state = getDefaultState('test');
       const context = makeContext(state, tempDir);


### PR DESCRIPTION
----
## Summary by Gitar

- **Branding Update:**
    - Renamed all instances of CAG and SQAA consistently to `Vortex` across commands, protocols, hooks, and tests


<sub>This will update automatically on new commits.</sub>