### PR TITLE
CLI-981 Import telemetry: emit UserOnboardingStarted / Completed / Exited

### DIFF
--- a/src/commands/import/index.ts
+++ b/src/commands/import/index.ts
@@ -26,6 +26,11 @@ import {
   type ProvisionedProject,
   SonarQubeClient,
 } from '@/core/server/client.ts';
+import {
+  emitUserOnboardingCompleted,
+  emitUserOnboardingExited,
+  emitUserOnboardingStarted,
+} from '@/core/telemetry/telemetry-events.ts';
 import { info, intro, outro } from '@/core/ui';
 import { ImportProgress } from '@/core/ui/components/import-progress.ts';
 
@@ -231,47 +236,77 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
 
   intro('Import repositories', 'SonarQube');
 
-  const resolution = await resolveOrgAndRepos(client, auth.orgKey, options);
+  emitUserOnboardingStarted(auth, { devops_platform: null, plan: null }).catch(() => {});
 
-  if (resolution.kind === 'streaming') {
-    const { succeeded, failed, skipped } = await runBulkImportJob(
-      client,
-      resolution.orgKey,
-      resolution.almKey,
-      resolution.collection,
-      resolution.regex,
-    );
+  let almKey: string | undefined;
+  let completedEmitted = false;
+  try {
+    const resolution = await resolveOrgAndRepos(client, auth.orgKey, options);
+    almKey = resolution.almKey;
+
+    if (resolution.kind === 'streaming') {
+      const { succeeded, failed, skipped } = await runBulkImportJob(
+        client,
+        resolution.orgKey,
+        resolution.almKey,
+        resolution.collection,
+        resolution.regex,
+      );
+      reportSkipped(skipped);
+      emitUserOnboardingCompleted(auth, {
+        devops_platform: resolution.almKey ?? null,
+        import_method: 'bulk',
+        plan: null,
+        project_count: succeeded,
+      }).catch(() => {});
+      completedEmitted = true;
+      reportOutcome(
+        succeeded,
+        failed,
+        skipped.length,
+        buildOnboardingDashboardUrl(auth.serverUrl, resolution.orgKey),
+      );
+      return;
+    }
+
+    const { repos, skipped } = resolution;
+
+    info(`Repositories to import: ${repos.length}`);
     reportSkipped(skipped);
+
+    const progress = new ImportProgress({ maxVisible: IMPORT_PROVISION_CONCURRENCY_LIMIT });
+    progress.setTotal(repos.length);
+    progress.addRepos(repos.map((repo) => repo.slug));
+    progress.start();
+
+    await runWithConcurrencyLimit(
+      repos,
+      IMPORT_PROVISION_CONCURRENCY_LIMIT,
+      createProvisionTask(client, resolution.orgKey, progress),
+    );
+
+    const { succeeded, failed } = progress.finish();
+    emitUserOnboardingCompleted(auth, {
+      devops_platform: resolution.almKey ?? null,
+      import_method: 'single',
+      plan: null,
+      project_count: succeeded,
+    }).catch(() => {});
+    completedEmitted = true;
     reportOutcome(
       succeeded,
       failed,
       skipped.length,
       buildOnboardingDashboardUrl(auth.serverUrl, resolution.orgKey),
     );
-    return;
+  } catch (err) {
+    if (!completedEmitted) {
+      emitUserOnboardingExited(auth, {
+        destination: 'error',
+        devops_platform: almKey ?? null,
+        plan: null,
+      }).catch(() => {});
+    }
+    throw err;
   }
-
-  const { repos, skipped } = resolution;
-
-  info(`Repositories to import: ${repos.length}`);
-  reportSkipped(skipped);
-
-  const progress = new ImportProgress({ maxVisible: IMPORT_PROVISION_CONCURRENCY_LIMIT });
-  progress.setTotal(repos.length);
-  progress.addRepos(repos.map((repo) => repo.slug));
-  progress.start();
-
-  await runWithConcurrencyLimit(
-    repos,
-    IMPORT_PROVISION_CONCURRENCY_LIMIT,
-    createProvisionTask(client, resolution.orgKey, progress),
-  );
-
-  const { succeeded, failed } = progress.finish();
-  reportOutcome(
-    succeeded,
-    failed,
-    skipped.length,
-    buildOnboardingDashboardUrl(auth.serverUrl, resolution.orgKey),
-  );
 }

