### PR TITLE
CLI-978 Forward custom user home to the MCP server declaration

### DIFF
--- a/src/core/host/mcp/mcp-helper.ts
+++ b/src/core/host/mcp/mcp-helper.ts
@@ -36,6 +36,8 @@ import { pemToPkcs12 } from '@/core/host/crypto/pkcs12.ts';
 import {
   ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON,
   CLI_TMP_DIR,
+  ENV_SONAR_USER_HOME,
+  getSonarUserHome,
   SONARQUBE_MCP_DOCKER_IMAGE_NAME,
 } from '../../config-constants.ts';
 import { normalizePath } from '../../io/fs-utils.ts';
@@ -45,6 +47,7 @@ import type { RedactedUrl } from '../redacted-url.ts';
 export interface McpServerConfig {
   command: string;
   args: string[];
+  env?: Record<string, string>;
 }
 
 export interface McpContainerCommand {
@@ -65,6 +68,14 @@ export type McpServerContext =
       projectRoot: string;
       projectKey?: string;
     };
+
+function mcpServerEnv(): Record<string, string> | undefined {
+  const customHome = process.env[ENV_SONAR_USER_HOME];
+  if (customHome === undefined || customHome.trim() === '') {
+    return undefined;
+  }
+  return { [ENV_SONAR_USER_HOME]: getSonarUserHome() };
+}
 
 export function getMcpConfig(
   cliPath: string,
@@ -89,7 +100,8 @@ export function getMcpConfig(
     args.push('--toolsets', options.toolsets);
   }
 
-  return { command: cliPath, args };
+  const env = mcpServerEnv();
+  return env === undefined ? { command: cliPath, args } : { command: cliPath, args, env };
 }
 
 // Path where update-ca-certificates picks up custom CA certs inside the MCP container (Debian/Alpine convention).

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -26,6 +26,7 @@
 import { isAbsolute } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { parse as parseToml } from 'smol-toml';
 
 import { CONTEXT_AUGMENTATION_FEATURE_ID } from '../../../../src/commands/integrate/_common/features/context-augmentation-feature';
 import {
@@ -315,7 +316,10 @@ describe('integrate codex', () => {
         expect(result.exitCode).toBe(0);
         const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
         expect(tomlBody).toContain('[mcp_servers.sonarqube.env]');
-        expect(tomlBody).toContain(customHome);
+        const parsed = parseToml(tomlBody) as {
+          mcp_servers?: { sonarqube?: { env?: Record<string, string> } };
+        };
+        expect(parsed.mcp_servers?.sonarqube?.env?.[ENV_SONAR_USER_HOME]).toBe(customHome);
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -34,6 +34,7 @@ import {
 } from '../../../../src/commands/integrate/_common/features/sqaa-instructions-feature';
 import { VORTEX_FEATURE_ID } from '../../../../src/commands/integrate/_common/vortex';
 import { codexIntegration } from '../../../../src/commands/integrate/codex/declaration';
+import { ENV_SONAR_USER_HOME } from '../../../../src/core/config-constants.ts';
 import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
@@ -272,6 +273,7 @@ describe('integrate codex', () => {
         expect(tomlBody).toContain('mcp');
         expect(tomlBody).toContain('--project');
         expect(tomlBody).toContain('my-project');
+        expect(tomlBody).not.toContain('[mcp_servers.sonarqube.env]');
 
         // Assert on the state
         const state = harness.stateJsonFile.asJson();
@@ -290,6 +292,30 @@ describe('integrate codex', () => {
             },
           ],
         });
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'forwards SONAR_USER_HOME into [mcp_servers.sonarqube.env] and refreshes a prior entry',
+      async () => {
+        harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=my-project\n');
+
+        const first = await harness.run('integrate codex --non-interactive');
+        expect(first.exitCode).toBe(0);
+        expect(harness.cwd.file(...CONFIG_TOML_DIRS).asText()).not.toContain(
+          '[mcp_servers.sonarqube.env]',
+        );
+
+        const customHome = harness.sonarUserHome.path;
+        const result = await harness.run('integrate codex --non-interactive', {
+          extraEnv: { [ENV_SONAR_USER_HOME]: customHome },
+        });
+
+        expect(result.exitCode).toBe(0);
+        const tomlBody = harness.cwd.file(...CONFIG_TOML_DIRS).asText();
+        expect(tomlBody).toContain('[mcp_servers.sonarqube.env]');
+        expect(tomlBody).toContain(customHome);
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -23,7 +23,8 @@
 // hook-agent-prompt-submit.test.ts; this spec only exercises the integrate
 // command — script + hooks.json layout, scope semantics, and idempotency.
 
-import { isAbsolute } from 'node:path';
+import { cpSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { parse as parseToml } from 'smol-toml';
@@ -308,7 +309,10 @@ describe('integrate codex', () => {
           '[mcp_servers.sonarqube.env]',
         );
 
-        const customHome = harness.sonarUserHome.path;
+        // Distinct from $HOME/.sonar. Copy cliHome because harness.run() always
+        // writes state there, and the child with a custom home must still find auth.
+        const customHome = join(harness.userHome.path, 'custom-sonar');
+        cpSync(harness.cliHome.path, join(customHome, 'sonarqube-cli'), { recursive: true });
         const result = await harness.run('integrate codex --non-interactive', {
           extraEnv: { [ENV_SONAR_USER_HOME]: customHome },
         });

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -22,8 +22,8 @@
 // PR 1 (CLI-619): covers MCP server setup, scope semantics, idempotency, and
 // state recording. Hook and CAG tests are added in subsequent PRs.
 
-import { readFileSync } from 'node:fs';
-import { isAbsolute } from 'node:path';
+import { cpSync, readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
@@ -125,7 +125,10 @@ describe('integrate cursor', () => {
           (harness.cwd.file(...MCP_JSON_DIRS).asJson() as CursorMcpFile).mcpServers?.sonarqube,
         ).not.toHaveProperty('env');
 
-        const customHome = harness.sonarUserHome.path;
+        // Distinct from $HOME/.sonar. Copy cliHome because harness.run() always
+        // writes state there, and the child with a custom home must still find auth.
+        const customHome = join(harness.userHome.path, 'custom-sonar');
+        cpSync(harness.cliHome.path, join(customHome, 'sonarqube-cli'), { recursive: true });
         const result = await harness.run('integrate cursor --non-interactive', {
           extraEnv: { [ENV_SONAR_USER_HOME]: customHome },
         });

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -28,6 +28,7 @@ import { isAbsolute } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { cursorIntegration } from '../../../../src/commands/integrate/cursor/declaration';
+import { ENV_SONAR_USER_HOME } from '../../../../src/core/config-constants.ts';
 import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
@@ -42,7 +43,7 @@ const HOOKS_JSON_DIRS = ['.cursor', 'hooks.json'];
 const CURSOR_PROMPT_STDIN_DELAY_MS = 1000;
 
 interface CursorMcpFile {
-  mcpServers?: Record<string, { command?: string; args?: string[] }>;
+  mcpServers?: Record<string, { command?: string; args?: string[]; env?: Record<string, string> }>;
 }
 
 type CursorHookEntry = { command?: string; matcher?: string };
@@ -99,6 +100,39 @@ describe('integrate cursor', () => {
         expect(mcp.mcpServers?.sonarqube).toBeDefined();
         expect(mcp.mcpServers?.sonarqube?.command).toBeDefined();
         expect(mcp.mcpServers?.sonarqube?.args).toContain('mcp');
+        expect(mcp.mcpServers?.sonarqube).not.toHaveProperty('env');
+      },
+      { timeout: 30000 },
+    );
+
+    it(
+      'forwards SONAR_USER_HOME into the MCP server env and refreshes a prior entry',
+      async () => {
+        const server = await harness
+          .newFakeServer()
+          .withAuthToken('test-token')
+          .withProject('my-project')
+          .start();
+        harness.withAuth(server.baseUrl(), 'test-token');
+        harness.cwd.writeFile(
+          'sonar-project.properties',
+          [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=my-project'].join('\n'),
+        );
+
+        const first = await harness.run('integrate cursor --non-interactive');
+        expect(first.exitCode).toBe(0);
+        expect(
+          (harness.cwd.file(...MCP_JSON_DIRS).asJson() as CursorMcpFile).mcpServers?.sonarqube,
+        ).not.toHaveProperty('env');
+
+        const customHome = harness.sonarUserHome.path;
+        const result = await harness.run('integrate cursor --non-interactive', {
+          extraEnv: { [ENV_SONAR_USER_HOME]: customHome },
+        });
+
+        expect(result.exitCode).toBe(0);
+        const mcp: CursorMcpFile = harness.cwd.file(...MCP_JSON_DIRS).asJson();
+        expect(mcp.mcpServers?.sonarqube?.env?.[ENV_SONAR_USER_HOME]).toBe(customHome);
       },
       { timeout: 30000 },
     );

--- a/tests/unit/core/host/mcp/mcp-helper.test.ts
+++ b/tests/unit/core/host/mcp/mcp-helper.test.ts
@@ -1,0 +1,59 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import { ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
+import { getMcpConfig } from '@/core/host/mcp/mcp-helper.ts';
+
+import { restoreEnv } from '../../../../_common/isolated-cli-env.ts';
+
+describe('getMcpConfig', () => {
+  const previousSonarUserHome = process.env[ENV_SONAR_USER_HOME];
+
+  afterEach(() => {
+    restoreEnv(ENV_SONAR_USER_HOME, previousSonarUserHome);
+  });
+
+  it('omits env when SONAR_USER_HOME is unset', () => {
+    delete process.env[ENV_SONAR_USER_HOME];
+
+    expect(getMcpConfig('sonar', { withFsMount: false })).toEqual({
+      command: 'sonar',
+      args: ['run', 'mcp'],
+    });
+  });
+
+  it('omits env when SONAR_USER_HOME is blank', () => {
+    process.env[ENV_SONAR_USER_HOME] = '   ';
+
+    expect(getMcpConfig('sonar', { withFsMount: false })).not.toHaveProperty('env');
+  });
+
+  it('forwards the resolved SONAR_USER_HOME path when set', () => {
+    process.env[ENV_SONAR_USER_HOME] = '/custom/sonar-home';
+
+    expect(getMcpConfig('sonar', { withFsMount: false, projectKey: 'my-project' })).toEqual({
+      command: 'sonar',
+      args: ['run', 'mcp', '--project', 'my-project'],
+      env: { [ENV_SONAR_USER_HOME]: '/custom/sonar-home' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Bake a custom `SONAR_USER_HOME` into the generated MCP server `env` block so `sonar run mcp` can load the same CLI state the user authenticated against
- Leave default `~/.sonar` installs unchanged (no `env` key); re-running integrate refreshes an older entry that was missing it
- Shared `getMcpConfig()` writer, so Claude, Copilot, Cursor, Codex, and Antigravity all pick this up