### PR TITLE
CLI-960 Send x-sonar-invocation-id on Vortex analysis requests

### DIFF
--- a/src/core/server/client.ts
+++ b/src/core/server/client.ts
@@ -21,6 +21,7 @@
 // SonarQube API HTTP client
 
 import { buildFetchNetworkOptions } from '@/core/host/connectivity/network-config.ts';
+import { INVOCATION_ID, SONAR_INVOCATION_ID_HEADER } from '@/core/telemetry/invocation-id.ts';
 import { print } from '@/core/ui';
 
 import { version as VERSION } from '../../../package.json';
@@ -267,14 +268,20 @@ export class SonarQubeClient {
   /**
    * Make POST request to SonarQube API using Bearer token
    */
-  async post<T>(endpoint: string, body: unknown, baseUrl?: string): Promise<T> {
+  async post<T>(
+    endpoint: string,
+    body: unknown,
+    baseUrl?: string,
+    extraHeaders?: Record<string, string>,
+  ): Promise<T> {
     const url = `${baseUrl ?? this.serverURL}${endpoint}`;
+    const headers = { ...this.commonHeaders('json'), ...extraHeaders };
 
     const response = await fetchGuarded(
       url,
       buildFetchInit(
         'POST',
-        this.commonHeaders('json'),
+        headers,
         POST_REQUEST_TIMEOUT_MS,
         JSON.stringify(body),
         buildFetchNetworkOptions(url),
@@ -896,6 +903,7 @@ export class SonarQubeClient {
         endpoint,
         request,
         resolveFromEndpoint(this.serverURL, endpoint),
+        { [SONAR_INVOCATION_ID_HEADER]: INVOCATION_ID },
       );
     } catch (err) {
       // 403 on this endpoint means Agentic Pack entitlement was revoked.

--- a/src/core/telemetry/invocation-id.ts
+++ b/src/core/telemetry/invocation-id.ts
@@ -20,6 +20,9 @@
 
 import { randomUUID } from 'node:crypto';
 
+/** HTTP header name used when forwarding INVOCATION_ID to Vortex / CAG. */
+export const SONAR_INVOCATION_ID_HEADER = 'x-sonar-invocation-id';
+
 // Per-CLI-process correlation id. Shared between the CLI's own telemetry
 // event payload and the `SONAR_CONTEXT_INVOCATION_ID` env var forwarded to every
 // sonar-context-augmentation subprocess so the CAG daemon can correlate

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -113,6 +113,9 @@ describe('analyze (no subcommand)', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/a3s-analysis/analyses');
       expect(sqaaCalls).toHaveLength(1);
+      expect(sqaaCalls[0].headers['x-sonar-invocation-id']).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
     },
     { timeout: 15000 },
   );

--- a/tests/unit/commands/run/mcp.test.ts
+++ b/tests/unit/commands/run/mcp.test.ts
@@ -140,12 +140,13 @@ describe('runMcp', () => {
 
       await runMcp(FAKE_AUTH);
 
-      expect(spawnSpy).toHaveBeenCalledWith(
-        'wsl.exe',
-        ['sh', '-c', expect.stringContaining(`${runtime} run`)],
-        expect.objectContaining({ stdio: 'inherit' }),
-      );
-      const spawnEnv = spawnSpy.mock.calls[0][2].env as Record<string, string>;
+      // Prefer the wsl.exe call: mock.module('node:child_process') in other
+      // suites (e.g. update-version) can leave earlier spawn calls on the shared mock.
+      const wslCall = spawnSpy.mock.calls.find((call) => call[0] === 'wsl.exe');
+      expect(wslCall).toBeDefined();
+      expect(wslCall![1]).toEqual(['sh', '-c', expect.stringContaining(`${runtime} run`)]);
+      expect(wslCall![2]).toEqual(expect.objectContaining({ stdio: 'inherit' }));
+      const spawnEnv = (wslCall![2] as { env: Record<string, string> }).env;
       expect(spawnEnv.WSLENV).toContain('SONARQUBE_TOKEN/u');
     },
   );

--- a/tests/unit/commands/run/mcp.test.ts
+++ b/tests/unit/commands/run/mcp.test.ts
@@ -142,7 +142,9 @@ describe('runMcp', () => {
 
       // Prefer the wsl.exe call: mock.module('node:child_process') in other
       // suites (e.g. update-version) can leave earlier spawn calls on the shared mock.
-      const wslCall = spawnSpy.mock.calls.find((call) => call[0] === 'wsl.exe');
+      const wslCall = spawnSpy.mock.calls.find(
+        (call: unknown[]) => Array.isArray(call) && call[0] === 'wsl.exe',
+      );
       expect(wslCall).toBeDefined();
       expect(wslCall![1]).toEqual(['sh', '-c', expect.stringContaining(`${runtime} run`)]);
       expect(wslCall![2]).toEqual(expect.objectContaining({ stdio: 'inherit' }));

--- a/tests/unit/core/server/client.test.ts
+++ b/tests/unit/core/server/client.test.ts
@@ -29,6 +29,7 @@ import {
 import { SonarQubeClient } from '@/core/server/client.ts';
 import { ForbiddenApiError } from '@/core/server/errors.ts';
 import { fetchGuarded } from '@/core/server/fetch-guarded.ts';
+import { INVOCATION_ID } from '@/core/telemetry/invocation-id.ts';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 
 import { version as VERSION } from '../../../../package.json';
@@ -1133,6 +1134,16 @@ describe('SonarQubeClient', () => {
 
       const init = lastFetchInit(fetchSpy);
       expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`);
+    });
+
+    it('sends x-sonar-invocation-id header from INVOCATION_ID', async () => {
+      fetchSpy = mockFetch({ id: 'a1', issues: [], errors: null });
+
+      await client.createAnalysis(singleFileRequest);
+
+      expect(lastFetchInit(fetchSpy).headers).toMatchObject({
+        'x-sonar-invocation-id': INVOCATION_ID,
+      });
     });
 
     it('sends request body as JSON with files[]', async () => {


### PR DESCRIPTION
## Summary
- Forward the per-process `INVOCATION_ID` on Vortex `createAnalysis` requests via `x-sonar-invocation-id` (same header CAG already uses)
- Extend `SonarQubeClient.post` with an optional `extraHeaders` param so only analysis POSTs carry the header
- Cover with unit and integration assertions against `/a3s-analysis/analyses`

Related: [CLI-960](https://sonarsource.atlassian.net/browse/CLI-960)

[CLI-960]: https://sonarsource.atlassian.net/browse/CLI-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