--- a/src/commands/import/index.ts
+++ b/src/commands/import/index.ts
@@ -42,7 +42,6 @@ import type {
 import {
   assertSupportedAlm,
   computeInstallationKey,
-  type RepoResolution,
   resolveAlmKey,
   type ResolvedRepo,
   resolveOrg,
@@ -56,39 +55,6 @@ const noop = () => undefined;
 
 /** Max number of `provision_projects` calls run concurrently. */
 const IMPORT_PROVISION_CONCURRENCY_LIMIT = 10;
-
-/** Resolves the org tied to the active connection, then the repos to import into it. */
-async function resolveOrgAndRepos(
-  client: SonarQubeClient,
-  orgKey: string | undefined,
-  options: ImportOptions,
-): Promise<{ orgKey: string; almKey: string | undefined } & RepoResolution> {
-  const {
-    key: resolvedOrgKey,
-    almKey: resolvedAlmKey,
-    onlyPrivateProjectsEnabled,
-  } = await resolveOrg(client, orgKey);
-
-  info(`Organization: ${resolvedOrgKey}`);
-
-  const [almKey, privateProjectsAvailable] = await Promise.all([
-    resolveAlmKey(client, resolvedOrgKey, resolvedAlmKey),
-    client.hasPrivateProjectsEntitlement(resolvedOrgKey),
-  ]);
-
-  // Before any repository is listed, so an unsupported org stops here rather than after a full
-  // paginated fetch.
-  assertSupportedAlm(resolvedOrgKey, almKey);
-
-  const onlyPrivateProjects: OnlyPrivateProjects = {
-    enabled: onlyPrivateProjectsEnabled ?? false,
-    available: privateProjectsAvailable,
-  };
-
-  const outcome = await resolveRepos(client, resolvedOrgKey, almKey, onlyPrivateProjects, options);
-
-  return { orgKey: resolvedOrgKey, almKey, ...outcome };
-}
 
 /** Builds the `runWithConcurrencyLimit` task that provisions one repo and updates `progress`. */
 function createProvisionTask(
@@ -240,23 +206,41 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
 
   emitUserOnboardingStarted(auth, { devops_platform: null, plan: null }).catch(noop);
 
+  // almKey is set before assertSupportedAlm so UserOnboardingExited always carries the platform.
   let almKey: string | undefined;
   let completedEmitted = false;
   try {
-    const resolution = await resolveOrgAndRepos(client, auth.orgKey, options);
-    almKey = resolution.almKey;
+    const {
+      key: resolvedOrgKey,
+      almKey: orgRecordAlmKey,
+      onlyPrivateProjectsEnabled,
+    } = await resolveOrg(client, auth.orgKey);
+    info(`Organization: ${resolvedOrgKey}`);
+    const [resolvedAlmKey, privateProjectsAvailable] = await Promise.all([
+      resolveAlmKey(client, resolvedOrgKey, orgRecordAlmKey),
+      client.hasPrivateProjectsEntitlement(resolvedOrgKey),
+    ]);
+    almKey = resolvedAlmKey;
+
+    assertSupportedAlm(resolvedOrgKey, almKey);
+
+    const onlyPrivateProjects: OnlyPrivateProjects = {
+      enabled: onlyPrivateProjectsEnabled ?? false,
+      available: privateProjectsAvailable,
+    };
+    const resolution = await resolveRepos(client, resolvedOrgKey, almKey, onlyPrivateProjects, options);
 
     if (resolution.kind === 'streaming') {
       const { succeeded, failed, skipped } = await runBulkImportJob(
         client,
-        resolution.orgKey,
-        resolution.almKey,
+        resolvedOrgKey,
+        almKey,
         resolution.collection,
         resolution.regex,
       );
       reportSkipped(skipped);
       emitUserOnboardingCompleted(auth, {
-        devops_platform: resolution.almKey ?? null,
+        devops_platform: almKey ?? null,
         import_method: 'bulk',
         plan: null,
         project_count: succeeded,
@@ -266,7 +250,7 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
         succeeded,
         failed,
         skipped.length,
-        buildOnboardingDashboardUrl(auth.serverUrl, resolution.orgKey),
+        buildOnboardingDashboardUrl(auth.serverUrl, resolvedOrgKey),
       );
       return;
     }
@@ -284,12 +268,12 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
     await runWithConcurrencyLimit(
       repos,
       IMPORT_PROVISION_CONCURRENCY_LIMIT,
-      createProvisionTask(client, resolution.orgKey, progress),
+      createProvisionTask(client, resolvedOrgKey, progress),
     );
 
     const { succeeded, failed } = progress.finish();
     emitUserOnboardingCompleted(auth, {
-      devops_platform: resolution.almKey ?? null,
+      devops_platform: almKey ?? null,
       import_method: 'single',
       plan: null,
       project_count: succeeded,
@@ -299,7 +283,7 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
       succeeded,
       failed,
       skipped.length,
-      buildOnboardingDashboardUrl(auth.serverUrl, resolution.orgKey),
+      buildOnboardingDashboardUrl(auth.serverUrl, resolvedOrgKey),
     );
   } catch (err) {
     if (!completedEmitted) {

--- a/src/commands/import/index.ts
+++ b/src/commands/import/index.ts
@@ -52,6 +52,8 @@ import type { ImportOptions } from './_common/types';
 
 export { type ImportOptions } from './_common/types';
 
+const noop = () => undefined;
+
 /** Max number of `provision_projects` calls run concurrently. */
 const IMPORT_PROVISION_CONCURRENCY_LIMIT = 10;
 
@@ -236,7 +238,7 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
 
   intro('Import repositories', 'SonarQube');
 
-  emitUserOnboardingStarted(auth, { devops_platform: null, plan: null }).catch(() => {});
+  emitUserOnboardingStarted(auth, { devops_platform: null, plan: null }).catch(noop);
 
   let almKey: string | undefined;
   let completedEmitted = false;
@@ -258,7 +260,7 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
         import_method: 'bulk',
         plan: null,
         project_count: succeeded,
-      }).catch(() => {});
+      }).catch(noop);
       completedEmitted = true;
       reportOutcome(
         succeeded,
@@ -291,7 +293,7 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
       import_method: 'single',
       plan: null,
       project_count: succeeded,
-    }).catch(() => {});
+    }).catch(noop);
     completedEmitted = true;
     reportOutcome(
       succeeded,
@@ -305,7 +307,7 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
         destination: 'error',
         devops_platform: almKey ?? null,
         plan: null,
-      }).catch(() => {});
+      }).catch(noop);
     }
     throw err;
   }

