### PR TITLE
CLI-959 Add agent_session_id to CLI telemetry identity

### DIFF
--- a/src/commands/analyze/sqaa-run.ts
+++ b/src/commands/analyze/sqaa-run.ts
@@ -77,9 +77,17 @@ async function emitSqaaTelemetryIfRequested(
   tally: RunTally,
   durationMs: number,
   exitCode: number,
+  agentSessionId?: string | null,
 ): Promise<void> {
   if (!telemetryCallerCommand) return;
-  await emitSqaaAnalysisTelemetry(telemetryCallerCommand, auth, tally, durationMs, exitCode);
+  await emitSqaaAnalysisTelemetry(
+    telemetryCallerCommand,
+    auth,
+    tally,
+    durationMs,
+    exitCode,
+    agentSessionId,
+  );
 }
 
 export async function finishSqaaTelemetryFromReport(
@@ -102,6 +110,7 @@ export async function finishSqaaTelemetryFromReport(
     tallyFromSqaaJsonReport(report),
     durationMs,
     exitCode,
+    runOptions.agentSessionId,
   );
 }
 
@@ -123,6 +132,7 @@ async function finishSqaaRun(
     tally,
     durationMs,
     exitCode,
+    options.agentSessionId,
   );
 }
 

--- a/src/commands/analyze/sqaa-types.ts
+++ b/src/commands/analyze/sqaa-types.ts
@@ -33,6 +33,8 @@ export interface AnalyzeSqaaRunOptions {
   telemetryCallerCommand?: SqaaTelemetryCallerCommand;
   /** Overrides computed CLI exit for telemetry only (e.g. non-blocking hooks always exit 0). */
   telemetryProcessExitCode?: number | null;
+  /** Hook-derived agent session id; merged into telemetry identity when present. */
+  agentSessionId?: string | null;
 }
 
 export interface AnalyzeSqaaOptions {
@@ -61,6 +63,7 @@ export interface SqaaBatchRunOptions {
   wireDepth?: SqaaDeepWireDepth;
   displayDepth?: SqaaAnalysisDepth;
   telemetryCallerCommand?: SqaaTelemetryCallerCommand;
+  agentSessionId?: string | null;
 }
 
 export interface SingleFileRunOptions {

--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -803,9 +803,12 @@ function buildCommandTree(runtime: CliRuntime): SonarCommand {
   // Collect a telemetry event after every command action.
   COMMAND_TREE.hook('postAction', async (_thisCommand, actionCommand) => {
     // Resolve/cache the agent session id for this invocation (env fallback when
-    // no hook id). Emitting it on telemetry is CLI-959.
-    resolveAgentSessionId(agentSession);
-    await storeEvent(actionCommand, (process.exitCode ?? 0) === 0);
+    // no hook id), then pass it into telemetry.
+    await storeEvent(
+      actionCommand,
+      (process.exitCode ?? 0) === 0,
+      resolveAgentSessionId(agentSession),
+    );
     await COMMAND_TREE.updateNotifier.maybeNotify(actionCommand);
   });
 

--- a/src/commands/hook/agent-post-tool-use.ts
+++ b/src/commands/hook/agent-post-tool-use.ts
@@ -28,6 +28,7 @@ import { canonicalizePath, toRelativePosixPath } from '@/core/io/fs-utils.ts';
 import logger from '@/core/observability/logger.ts';
 import { timed } from '@/core/observability/timed.ts';
 import { SqaaForbiddenError } from '@/core/server/errors.ts';
+import { resolveAgentSessionIdForEmit } from '@/core/telemetry/agent-session.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import {
   emitSqaaHookFailureTelemetry,
@@ -53,14 +54,18 @@ export interface AgentPostToolUseOptions {
   project?: string;
 }
 
-const CLAUDE_HOOK_TELEMETRY_OPTIONS = {
-  telemetryCallerCommand: SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
-  telemetryProcessExitCode: SQAA_HOOK_TELEMETRY_EXIT_CODE,
-} as const;
+function claudeHookTelemetryOptions(agentSessionId: string | null) {
+  return {
+    telemetryCallerCommand: SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
+    telemetryProcessExitCode: SQAA_HOOK_TELEMETRY_EXIT_CODE,
+    agentSessionId,
+  } as const;
+}
 
 async function handleSqaaPostToolUse(
   payload: ClaudePostToolUsePayload,
   projectKey: string | undefined,
+  agentSessionId: string | null,
 ): Promise<ClaudePostToolUseResult> {
   const filePath = payload.tool_input?.file_path;
   if (!filePath || !existsSync(filePath)) {
@@ -109,7 +114,7 @@ async function handleSqaaPostToolUse(
     await finishSqaaTelemetryFromReport(
       fetchResult.report,
       auth,
-      CLAUDE_HOOK_TELEMETRY_OPTIONS,
+      claudeHookTelemetryOptions(agentSessionId),
       timedFetch.durationMs,
     ).catch(() => undefined);
   } catch (err) {
@@ -117,6 +122,7 @@ async function handleSqaaPostToolUse(
       SQAA_CLAUDE_POST_TOOL_USE_CALLER_COMMAND,
       auth,
       Math.round(performance.now() - runStart),
+      agentSessionId,
     ).catch(() => undefined);
     logger.debug(`PostToolUse SQAA analysis failed: ${(err as Error).message}`);
     return { decision: 'none' };
@@ -143,11 +149,12 @@ async function handleSqaaPostToolUse(
 
 function createSqaaPostToolUseSubscriber(
   projectKey: string | undefined,
+  agentSessionId: string | null,
 ): ClaudePostToolUseSubscriber {
   return {
     id: 'sqaa',
     matches: (toolName) => toolName === 'Edit' || toolName === 'Write',
-    handle: (payload) => handleSqaaPostToolUse(payload, projectKey),
+    handle: (payload) => handleSqaaPostToolUse(payload, projectKey, agentSessionId),
   };
 }
 
@@ -162,12 +169,13 @@ export async function agentPostToolUse(
     return { agentSessionId: null }; // unparseable stdin — non-blocking
   }
 
-  const agentSessionId = payload.session_id ?? null;
+  const fromHook = payload.session_id ?? null;
+  const sessionId = resolveAgentSessionIdForEmit(fromHook);
 
   await runClaudePostToolUseDispatch(payload, raw, [
-    createSqaaPostToolUseSubscriber(options.project),
+    createSqaaPostToolUseSubscriber(options.project, sessionId),
     contextAugmentationPostToolUseSubscriber,
   ]);
 
-  return { agentSessionId };
+  return { agentSessionId: fromHook };
 }

--- a/src/commands/hook/codex-post-tool-use.ts
+++ b/src/commands/hook/codex-post-tool-use.ts
@@ -24,6 +24,7 @@ import { buildSqaaJsonReport } from '@/commands/analyze/sqaa.ts';
 import type { SqaaJsonReport } from '@/commands/analyze/sqaa-display.ts';
 import { resolveAuth } from '@/core/auth/auth-resolver.ts';
 import logger from '@/core/observability/logger.ts';
+import { resolveAgentSessionIdForEmit } from '@/core/telemetry/agent-session.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import {
   emitSqaaHookFailureTelemetry,
@@ -43,10 +44,13 @@ export interface CodexPostToolUseOptions {
   project?: string;
 }
 
-const CODEX_HOOK_TELEMETRY_OPTIONS = {
-  telemetryCallerCommand: SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
-  telemetryProcessExitCode: SQAA_HOOK_TELEMETRY_EXIT_CODE,
-} as const;
+function codexHookTelemetryOptions(agentSessionId: string | null) {
+  return {
+    telemetryCallerCommand: SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
+    telemetryProcessExitCode: SQAA_HOOK_TELEMETRY_EXIT_CODE,
+    agentSessionId,
+  } as const;
+}
 
 interface CodexPostToolUsePayload {
   session_id?: string;
@@ -57,22 +61,23 @@ export async function codexPostToolUse(
 ): Promise<HookCommandResult> {
   // Best-effort: when Codex pipes PostToolUse JSON, capture session_id. Skip when
   // stdin is a TTY — otherwise readStdinJson waits up to 5s for data that never
-  // arrives. Env-based CODEX_* ids still resolve later via resolveAgentSessionId.
-  let agentSessionId: string | null = null;
+  // arrives. Env-based CODEX_* ids still resolve for mid-command SQAA without this.
+  let fromHook: string | null = null;
   if (!process.stdin.isTTY) {
     try {
       const payload = await readStdinJson<CodexPostToolUsePayload>();
-      agentSessionId = payload.session_id ?? null;
+      fromHook = payload.session_id ?? null;
     } catch {
       // ignore
     }
   }
+  const agentSessionId = resolveAgentSessionIdForEmit(fromHook);
 
   const projectKey = options.project;
-  if (!projectKey) return { agentSessionId };
+  if (!projectKey) return { agentSessionId: fromHook };
 
   const auth = await resolveAuth().catch(() => null);
-  if (auth?.connectionType !== 'cloud' || !auth.orgKey) return { agentSessionId };
+  if (auth?.connectionType !== 'cloud' || !auth.orgKey) return { agentSessionId: fromHook };
 
   noteProject(auth, projectKey);
 
@@ -82,23 +87,24 @@ export async function codexPostToolUse(
     report = await buildSqaaJsonReport(
       { project: projectKey, force: true, format: 'json', forcedDepth: 'STANDARD' },
       auth,
-      CODEX_HOOK_TELEMETRY_OPTIONS,
+      codexHookTelemetryOptions(agentSessionId),
     );
   } catch (err) {
     await emitSqaaHookFailureTelemetry(
       SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
       auth,
       Math.round(performance.now() - runStart),
+      agentSessionId,
     ).catch(() => undefined);
     logger.debug(`Codex PostToolUse SQAA analysis failed: ${(err as Error).message}`);
-    return { agentSessionId };
+    return { agentSessionId: fromHook };
   }
 
-  if (!report) return { agentSessionId };
+  if (!report) return { agentSessionId: fromHook };
 
   if (report.globalError?.kind === 'forbidden') {
     await emitVortexUnavailableHookNotice(auth);
-    return { agentSessionId };
+    return { agentSessionId: fromHook };
   }
 
   try {
@@ -110,5 +116,5 @@ export async function codexPostToolUse(
     logger.debug(`Codex PostToolUse SQAA hook output failed: ${(err as Error).message}`);
   }
 
-  return { agentSessionId };
+  return { agentSessionId: fromHook };
 }

--- a/src/core/state/state.ts
+++ b/src/core/state/state.ts
@@ -451,6 +451,8 @@ export interface TelemetryEventIdentityPayload {
   organization_uuid_v4: string | null;
   sqs_installation_id: string | null;
   caller_agent: CallerAgent | null;
+  /** Opaque agent conversation/session id when known; null when unknown (omitted on flush). */
+  agent_session_id: string | null;
 }
 
 export type AnalysisTelemetryAnalyzer = 'sonar-secrets' | 'sqaa' | 'sca-scanner-cli';

--- a/src/core/telemetry/agent-session.ts
+++ b/src/core/telemetry/agent-session.ts
@@ -93,6 +93,18 @@ export function resolveAgentSessionId(
 }
 
 /**
+ * Prefers a hook-payload id (normalized); otherwise falls back to env.
+ * Callers that have not already verified telemetry is on should use
+ * {@link resolveAgentSessionIdForEmit} instead.
+ */
+export function resolveAgentSessionIdFromHookOrEnv(
+  hookSessionId: string | null,
+  env: NodeJS.ProcessEnv = process.env,
+): string | null {
+  return normalizeAgentSessionId(hookSessionId) ?? resolveAgentSessionIdFromEnv(env);
+}
+
+/**
  * Session id for an in-command telemetry emit (e.g. SQAA during a hook).
  * Prefers a hook-payload id (normalized); otherwise falls back to env when
  * collection is on. Does not touch the command-tree slot — postAction owns that.
@@ -102,5 +114,5 @@ export function resolveAgentSessionIdForEmit(
   env: NodeJS.ProcessEnv = process.env,
 ): string | null {
   if (!shouldIdentifyAgentSession()) return null;
-  return normalizeAgentSessionId(hookSessionId) ?? resolveAgentSessionIdFromEnv(env);
+  return resolveAgentSessionIdFromHookOrEnv(hookSessionId, env);
 }

--- a/src/core/telemetry/index.ts
+++ b/src/core/telemetry/index.ts
@@ -44,8 +44,15 @@ export function setPassthroughSubcommand(command: Command, subcommand: string | 
  *
  * No-ops when called from within a flush worker (prevents infinite recursion) or when
  * telemetry is disabled.
+ *
+ * `agentSessionId` is resolved by the caller (buildCommandTree postAction) so session
+ * identification stays outside SonarCommand / CliRuntime.
  */
-export async function storeEvent(command: Command, success: boolean): Promise<void> {
+export async function storeEvent(
+  command: Command,
+  success: boolean,
+  agentSessionId: string | null = null,
+): Promise<void> {
   if (process.env[TELEMETRY_FLUSH_MODE_ENV]) return;
   const state = tryLoadState();
   if (!state || !isTelemetryEnabled(state)) return;
@@ -65,16 +72,19 @@ export async function storeEvent(command: Command, success: boolean): Promise<vo
   } else {
     subcommand = fallbackSubcommand;
   }
-  await emitCommandExecuted({
-    command: topCommand,
-    subcommand,
-    result: success ? 'success' : 'failure',
-    distribution: DISTRIBUTION,
-    // Per-invocation, published by whichever command resolved a project key (see
-    // noteProject). `null` for commands that never resolve one; the other telemetry
-    // events recover it by joining on the shared invocation_id.
-    project_uuid: await currentProjectUuid(),
-  });
+  await emitCommandExecuted(
+    {
+      command: topCommand,
+      subcommand,
+      result: success ? 'success' : 'failure',
+      distribution: DISTRIBUTION,
+      // Per-invocation, published by whichever command resolved a project key (see
+      // noteProject). `null` for commands that never resolve one; the other telemetry
+      // events recover it by joining on the shared invocation_id.
+      project_uuid: await currentProjectUuid(),
+    },
+    { agentSessionId },
+  );
 
   // Gated at the spawn rather than in the worker: a process that is never created cannot
   // transmit, whatever the drain does.

--- a/src/core/telemetry/sqaa-analysis-telemetry.ts
+++ b/src/core/telemetry/sqaa-analysis-telemetry.ts
@@ -60,6 +60,7 @@ export async function emitSqaaHookFailureTelemetry(
   callerCommand: SqaaTelemetryCallerCommand,
   auth: ResolvedAuth,
   durationMs: number,
+  agentSessionId?: string | null,
 ): Promise<void> {
   await emitSqaaAnalysisTelemetry(
     callerCommand,
@@ -67,6 +68,7 @@ export async function emitSqaaHookFailureTelemetry(
     { allResults: [], totalIssues: 0, totalErrors: 0, totalFailures: 1 },
     durationMs,
     SQAA_HOOK_TELEMETRY_EXIT_CODE,
+    agentSessionId,
   );
 }
 
@@ -150,6 +152,7 @@ export async function emitSqaaAnalysisTelemetry(
   tally: RunTally,
   durationMs: number,
   exitCode?: number | null,
+  agentSessionId?: string | null,
 ): Promise<void> {
   try {
     const analysisId = randomUUID();
@@ -157,17 +160,21 @@ export async function emitSqaaAnalysisTelemetry(
     const details =
       findingsCount > 0 ? JSON.stringify(collectRuleCounts(collectIssuesFromTally(tally))) : '';
 
-    await emitAnalysisCompleted(auth, {
-      caller_command: callerCommand,
-      analyzer: 'sqaa',
-      analysis_id: analysisId,
-      findings_count: findingsCount,
-      exit_code: exitCode ?? null,
-      errors_count: tally.totalErrors,
-      failures_count: tally.totalFailures,
-      scan_duration_ms: durationMs,
-      details,
-    });
+    await emitAnalysisCompleted(
+      auth,
+      {
+        caller_command: callerCommand,
+        analyzer: 'sqaa',
+        analysis_id: analysisId,
+        findings_count: findingsCount,
+        exit_code: exitCode ?? null,
+        errors_count: tally.totalErrors,
+        failures_count: tally.totalFailures,
+        scan_duration_ms: durationMs,
+        details,
+      },
+      { agentSessionId },
+    );
   } catch {
     // Telemetry is strictly fire-and-forget; never surface to the command handler.
   }

--- a/src/core/telemetry/telemetry-events.ts
+++ b/src/core/telemetry/telemetry-events.ts
@@ -41,6 +41,7 @@ import type {
   TelemetryEventIdentityPayload,
 } from '../state/state.ts';
 import { getActiveConnection, tryLoadState } from '../state/state-manager.ts';
+import { resolveAgentSessionIdForEmit } from './agent-session.ts';
 import { isTelemetryEnabled } from './enabled.ts';
 import {
   resolveCommandTelemetryIdentity,
@@ -104,7 +105,7 @@ async function buildIdentityBase(
     organization_uuid_v4: identity.organization_uuid_v4,
     sqs_installation_id: identity.sqs_installation_id,
     caller_agent: detectCallerAgent(),
-    agent_session_id: identityOptions?.agentSessionId ?? null,
+    agent_session_id: resolveAgentSessionIdForEmit(identityOptions?.agentSessionId ?? null),
   };
 }
 
@@ -124,7 +125,10 @@ export type CommandExecutedFields = Omit<
 >;
 
 export type IdentityEmitOptions = {
-  /** Agent session id for this emit (hook-noted or env-resolved); null/omit when unknown. */
+  /**
+   * Agent session id for this emit. Prefers a hook-payload id when given;
+   * otherwise `buildIdentityBase` falls back to agent-native env vars.
+   */
   agentSessionId?: string | null;
 };
 
@@ -160,8 +164,12 @@ export async function emitAnalysisCompleted(
 export async function emitIntegrationConfigured(
   auth: ResolvedAuth,
   fields: IntegrationConfiguredFields,
+  identityOptions?: IdentityEmitOptions,
 ): Promise<void> {
-  const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
+  const base = await buildIdentityBase(
+    (conn) => resolveCommandTelemetryIdentity(conn, auth),
+    identityOptions,
+  );
   if (!base) return;
   appendTelemetryEvent({
     metadata: {

--- a/src/core/telemetry/telemetry-events.ts
+++ b/src/core/telemetry/telemetry-events.ts
@@ -41,7 +41,7 @@ import type {
   TelemetryEventIdentityPayload,
 } from '../state/state.ts';
 import { getActiveConnection, tryLoadState } from '../state/state-manager.ts';
-import { resolveAgentSessionIdForEmit } from './agent-session.ts';
+import { resolveAgentSessionIdFromHookOrEnv } from './agent-session.ts';
 import { isTelemetryEnabled } from './enabled.ts';
 import {
   resolveCommandTelemetryIdentity,
@@ -105,7 +105,7 @@ async function buildIdentityBase(
     organization_uuid_v4: identity.organization_uuid_v4,
     sqs_installation_id: identity.sqs_installation_id,
     caller_agent: detectCallerAgent(),
-    agent_session_id: resolveAgentSessionIdForEmit(identityOptions?.agentSessionId ?? null),
+    agent_session_id: resolveAgentSessionIdFromHookOrEnv(identityOptions?.agentSessionId ?? null),
   };
 }
 
@@ -164,12 +164,8 @@ export async function emitAnalysisCompleted(
 export async function emitIntegrationConfigured(
   auth: ResolvedAuth,
   fields: IntegrationConfiguredFields,
-  identityOptions?: IdentityEmitOptions,
 ): Promise<void> {
-  const base = await buildIdentityBase(
-    (conn) => resolveCommandTelemetryIdentity(conn, auth),
-    identityOptions,
-  );
+  const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
   if (!base) return;
   appendTelemetryEvent({
     metadata: {

--- a/src/core/telemetry/telemetry-events.ts
+++ b/src/core/telemetry/telemetry-events.ts
@@ -83,6 +83,7 @@ type IdentityResolver = (
  */
 async function buildIdentityBase(
   resolve: IdentityResolver,
+  identityOptions?: IdentityEmitOptions,
 ): Promise<TelemetryEventIdentityPayload | null> {
   const state = tryLoadState();
   if (!state || !isTelemetryEnabled(state)) return null;
@@ -103,6 +104,7 @@ async function buildIdentityBase(
     organization_uuid_v4: identity.organization_uuid_v4,
     sqs_installation_id: identity.sqs_installation_id,
     caller_agent: detectCallerAgent(),
+    agent_session_id: identityOptions?.agentSessionId ?? null,
   };
 }
 
@@ -121,6 +123,11 @@ export type CommandExecutedFields = Omit<
   keyof TelemetryEventIdentityPayload
 >;
 
+export type IdentityEmitOptions = {
+  /** Agent session id for this emit (hook-noted or env-resolved); null/omit when unknown. */
+  agentSessionId?: string | null;
+};
+
 /**
  * Emits one CliAnalysisCompleted event when telemetry is enabled.
  * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
@@ -128,8 +135,12 @@ export type CommandExecutedFields = Omit<
 export async function emitAnalysisCompleted(
   auth: ResolvedAuth,
   fields: AnalysisCompletedFields,
+  identityOptions?: IdentityEmitOptions,
 ): Promise<void> {
-  const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
+  const base = await buildIdentityBase(
+    (conn) => resolveCommandTelemetryIdentity(conn, auth),
+    identityOptions,
+  );
   if (!base) return;
   appendTelemetryEvent({
     metadata: {
@@ -167,8 +178,11 @@ export async function emitIntegrationConfigured(
  * Emits one CliCommandExecuted event when telemetry is enabled.
  * Resolves identity from the active connection; no-ops on opt-out or missing installationId.
  */
-export async function emitCommandExecuted(fields: CommandExecutedFields): Promise<void> {
-  const base = await buildIdentityBase(resolveStoreEventTelemetryIdentitySafely);
+export async function emitCommandExecuted(
+  fields: CommandExecutedFields,
+  identityOptions?: IdentityEmitOptions,
+): Promise<void> {
+  const base = await buildIdentityBase(resolveStoreEventTelemetryIdentitySafely, identityOptions);
   if (!base) return;
   appendTelemetryEvent({
     metadata: {

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -1140,6 +1140,35 @@ describe('analyze agentic — analysis telemetry', () => {
   );
 
   it(
+    'records agent_session_id from CLAUDE_CODE_SESSION_ID on CliAnalysisCompleted',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withSqaaResponse({ issues: [] })
+        .start();
+
+      enableFlushTelemetry();
+      harness
+        .state()
+        .withTelemetryEnabled()
+        .withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG)
+        .withSqaaFeature(harness.cwd.path, TEST_PROJECT, TEST_ORG, server.baseUrl());
+
+      harness.cwd.writeFile('src/index.ts', 'const x = 1;');
+
+      const result = await harness.run('analyze agentic --file src/index.ts', {
+        extraEnv: { CLAUDE_CODE_SESSION_ID: 'claude-analyze-session' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      const [completed] = readAnalysisEvents(harness.sonarUserHome.path);
+      expect(completed.event_payload.agent_session_id).toBe('claude-analyze-session');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'writes a single CliAnalysisCompleted with populated details when issues are found',
     async () => {
       const server = await harness

--- a/tests/integration/specs/telemetry/agent-session-id.test.ts
+++ b/tests/integration/specs/telemetry/agent-session-id.test.ts
@@ -1,0 +1,64 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { readCommandEvents } from '../../../_common/telemetry-helpers.ts';
+import { TestHarness } from '../../harness';
+
+const VALID_TOKEN = 'squ_valid_token';
+
+describe('agent_session_id on CliCommandExecuted', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it('records agent_session_id from CLAUDE_CODE_SESSION_ID', async () => {
+    const server = await harness.newFakeServer().withAuthToken(VALID_TOKEN).start();
+    harness.state().withTelemetryEnabled();
+    harness.withAuth(server.baseUrl(), VALID_TOKEN);
+
+    const result = await harness.run('system status', {
+      extraEnv: { CLAUDE_CODE_SESSION_ID: 'claude-integration-session' },
+    });
+    expect(result.exitCode).toBe(0);
+
+    const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+    expect(commandEvent.event_payload.agent_session_id).toBe('claude-integration-session');
+  });
+
+  it('records null agent_session_id when no agent session source is present', async () => {
+    const server = await harness.newFakeServer().withAuthToken(VALID_TOKEN).start();
+    harness.state().withTelemetryEnabled();
+    harness.withAuth(server.baseUrl(), VALID_TOKEN);
+
+    const result = await harness.run('system status');
+    expect(result.exitCode).toBe(0);
+
+    const [commandEvent] = readCommandEvents(harness.sonarUserHome.path);
+    expect(commandEvent.event_payload.agent_session_id).toBeNull();
+  });
+});

--- a/tests/unit/commands/hook/agent-post-tool-use.test.ts
+++ b/tests/unit/commands/hook/agent-post-tool-use.test.ts
@@ -111,6 +111,7 @@ describe('agentPostToolUse', () => {
       expect.objectContaining({ totalIssues: 0, totalFailures: 0 }),
       expect.any(Number),
       SQAA_HOOK_TELEMETRY_EXIT_CODE,
+      null,
     );
   });
 
@@ -135,6 +136,7 @@ describe('agentPostToolUse', () => {
       expect.objectContaining({ totalIssues: 1, totalFailures: 0 }),
       expect.any(Number),
       SQAA_HOOK_TELEMETRY_EXIT_CODE,
+      null,
     );
   });
 
@@ -288,6 +290,7 @@ describe('agentPostToolUse', () => {
       expect.objectContaining({ totalIssues: 0, totalFailures: 1 }),
       expect.any(Number),
       SQAA_HOOK_TELEMETRY_EXIT_CODE,
+      null,
     );
   });
 
@@ -306,6 +309,7 @@ describe('agentPostToolUse', () => {
       expect.objectContaining({ totalIssues: 0, totalFailures: 1 }),
       expect.any(Number),
       SQAA_HOOK_TELEMETRY_EXIT_CODE,
+      null,
     );
   });
 
@@ -321,6 +325,7 @@ describe('agentPostToolUse', () => {
       expect.objectContaining({ totalIssues: 0, totalFailures: 1 }),
       expect.any(Number),
       SQAA_HOOK_TELEMETRY_EXIT_CODE,
+      null,
     );
   });
 

--- a/tests/unit/commands/hook/codex-post-tool-use.test.ts
+++ b/tests/unit/commands/hook/codex-post-tool-use.test.ts
@@ -21,6 +21,7 @@
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import * as authResolver from '@/core/auth/auth-resolver.ts';
+import * as agentSession from '@/core/telemetry/agent-session.ts';
 import * as sqaaTelemetry from '@/core/telemetry/sqaa-analysis-telemetry.ts';
 import {
   SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
@@ -64,6 +65,7 @@ describe('codexPostToolUse', () => {
       sqaaTelemetry,
       'emitSqaaAnalysisTelemetry',
     ).mockImplementation(() => Promise.resolve());
+    spyOn(agentSession, 'resolveAgentSessionIdForEmit').mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -105,6 +107,7 @@ describe('codexPostToolUse', () => {
       {
         telemetryCallerCommand: SQAA_CODEX_POST_TOOL_USE_CALLER_COMMAND,
         telemetryProcessExitCode: SQAA_HOOK_TELEMETRY_EXIT_CODE,
+        agentSessionId: null,
       },
     );
     expect(stdoutSpy).toHaveBeenCalledTimes(1);
@@ -213,6 +216,7 @@ describe('codexPostToolUse', () => {
       expect.objectContaining({ totalIssues: 0, totalFailures: 1 }),
       expect.any(Number),
       SQAA_HOOK_TELEMETRY_EXIT_CODE,
+      null,
     );
   });
 

--- a/tests/unit/core/telemetry/agent-session.test.ts
+++ b/tests/unit/core/telemetry/agent-session.test.ts
@@ -27,6 +27,7 @@ import {
   resolveAgentSessionId,
   resolveAgentSessionIdForEmit,
   resolveAgentSessionIdFromEnv,
+  resolveAgentSessionIdFromHookOrEnv,
 } from '@/core/telemetry/agent-session.ts';
 
 import { restoreEnv } from '../../../_common/isolated-cli-env.ts';
@@ -173,5 +174,19 @@ describe('resolveAgentSessionIdForEmit', () => {
     expect(
       resolveAgentSessionIdForEmit('hook-id', { CLAUDE_CODE_SESSION_ID: 'env-id' }),
     ).toBeNull();
+  });
+});
+
+describe('resolveAgentSessionIdFromHookOrEnv', () => {
+  it('prefers the hook id over env without consulting telemetry state', () => {
+    expect(
+      resolveAgentSessionIdFromHookOrEnv('hook-id', { CLAUDE_CODE_SESSION_ID: 'env-id' }),
+    ).toBe('hook-id');
+  });
+
+  it('falls back to env when the hook id is null', () => {
+    expect(resolveAgentSessionIdFromHookOrEnv(null, { CODEX_SESSION_ID: 'codex-id' })).toBe(
+      'codex-id',
+    );
   });
 });

--- a/tests/unit/core/telemetry/telemetry-events.test.ts
+++ b/tests/unit/core/telemetry/telemetry-events.test.ts
@@ -80,6 +80,7 @@ function makeIdentityPayload() {
     organization_uuid_v4: null,
     sqs_installation_id: null,
     caller_agent: null,
+    agent_session_id: null,
   } as const;
 }
 
@@ -267,6 +268,20 @@ describe('emitAnalysisCompleted()', () => {
 
     const payload = readAnalysisEvents(testSonarUserHome)[0].event_payload;
     expect(payload.caller_agent).toBe('cursor');
+  });
+
+  it('sets agent_session_id from identityOptions', async () => {
+    await emitAnalysisCompleted(AUTH, makeCompletedFields(), { agentSessionId: 'sess-abc' });
+
+    const payload = readAnalysisEvents(testSonarUserHome)[0].event_payload;
+    expect(payload.agent_session_id).toBe('sess-abc');
+  });
+
+  it('sets agent_session_id to null when identityOptions omit a session', async () => {
+    await emitAnalysisCompleted(AUTH, makeCompletedFields());
+
+    const payload = readAnalysisEvents(testSonarUserHome)[0].event_payload;
+    expect(payload.agent_session_id).toBeNull();
   });
 
   it('creates the telemetry directory if it does not exist', async () => {

--- a/tests/unit/core/telemetry/telemetry-events.test.ts
+++ b/tests/unit/core/telemetry/telemetry-events.test.ts
@@ -57,6 +57,7 @@ import {
 } from '@/core/telemetry/telemetry-events.ts';
 import * as userModule from '@/core/telemetry/user.ts';
 
+import { restoreEnv } from '../../../_common/isolated-cli-env.ts';
 import {
   makeTelemetryState,
   readAnalysisEvents,
@@ -144,6 +145,13 @@ const AUTH: ResolvedAuth = {
 
 // ─── Setup ────────────────────────────────────────────────────────────────────
 
+const AGENT_SESSION_ENV_KEYS = [
+  'CLAUDE_CODE_SESSION_ID',
+  'CODEX_SESSION_ID',
+  'CODEX_THREAD_ID',
+  'GEMINI_SESSION_ID',
+] as const;
+
 let testSonarUserHome: string;
 const previousSonarUserHome = process.env[ENV_SONAR_USER_HOME];
 
@@ -153,6 +161,7 @@ let getUserIdSpy: ReturnType<typeof spyOn>;
 let detectAgentSpy: ReturnType<typeof spyOn>;
 let defaultFetchSpy: ReturnType<typeof spyOn>;
 let savedDoNotTrack: string | undefined;
+let savedAgentSessionEnv: Partial<Record<(typeof AGENT_SESSION_ENV_KEYS)[number], string>>;
 
 beforeEach(async () => {
   testSonarUserHome = await mkdtemp(join(tmpdir(), 'cli-telemetry-events-test-'));
@@ -160,6 +169,12 @@ beforeEach(async () => {
 
   savedDoNotTrack = process.env.DO_NOT_TRACK;
   delete process.env.DO_NOT_TRACK;
+
+  savedAgentSessionEnv = {};
+  for (const key of AGENT_SESSION_ENV_KEYS) {
+    savedAgentSessionEnv[key] = process.env[key];
+    delete process.env[key];
+  }
 
   loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(makeTelemetryState());
   getConnectionSpy = spyOn(stateManager, 'getActiveConnection').mockReturnValue(undefined);
@@ -178,6 +193,10 @@ afterEach(async () => {
     process.env.DO_NOT_TRACK = savedDoNotTrack;
   } else {
     delete process.env.DO_NOT_TRACK;
+  }
+
+  for (const key of AGENT_SESSION_ENV_KEYS) {
+    restoreEnv(key, savedAgentSessionEnv[key]);
   }
 
   loadStateSpy.mockRestore();
@@ -277,7 +296,25 @@ describe('emitAnalysisCompleted()', () => {
     expect(payload.agent_session_id).toBe('sess-abc');
   });
 
-  it('sets agent_session_id to null when identityOptions omit a session', async () => {
+  it('sets agent_session_id from env when identityOptions omit a session', async () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'env-session';
+
+    await emitAnalysisCompleted(AUTH, makeCompletedFields());
+
+    const payload = readAnalysisEvents(testSonarUserHome)[0].event_payload;
+    expect(payload.agent_session_id).toBe('env-session');
+  });
+
+  it('prefers identityOptions.agentSessionId over env', async () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'env-session';
+
+    await emitAnalysisCompleted(AUTH, makeCompletedFields(), { agentSessionId: 'hook-session' });
+
+    const payload = readAnalysisEvents(testSonarUserHome)[0].event_payload;
+    expect(payload.agent_session_id).toBe('hook-session');
+  });
+
+  it('sets agent_session_id to null when identityOptions and env omit a session', async () => {
     await emitAnalysisCompleted(AUTH, makeCompletedFields());
 
     const payload = readAnalysisEvents(testSonarUserHome)[0].event_payload;
@@ -338,6 +375,27 @@ describe('emitIntegrationConfigured()', () => {
     expect(configured.event_payload.is_from_router).toBe(true);
     // Identity base is merged in.
     expect(configured.event_payload.cli_installation_id).toBe('install-id');
+    expect(configured.event_payload.agent_session_id).toBeNull();
+  });
+
+  it('sets agent_session_id from env when identityOptions omit a session', async () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'env-integrate-session';
+
+    await emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields());
+
+    const [event] = readIntegrationEvents(testSonarUserHome);
+    expect(event.event_payload.agent_session_id).toBe('env-integrate-session');
+  });
+
+  it('sets agent_session_id from identityOptions', async () => {
+    process.env.CLAUDE_CODE_SESSION_ID = 'env-integrate-session';
+
+    await emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields(), {
+      agentSessionId: 'hook-integrate-session',
+    });
+
+    const [event] = readIntegrationEvents(testSonarUserHome);
+    expect(event.event_payload.agent_session_id).toBe('hook-integrate-session');
   });
 
   it('does not append when telemetry is disabled', async () => {

--- a/tests/unit/core/telemetry/telemetry-events.test.ts
+++ b/tests/unit/core/telemetry/telemetry-events.test.ts
@@ -378,24 +378,13 @@ describe('emitIntegrationConfigured()', () => {
     expect(configured.event_payload.agent_session_id).toBeNull();
   });
 
-  it('sets agent_session_id from env when identityOptions omit a session', async () => {
+  it('sets agent_session_id from env when a session is present', async () => {
     process.env.CLAUDE_CODE_SESSION_ID = 'env-integrate-session';
 
     await emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields());
 
     const [event] = readIntegrationEvents(testSonarUserHome);
     expect(event.event_payload.agent_session_id).toBe('env-integrate-session');
-  });
-
-  it('sets agent_session_id from identityOptions', async () => {
-    process.env.CLAUDE_CODE_SESSION_ID = 'env-integrate-session';
-
-    await emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields(), {
-      agentSessionId: 'hook-integrate-session',
-    });
-
-    const [event] = readIntegrationEvents(testSonarUserHome);
-    expect(event.event_payload.agent_session_id).toBe('hook-integrate-session');
   });
 
   it('does not append when telemetry is disabled', async () => {

--- a/tests/unit/core/telemetry/telemetry.test.ts
+++ b/tests/unit/core/telemetry/telemetry.test.ts
@@ -29,8 +29,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
-import type { Command } from 'commander';
 
+import { SonarCommand } from '@/commands/sonar-command.ts';
 import * as authResolver from '@/core/auth/auth-resolver.ts';
 import { ENV_ORG, ENV_SERVER, ENV_TOKEN } from '@/core/auth/auth-resolver.ts';
 import { ENV_DO_NOT_TRACK, ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
@@ -62,14 +62,16 @@ import { mockIdentityGetSafe } from './identity-api-mock.ts';
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /**
- * Build a fake Commander command chain from a space-separated command path.
- * e.g. makeCommand('auth login') produces: root ← auth ← login
+ * Build a SonarCommand chain from a space-separated command path.
+ * e.g. makeCommand('auth login') produces leaf `login` under `auth` under root.
  */
-function makeCommand(path: string): Command {
-  const root = { name: () => '', parent: null } as unknown as Command;
-  return path
-    .split(' ')
-    .reduce((parent, name) => ({ name: () => name, parent }) as unknown as Command, root);
+function makeCommand(path: string): SonarCommand {
+  const root = new SonarCommand('sonar');
+  let current: SonarCommand = root;
+  for (const name of path.split(' ')) {
+    current = current.command(name);
+  }
+  return current;
 }
 
 function mockFetch(ok = true, status = 200): ReturnType<typeof spyOn> {
@@ -249,6 +251,16 @@ describe('storeEvent', () => {
       } finally {
         spy.mockRestore();
       }
+    });
+
+    it('sets event_payload.agent_session_id from the storeEvent argument', async () => {
+      await storeEvent(makeCommand('auth login'), true, 'claude-sess-1');
+      expect(readCommandEvents(testDir)[0].event_payload.agent_session_id).toBe('claude-sess-1');
+    });
+
+    it('sets event_payload.agent_session_id to null when omitted', async () => {
+      await storeEvent(makeCommand('auth login'), true);
+      expect(readCommandEvents(testDir)[0].event_payload.agent_session_id).toBeNull();
     });
 
     it('uses the machine_id returned by getOrCreateUserId', async () => {
@@ -647,6 +659,7 @@ function makeCompletedFinding(): StoredAnalysisCompletedEvent {
       organization_uuid_v4: null,
       sqs_installation_id: null,
       caller_agent: null,
+      agent_session_id: null,
       caller_command: 'analyze secrets',
       analyzer: 'sonar-secrets',
       analysis_id: 'analysis-id',

--- a/tests/unit/core/telemetry/telemetry.test.ts
+++ b/tests/unit/core/telemetry/telemetry.test.ts
@@ -96,17 +96,29 @@ let testDir: string;
 let savedSonarUserHome: string | undefined;
 let savedDoNotTrack: string | undefined;
 let savedEgress: string | undefined;
+let savedClaudeCodeSessionId: string | undefined;
+let savedCodexSessionId: string | undefined;
+let savedCodexThreadId: string | undefined;
+let savedGeminiSessionId: string | undefined;
 
 beforeEach(() => {
   savedSonarUserHome = process.env[ENV_SONAR_USER_HOME];
   savedDoNotTrack = process.env[ENV_DO_NOT_TRACK];
   savedEgress = process.env[ENV_TELEMETRY_EGRESS];
+  savedClaudeCodeSessionId = process.env.CLAUDE_CODE_SESSION_ID;
+  savedCodexSessionId = process.env.CODEX_SESSION_ID;
+  savedCodexThreadId = process.env.CODEX_THREAD_ID;
+  savedGeminiSessionId = process.env.GEMINI_SESSION_ID;
   testDir = mkdtempSync(join(tmpdir(), 'telemetry-test-'));
   process.env[ENV_SONAR_USER_HOME] = testDir;
   // Enable telemetry for these tests; writes land in the isolated testDir.
   delete process.env[ENV_DO_NOT_TRACK];
   // Cleared so the spawn and drain paths run; Bun.spawn and fetch are mocked below.
   delete process.env[ENV_TELEMETRY_EGRESS];
+  delete process.env.CLAUDE_CODE_SESSION_ID;
+  delete process.env.CODEX_SESSION_ID;
+  delete process.env.CODEX_THREAD_ID;
+  delete process.env.GEMINI_SESSION_ID;
   loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
   saveStateSpy = spyOn(stateRepository, 'saveState').mockImplementation(() => undefined);
   getUserIdSpy = spyOn(userModule, 'getOrCreateUserId').mockReturnValue('test-machine-id');
@@ -123,6 +135,10 @@ afterEach(() => {
   restoreEnv(ENV_SONAR_USER_HOME, savedSonarUserHome);
   restoreEnv(ENV_DO_NOT_TRACK, savedDoNotTrack);
   restoreEnv(ENV_TELEMETRY_EGRESS, savedEgress);
+  restoreEnv('CLAUDE_CODE_SESSION_ID', savedClaudeCodeSessionId);
+  restoreEnv('CODEX_SESSION_ID', savedCodexSessionId);
+  restoreEnv('CODEX_THREAD_ID', savedCodexThreadId);
+  restoreEnv('GEMINI_SESSION_ID', savedGeminiSessionId);
   delete process.env[TELEMETRY_FLUSH_MODE_ENV];
   delete process.env.CLAUDECODE;
   delete process.env.CLAUDE_CODE_ENTRYPOINT;
@@ -258,7 +274,19 @@ describe('storeEvent', () => {
       expect(readCommandEvents(testDir)[0].event_payload.agent_session_id).toBe('claude-sess-1');
     });
 
-    it('sets event_payload.agent_session_id to null when omitted', async () => {
+    it('sets event_payload.agent_session_id from env when the argument is omitted', async () => {
+      process.env.CLAUDE_CODE_SESSION_ID = 'env-command-session';
+      try {
+        await storeEvent(makeCommand('auth login'), true);
+        expect(readCommandEvents(testDir)[0].event_payload.agent_session_id).toBe(
+          'env-command-session',
+        );
+      } finally {
+        delete process.env.CLAUDE_CODE_SESSION_ID;
+      }
+    });
+
+    it('sets event_payload.agent_session_id to null when omitted and env has no session', async () => {
       await storeEvent(makeCommand('auth login'), true);
       expect(readCommandEvents(testDir)[0].event_payload.agent_session_id).toBeNull();
     });

--- a/tests/unit/core/update/telemetry-migration.test.ts
+++ b/tests/unit/core/update/telemetry-migration.test.ts
@@ -56,6 +56,7 @@ function makeLegacyCommandEvent(command: string): StoredCommandExecutedEvent {
       organization_uuid_v4: null,
       sqs_installation_id: null,
       caller_agent: null,
+      agent_session_id: null,
       command,
       subcommand: null,
       result: 'success',


### PR DESCRIPTION
## Summary
- Add nullable `agent_session_id` to `TelemetryEventIdentityPayload` (same lifecycle as `caller_agent`)
- Populate it in `buildIdentityBase` via `resolveAgentSessionId` from CLI-958
- Cover unit + integration paths with known session env and without

Depends on #695 (CLI-958). Retarget to `master` after that merges.