### PR TITLE
CLI-933 Allow contributors to declare Alpha commands

### DIFF
--- a/src/commands/root-help.ts
+++ b/src/commands/root-help.ts
@@ -23,7 +23,12 @@ import type { Help, Option } from 'commander';
 import { softBlue, underline } from '@/core/ui/colors.ts';
 
 import { version as VERSION } from '../../package.json';
-import { COMMAND_CATEGORIES, type CommandCategory, type SonarCommand } from './sonar-command.ts';
+import {
+  ALPHA_HELP_TAG,
+  COMMAND_CATEGORIES,
+  type CommandCategory,
+  type SonarCommand,
+} from './sonar-command.ts';
 
 const BANNER_ART = [
   '  █▀ █▀█ █▄ █ ▄▀█ █▀█ █▀█ █ █ █▄▄ █▀▀   ▄█▀ █   █',
@@ -90,7 +95,10 @@ function getRootCommandLabel(command: SonarCommand, helper: Help): string {
     return command.name();
   }
 
-  return `${command.name()} <${visibleChildren.map((child) => child.name()).join('|')}>`;
+  const childLabels = visibleChildren.map(
+    (child) => `${child.name()}${child.isAlpha ? ALPHA_HELP_TAG : ''}`,
+  );
+  return `${command.name()} <${childLabels.join('|')}>`;
 }
 
 function getRootCommandCategory(command: SonarCommand): CommandCategory {
@@ -112,26 +120,34 @@ function getRootCommandEntries(rootCommand: SonarCommand, helper: Help): HelpMen
   const groupedEntries = new Map<CommandCategory, HelpMenuEntry[]>(
     COMMAND_CATEGORIES.map((category) => [category, []]),
   );
+  const alphaEntries: HelpMenuEntry[] = [];
 
   for (const command of getVisibleChildCommands(rootCommand, helper)) {
+    const commandEntries = [
+      {
+        label: getRootCommandLabel(command, helper),
+        summary: command.description(),
+      },
+      ...getRootCommandSubcommandEntries(command, helper),
+    ];
+    if (command.isAlpha) {
+      alphaEntries.push(...commandEntries);
+      continue;
+    }
+
     const category = getRootCommandCategory(command);
     const entries = groupedEntries.get(category);
     if (!entries) {
       continue;
     }
 
-    entries.push(
-      {
-        label: getRootCommandLabel(command, helper),
-        summary: command.description(),
-      },
-      ...getRootCommandSubcommandEntries(command, helper),
-    );
+    entries.push(...commandEntries);
   }
 
-  return COMMAND_CATEGORIES.map((category) => groupedEntries.get(category) ?? []).filter(
-    (entries) => entries.length > 0,
-  );
+  return [
+    ...COMMAND_CATEGORIES.map((category) => groupedEntries.get(category) ?? []),
+    alphaEntries,
+  ].filter((entries) => entries.length > 0);
 }
 
 function compareRootOptions(optionA: Option, optionB: Option): number {

--- a/src/commands/sonar-command.ts
+++ b/src/commands/sonar-command.ts
@@ -20,8 +20,8 @@
 
 // SonarCommand — Commander Command subclass with built-in error handling and auth support
 
-import type { CommandOptions } from 'commander';
-import { Command } from 'commander';
+import type { CommandOptions, Option } from 'commander';
+import { Command, Help } from 'commander';
 
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { resolveAuth } from '@/core/auth/auth-resolver.ts';
@@ -33,6 +33,7 @@ import { UpdateNotifier } from '@/core/update/notification.ts';
 
 export const ALPHA_ENV_VAR = 'SONARQUBE_CLI_ALPHA';
 export const ALPHA_HELP_TAG = '[ALPHA]';
+const ALPHA_HELP_GROUP = '__SONARQUBE_CLI_ALPHA_COMMANDS__';
 
 export const COMMAND_CATEGORIES = ['core', 'data', 'integrate', 'cli-management'] as const;
 export type CommandCategory = (typeof COMMAND_CATEGORIES)[number];
@@ -50,6 +51,37 @@ export interface RootHelpMetadata {
 
 type CommandArgs = unknown[];
 type CommandResult = void | Promise<void>;
+
+class SonarHelp extends Help {
+  override visibleCommands(command: Command): Command[] {
+    const visibleCommands = super.visibleCommands(command) as SonarCommand[];
+    return [
+      ...visibleCommands.filter((child) => !child.isAlpha),
+      ...visibleCommands.filter((child) => child.isAlpha),
+    ];
+  }
+
+  override groupItems<T extends Command | Option>(
+    unsortedItems: T[],
+    visibleItems: T[],
+    getGroup: (item: T) => string,
+  ): Map<string, T[]> {
+    const groups = super.groupItems(unsortedItems, visibleItems, getGroup);
+    const alphaCommands = groups.get(ALPHA_HELP_GROUP);
+    if (alphaCommands) {
+      groups.delete(ALPHA_HELP_GROUP);
+      groups.set(ALPHA_HELP_GROUP, alphaCommands);
+    }
+    return groups;
+  }
+
+  override formatItemList(heading: string, items: string[], helper: Help): string[] {
+    if (heading === ALPHA_HELP_GROUP) {
+      return items.length === 0 ? [] : [...items, ''];
+    }
+    return super.formatItemList(heading, items, helper);
+  }
+}
 
 /**
  * Commander Command subclass for the Sonar CLI.
@@ -83,6 +115,10 @@ export class SonarCommand extends Command {
   /** Ensures subcommands created via .command() are also SonarCommand instances. */
   createCommand(name?: string): SonarCommand {
     return new SonarCommand(name, this._updateNotifier);
+  }
+
+  createHelp(): Help {
+    return Object.assign(new SonarHelp(), this.configureHelp());
   }
 
   /**
@@ -125,6 +161,7 @@ export class SonarCommand extends Command {
     }
 
     this._isAlpha = true;
+    this.helpGroup(ALPHA_HELP_GROUP);
     if (!isAlphaEnabled()) {
       // Commander has no public command-removal API, so remove it from the registration array.
       const siblings = this.parent?.commands as Command[] | undefined;

--- a/src/commands/sonar-command.ts
+++ b/src/commands/sonar-command.ts
@@ -27,9 +27,12 @@ import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { resolveAuth } from '@/core/auth/auth-resolver.ts';
 import { CliError, CommandFailedError, remediationHintFor } from '@/core/command-error.ts';
 import logger from '@/core/observability/logger.ts';
-import { blank, error, print } from '@/core/ui';
+import { blank, error, print, warn } from '@/core/ui';
 import type { UpdateNotificationCondition } from '@/core/update/notification.ts';
 import { UpdateNotifier } from '@/core/update/notification.ts';
+
+export const ALPHA_ENV_VAR = 'SONARQUBE_CLI_ALPHA';
+export const ALPHA_HELP_TAG = '[ALPHA]';
 
 export const COMMAND_CATEGORIES = ['core', 'data', 'integrate', 'cli-management'] as const;
 export type CommandCategory = (typeof COMMAND_CATEGORIES)[number];
@@ -56,6 +59,7 @@ type CommandResult = void | Promise<void>;
  *                          useful for documentation generation
  */
 export class SonarCommand extends Command {
+  private _isAlpha = false;
   private _requiresAuth = false;
   private _rootHelp: RootHelpMetadata = {};
   private readonly _updateNotifier: UpdateNotifier;
@@ -104,6 +108,58 @@ export class SonarCommand extends Command {
   rootHelp(metadata: RootHelpMetadata): this {
     this._rootHelp = { ...this._rootHelp, ...metadata };
     return this;
+  }
+
+  /**
+   * Mark this command as alpha. Alpha commands are registered only when the
+   * SONARQUBE_CLI_ALPHA environment variable is set.
+   */
+  alpha(): this {
+    if (this._isAlpha) {
+      return this;
+    }
+
+    this._isAlpha = true;
+    if (process.env[ALPHA_ENV_VAR] === undefined) {
+      // Commander has no public command-removal API, so remove it from the registration array.
+      const siblings = this.parent?.commands as Command[] | undefined;
+      const commandIndex = siblings?.indexOf(this) ?? -1;
+      if (commandIndex >= 0) {
+        siblings?.splice(commandIndex, 1);
+      }
+      return this;
+    }
+
+    this.hook('preAction', () => {
+      warn(`'${this.name()}' is in alpha; may change or be removed without notice.`);
+    });
+    return this;
+  }
+
+  description(str: string, argsDescription?: Record<string, string>): this;
+  description(): string;
+  description(str?: string, argsDescription?: Record<string, string>): this | string {
+    if (str !== undefined) {
+      // Preserve Commander's deprecated argument-description overload for substitutability.
+      return argsDescription === undefined
+        ? super.description(str)
+        : // eslint-disable-next-line @typescript-eslint/no-deprecated
+          super.description(str, argsDescription);
+    }
+
+    const description = super.description();
+    return this._isAlpha ? `${description} ${ALPHA_HELP_TAG}` : description;
+  }
+
+  summary(str: string): this;
+  summary(): string;
+  summary(str?: string): this | string {
+    if (str !== undefined) {
+      return super.summary(str);
+    }
+
+    const summary = super.summary();
+    return this._isAlpha && summary ? `${summary} ${ALPHA_HELP_TAG}` : summary;
   }
 
   /**
@@ -191,6 +247,11 @@ export class SonarCommand extends Command {
   /** True when this command was registered with authenticatedAction(). */
   get requiresAuth(): boolean {
     return this._requiresAuth;
+  }
+
+  /** True when this command was declared as alpha. */
+  get isAlpha(): boolean {
+    return this._isAlpha;
   }
 
   /** Metadata used by the custom root help menu. */

--- a/src/commands/sonar-command.ts
+++ b/src/commands/sonar-command.ts
@@ -37,6 +37,11 @@ export const ALPHA_HELP_TAG = '[ALPHA]';
 export const COMMAND_CATEGORIES = ['core', 'data', 'integrate', 'cli-management'] as const;
 export type CommandCategory = (typeof COMMAND_CATEGORIES)[number];
 
+function isAlphaEnabled(): boolean {
+  const value = process.env[ALPHA_ENV_VAR];
+  return value === 'true' || value === '1';
+}
+
 export interface RootHelpMetadata {
   category?: CommandCategory;
   expandSubcommands?: boolean;
@@ -112,7 +117,7 @@ export class SonarCommand extends Command {
 
   /**
    * Mark this command as alpha. Alpha commands are registered only when the
-   * SONARQUBE_CLI_ALPHA environment variable is set.
+   * SONARQUBE_CLI_ALPHA environment variable is set to true or 1.
    */
   alpha(): this {
     if (this._isAlpha) {
@@ -120,7 +125,7 @@ export class SonarCommand extends Command {
     }
 
     this._isAlpha = true;
-    if (process.env[ALPHA_ENV_VAR] === undefined) {
+    if (!isAlphaEnabled()) {
       // Commander has no public command-removal API, so remove it from the registration array.
       const siblings = this.parent?.commands as Command[] | undefined;
       const commandIndex = siblings?.indexOf(this) ?? -1;

--- a/tests/unit/commands/sonar-command.test.ts
+++ b/tests/unit/commands/sonar-command.test.ts
@@ -22,7 +22,8 @@
 
 import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
-import { SonarCommand } from '@/commands/sonar-command.ts';
+import { getCustomRootHelp } from '@/commands/root-help.ts';
+import { ALPHA_ENV_VAR, SonarCommand } from '@/commands/sonar-command.ts';
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import * as authResolver from '@/core/auth/auth-resolver.ts';
 import { CommandFailedError, InvalidOptionError } from '@/core/command-error.ts';
@@ -37,10 +38,13 @@ const FAKE_AUTH: ResolvedAuth = {
 
 describe('SonarCommand', () => {
   let resolveAuthSpy: ReturnType<typeof spyOn>;
+  let originalAlphaEnv: string | undefined;
   let originalExitCode: number | string | null | undefined;
 
   beforeEach(() => {
     setMockUi(true);
+    originalAlphaEnv = process.env[ALPHA_ENV_VAR];
+    delete process.env[ALPHA_ENV_VAR];
     originalExitCode = process.exitCode;
     process.exitCode = 0;
   });
@@ -50,6 +54,11 @@ describe('SonarCommand', () => {
     setMockUi(false);
     process.exitCode = originalExitCode ?? 0;
     resolveAuthSpy?.mockRestore();
+    if (originalAlphaEnv === undefined) {
+      delete process.env[ALPHA_ENV_VAR];
+    } else {
+      process.env[ALPHA_ENV_VAR] = originalAlphaEnv;
+    }
   });
 
   // ─── action() ────────────────────────────────────────────────────────────
@@ -166,6 +175,122 @@ describe('SonarCommand', () => {
 
       const hintCall = getMockUiCalls().find((c) => c.method === 'print');
       expect(hintCall?.args[0]).toBe('  → Wait a moment and try again.');
+    });
+  });
+
+  // ─── alpha() ──────────────────────────────────────────────────────────────
+
+  describe('alpha()', () => {
+    it('marks the command as alpha', () => {
+      const cmd = new SonarCommand('experimental');
+
+      expect(cmd.isAlpha).toBe(false);
+      expect(cmd.alpha().isAlpha).toBe(true);
+    });
+
+    it('unregisters the command when SONARQUBE_CLI_ALPHA is not set', () => {
+      const root = new SonarCommand('sonar');
+      root.command('experimental').description('Experimental command').alpha();
+
+      expect(root.commands.map((command) => command.name())).not.toContain('experimental');
+      expect(root.helpInformation()).not.toContain('Experimental command');
+    });
+
+    it('does not execute an unregistered alpha command', async () => {
+      const rootHandler = mock((_command?: string) => {});
+      const alphaHandler = mock(() => {});
+      const root = new SonarCommand('sonar').argument('[command]').anonymousAction(rootHandler);
+      root.command('experimental').alpha().anonymousAction(alphaHandler);
+
+      await root.parseAsync(['experimental'], { from: 'user' });
+
+      expect(rootHandler.mock.calls[0]?.[0]).toBe('experimental');
+      expect(alphaHandler).not.toHaveBeenCalled();
+    });
+
+    it('registers the command and tags help when SONARQUBE_CLI_ALPHA is set', () => {
+      process.env[ALPHA_ENV_VAR] = '';
+      const root = new SonarCommand('sonar');
+      const alphaCommand = root.command('experimental').description('Experimental command').alpha();
+
+      expect(root.commands.map((command) => command.name())).toContain('experimental');
+      expect(root.helpInformation()).toContain('Experimental command [ALPHA]');
+      expect(alphaCommand.helpInformation()).toContain('Experimental command [ALPHA]');
+    });
+
+    it('tags an explicit command summary', () => {
+      process.env[ALPHA_ENV_VAR] = '1';
+      const root = new SonarCommand('sonar');
+      root
+        .command('experimental')
+        .description('Long experimental description')
+        .summary('Experimental summary')
+        .alpha();
+
+      expect(root.helpInformation()).toContain('Experimental summary [ALPHA]');
+    });
+
+    it('groups alpha commands together after all stable root-help categories', () => {
+      process.env[ALPHA_ENV_VAR] = '1';
+      const root = new SonarCommand('sonar');
+      root.command('stable-core').description('Stable core command').rootHelp({ category: 'core' });
+      root
+        .command('alpha-core')
+        .description('Alpha core command')
+        .rootHelp({ category: 'core' })
+        .alpha();
+      root
+        .command('stable-management')
+        .description('Stable management command')
+        .rootHelp({ category: 'cli-management' });
+      root
+        .command('alpha-data')
+        .description('Alpha data command')
+        .rootHelp({ category: 'data' })
+        .alpha();
+
+      const help = getCustomRootHelp(root, root.createHelp());
+      const stableCoreIndex = help.indexOf('Stable core command');
+      const stableManagementIndex = help.indexOf('Stable management command');
+      const alphaCoreIndex = help.indexOf('Alpha core command [ALPHA]');
+      const alphaDataIndex = help.indexOf('Alpha data command [ALPHA]');
+
+      expect(stableCoreIndex).toBeGreaterThan(-1);
+      expect(stableManagementIndex).toBeGreaterThan(stableCoreIndex);
+      expect(alphaCoreIndex).toBeGreaterThan(stableManagementIndex);
+      expect(alphaDataIndex).toBeGreaterThan(alphaCoreIndex);
+      expect(help.slice(stableManagementIndex, alphaCoreIndex)).toContain('\n\n');
+    });
+
+    it('tags alpha subcommands in an expanded root-help label', () => {
+      process.env[ALPHA_ENV_VAR] = '1';
+      const root = new SonarCommand('sonar');
+      const system = root
+        .command('system')
+        .description('System commands')
+        .rootHelp({ category: 'cli-management' });
+      system.command('status').description('Stable status command');
+      system.command('reset').description('Stable reset command');
+      system.command('alpha-example').description('Nested alpha command').alpha();
+
+      const help = getCustomRootHelp(root, root.createHelp());
+
+      expect(help).toContain('system <status|reset|alpha-example[ALPHA]>');
+    });
+
+    it('warns on stderr before invoking the command handler', async () => {
+      process.env[ALPHA_ENV_VAR] = '1';
+      const handler = mock(() => {});
+      const root = new SonarCommand('sonar');
+      root.command('experimental').alpha().anonymousAction(handler);
+
+      await root.parseAsync(['experimental'], { from: 'user' });
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      const warning = getMockUiCalls().find((call) => call.method === 'warn');
+      expect(warning?.args[0]).toBe(
+        "'experimental' is in alpha; may change or be removed without notice.",
+      );
     });
   });
 

--- a/tests/unit/commands/sonar-command.test.ts
+++ b/tests/unit/commands/sonar-command.test.ts
@@ -288,12 +288,39 @@ describe('SonarCommand', () => {
         .description('System commands')
         .rootHelp({ category: 'cli-management' });
       system.command('status').description('Stable status command');
-      system.command('reset').description('Stable reset command');
       system.command('alpha-example').description('Nested alpha command').alpha();
+      system.command('reset').description('Stable reset command');
 
       const help = getCustomRootHelp(root, root.createHelp());
 
       expect(help).toContain('system <status|reset|alpha-example[ALPHA]>');
+    });
+
+    it('lists alpha subcommands in a separate group at the bottom of their parent help', () => {
+      process.env[ALPHA_ENV_VAR] = '1';
+      const parent = new SonarCommand('parent');
+      parent.command('alpha-one').description('First alpha command').alpha();
+      parent.command('stable-one').description('First stable command');
+      parent.command('alpha-two').description('Second alpha command').alpha();
+      parent.command('stable-two').description('Second stable command');
+
+      expect(parent.helpInformation()).toBe(
+        [
+          'Usage: parent [options] [command]',
+          '',
+          'Options:',
+          '  -h, --help      display help for command',
+          '',
+          'Commands:',
+          '  stable-one      First stable command',
+          '  stable-two      Second stable command',
+          '  help [command]  display help for command',
+          '',
+          '  alpha-one       First alpha command [ALPHA]',
+          '  alpha-two       Second alpha command [ALPHA]',
+          '',
+        ].join('\n'),
+      );
     });
 
     it('warns on stderr before invoking the command handler', async () => {

--- a/tests/unit/commands/sonar-command.test.ts
+++ b/tests/unit/commands/sonar-command.test.ts
@@ -196,6 +196,18 @@ describe('SonarCommand', () => {
       expect(root.helpInformation()).not.toContain('Experimental command');
     });
 
+    it.each(['false', '0', '', 'yes', 'TRUE'])(
+      'unregisters the command when SONARQUBE_CLI_ALPHA is set to %s',
+      (value) => {
+        process.env[ALPHA_ENV_VAR] = value;
+        const root = new SonarCommand('sonar');
+        root.command('experimental').description('Experimental command').alpha();
+
+        expect(root.commands.map((command) => command.name())).not.toContain('experimental');
+        expect(root.helpInformation()).not.toContain('Experimental command');
+      },
+    );
+
     it('does not execute an unregistered alpha command', async () => {
       const rootHandler = mock((_command?: string) => {});
       const alphaHandler = mock(() => {});
@@ -208,15 +220,21 @@ describe('SonarCommand', () => {
       expect(alphaHandler).not.toHaveBeenCalled();
     });
 
-    it('registers the command and tags help when SONARQUBE_CLI_ALPHA is set', () => {
-      process.env[ALPHA_ENV_VAR] = '';
-      const root = new SonarCommand('sonar');
-      const alphaCommand = root.command('experimental').description('Experimental command').alpha();
+    it.each(['true', '1'])(
+      'registers the command and tags help when SONARQUBE_CLI_ALPHA is set to %s',
+      (value) => {
+        process.env[ALPHA_ENV_VAR] = value;
+        const root = new SonarCommand('sonar');
+        const alphaCommand = root
+          .command('experimental')
+          .description('Experimental command')
+          .alpha();
 
-      expect(root.commands.map((command) => command.name())).toContain('experimental');
-      expect(root.helpInformation()).toContain('Experimental command [ALPHA]');
-      expect(alphaCommand.helpInformation()).toContain('Experimental command [ALPHA]');
-    });
+        expect(root.commands.map((command) => command.name())).toContain('experimental');
+        expect(root.helpInformation()).toContain('Experimental command [ALPHA]');
+        expect(alphaCommand.helpInformation()).toContain('Experimental command [ALPHA]');
+      },
+    );
 
     it('tags an explicit command summary', () => {
       process.env[ALPHA_ENV_VAR] = '1';


### PR DESCRIPTION
----
## Summary by Gitar

- **Commands:**
    - Added `alpha()` method to `SonarCommand` to declare alpha commands conditioned on `SONARQUBE_CLI_ALPHA`
    - Appended `[ALPHA]` tags to alpha command descriptions and summaries
    - Grouped alpha commands together in custom root help output and warned users on execution


<sub>This will update automatically on new commits.</sub>