--- a/src/commands/import/index.ts
+++ b/src/commands/import/index.ts
@@ -216,11 +216,10 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
       onlyPrivateProjectsEnabled,
     } = await resolveOrg(client, auth.orgKey);
     info(`Organization: ${resolvedOrgKey}`);
-    const [resolvedAlmKey, privateProjectsAvailable] = await Promise.all([
-      resolveAlmKey(client, resolvedOrgKey, orgRecordAlmKey),
-      client.hasPrivateProjectsEntitlement(resolvedOrgKey),
-    ]);
-    almKey = resolvedAlmKey;
+    const almKeyPromise = resolveAlmKey(client, resolvedOrgKey, orgRecordAlmKey);
+    const entitlementPromise = client.hasPrivateProjectsEntitlement(resolvedOrgKey);
+    almKey = await almKeyPromise;
+    const privateProjectsAvailable = await entitlementPromise;
 
     assertSupportedAlm(resolvedOrgKey, almKey);
 
@@ -228,7 +227,13 @@ export async function importHandler(options: ImportOptions, auth: ResolvedAuth):
       enabled: onlyPrivateProjectsEnabled ?? false,
       available: privateProjectsAvailable,
     };
-    const resolution = await resolveRepos(client, resolvedOrgKey, almKey, onlyPrivateProjects, options);
+    const resolution = await resolveRepos(
+      client,
+      resolvedOrgKey,
+      almKey,
+      onlyPrivateProjects,
+      options,
+    );
 
     if (resolution.kind === 'streaming') {
       const { succeeded, failed, skipped } = await runBulkImportJob(

--- a/src/core/state/state.ts
+++ b/src/core/state/state.ts
@@ -573,9 +573,66 @@ export interface StoredCommandExecutedEvent {
   event_payload: CommandExecutedEventPayload;
 }
 
+export interface UserOnboardingStartedEventPayload {
+  devops_platform: string | null;
+  plan: string | null;
+  source: 'cli';
+  user_uuid: string | null;
+  version: string;
+}
+
+export interface StoredUserOnboardingStartedEvent {
+  metadata: TelemetryEventMetadataBase & {
+    event_type: 'Analytics.Cli.UserOnboardingStarted';
+    event_version: '0';
+  };
+  event_payload: UserOnboardingStartedEventPayload;
+}
+
+export interface UserOnboardingCompletedEventPayload {
+  devops_platform: string | null;
+  import_method: 'bulk' | 'single';
+  organization_uuid_v4: string | null;
+  plan: string | null;
+  project_count: number;
+  source: 'cli';
+  user_uuid: string | null;
+  version: string;
+}
+
+export interface StoredUserOnboardingCompletedEvent {
+  metadata: TelemetryEventMetadataBase & {
+    event_type: 'Analytics.Cli.UserOnboardingCompleted';
+    event_version: '0';
+  };
+  event_payload: UserOnboardingCompletedEventPayload;
+}
+
+export interface UserOnboardingExitedEventPayload {
+  destination: string;
+  devops_platform: string | null;
+  plan: string | null;
+  source: 'cli';
+  user_uuid: string | null;
+  version: string;
+}
+
+export interface StoredUserOnboardingExitedEvent {
+  metadata: TelemetryEventMetadataBase & {
+    event_type: 'Analytics.Cli.UserOnboardingExited';
+    event_version: '0';
+  };
+  event_payload: UserOnboardingExitedEventPayload;
+}
+
 /** Any event stored in telemetry-events.ndjson and drained by flushTelemetryEvents. */
 export type StoredTelemetryEvent =
-  StoredAnalysisCompletedEvent | StoredIntegrationConfiguredEvent | StoredCommandExecutedEvent;
+  | StoredAnalysisCompletedEvent
+  | StoredIntegrationConfiguredEvent
+  | StoredCommandExecutedEvent
+  | StoredUserOnboardingStartedEvent
+  | StoredUserOnboardingCompletedEvent
+  | StoredUserOnboardingExitedEvent;
 
 /**
  * Telemetry configuration and pending event batch

--- a/src/core/telemetry/telemetry-events.ts
+++ b/src/core/telemetry/telemetry-events.ts
@@ -181,9 +181,10 @@ export async function emitIntegrationConfigured(
   });
 }
 
-export async function emitUserOnboardingStarted(
+async function appendLeanOnboardingEvent(
   auth: ResolvedAuth,
-  fields: UserOnboardingStartedFields,
+  eventType: 'Analytics.Cli.UserOnboardingStarted' | 'Analytics.Cli.UserOnboardingExited',
+  fields: UserOnboardingStartedFields | UserOnboardingExitedFields,
 ): Promise<void> {
   const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
   if (!base) return;
@@ -191,7 +192,7 @@ export async function emitUserOnboardingStarted(
     metadata: {
       event_id: randomUUID(),
       source: { domain: 'CLI' },
-      event_type: 'Analytics.Cli.UserOnboardingStarted',
+      event_type: eventType,
       event_version: '0',
       event_timestamp: String(Date.now()),
     },
@@ -201,7 +202,14 @@ export async function emitUserOnboardingStarted(
       version: VERSION,
       ...fields,
     },
-  });
+  } as StoredTelemetryEvent);
+}
+
+export async function emitUserOnboardingStarted(
+  auth: ResolvedAuth,
+  fields: UserOnboardingStartedFields,
+): Promise<void> {
+  await appendLeanOnboardingEvent(auth, 'Analytics.Cli.UserOnboardingStarted', fields);
 }
 
 export async function emitUserOnboardingCompleted(
@@ -232,23 +240,7 @@ export async function emitUserOnboardingExited(
   auth: ResolvedAuth,
   fields: UserOnboardingExitedFields,
 ): Promise<void> {
-  const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
-  if (!base) return;
-  appendTelemetryEvent({
-    metadata: {
-      event_id: randomUUID(),
-      source: { domain: 'CLI' },
-      event_type: 'Analytics.Cli.UserOnboardingExited',
-      event_version: '0',
-      event_timestamp: String(Date.now()),
-    },
-    event_payload: {
-      source: 'cli' as const,
-      user_uuid: base.user_uuid,
-      version: VERSION,
-      ...fields,
-    },
-  });
+  await appendLeanOnboardingEvent(auth, 'Analytics.Cli.UserOnboardingExited', fields);
 }
 
 /**

--- a/src/core/telemetry/telemetry-events.ts
+++ b/src/core/telemetry/telemetry-events.ts
@@ -39,6 +39,9 @@ import type {
   StoredTelemetryEvent,
   TelemetryConnectionType,
   TelemetryEventIdentityPayload,
+  UserOnboardingCompletedEventPayload,
+  UserOnboardingExitedEventPayload,
+  UserOnboardingStartedEventPayload,
 } from '../state/state.ts';
 import { getActiveConnection, tryLoadState } from '../state/state-manager.ts';
 import { isTelemetryEnabled } from './enabled.ts';
@@ -121,6 +124,21 @@ export type CommandExecutedFields = Omit<
   keyof TelemetryEventIdentityPayload
 >;
 
+export type UserOnboardingStartedFields = Omit<
+  UserOnboardingStartedEventPayload,
+  'source' | 'version' | 'user_uuid'
+>;
+
+export type UserOnboardingCompletedFields = Omit<
+  UserOnboardingCompletedEventPayload,
+  'source' | 'version' | 'user_uuid' | 'organization_uuid_v4'
+>;
+
+export type UserOnboardingExitedFields = Omit<
+  UserOnboardingExitedEventPayload,
+  'source' | 'version' | 'user_uuid'
+>;
+
 /**
  * Emits one CliAnalysisCompleted event when telemetry is enabled.
  * Resolves identity from state + auth; no-ops on opt-out or missing installationId.
@@ -160,6 +178,76 @@ export async function emitIntegrationConfigured(
       event_timestamp: String(Date.now()),
     },
     event_payload: { ...base, ...fields },
+  });
+}
+
+export async function emitUserOnboardingStarted(
+  auth: ResolvedAuth,
+  fields: UserOnboardingStartedFields,
+): Promise<void> {
+  const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
+  if (!base) return;
+  appendTelemetryEvent({
+    metadata: {
+      event_id: randomUUID(),
+      source: { domain: 'CLI' },
+      event_type: 'Analytics.Cli.UserOnboardingStarted',
+      event_version: '0',
+      event_timestamp: String(Date.now()),
+    },
+    event_payload: {
+      source: 'cli' as const,
+      user_uuid: base.user_uuid,
+      version: VERSION,
+      ...fields,
+    },
+  });
+}
+
+export async function emitUserOnboardingCompleted(
+  auth: ResolvedAuth,
+  fields: UserOnboardingCompletedFields,
+): Promise<void> {
+  const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
+  if (!base) return;
+  appendTelemetryEvent({
+    metadata: {
+      event_id: randomUUID(),
+      source: { domain: 'CLI' },
+      event_type: 'Analytics.Cli.UserOnboardingCompleted',
+      event_version: '0',
+      event_timestamp: String(Date.now()),
+    },
+    event_payload: {
+      organization_uuid_v4: base.organization_uuid_v4,
+      source: 'cli' as const,
+      user_uuid: base.user_uuid,
+      version: VERSION,
+      ...fields,
+    },
+  });
+}
+
+export async function emitUserOnboardingExited(
+  auth: ResolvedAuth,
+  fields: UserOnboardingExitedFields,
+): Promise<void> {
+  const base = await buildIdentityBase((conn) => resolveCommandTelemetryIdentity(conn, auth));
+  if (!base) return;
+  appendTelemetryEvent({
+    metadata: {
+      event_id: randomUUID(),
+      source: { domain: 'CLI' },
+      event_type: 'Analytics.Cli.UserOnboardingExited',
+      event_version: '0',
+      event_timestamp: String(Date.now()),
+    },
+    event_payload: {
+      source: 'cli' as const,
+      user_uuid: base.user_uuid,
+      version: VERSION,
+      ...fields,
+    },
   });
 }
 

--- a/tests/unit/core/telemetry/telemetry-events.test.ts
+++ b/tests/unit/core/telemetry/telemetry-events.test.ts
@@ -42,6 +42,9 @@ import * as fetchGuardedModule from '@/core/server/fetch-guarded.ts';
 import type {
   AnalysisCompletedEventPayload,
   StoredAnalysisCompletedEvent,
+  StoredUserOnboardingCompletedEvent,
+  StoredUserOnboardingExitedEvent,
+  StoredUserOnboardingStartedEvent,
 } from '@/core/state/state.ts';
 import * as stateManager from '@/core/state/state-manager.ts';
 import * as stateRepository from '@/core/state/state-repository.ts';
@@ -52,6 +55,9 @@ import {
   emitAnalysisCompleted,
   emitCommandExecuted,
   emitIntegrationConfigured,
+  emitUserOnboardingCompleted,
+  emitUserOnboardingExited,
+  emitUserOnboardingStarted,
   flushTelemetryEvents,
   type IntegrationConfiguredFields,
 } from '@/core/telemetry/telemetry-events.ts';
@@ -62,6 +68,7 @@ import {
   readAnalysisEvents,
   readCommandEvents,
   readIntegrationEvents,
+  readTelemetryEvents,
   telemetryEventsPath,
   writeTelemetryEvent,
 } from '../../../_common/telemetry-helpers.ts';
@@ -331,6 +338,139 @@ describe('emitIntegrationConfigured()', () => {
     await emitIntegrationConfigured(AUTH, makeIntegrationConfiguredFields());
 
     expect(readIntegrationEvents(testSonarUserHome)).toHaveLength(0);
+  });
+});
+
+// ─── emitUserOnboardingStarted ────────────────────────────────────────────────
+
+describe('emitUserOnboardingStarted()', () => {
+  it('writes a UserOnboardingStarted envelope with event_version 0 and lean payload', async () => {
+    await emitUserOnboardingStarted(AUTH, { devops_platform: 'github', plan: null });
+
+    const [event] = readTelemetryEvents<StoredUserOnboardingStartedEvent>(
+      testSonarUserHome,
+      'Analytics.Cli.UserOnboardingStarted',
+    );
+    expect(event.metadata.event_type).toBe('Analytics.Cli.UserOnboardingStarted');
+    expect(event.metadata.event_version).toBe('0');
+    expect(event.event_payload.source).toBe('cli');
+    expect(event.event_payload.devops_platform).toBe('github');
+    expect(event.event_payload.plan).toBeNull();
+    expect(typeof event.event_payload.version).toBe('string');
+    expect('cli_installation_id' in event.event_payload).toBe(false);
+  });
+
+  it('does not append when telemetry is disabled', async () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+
+    await emitUserOnboardingStarted(AUTH, { devops_platform: null, plan: null });
+
+    expect(
+      readTelemetryEvents(testSonarUserHome, 'Analytics.Cli.UserOnboardingStarted'),
+    ).toHaveLength(0);
+  });
+});
+
+// ─── emitUserOnboardingCompleted ──────────────────────────────────────────────
+
+describe('emitUserOnboardingCompleted()', () => {
+  it('writes a UserOnboardingCompleted envelope with import_method and project_count', async () => {
+    await emitUserOnboardingCompleted(AUTH, {
+      devops_platform: 'microsoft',
+      import_method: 'bulk',
+      plan: null,
+      project_count: 7,
+    });
+
+    const [event] = readTelemetryEvents<StoredUserOnboardingCompletedEvent>(
+      testSonarUserHome,
+      'Analytics.Cli.UserOnboardingCompleted',
+    );
+    expect(event.metadata.event_type).toBe('Analytics.Cli.UserOnboardingCompleted');
+    expect(event.metadata.event_version).toBe('0');
+    expect(event.event_payload.source).toBe('cli');
+    expect(event.event_payload.devops_platform).toBe('microsoft');
+    expect(event.event_payload.import_method).toBe('bulk');
+    expect(event.event_payload.project_count).toBe(7);
+    expect('cli_installation_id' in event.event_payload).toBe(false);
+  });
+
+  it('carries organization_uuid_v4 from the active connection', async () => {
+    getConnectionSpy.mockReturnValue({
+      id: 'conn-id',
+      type: 'cloud',
+      serverUrl: 'https://sonarcloud.io',
+      orgKey: 'my-org',
+      authenticatedAt: '2026-01-01T00:00:00.000Z',
+      userUuid: 'user-uuid-abc',
+      organizationUuidV4: 'org-uuid-xyz',
+      sqsInstallationId: null,
+    });
+
+    await emitUserOnboardingCompleted(AUTH, {
+      devops_platform: 'github',
+      import_method: 'single',
+      plan: null,
+      project_count: 1,
+    });
+
+    const [event] = readTelemetryEvents<StoredUserOnboardingCompletedEvent>(
+      testSonarUserHome,
+      'Analytics.Cli.UserOnboardingCompleted',
+    );
+    expect(event.event_payload.organization_uuid_v4).toBe('org-uuid-xyz');
+  });
+
+  it('does not append when telemetry is disabled', async () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+
+    await emitUserOnboardingCompleted(AUTH, {
+      devops_platform: null,
+      import_method: 'single',
+      plan: null,
+      project_count: 0,
+    });
+
+    expect(
+      readTelemetryEvents(testSonarUserHome, 'Analytics.Cli.UserOnboardingCompleted'),
+    ).toHaveLength(0);
+  });
+});
+
+// ─── emitUserOnboardingExited ─────────────────────────────────────────────────
+
+describe('emitUserOnboardingExited()', () => {
+  it('writes a UserOnboardingExited envelope with destination and devops_platform', async () => {
+    await emitUserOnboardingExited(AUTH, {
+      destination: 'error',
+      devops_platform: 'github',
+      plan: null,
+    });
+
+    const [event] = readTelemetryEvents<StoredUserOnboardingExitedEvent>(
+      testSonarUserHome,
+      'Analytics.Cli.UserOnboardingExited',
+    );
+    expect(event.metadata.event_type).toBe('Analytics.Cli.UserOnboardingExited');
+    expect(event.metadata.event_version).toBe('0');
+    expect(event.event_payload.source).toBe('cli');
+    expect(event.event_payload.destination).toBe('error');
+    expect(event.event_payload.devops_platform).toBe('github');
+    expect('cli_installation_id' in event.event_payload).toBe(false);
+  });
+
+  it('does not append when telemetry is disabled', async () => {
+    loadStateSpy.mockReturnValue(makeTelemetryState(false));
+
+    await emitUserOnboardingExited(AUTH, {
+      destination: 'error',
+      devops_platform: null,
+      plan: null,
+    });
+
+    expect(
+      readTelemetryEvents(testSonarUserHome, 'Analytics.Cli.UserOnboardingExited'),
+    ).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds three Gessie telemetry events to `sonar import` that mirror the sonarcloud-webapp's onboarding event schema, with `source: 'cli'` instead of `'ui'`.

---

## Events

### `Analytics.Cli.UserOnboardingStarted`

Fired at the very start of `importHandler`, immediately after the intro banner, before any org or repo resolution happens.

| Field | Type | Value |
|---|---|---|
| `devops_platform` | `string \| null` | Always `null` at start (ALM not yet resolved) |
| `plan` | `string \| null` | Always `null` (not available in CLI context) |
| `source` | `'cli'` | Fixed |
| `user_uuid` | `string \| null` | Resolved from telemetry identity |
| `version` | `string` | Running CLI version (e.g. `1.2.3`) |

---

### `Analytics.Cli.UserOnboardingCompleted`

Fired after the import job finishes (whether all repos succeeded or some failed), before `reportOutcome` renders the result. Fires for both the streaming (`--all` / `--regex`) and batch (`--repo`) flows.

| Field | Type | Value |
|---|---|---|
| `devops_platform` | `string \| null` | ALM key resolved from the org (e.g. `github`, `azure`), or `null` if unavailable |
| `import_method` | `'bulk' \| 'single'` | `'bulk'` for streaming (`--all` / `--regex`), `'single'` for batch (`--repo`) |
| `organization_uuid_v4` | `string \| null` | Resolved from telemetry identity |
| `plan` | `string \| null` | Always `null` (not available in CLI context) |
| `project_count` | `number` | Number of repositories successfully imported |
| `source` | `'cli'` | Fixed |
| `user_uuid` | `string \| null` | Resolved from telemetry identity |
| `version` | `string` | Running CLI version |

---

### `Analytics.Cli.UserOnboardingExited`

Fired when the flow is aborted before `UserOnboardingCompleted` — i.e. any error that prevents the import from finishing (org not found, unsupported ALM, page-fetch failure mid-stream, etc.). Not fired when `reportOutcome` throws due to partial repo failures, because `UserOnboardingCompleted` has already been emitted by then.

| Field | Type | Value |
|---|---|---|
| `destination` | `string` | `'error'` (type of cancellation) |
| `devops_platform` | `string \| null` | ALM key if it was resolved before the error, otherwise `null` |
| `plan` | `string \| null` | Always `null` |
| `source` | `'cli'` | Fixed |
| `user_uuid` | `string \| null` | Resolved from telemetry identity |
| `version` | `string` | Running CLI version |

---

## Implementation notes

- Payloads deliberately do **not** extend `TelemetryEventIdentityPayload` — they carry only `user_uuid` / `organization_uuid_v4` drawn from the identity base, matching the lean webapp schema.
- `event_version: '0'` is set in metadata on all three events (matching webapp convention).
- All three emit calls are fire-and-forget (`.catch(() => {})`), so a telemetry failure never affects the import result.
- A `completedEmitted` flag gates `UserOnboardingExited`: set to `true` after each `emitUserOnboardingCompleted` call, checked in the catch block to avoid double-firing.

## Test plan

- [ ] Run `sonar import` against a real org and verify the three events land in `telemetry-events.ndjson`
- [ ] Trigger an error early (e.g. an org without a connected DevOps platform) and verify `UserOnboardingExited` fires with `devops_platform: null`
- [ ] Trigger an error after ALM resolution and verify `UserOnboardingExited` fires with the correct `devops_platform`
- [ ] Let an import complete with failures and verify only `UserOnboardingCompleted` fires (not `UserOnboardingExited`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)