### PR TITLE
CLI-906 Make sure Vortex is disabled by default

### DIFF
--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -617,7 +617,7 @@ runCommand
   .option('--read-only', 'Start the MCP server in read-only mode')
   .option(
     '--toolsets <toolsets>',
-    'Comma-separated list of toolsets to enable (e.g. issues,quality-gates,duplications,dependency-risks,coverage,cag,portfolios)',
+    'Comma-separated list of toolsets to enable (e.g. issues,quality-gates,duplications,dependency-risks,coverage,vortex,portfolios)',
   )
   .option('-p, --project <project>', 'Project key (overrides auto-discovery)')
   .addHelpText(`after`, projectKeyExtraHelp)

--- a/src/core/host/mcp/mcp-helper.ts
+++ b/src/core/host/mcp/mcp-helper.ts
@@ -98,10 +98,10 @@ export const MCP_CONTAINER_CA_CERT_PATH = '/usr/local/share/ca-certificates/sona
 // Fixed mount path for the client certificate PKCS12 keystore inside the MCP container.
 export const MCP_CONTAINER_CLIENT_CERT_PATH = '/etc/ssl/mcp/client.p12';
 
-// All MCP toolsets supported by the server, excluding 'cag' which is available directly via the CLI.
-// Passed explicitly to avoid relying on MCP-side defaults.
+// All MCP toolsets supported by the server, excluding 'cag'/'vortex' which are available
+// directly via the CLI's own Vortex analysis. Passed explicitly to avoid relying on MCP-side defaults.
 export const MCP_DEFAULT_TOOLSETS =
-  'analysis,issues,projects,quality-gates,rules,duplications,measures,security-hotspots,dependency-risks,coverage';
+  'issues,projects,quality-gates,rules,duplications,measures,security-hotspots,dependency-risks,coverage,ide';
 
 function toJavaNonProxyHosts(noProxy: string): string {
   return noProxy

--- a/tests/integration/specs/run/mcp.test.ts
+++ b/tests/integration/specs/run/mcp.test.ts
@@ -211,7 +211,7 @@ describe('run mcp', () => {
   );
 
   it(
-    'uses default toolsets (excluding cag) when --toolsets is not set',
+    'uses default toolsets (including ide, excluding vortex) when --toolsets is not set',
     async () => {
       const server = await harness.newFakeServer().withAuthToken('test-token').start();
       harness.withAuth(server.baseUrl(), 'test-token');
@@ -226,26 +226,29 @@ describe('run mcp', () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('-e SONARQUBE_TOOLSETS');
-      expect(result.stdout).toContain('ENV_TOOLSETS=analysis,issues,projects');
+      expect(result.stdout).toContain(
+        'ENV_TOOLSETS=issues,projects,quality-gates,rules,duplications,measures,security-hotspots,dependency-risks,coverage,ide',
+      );
       expect(result.stdout).not.toContain('cag');
+      expect(result.stdout).not.toContain('vortex');
     },
     { timeout: 15000 },
   );
 
   it(
-    'passes cag through when explicitly included in --toolsets',
+    'passes cag/vortex through when explicitly included in --toolsets',
     async () => {
       const server = await harness.newFakeServer().withAuthToken('test-token').start();
       harness.withAuth(server.baseUrl(), 'test-token');
       const fakeBinDir = setupFakeDocker();
 
-      const result = await harness.run('run mcp --toolsets cag,issues', {
+      const result = await harness.run('run mcp --toolsets cag,vortex,issues', {
         extraEnv: { PATH: `${fakeBinDir}${PATH_SEP}${process.env.PATH ?? ''}` },
       });
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('-e SONARQUBE_TOOLSETS');
-      expect(result.stdout).toContain('ENV_TOOLSETS=cag,issues');
+      expect(result.stdout).toContain('ENV_TOOLSETS=cag,vortex,issues');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/system/system-status.test.ts
+++ b/tests/integration/specs/system/system-status.test.ts
@@ -1256,6 +1256,7 @@ describe('system status', () => {
     const FIXTURE_DIR = join(import.meta.dir, '../../../fixtures/client-cert');
     const CERT_PATH = join(FIXTURE_DIR, 'client-cert.pem');
     const KEY_PATH = join(FIXTURE_DIR, 'client-key.pem');
+    const KEY_PATH_ENCRYPTED = join(FIXTURE_DIR, 'client-key-encrypted-pkcs8.pem');
     const P12_PATH = join(FIXTURE_DIR, 'client-cert.p12');
     const P12_NO_PASSPHRASE_PATH = join(FIXTURE_DIR, 'client-cert-no-passphrase.p12');
 
@@ -1286,11 +1287,11 @@ describe('system status', () => {
     it('shows Passphrase: Set for PEM cert with passphrase', async () => {
       const result = await runStatus({
         SONAR_TLS_CLIENT_CERT: CERT_PATH,
-        SONAR_TLS_CLIENT_KEY_FILE: KEY_PATH,
-        SONAR_TLS_CLIENT_PASSPHRASE: 'secret',
+        SONAR_TLS_CLIENT_KEY_FILE: KEY_PATH_ENCRYPTED,
+        SONAR_TLS_CLIENT_PASSPHRASE: 'testpassword',
       });
 
-      expect(result.stdout).toContain(`Key:         ${KEY_PATH}`);
+      expect(result.stdout).toContain(`Key:         ${KEY_PATH_ENCRYPTED}`);
       expect(result.stdout).toContain('Passphrase:  Set');
     });
 
@@ -1349,8 +1350,8 @@ describe('system status', () => {
       it('sets passphraseSet: true for PEM cert with passphrase', async () => {
         const cert = await runStatusJson({
           SONAR_TLS_CLIENT_CERT: CERT_PATH,
-          SONAR_TLS_CLIENT_KEY_FILE: KEY_PATH,
-          SONAR_TLS_CLIENT_PASSPHRASE: 'secret',
+          SONAR_TLS_CLIENT_KEY_FILE: KEY_PATH_ENCRYPTED,
+          SONAR_TLS_CLIENT_PASSPHRASE: 'testpassword',
         });
         expect(cert).toMatchObject({ passphraseSet: true });
       });


### PR DESCRIPTION
----
## Summary by Gitar

- **MCP toolsets update:**
    - Added `ide` to `MCP_DEFAULT_TOOLSETS` and excluded `vortex` by default
- **Command options & tests:**
    - Updated `--toolsets` option help text and integration tests to verify `vortex` behavior
- **System status tests:**
    - Switched client certificate test fixtures to use an encrypted PKCS8 key with `client-key-encrypted-pkcs8.pem`

<sub>This will update automatically on new commits.</sub>