### PR TITLE
CLI-950 Improve output formatting for secrets pre-push hook

### DIFF
--- a/src/commands/hook/git-pre-commit-secrets.ts
+++ b/src/commands/hook/git-pre-commit-secrets.ts
@@ -22,7 +22,6 @@ import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { CommandFailedError } from '@/core/command-error.ts';
 import { resolveSecretsBinaryPath } from '@/core/host/install/secrets.ts';
 import { SECRETS_CALLER_COMMANDS } from '@/core/telemetry/secrets-analysis-telemetry.ts';
-import { print } from '@/core/ui';
 
 import {
   EXIT_CODE_SECRETS_FOUND,
@@ -35,6 +34,7 @@ import {
   MissingDependenciesError,
   SECRETS_INACTIVE_BINARY_MISSING,
 } from './hook-dependencies.ts';
+import { printSecretsFindingsOrStderr } from './secrets-display.ts';
 
 export async function runCommitSecretsStage(files: string[], auth: ResolvedAuth): Promise<void> {
   const binaryPath = resolveSecretsBinaryPath();
@@ -57,16 +57,7 @@ export async function runCommitSecretsStage(files: string[], auth: ResolvedAuth)
   warnScanErrors(errors);
 
   if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
-    if (issues.length > 0) {
-      const lines = issues.map((issue) => {
-        const location = issue.location ? `:${String(issue.location.startLine)}` : '';
-        const secret = issue.maskedSecret ? ` (secret: ${issue.maskedSecret})` : '';
-        return `  • ${issue.file ?? '(unknown)'}${location} — ${issue.description}${secret}`;
-      });
-      print(lines.join('\n'));
-    } else if (result.stderr) {
-      print(result.stderr);
-    }
+    printSecretsFindingsOrStderr(issues, result.stderr);
     throw new CommandFailedError('Secrets detected in staged files.', {
       remediationHint: 'Remove the reported secret, then retry the commit.',
     });

--- a/src/commands/hook/git-pre-push-secrets.ts
+++ b/src/commands/hook/git-pre-push-secrets.ts
@@ -34,6 +34,7 @@ import {
   MissingDependenciesError,
   SECRETS_INACTIVE_BINARY_MISSING,
 } from './hook-dependencies.ts';
+import { printSecretsFindingsOrStderr } from './secrets-display.ts';
 
 export async function runSecretsStage(files: string[], auth: ResolvedAuth): Promise<void> {
   if (files.length === 0) return;
@@ -56,6 +57,7 @@ export async function runSecretsStage(files: string[], auth: ResolvedAuth): Prom
   warnScanErrors(parsed.errors);
 
   if ((result.exitCode ?? 1) === EXIT_CODE_SECRETS_FOUND) {
+    printSecretsFindingsOrStderr(parsed.issues, result.stderr);
     throw new CommandFailedError('Secrets detected in pushed commits.', {
       remediationHint:
         'Remove the reported secret, amend the commit if needed, then retry the push.',

--- a/src/commands/hook/secrets-display.ts
+++ b/src/commands/hook/secrets-display.ts
@@ -1,0 +1,37 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { SecretsJsonIssue } from '@/commands/analyze/secrets.ts';
+import { print } from '@/core/ui';
+
+function formatSecretsFindingLine(issue: SecretsJsonIssue): string {
+  const location = issue.location ? `:${String(issue.location.startLine)}` : '';
+  const secret = issue.maskedSecret ? ` (secret: ${issue.maskedSecret})` : '';
+  return `  • ${issue.file ?? '(unknown)'}${location} — ${issue.description}${secret}`;
+}
+
+/** Shared by the git pre-commit/pre-push hooks to surface finding detail before blocking. */
+export function printSecretsFindingsOrStderr(issues: SecretsJsonIssue[], stderr: string): void {
+  if (issues.length > 0) {
+    print(issues.map(formatSecretsFindingLine).join('\n'));
+  } else if (stderr) {
+    print(stderr);
+  }
+}

--- a/tests/unit/commands/hook/git.test.ts
+++ b/tests/unit/commands/hook/git.test.ts
@@ -24,6 +24,7 @@ import * as authResolver from '@/core/auth/auth-resolver.ts';
 import { CommandFailedError } from '@/core/command-error.ts';
 import * as installSecrets from '@/core/host/install/secrets.ts';
 import * as processLib from '@/core/process/process.ts';
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 
 import * as analyzeSecrets from '../../../../src/commands/analyze/secrets.ts';
 import { gitPreCommit } from '../../../../src/commands/hook/git-pre-commit.ts';
@@ -47,6 +48,21 @@ const FAKE_AUTH = {
 
 const OK_RESULT = { exitCode: 0, stdout: '', stderr: '' };
 const SECRETS_RESULT = { exitCode: EXIT_CODE_SECRETS_FOUND, stdout: '', stderr: '' };
+const SECRETS_RESULT_WITH_ISSUES = {
+  exitCode: EXIT_CODE_SECRETS_FOUND,
+  stdout: JSON.stringify({
+    issues: [
+      {
+        ruleKey: 'secrets:S6640',
+        description: 'AWS key detected',
+        file: 'src/config.ts',
+        location: { startLine: 12, startColumn: 1, endLine: 12, endColumn: 40 },
+        maskedSecret: 'AKIA****',
+      },
+    ],
+  }),
+  stderr: '',
+};
 
 describe('gitPreCommit', () => {
   let resolveAuthSpy: ReturnType<typeof spyOn>;
@@ -55,6 +71,8 @@ describe('gitPreCommit', () => {
   let runSecretsBinarySpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
     resolveAuthSpy = spyOn(authResolver, 'resolveAuth').mockResolvedValue(FAKE_AUTH);
     spawnProcessSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
       exitCode: 0,
@@ -68,6 +86,7 @@ describe('gitPreCommit', () => {
   });
 
   afterEach(() => {
+    setMockUi(false);
     resolveAuthSpy.mockRestore();
     spawnProcessSpy.mockRestore();
     resolveSecretsBinaryPathSpy.mockRestore();
@@ -93,6 +112,19 @@ describe('gitPreCommit', () => {
     }
     expect(thrown).toBeInstanceOf(CommandFailedError);
     expect((thrown as CommandFailedError).message).toBe('Secrets detected in staged files.');
+  });
+
+  it('prints finding detail (file, line, masked secret) when secrets are found', async () => {
+    runSecretsBinarySpy.mockResolvedValue(SECRETS_RESULT_WITH_ISSUES);
+
+    await gitPreCommit().catch(() => undefined);
+
+    const prints = getMockUiCalls()
+      .filter((c) => c.method === 'print')
+      .map((c) => String(c.args[0]));
+    expect(prints.some((m) => m.includes('src/config.ts:12'))).toBe(true);
+    expect(prints.some((m) => m.includes('AWS key detected'))).toBe(true);
+    expect(prints.some((m) => m.includes('AKIA****'))).toBe(true);
   });
 
   it('resolves without throwing when no secrets are found', async () => {
@@ -188,6 +220,8 @@ describe('gitPrePush', () => {
   };
 
   beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
     resolveAuthSpy = spyOn(authResolver, 'resolveAuth').mockResolvedValue(FAKE_AUTH);
     spawnProcessSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
       exitCode: 0,
@@ -202,6 +236,7 @@ describe('gitPrePush', () => {
   });
 
   afterEach(() => {
+    setMockUi(false);
     resolveAuthSpy.mockRestore();
     spawnProcessSpy.mockRestore();
     resolveSecretsBinaryPathSpy.mockRestore();
@@ -228,6 +263,19 @@ describe('gitPrePush', () => {
     }
     expect(thrown).toBeInstanceOf(CommandFailedError);
     expect((thrown as CommandFailedError).message).toBe('Secrets detected in pushed commits.');
+  });
+
+  it('prints finding detail (file, line, masked secret) when secrets are found', async () => {
+    runSecretsBinarySpy.mockResolvedValue(SECRETS_RESULT_WITH_ISSUES);
+
+    await gitPrePush().catch(() => undefined);
+
+    const prints = getMockUiCalls()
+      .filter((c) => c.method === 'print')
+      .map((c) => String(c.args[0]));
+    expect(prints.some((m) => m.includes('src/config.ts:12'))).toBe(true);
+    expect(prints.some((m) => m.includes('AWS key detected'))).toBe(true);
+    expect(prints.some((m) => m.includes('AKIA****'))).toBe(true);
   });
 
   it('resolves without throwing when no secrets found', async () => {

--- a/tests/unit/commands/hook/secrets-display.test.ts
+++ b/tests/unit/commands/hook/secrets-display.test.ts
@@ -1,0 +1,124 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import type { SecretsJsonIssue } from '@/commands/analyze/secrets.ts';
+import { printSecretsFindingsOrStderr } from '@/commands/hook/secrets-display.ts';
+import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
+
+function printedLines(): string[] {
+  return getMockUiCalls()
+    .filter((c) => c.method === 'print')
+    .map((c) => String(c.args[0]));
+}
+
+describe('printSecretsFindingsOrStderr', () => {
+  beforeEach(() => {
+    setMockUi(true);
+    clearMockUiCalls();
+  });
+
+  afterEach(() => {
+    setMockUi(false);
+  });
+
+  it('formats a full finding with file, line, description, and masked secret', () => {
+    const issue: SecretsJsonIssue = {
+      ruleKey: 'aws-key',
+      description: 'AWS key detected',
+      file: 'src/config.ts',
+      location: { startLine: 12, startColumn: 1, endLine: 12, endColumn: 20 },
+      maskedSecret: 'AKIA****',
+    };
+
+    printSecretsFindingsOrStderr([issue], '');
+
+    const [line] = printedLines();
+    expect(line).toBe('  • src/config.ts:12 — AWS key detected (secret: AKIA****)');
+  });
+
+  it('omits the line suffix when location is missing', () => {
+    const issue: SecretsJsonIssue = {
+      ruleKey: 'aws-key',
+      description: 'AWS key detected',
+      file: 'src/config.ts',
+      maskedSecret: 'AKIA****',
+    };
+
+    printSecretsFindingsOrStderr([issue], '');
+
+    const [line] = printedLines();
+    expect(line).toBe('  • src/config.ts — AWS key detected (secret: AKIA****)');
+  });
+
+  it('omits the masked-secret suffix when maskedSecret is missing', () => {
+    const issue: SecretsJsonIssue = {
+      ruleKey: 'aws-key',
+      description: 'AWS key detected',
+      file: 'src/config.ts',
+      location: { startLine: 12, startColumn: 1, endLine: 12, endColumn: 20 },
+    };
+
+    printSecretsFindingsOrStderr([issue], '');
+
+    const [line] = printedLines();
+    expect(line).toBe('  • src/config.ts:12 — AWS key detected');
+  });
+
+  it('falls back to "(unknown)" when file is missing', () => {
+    const issue: SecretsJsonIssue = {
+      ruleKey: 'aws-key',
+      description: 'AWS key detected',
+    };
+
+    printSecretsFindingsOrStderr([issue], '');
+
+    const [line] = printedLines();
+    expect(line).toBe('  • (unknown) — AWS key detected');
+  });
+
+  it('joins multiple findings on separate lines in a single print call', () => {
+    const issues: SecretsJsonIssue[] = [
+      { ruleKey: 'aws-key', description: 'AWS key detected', file: 'src/a.ts' },
+      { ruleKey: 'gh-token', description: 'GitHub token detected', file: 'src/b.ts' },
+    ];
+
+    printSecretsFindingsOrStderr(issues, '');
+
+    const calls = getMockUiCalls().filter((c) => c.method === 'print');
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]?.args[0])).toBe(
+      '  • src/a.ts — AWS key detected\n  • src/b.ts — GitHub token detected',
+    );
+  });
+
+  it('prints stderr when there are no issues but stderr is non-empty', () => {
+    printSecretsFindingsOrStderr([], 'binary crashed');
+
+    expect(printedLines()).toEqual(['binary crashed']);
+  });
+
+  it('prints nothing when there are no issues and stderr is empty', () => {
+    printSecretsFindingsOrStderr([], '');
+
+    expect(printedLines()).toEqual([]);
+  });
+});


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Refactoring & UI:**
    - Extracted shared `printSecretsFindingsOrStderr` helper in `secrets-display.ts` for pre-commit and pre-push hooks
    - Enabled secrets findings display in `gitPrePush` hook output when vulnerabilities are detected
- **Tests:**
    - Added unit test coverage for secret finding details output in both pre-commit and pre-push hooks

<sub>This will update automatically on new commits.</sub>