### PR TITLE
CLI-997 Send SonarQube Cloud enterprise UUID to LaunchDarkly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,18 +129,20 @@ The two inputs are separate because the single boolean made _collect but do not 
 
 **Resolution order** (per auth token, keyed by connection type + server URL + org key + token fingerprint):
 
-1. **Connection seed** — `identityFromConnection()` maps `AuthConnection.userUuid`, `organizationUuidV4`, and `sqsInstallationId` — kept in sync for both keychain and env-var auth by `recordConnectionFromAuth()` (see CLI-866 below), not just at `sonar auth login`.
+1. **Connection seed** — `identityFromConnection()` maps `AuthConnection.userUuid`, `organizationUuidV4`, `enterpriseUuid`, and `sqsInstallationId` — kept in sync for both keychain and env-var auth by `recordConnectionFromAuth()` (see CLI-866 below), not just at `sonar auth login`.
 2. **Disk cache** — `{SONAR_USER_HOME}/sonarqube-cli/telemetry/identity-cache.json`, one entry per auth fingerprint (`src/core/telemetry/identity-fetch.ts`). Avoids repeat API calls across CLI invocations, independently of the connection seed.
-3. **API enrichment** — `SonarQubeClient.getSafe()` fetches only missing fields: `/api/users/current` (cloud and server), `/organizations/organizations` (cloud only, when `orgKey` is set), `/api/system/status` (server only).
+3. **API enrichment** — `SonarQubeClient.getSafe()` fetches only missing fields: `/api/users/current` (cloud and server), `/organizations/organizations` (cloud only, when `orgKey` is set), `/enterprises/enterprise-organizations` (cloud only, keyed by the org's legacy `id` from that lookup), `/api/system/status` (server only).
 
 **Fast path** (skip resolving auth entirely, in `resolveStoreEventTelemetryIdentity`): when `conn` (the currently active `AuthConnection`, read fresh from state) already satisfies `needsIdentityEnrichment() === false`. This check is source-agnostic — it is not gated on `isEnvBasedAuth()` — because `resolveAuth()`'s env branch keeps `state.auth.connections` synced before this ever runs (see CLI-866 below), so a fully-populated `conn` is trustworthy regardless of which auth source produced it. When the fast path doesn't apply, telemetry calls `resolveAuth({ silent: true })` — `silent` suppresses the "partial env vars" warning so this best-effort, source-agnostic shadow resolution never prints a diagnostic the command's own `resolveAuth()` call would already have shown (or wouldn't have shown at all, for a non-authenticated command).
 
 **Field completeness** (`isIdentityCompleteForConnection`, in `src/core/telemetry/identity-fetch.ts`):
 
-- **Cloud** — requires `user_uuid` and `organization_uuid_v4`.
-- **Server** — requires `sqs_installation_id` only; `user_uuid` is optional on older SonarQube Server versions that do not return it (see `TelemetryEventPayload`).
+- **Cloud** — requires `user_uuid` and `organization_uuid_v4`. `enterprise_uuid` is optional: orgs that are not in an enterprise still evaluate LaunchDarkly with user + organization. A Cloud connection that already has user+org but `enterpriseUuid === undefined` (state written before this field existed) is still enriched once.
+- **Server** — requires `sqs_installation_id` only; `user_uuid` is optional on older SonarQube Server versions that do not return it (see `TelemetryEventPayload`). SonarQube Server has no enterprise context.
 
 **`user_uuid` policy** — always attempted for cloud and server (login and env-var auth) whenever not already known. `recordConnectionFromAuth()` persists `userUuid` on the connection (`string` or explicit `null` after a successful fetch), for both auth sources. Telemetry skips re-fetch when `conn.userUuid !== undefined`. A successful API response with no user id is cached as confirmed-absent (`userUuid: null` in the disk entry) so old servers do not cause infinite re-fetch; transient API failures are not cached and retry on the next command.
+
+**`enterprise_uuid` policy** — Cloud only, when `orgKey` is set. After resolving the org (for its `uuidV4` and legacy `id`), `GET /enterprises/enterprise-organizations?organizationId=<legacy id>` maps the org to an enterprise. An empty list is confirmed-absent (`enterpriseUuid: null` on the connection and disk cache) so flags still evaluate without an `enterprise` context. Transient failures are not persisted, so the next command retries. Private Beta LaunchDarkly evaluation sends a Cloud multi-context of `user` + `organization`, plus `enterprise` when the UUID is known. `enterprise_uuid` is **not** added to telemetry event payloads.
 
 **Caching rules** — disk entries are written only when the API call succeeded (`response.ok`). Non-null values and confirmed-absent nulls are persisted; failed/transient responses are omitted so the next run retries. The `'fieldName' in entry` check in `planFieldsToFetch()` distinguishes “not yet tried” from “confirmed absent”.
 

--- a/src/core/auth/auth-connection-recorder.ts
+++ b/src/core/auth/auth-connection-recorder.ts
@@ -33,7 +33,7 @@ import { loadState, saveState } from '../state/state-repository.ts';
 import {
   identityFromConnection,
   needsIdentityEnrichment,
-  resolveTelemetryIdentity,
+  resolveTelemetryIdentityResolution,
   type TelemetryIdentity,
 } from '../telemetry/identity-fetch.ts';
 
@@ -72,8 +72,11 @@ export async function recordConnectionFromAuth(
     envOnly: options.envOnly,
   });
 
-  const identity = await resolveTelemetryIdentity(auth, seedIdentity);
-  applyIdentityToConnection(connection, auth, identity);
+  const { identity, persistEnterprise } = await resolveTelemetryIdentityResolution(
+    auth,
+    seedIdentity,
+  );
+  applyIdentityToConnection(connection, auth, identity, persistEnterprise);
 
   saveState(state);
   return connection;
@@ -84,10 +87,14 @@ function applyIdentityToConnection(
   connection: AuthConnection,
   auth: ResolvedAuth,
   identity: TelemetryIdentity,
+  persistEnterprise: boolean,
 ): void {
   connection.userUuid = identity.user_uuid;
   if (auth.connectionType === 'cloud' && auth.orgKey) {
     connection.organizationUuidV4 = identity.organization_uuid_v4;
+    if (persistEnterprise) {
+      connection.enterpriseUuid = identity.enterprise_uuid;
+    }
   } else if (auth.connectionType === 'on-premise') {
     connection.sqsInstallationId = identity.sqs_installation_id;
   }

--- a/src/core/auth/auth-connection-recorder.ts
+++ b/src/core/auth/auth-connection-recorder.ts
@@ -33,7 +33,7 @@ import { loadState, saveState } from '../state/state-repository.ts';
 import {
   identityFromConnection,
   needsIdentityEnrichment,
-  resolveTelemetryIdentityResolution,
+  resolveTelemetryIdentity,
   type TelemetryIdentity,
 } from '../telemetry/identity-fetch.ts';
 
@@ -72,11 +72,8 @@ export async function recordConnectionFromAuth(
     envOnly: options.envOnly,
   });
 
-  const { identity, persistEnterprise } = await resolveTelemetryIdentityResolution(
-    auth,
-    seedIdentity,
-  );
-  applyIdentityToConnection(connection, auth, identity, persistEnterprise);
+  const identity = await resolveTelemetryIdentity(auth, seedIdentity);
+  applyIdentityToConnection(connection, auth, identity);
 
   saveState(state);
   return connection;
@@ -87,12 +84,11 @@ function applyIdentityToConnection(
   connection: AuthConnection,
   auth: ResolvedAuth,
   identity: TelemetryIdentity,
-  persistEnterprise: boolean,
 ): void {
   connection.userUuid = identity.user_uuid;
   if (auth.connectionType === 'cloud' && auth.orgKey) {
     connection.organizationUuidV4 = identity.organization_uuid_v4;
-    if (persistEnterprise) {
+    if (identity.enterprise_uuid !== undefined) {
       connection.enterpriseUuid = identity.enterprise_uuid;
     }
   } else if (auth.connectionType === 'on-premise') {

--- a/src/core/launch-darkly/cache.ts
+++ b/src/core/launch-darkly/cache.ts
@@ -47,6 +47,7 @@ export function identityCacheKey(identity: FeatureFlagIdentity): string {
     identity.connectionType,
     `user:${identity.userUuid ?? ''}`,
     `organization:${identity.organizationUuidV4 ?? ''}`,
+    `enterprise:${identity.enterpriseUuid ?? ''}`,
     `installation:${identity.sqsInstallationId ?? ''}`,
   ].join('|');
 }

--- a/src/core/launch-darkly/index.ts
+++ b/src/core/launch-darkly/index.ts
@@ -168,7 +168,7 @@ async function resolveFeatureFlagIdentity(auth: ResolvedAuth): Promise<FeatureFl
     connectionType: auth.connectionType,
     userUuid: identity.user_uuid,
     organizationUuidV4: identity.organization_uuid_v4,
-    enterpriseUuid: identity.enterprise_uuid,
+    enterpriseUuid: identity.enterprise_uuid ?? null,
     sqsInstallationId: identity.sqs_installation_id,
   };
 }

--- a/src/core/launch-darkly/index.ts
+++ b/src/core/launch-darkly/index.ts
@@ -72,6 +72,7 @@ export function buildLaunchDarklyContext(identity: FeatureFlagIdentity): LDConte
       kind: 'multi',
       user: { key: identity.userUuid },
       organization: { key: identity.organizationUuidV4 },
+      ...(identity.enterpriseUuid ? { enterprise: { key: identity.enterpriseUuid } } : {}),
     };
   }
 
@@ -167,6 +168,7 @@ async function resolveFeatureFlagIdentity(auth: ResolvedAuth): Promise<FeatureFl
     connectionType: auth.connectionType,
     userUuid: identity.user_uuid,
     organizationUuidV4: identity.organization_uuid_v4,
+    enterpriseUuid: identity.enterprise_uuid,
     sqsInstallationId: identity.sqs_installation_id,
   };
 }

--- a/src/core/launch-darkly/types.ts
+++ b/src/core/launch-darkly/types.ts
@@ -25,6 +25,7 @@ export interface FeatureFlagIdentity {
   connectionType: ServerType;
   userUuid: string | null;
   organizationUuidV4: string | null;
+  enterpriseUuid: string | null;
   sqsInstallationId: string | null;
 }
 

--- a/src/core/state/state.ts
+++ b/src/core/state/state.ts
@@ -76,6 +76,8 @@ export interface AuthConnection {
   userUuid?: string | null;
   /** UUID of the SonarQube Cloud organization (fetched at auth time, SQC only) */
   organizationUuidV4?: string | null;
+  /** UUID of the SonarQube Cloud enterprise that owns the org (fetched at auth time, SQC only) */
+  enterpriseUuid?: string | null;
   /** Installation ID of the SonarQube Server (fetched at auth time, SQS only) */
   sqsInstallationId?: string | null;
   /**

--- a/src/core/telemetry/identity-fetch.ts
+++ b/src/core/telemetry/identity-fetch.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Fetches and disk-caches server-side identity fields (user/org/installation UUIDs) for a resolved auth.
+// Fetches and disk-caches server-side identity fields (user/org/enterprise/installation UUIDs) for a resolved auth.
 
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -31,15 +31,20 @@ import { resolveFromEndpoint } from '@/core/server/sonarcloud-region.ts';
 import { getTelemetryDir } from '../config-constants.ts';
 import type { AuthConnection, ServerType } from '../state/state.ts';
 
+const ORGANIZATIONS_ENDPOINT = '/organizations/organizations';
+const ENTERPRISE_ORGANIZATIONS_ENDPOINT = '/enterprises/enterprise-organizations';
+
 export interface TelemetryIdentity {
   user_uuid: string | null;
   organization_uuid_v4: string | null;
+  enterprise_uuid: string | null;
   sqs_installation_id: string | null;
 }
 
 export const EMPTY_IDENTITY: TelemetryIdentity = {
   user_uuid: null,
   organization_uuid_v4: null,
+  enterprise_uuid: null,
   sqs_installation_id: null,
 };
 
@@ -47,6 +52,7 @@ export function identityFromConnection(conn: AuthConnection | undefined): Teleme
   return {
     user_uuid: conn?.userUuid ?? null,
     organization_uuid_v4: conn?.organizationUuidV4 ?? null,
+    enterprise_uuid: conn?.enterpriseUuid ?? null,
     sqs_installation_id: conn?.sqsInstallationId ?? null,
   };
 }
@@ -67,6 +73,11 @@ function connectionUserUuidResolved(conn: AuthConnection | undefined): boolean {
   return conn?.userUuid !== undefined;
 }
 
+/** Login persists `enterpriseUuid` (string or null); undefined means we have not tried yet. */
+function connectionEnterpriseUuidResolved(conn: AuthConnection | undefined): boolean {
+  return conn?.enterpriseUuid !== undefined;
+}
+
 export function needsIdentityEnrichment(
   identity: TelemetryIdentity,
   connectionType: ServerType,
@@ -75,12 +86,16 @@ export function needsIdentityEnrichment(
   if (!isIdentityCompleteForConnection(identity, connectionType)) {
     return true;
   }
-  return !identity.user_uuid && !connectionUserUuidResolved(conn);
+  if (!identity.user_uuid && !connectionUserUuidResolved(conn)) {
+    return true;
+  }
+  return connectionType === 'cloud' && !connectionEnterpriseUuidResolved(conn);
 }
 
 interface CacheEntry {
   userUuid?: string | null;
   organizationUuidV4?: string | null;
+  enterpriseUuid?: string | null;
   sqsInstallationId?: string | null;
 }
 
@@ -91,6 +106,7 @@ interface IdentityCacheFile {
 interface IdentityFetchPlan {
   user: boolean;
   org: boolean;
+  enterprise: boolean;
   sqs: boolean;
 }
 
@@ -104,6 +120,7 @@ export function mergeIdentity(
   return {
     user_uuid: partial.user_uuid ?? base.user_uuid,
     organization_uuid_v4: partial.organization_uuid_v4 ?? base.organization_uuid_v4,
+    enterprise_uuid: partial.enterprise_uuid ?? base.enterprise_uuid,
     sqs_installation_id: partial.sqs_installation_id ?? base.sqs_installation_id,
   };
 }
@@ -120,12 +137,13 @@ function cacheEntryToIdentity(entry: CacheEntry): TelemetryIdentity {
   return {
     user_uuid: entry.userUuid ?? null,
     organization_uuid_v4: entry.organizationUuidV4 ?? null,
+    enterprise_uuid: entry.enterpriseUuid ?? null,
     sqs_installation_id: entry.sqsInstallationId ?? null,
   };
 }
 
 function fetchPlanIsComplete(plan: IdentityFetchPlan): boolean {
-  return !plan.user && !plan.org && !plan.sqs;
+  return !plan.user && !plan.org && !plan.enterprise && !plan.sqs;
 }
 
 function planFieldsToFetch(
@@ -140,6 +158,11 @@ function planFieldsToFetch(
       !!auth.orgKey &&
       !identity.organization_uuid_v4 &&
       !(entry && 'organizationUuidV4' in entry),
+    enterprise:
+      auth.connectionType === 'cloud' &&
+      !!auth.orgKey &&
+      !identity.enterprise_uuid &&
+      !(entry && 'enterpriseUuid' in entry),
     sqs:
       auth.connectionType === 'on-premise' &&
       !identity.sqs_installation_id &&
@@ -182,6 +205,17 @@ interface FieldFetchResult {
   resolved: boolean;
 }
 
+interface OrganizationRecord {
+  id?: string;
+  uuidV4?: string;
+}
+
+interface OrganizationLookupResult {
+  uuidV4: string | null;
+  id: string | null;
+  resolved: boolean;
+}
+
 async function fetchUserUuid(client: SonarQubeClient): Promise<FieldFetchResult> {
   try {
     const { response, value } = await client.getSafe<{ id: string }>('/api/users/current');
@@ -194,22 +228,42 @@ async function fetchUserUuid(client: SonarQubeClient): Promise<FieldFetchResult>
   }
 }
 
-async function fetchOrganizationUuid(
+async function fetchOrganizationRecord(
   client: SonarQubeClient,
   serverUrl: string,
   orgKey: string,
+): Promise<OrganizationLookupResult> {
+  try {
+    const { response, value } = await client.getSafe<OrganizationRecord[]>(
+      ORGANIZATIONS_ENDPOINT,
+      { organizationKey: orgKey, excludeEligibility: 'true' },
+      resolveFromEndpoint(serverUrl, ORGANIZATIONS_ENDPOINT),
+    );
+    if (!response.ok) {
+      return { uuidV4: null, id: null, resolved: false };
+    }
+    const org = value?.[0];
+    return { uuidV4: org?.uuidV4 ?? null, id: org?.id ?? null, resolved: true };
+  } catch {
+    return { uuidV4: null, id: null, resolved: false };
+  }
+}
+
+async function fetchEnterpriseUuid(
+  client: SonarQubeClient,
+  serverUrl: string,
+  organizationId: string,
 ): Promise<FieldFetchResult> {
   try {
-    const endpoint = '/organizations/organizations';
-    const { response, value } = await client.getSafe<Array<{ uuidV4: string }>>(
-      endpoint,
-      { organizationKey: orgKey, excludeEligibility: 'true' },
-      resolveFromEndpoint(serverUrl, endpoint),
+    const { response, value } = await client.getSafe<Array<{ enterpriseId?: string }>>(
+      ENTERPRISE_ORGANIZATIONS_ENDPOINT,
+      { organizationId },
+      resolveFromEndpoint(serverUrl, ENTERPRISE_ORGANIZATIONS_ENDPOINT),
     );
     if (!response.ok) {
       return { value: null, resolved: false };
     }
-    return { value: value?.[0]?.uuidV4 ?? null, resolved: true };
+    return { value: value?.[0]?.enterpriseId ?? null, resolved: true };
   } catch {
     return { value: null, resolved: false };
   }
@@ -238,18 +292,33 @@ async function fetchMissingFromApi(
   fetchPlan: IdentityFetchPlan,
 ): Promise<IdentityFetchResult> {
   const client = new SonarQubeClient(auth.serverUrl, auth.token);
-  let { user_uuid, organization_uuid_v4, sqs_installation_id } = identity;
-  const resolved: IdentityFetchPlan = { user: false, org: false, sqs: false };
+  let { user_uuid, organization_uuid_v4, enterprise_uuid, sqs_installation_id } = identity;
+  const resolved: IdentityFetchPlan = { user: false, org: false, enterprise: false, sqs: false };
 
   if (fetchPlan.user) {
     const user = await fetchUserUuid(client);
     user_uuid = user.value;
     resolved.user = user.resolved;
   }
-  if (fetchPlan.org && auth.orgKey) {
-    const org = await fetchOrganizationUuid(client, auth.serverUrl, auth.orgKey);
-    organization_uuid_v4 = org.value;
-    resolved.org = org.resolved;
+  if ((fetchPlan.org || fetchPlan.enterprise) && auth.orgKey) {
+    const org = await fetchOrganizationRecord(client, auth.serverUrl, auth.orgKey);
+    if (fetchPlan.org) {
+      organization_uuid_v4 = org.uuidV4;
+      resolved.org = org.resolved;
+    }
+    if (fetchPlan.enterprise) {
+      if (!org.resolved) {
+        enterprise_uuid = null;
+        resolved.enterprise = false;
+      } else if (!org.id) {
+        enterprise_uuid = null;
+        resolved.enterprise = true;
+      } else {
+        const enterprise = await fetchEnterpriseUuid(client, auth.serverUrl, org.id);
+        enterprise_uuid = enterprise.value;
+        resolved.enterprise = enterprise.resolved;
+      }
+    }
   }
   if (fetchPlan.sqs) {
     const sqs = await fetchSqsInstallationId(client);
@@ -258,9 +327,15 @@ async function fetchMissingFromApi(
   }
 
   return {
-    identity: { user_uuid, organization_uuid_v4, sqs_installation_id },
+    identity: { user_uuid, organization_uuid_v4, enterprise_uuid, sqs_installation_id },
     resolved,
   };
+}
+
+interface TelemetryIdentityResolution {
+  identity: TelemetryIdentity;
+  /** True when enterprise UUID is known, including confirmed-absent `null`. */
+  persistEnterprise: boolean;
 }
 
 /** Never throws — a failed fetch just leaves the field null and is retried next call. */
@@ -268,6 +343,18 @@ export async function resolveTelemetryIdentity(
   auth: ResolvedAuth,
   seed: TelemetryIdentity = EMPTY_IDENTITY,
 ): Promise<TelemetryIdentity> {
+  return (await resolveTelemetryIdentityResolution(auth, seed)).identity;
+}
+
+/**
+ * Like {@link resolveTelemetryIdentity}, plus whether `enterpriseUuid` is safe to
+ * persist on the connection. Transient enterprise lookup failures must not be
+ * written as confirmed-absent `null`, or later commands would skip the retry.
+ */
+export async function resolveTelemetryIdentityResolution(
+  auth: ResolvedAuth,
+  seed: TelemetryIdentity = EMPTY_IDENTITY,
+): Promise<TelemetryIdentityResolution> {
   const entryKey = cacheKey(auth);
   const diskCache = readDiskCache();
   const diskEntry = entryKey in diskCache.entries ? diskCache.entries[entryKey] : undefined;
@@ -279,7 +366,7 @@ export async function resolveTelemetryIdentity(
 
   const fetchPlan = planFieldsToFetch(auth, identity, diskEntry);
   if (fetchPlanIsComplete(fetchPlan)) {
-    return identity;
+    return { identity, persistEnterprise: !fetchPlan.enterprise };
   }
 
   const fetchResult = await fetchMissingFromApi(auth, identity, fetchPlan);
@@ -292,6 +379,9 @@ export async function resolveTelemetryIdentity(
   if (fetchPlan.org && fetchResult.resolved.org) {
     updatedEntry.organizationUuidV4 = identity.organization_uuid_v4;
   }
+  if (fetchPlan.enterprise && fetchResult.resolved.enterprise) {
+    updatedEntry.enterpriseUuid = identity.enterprise_uuid;
+  }
   if (fetchPlan.sqs && fetchResult.resolved.sqs) {
     updatedEntry.sqsInstallationId = identity.sqs_installation_id;
   }
@@ -300,5 +390,8 @@ export async function resolveTelemetryIdentity(
     writeDiskCache(diskCache);
   }
 
-  return identity;
+  return {
+    identity,
+    persistEnterprise: !fetchPlan.enterprise || fetchResult.resolved.enterprise,
+  };
 }

--- a/src/core/telemetry/identity-fetch.ts
+++ b/src/core/telemetry/identity-fetch.ts
@@ -120,6 +120,7 @@ export function mergeIdentity(
   return {
     user_uuid: partial.user_uuid ?? base.user_uuid,
     organization_uuid_v4: partial.organization_uuid_v4 ?? base.organization_uuid_v4,
+    // `??` would treat confirmed-absent `null` as missing and fall back to base.
     enterprise_uuid:
       partial.enterprise_uuid !== undefined ? partial.enterprise_uuid : base.enterprise_uuid,
     sqs_installation_id: partial.sqs_installation_id ?? base.sqs_installation_id,
@@ -146,8 +147,9 @@ function cacheEntryToIdentity(entry: CacheEntry): Partial<TelemetryIdentity> {
   return identity;
 }
 
+/** True when no identity fields remain to fetch. */
 function fetchPlanIsComplete(plan: IdentityFetchPlan): boolean {
-  return !plan.user && !plan.org && !plan.enterprise && !plan.sqs;
+  return !(plan.user || plan.org || plan.enterprise || plan.sqs);
 }
 
 function planFieldsToFetch(
@@ -273,6 +275,25 @@ async function fetchEnterpriseUuid(
   }
 }
 
+/** Unresolved stays `undefined` so the next command retries; `null` is confirmed-absent. */
+async function resolveEnterpriseUuid(
+  client: SonarQubeClient,
+  serverUrl: string,
+  org: OrganizationLookupResult,
+): Promise<{ value: string | null | undefined; resolved: boolean }> {
+  if (!org.resolved) {
+    return { value: undefined, resolved: false };
+  }
+  if (!org.id) {
+    return { value: null, resolved: true };
+  }
+  const enterprise = await fetchEnterpriseUuid(client, serverUrl, org.id);
+  return {
+    value: enterprise.resolved ? enterprise.value : undefined,
+    resolved: enterprise.resolved,
+  };
+}
+
 async function fetchSqsInstallationId(client: SonarQubeClient): Promise<FieldFetchResult> {
   try {
     const { response, value } = await client.getSafe<{ id?: string }>('/api/system/status');
@@ -311,17 +332,9 @@ async function fetchMissingFromApi(
       resolved.org = org.resolved;
     }
     if (fetchPlan.enterprise) {
-      if (!org.resolved) {
-        enterprise_uuid = undefined;
-        resolved.enterprise = false;
-      } else if (!org.id) {
-        enterprise_uuid = null;
-        resolved.enterprise = true;
-      } else {
-        const enterprise = await fetchEnterpriseUuid(client, auth.serverUrl, org.id);
-        enterprise_uuid = enterprise.resolved ? enterprise.value : undefined;
-        resolved.enterprise = enterprise.resolved;
-      }
+      const enterprise = await resolveEnterpriseUuid(client, auth.serverUrl, org);
+      enterprise_uuid = enterprise.value;
+      resolved.enterprise = enterprise.resolved;
     }
   }
   if (fetchPlan.sqs) {

--- a/src/core/telemetry/identity-fetch.ts
+++ b/src/core/telemetry/identity-fetch.ts
@@ -37,14 +37,14 @@ const ENTERPRISE_ORGANIZATIONS_ENDPOINT = '/enterprises/enterprise-organizations
 export interface TelemetryIdentity {
   user_uuid: string | null;
   organization_uuid_v4: string | null;
-  enterprise_uuid: string | null;
+  /** `undefined` = not resolved yet; `null` = confirmed the org is not in an enterprise. */
+  enterprise_uuid?: string | null;
   sqs_installation_id: string | null;
 }
 
 export const EMPTY_IDENTITY: TelemetryIdentity = {
   user_uuid: null,
   organization_uuid_v4: null,
-  enterprise_uuid: null,
   sqs_installation_id: null,
 };
 
@@ -52,7 +52,7 @@ export function identityFromConnection(conn: AuthConnection | undefined): Teleme
   return {
     user_uuid: conn?.userUuid ?? null,
     organization_uuid_v4: conn?.organizationUuidV4 ?? null,
-    enterprise_uuid: conn?.enterpriseUuid ?? null,
+    enterprise_uuid: conn?.enterpriseUuid,
     sqs_installation_id: conn?.sqsInstallationId ?? null,
   };
 }
@@ -120,7 +120,8 @@ export function mergeIdentity(
   return {
     user_uuid: partial.user_uuid ?? base.user_uuid,
     organization_uuid_v4: partial.organization_uuid_v4 ?? base.organization_uuid_v4,
-    enterprise_uuid: partial.enterprise_uuid ?? base.enterprise_uuid,
+    enterprise_uuid:
+      partial.enterprise_uuid !== undefined ? partial.enterprise_uuid : base.enterprise_uuid,
     sqs_installation_id: partial.sqs_installation_id ?? base.sqs_installation_id,
   };
 }
@@ -133,13 +134,16 @@ function cacheKey(auth: ResolvedAuth): string {
   return [auth.connectionType, auth.serverUrl, auth.orgKey ?? '', fingerprint].join('|');
 }
 
-function cacheEntryToIdentity(entry: CacheEntry): TelemetryIdentity {
-  return {
+function cacheEntryToIdentity(entry: CacheEntry): Partial<TelemetryIdentity> {
+  const identity: Partial<TelemetryIdentity> = {
     user_uuid: entry.userUuid ?? null,
     organization_uuid_v4: entry.organizationUuidV4 ?? null,
-    enterprise_uuid: entry.enterpriseUuid ?? null,
     sqs_installation_id: entry.sqsInstallationId ?? null,
   };
+  if ('enterpriseUuid' in entry) {
+    identity.enterprise_uuid = entry.enterpriseUuid ?? null;
+  }
+  return identity;
 }
 
 function fetchPlanIsComplete(plan: IdentityFetchPlan): boolean {
@@ -308,14 +312,14 @@ async function fetchMissingFromApi(
     }
     if (fetchPlan.enterprise) {
       if (!org.resolved) {
-        enterprise_uuid = null;
+        enterprise_uuid = undefined;
         resolved.enterprise = false;
       } else if (!org.id) {
         enterprise_uuid = null;
         resolved.enterprise = true;
       } else {
         const enterprise = await fetchEnterpriseUuid(client, auth.serverUrl, org.id);
-        enterprise_uuid = enterprise.value;
+        enterprise_uuid = enterprise.resolved ? enterprise.value : undefined;
         resolved.enterprise = enterprise.resolved;
       }
     }
@@ -332,29 +336,11 @@ async function fetchMissingFromApi(
   };
 }
 
-interface TelemetryIdentityResolution {
-  identity: TelemetryIdentity;
-  /** True when enterprise UUID is known, including confirmed-absent `null`. */
-  persistEnterprise: boolean;
-}
-
 /** Never throws — a failed fetch just leaves the field null and is retried next call. */
 export async function resolveTelemetryIdentity(
   auth: ResolvedAuth,
   seed: TelemetryIdentity = EMPTY_IDENTITY,
 ): Promise<TelemetryIdentity> {
-  return (await resolveTelemetryIdentityResolution(auth, seed)).identity;
-}
-
-/**
- * Like {@link resolveTelemetryIdentity}, plus whether `enterpriseUuid` is safe to
- * persist on the connection. Transient enterprise lookup failures must not be
- * written as confirmed-absent `null`, or later commands would skip the retry.
- */
-export async function resolveTelemetryIdentityResolution(
-  auth: ResolvedAuth,
-  seed: TelemetryIdentity = EMPTY_IDENTITY,
-): Promise<TelemetryIdentityResolution> {
   const entryKey = cacheKey(auth);
   const diskCache = readDiskCache();
   const diskEntry = entryKey in diskCache.entries ? diskCache.entries[entryKey] : undefined;
@@ -366,7 +352,7 @@ export async function resolveTelemetryIdentityResolution(
 
   const fetchPlan = planFieldsToFetch(auth, identity, diskEntry);
   if (fetchPlanIsComplete(fetchPlan)) {
-    return { identity, persistEnterprise: !fetchPlan.enterprise };
+    return identity;
   }
 
   const fetchResult = await fetchMissingFromApi(auth, identity, fetchPlan);
@@ -380,7 +366,7 @@ export async function resolveTelemetryIdentityResolution(
     updatedEntry.organizationUuidV4 = identity.organization_uuid_v4;
   }
   if (fetchPlan.enterprise && fetchResult.resolved.enterprise) {
-    updatedEntry.enterpriseUuid = identity.enterprise_uuid;
+    updatedEntry.enterpriseUuid = identity.enterprise_uuid ?? null;
   }
   if (fetchPlan.sqs && fetchResult.resolved.sqs) {
     updatedEntry.sqsInstallationId = identity.sqs_installation_id;
@@ -390,8 +376,5 @@ export async function resolveTelemetryIdentityResolution(
     writeDiskCache(diskCache);
   }
 
-  return {
-    identity,
-    persistEnterprise: !fetchPlan.enterprise || fetchResult.resolved.enterprise,
-  };
+  return identity;
 }

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -811,6 +811,13 @@ export class FakeSonarQubeServerBuilder {
           });
         }
 
+        if (path === '/enterprises/enterprise-organizations') {
+          // Orgs not in an enterprise map to an empty list; identity caches that as null.
+          return new Response(JSON.stringify([]), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
         if (path === '/dop-translation/dop-repositories') {
           const organizationId = query.organizationId;
           const allRepos = organizationId ? (dopRepositoriesByOrgId.get(organizationId) ?? []) : [];

--- a/tests/unit/core/auth/auth-connection-recorder.test.ts
+++ b/tests/unit/core/auth/auth-connection-recorder.test.ts
@@ -80,6 +80,7 @@ describe('recordConnectionFromAuth', () => {
     });
     existing.userUuid = 'u';
     existing.organizationUuidV4 = 'o';
+    existing.enterpriseUuid = null;
     saveState(state);
 
     const getSafeSpy = mockIdentityGetSafe();
@@ -107,6 +108,7 @@ describe('recordConnectionFromAuth', () => {
     expect(connection.serverUrl).toBe('https://sonarcloud.io');
     expect(connection.userUuid).toBe('fresh-user');
     expect(connection.organizationUuidV4).toBe('fresh-org');
+    expect(connection.enterpriseUuid).toBeNull();
 
     const reloaded = loadState();
     expect(reloaded.auth.connections).toHaveLength(1);
@@ -122,6 +124,7 @@ describe('recordConnectionFromAuth', () => {
     });
     existing.userUuid = 'u';
     existing.organizationUuidV4 = 'o';
+    existing.enterpriseUuid = null;
     saveState(state);
 
     const connection = await recordConnectionFromAuth(cloudAuth('t4'), {
@@ -139,14 +142,17 @@ describe('recordConnectionFromAuth', () => {
     });
     existing.userUuid = 'u';
     existing.organizationUuidV4 = 'o';
+    existing.enterpriseUuid = null;
     saveState(state);
 
+    const getSafeSpy = mockIdentityGetSafe();
     const connection = await recordConnectionFromAuth(cloudAuth('t4'), {
       tokenName: 'new-token-name',
       force: true,
     });
 
     expect(connection.tokenName).toBe('new-token-name');
+    getSafeSpy.mockRestore();
   });
 
   it('sets organizationUuidV4 only for cloud auth with an org key, and sqsInstallationId only for on-premise', async () => {
@@ -158,6 +164,7 @@ describe('recordConnectionFromAuth', () => {
     const onPremConnection = await recordConnectionFromAuth(serverAuth('t5'));
     expect(onPremConnection.sqsInstallationId).toBe('sqs-a');
     expect(onPremConnection.organizationUuidV4).toBeUndefined();
+    expect(onPremConnection.enterpriseUuid).toBeUndefined();
 
     getSafeSpy.mockRestore();
   });
@@ -180,6 +187,35 @@ describe('recordConnectionFromAuth', () => {
     });
 
     expect(connection.envOnly).toBeUndefined();
+    getSafeSpy.mockRestore();
+  });
+
+  it('persists enterpriseUuid for cloud auth with an org key', async () => {
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'user-a' }],
+      org: [{ ok: true, uuidV4: 'org-a', id: 'legacy-org-a' }],
+      enterprise: [{ ok: true, enterpriseId: 'ent-a' }],
+    });
+
+    const connection = await recordConnectionFromAuth(cloudAuth('t-ent'));
+
+    expect(connection.organizationUuidV4).toBe('org-a');
+    expect(connection.enterpriseUuid).toBe('ent-a');
+    expect(connection.sqsInstallationId).toBeUndefined();
+    getSafeSpy.mockRestore();
+  });
+
+  it('does not persist enterpriseUuid when the enterprise lookup fails transiently', async () => {
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'user-a' }],
+      org: [{ ok: true, uuidV4: 'org-a', id: 'legacy-org-a' }],
+      enterprise: [{ ok: false }],
+    });
+
+    const connection = await recordConnectionFromAuth(cloudAuth('t-ent-fail'));
+
+    expect(connection.organizationUuidV4).toBe('org-a');
+    expect(connection.enterpriseUuid).toBeUndefined();
     getSafeSpy.mockRestore();
   });
 });

--- a/tests/unit/core/launch-darkly/cache.test.ts
+++ b/tests/unit/core/launch-darkly/cache.test.ts
@@ -31,6 +31,7 @@ const identity: FeatureFlagIdentity = {
   connectionType: 'cloud',
   userUuid: 'user-1',
   organizationUuidV4: 'org-1',
+  enterpriseUuid: null,
   sqsInstallationId: null,
 };
 
@@ -118,5 +119,13 @@ describe('readFreshFlagDecisions', () => {
     expect(readFreshFlagDecisions(identity, ['cli.beta.private'], 'client-id', 1_000)).toEqual({
       'cli.beta.private': true,
     });
+  });
+});
+
+describe('identityCacheKey', () => {
+  it('changes when the enterprise UUID changes', () => {
+    expect(identityCacheKey({ ...identity, enterpriseUuid: 'ent-1' })).not.toBe(
+      identityCacheKey(identity),
+    );
   });
 });

--- a/tests/unit/core/launch-darkly/fetch-flags.test.ts
+++ b/tests/unit/core/launch-darkly/fetch-flags.test.ts
@@ -59,6 +59,7 @@ const cloudIdentity: FeatureFlagIdentity = {
   connectionType: 'cloud',
   userUuid: 'user-1',
   organizationUuidV4: 'org-1',
+  enterpriseUuid: null,
   sqsInstallationId: null,
 };
 
@@ -120,6 +121,21 @@ describe('fetchFlagsFromLaunchDarkly', () => {
     options.logger.error('e');
   });
 
+  it('sends an enterprise context to LaunchDarkly when the UUID is known', async () => {
+    await fetchFlagsFromLaunchDarkly({
+      ...cloudIdentity,
+      enterpriseUuid: 'ent-1',
+    });
+
+    const [, context] = initialize.mock.calls[0];
+    expect(context).toEqual({
+      kind: 'multi',
+      user: { key: 'user-1' },
+      organization: { key: 'org-1' },
+      enterprise: { key: 'ent-1' },
+    });
+  });
+
   it('returns null when SDK initialization fails', async () => {
     waitForInitialization.mockImplementation(() => Promise.reject(new Error('timeout')));
 
@@ -140,6 +156,7 @@ describe('fetchFlagsFromLaunchDarkly', () => {
         connectionType: 'cloud',
         userUuid: 'user-1',
         organizationUuidV4: null,
+        enterpriseUuid: null,
         sqsInstallationId: null,
       }),
     ).toBeNull();

--- a/tests/unit/core/launch-darkly/launchdarkly.test.ts
+++ b/tests/unit/core/launch-darkly/launchdarkly.test.ts
@@ -42,6 +42,7 @@ describe('buildLaunchDarklyContext', () => {
       connectionType: 'cloud',
       userUuid: 'user-1',
       organizationUuidV4: 'org-1',
+      enterpriseUuid: null,
       sqsInstallationId: null,
     };
 
@@ -52,11 +53,29 @@ describe('buildLaunchDarklyContext', () => {
     });
   });
 
+  it('adds an enterprise context when the Cloud enterprise UUID is known', () => {
+    const identity: FeatureFlagIdentity = {
+      connectionType: 'cloud',
+      userUuid: 'user-1',
+      organizationUuidV4: 'org-1',
+      enterpriseUuid: 'ent-1',
+      sqsInstallationId: null,
+    };
+
+    expect(buildLaunchDarklyContext(identity)).toEqual({
+      kind: 'multi',
+      user: { key: 'user-1' },
+      organization: { key: 'org-1' },
+      enterprise: { key: 'ent-1' },
+    });
+  });
+
   it('builds a Server multi-context when both installation and user are known', () => {
     const identity: FeatureFlagIdentity = {
       connectionType: 'on-premise',
       userUuid: 'user-1',
       organizationUuidV4: null,
+      enterpriseUuid: null,
       sqsInstallationId: 'install-1',
     };
 
@@ -72,6 +91,7 @@ describe('buildLaunchDarklyContext', () => {
       connectionType: 'on-premise',
       userUuid: null,
       organizationUuidV4: null,
+      enterpriseUuid: null,
       sqsInstallationId: 'install-1',
     };
 
@@ -87,6 +107,7 @@ describe('buildLaunchDarklyContext', () => {
         connectionType: 'cloud',
         userUuid: 'user-1',
         organizationUuidV4: null,
+        enterpriseUuid: null,
         sqsInstallationId: null,
       }),
     ).toBeNull();
@@ -98,6 +119,7 @@ describe('buildLaunchDarklyContext', () => {
         connectionType: 'on-premise',
         userUuid: 'user-1',
         organizationUuidV4: null,
+        enterpriseUuid: null,
         sqsInstallationId: null,
       }),
     ).toBeNull();

--- a/tests/unit/core/launch-darkly/private-beta.test.ts
+++ b/tests/unit/core/launch-darkly/private-beta.test.ts
@@ -66,6 +66,7 @@ describe('resolvePrivateBetaFlags', () => {
     connectionType: 'cloud',
     userUuid: 'user-1',
     organizationUuidV4: 'org-1',
+    enterpriseUuid: null,
     sqsInstallationId: null,
   };
 
@@ -88,6 +89,7 @@ describe('resolvePrivateBetaFlags', () => {
         authenticatedAt: new Date().toISOString(),
         userUuid: 'user-1',
         organizationUuidV4: 'org-1',
+        enterpriseUuid: null,
       },
     ];
     tryLoadStateSpy = spyOn(stateManager, 'tryLoadState').mockReturnValue(state);
@@ -200,6 +202,7 @@ describe('resolvePrivateBetaFlags', () => {
     resolveTelemetryIdentitySpy.mockResolvedValue({
       user_uuid: null,
       organization_uuid_v4: null,
+      enterprise_uuid: null,
       sqs_installation_id: null,
     });
     const fetchFlags = mock(() =>
@@ -233,6 +236,7 @@ describe('resolvePrivateBetaFlags', () => {
     resolveTelemetryIdentitySpy.mockResolvedValue({
       user_uuid: 'user-1',
       organization_uuid_v4: 'org-1',
+      enterprise_uuid: null,
       sqs_installation_id: null,
     });
     const fetchFlags = mock(() =>

--- a/tests/unit/core/telemetry/identity-api-mock.ts
+++ b/tests/unit/core/telemetry/identity-api-mock.ts
@@ -26,11 +26,13 @@ interface ApiStep {
   ok: boolean;
   id?: string;
   uuidV4?: string;
+  enterpriseId?: string;
 }
 
 interface IdentityApiMockOptions {
   user?: ApiStep[];
   org?: ApiStep[];
+  enterprise?: ApiStep[];
   status?: ApiStep[];
 }
 
@@ -49,6 +51,7 @@ export function mockIdentityGetSafe(
 
   const userSteps = options.user ? [...options.user] : undefined;
   const orgSteps = options.org ? [...options.org] : undefined;
+  const enterpriseSteps = options.enterprise ? [...options.enterprise] : undefined;
   const statusSteps = options.status ? [...options.status] : undefined;
 
   return spyOn(SonarQubeClient.prototype, 'getSafe').mockImplementation(
@@ -68,7 +71,16 @@ export function mockIdentityGetSafe(
         const step = shiftStep(orgSteps, { ok: true });
         return Promise.resolve({
           response: { ok: step.ok } as Response,
-          value: (step.uuidV4 ? [{ uuidV4: step.uuidV4 }] : []) as TValue,
+          value: (step.uuidV4
+            ? [{ uuidV4: step.uuidV4, id: step.id ?? `id-${step.uuidV4}` }]
+            : []) as TValue,
+        });
+      }
+      if (endpoint === '/enterprises/enterprise-organizations') {
+        const step = shiftStep(enterpriseSteps, { ok: true });
+        return Promise.resolve({
+          response: { ok: step.ok } as Response,
+          value: (step.enterpriseId ? [{ enterpriseId: step.enterpriseId }] : []) as TValue,
         });
       }
       if (endpoint === '/api/system/status') {

--- a/tests/unit/core/telemetry/identity.test.ts
+++ b/tests/unit/core/telemetry/identity.test.ts
@@ -42,7 +42,10 @@ import {
   resolveCommandTelemetryIdentity,
   resolveStoreEventTelemetryIdentitySafely,
 } from '@/core/telemetry/identity.ts';
-import { resolveTelemetryIdentity } from '@/core/telemetry/identity-fetch.ts';
+import {
+  needsIdentityEnrichment,
+  resolveTelemetryIdentity,
+} from '@/core/telemetry/identity-fetch.ts';
 
 import { mockIdentityGetSafe } from './identity-api-mock.ts';
 
@@ -107,17 +110,24 @@ describe('identityFromConnection()', () => {
     expect(identityFromConnection(undefined)).toEqual({
       user_uuid: null,
       organization_uuid_v4: null,
+      enterprise_uuid: null,
       sqs_installation_id: null,
     });
   });
 
   it('maps connection UUID fields into the identity payload', () => {
     const identity = identityFromConnection(
-      cloudConn({ userUuid: 'u', organizationUuidV4: 'o', sqsInstallationId: 's' }),
+      cloudConn({
+        userUuid: 'u',
+        organizationUuidV4: 'o',
+        enterpriseUuid: 'e',
+        sqsInstallationId: 's',
+      }),
     );
     expect(identity).toEqual({
       user_uuid: 'u',
       organization_uuid_v4: 'o',
+      enterprise_uuid: 'e',
       sqs_installation_id: 's',
     });
   });
@@ -127,7 +137,12 @@ describe('isIdentityCompleteForConnection()', () => {
   it('requires user_uuid for cloud', () => {
     expect(
       isIdentityCompleteForConnection(
-        { user_uuid: null, organization_uuid_v4: 'o', sqs_installation_id: null },
+        {
+          user_uuid: null,
+          organization_uuid_v4: 'o',
+          enterprise_uuid: null,
+          sqs_installation_id: null,
+        },
         'cloud',
       ),
     ).toBe(false);
@@ -136,13 +151,37 @@ describe('isIdentityCompleteForConnection()', () => {
   it('requires organization_uuid_v4 for cloud', () => {
     expect(
       isIdentityCompleteForConnection(
-        { user_uuid: 'u', organization_uuid_v4: null, sqs_installation_id: null },
+        {
+          user_uuid: 'u',
+          organization_uuid_v4: null,
+          enterprise_uuid: null,
+          sqs_installation_id: null,
+        },
         'cloud',
       ),
     ).toBe(false);
     expect(
       isIdentityCompleteForConnection(
-        { user_uuid: 'u', organization_uuid_v4: 'o', sqs_installation_id: null },
+        {
+          user_uuid: 'u',
+          organization_uuid_v4: 'o',
+          enterprise_uuid: null,
+          sqs_installation_id: null,
+        },
+        'cloud',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not require enterprise_uuid for cloud completeness', () => {
+    expect(
+      isIdentityCompleteForConnection(
+        {
+          user_uuid: 'u',
+          organization_uuid_v4: 'o',
+          enterprise_uuid: null,
+          sqs_installation_id: null,
+        },
         'cloud',
       ),
     ).toBe(true);
@@ -151,16 +190,38 @@ describe('isIdentityCompleteForConnection()', () => {
   it('requires sqs_installation_id for on-premise', () => {
     expect(
       isIdentityCompleteForConnection(
-        { user_uuid: null, organization_uuid_v4: null, sqs_installation_id: null },
+        {
+          user_uuid: null,
+          organization_uuid_v4: null,
+          enterprise_uuid: null,
+          sqs_installation_id: null,
+        },
         'on-premise',
       ),
     ).toBe(false);
     expect(
       isIdentityCompleteForConnection(
-        { user_uuid: null, organization_uuid_v4: null, sqs_installation_id: 's' },
+        {
+          user_uuid: null,
+          organization_uuid_v4: null,
+          enterprise_uuid: null,
+          sqs_installation_id: 's',
+        },
         'on-premise',
       ),
     ).toBe(true);
+  });
+});
+
+describe('needsIdentityEnrichment()', () => {
+  it('is true for a complete cloud connection that has never resolved enterpriseUuid', () => {
+    const conn = cloudConn({ userUuid: 'u', organizationUuidV4: 'o' });
+    expect(needsIdentityEnrichment(identityFromConnection(conn), 'cloud', conn)).toBe(true);
+  });
+
+  it('is false when cloud enterpriseUuid is confirmed absent', () => {
+    const conn = cloudConn({ userUuid: 'u', organizationUuidV4: 'o', enterpriseUuid: null });
+    expect(needsIdentityEnrichment(identityFromConnection(conn), 'cloud', conn)).toBe(false);
   });
 });
 
@@ -214,6 +275,45 @@ describe('resolveCommandTelemetryIdentity()', () => {
     expect(identity.sqs_installation_id).toBe('s');
     expect(identity.user_uuid).toBe('server-user');
     expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('skips enrichment when cloud connection has user, org, and resolved enterprise', async () => {
+    const conn = cloudConn({
+      userUuid: 'u',
+      organizationUuidV4: 'o',
+      enterpriseUuid: null,
+    });
+    const getSafeSpy = mockIdentityGetSafe();
+
+    const { identity } = await resolveCommandTelemetryIdentity(conn, cloudAuth('cloud-complete'));
+
+    expect(identity.user_uuid).toBe('u');
+    expect(identity.organization_uuid_v4).toBe('o');
+    expect(identity.enterprise_uuid).toBeNull();
+    expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('fetches enterprise when cloud connection has user and org but enterpriseUuid is unset', async () => {
+    const conn = cloudConn({ userUuid: 'u', organizationUuidV4: 'o' });
+    const getSafeSpy = mockIdentityGetSafe({
+      org: [{ ok: true, uuidV4: 'o', id: 'legacy-org' }],
+      enterprise: [{ ok: true, enterpriseId: 'ent-1' }],
+    });
+
+    const { identity } = await resolveCommandTelemetryIdentity(
+      conn,
+      cloudAuth('cloud-missing-enterprise'),
+    );
+
+    expect(identity.user_uuid).toBe('u');
+    expect(identity.enterprise_uuid).toBe('ent-1');
+    expect(
+      getSafeSpy.mock.calls.filter(
+        (call: [string]) => call[0] === '/enterprises/enterprise-organizations',
+      ),
+    ).toHaveLength(1);
     getSafeSpy.mockRestore();
   });
 
@@ -278,7 +378,11 @@ describe('resolveTelemetryIdentity()', () => {
 
   it('serves a complete identity from the disk cache without hitting the API', async () => {
     const auth = cloudAuth('disk-complete-token');
-    seedDiskCache(auth, { userUuid: 'disk-user', organizationUuidV4: 'disk-org' });
+    seedDiskCache(auth, {
+      userUuid: 'disk-user',
+      organizationUuidV4: 'disk-org',
+      enterpriseUuid: null,
+    });
 
     const getSafeSpy = mockIdentityGetSafe();
 
@@ -286,7 +390,74 @@ describe('resolveTelemetryIdentity()', () => {
 
     expect(identity.user_uuid).toBe('disk-user');
     expect(identity.organization_uuid_v4).toBe('disk-org');
+    expect(identity.enterprise_uuid).toBeNull();
     expect(getSafeSpy).not.toHaveBeenCalled();
+    getSafeSpy.mockRestore();
+  });
+
+  it('fetches enterprise UUID using the org legacy id even when user and org are cached', async () => {
+    const auth = cloudAuth('enterprise-fetch-token');
+    seedDiskCache(auth, { userUuid: 'disk-user', organizationUuidV4: 'disk-org' });
+    const getSafeSpy = mockIdentityGetSafe({
+      org: [{ ok: true, uuidV4: 'disk-org', id: 'legacy-org' }],
+      enterprise: [{ ok: true, enterpriseId: 'ent-1' }],
+    });
+
+    const identity = await resolveTelemetryIdentity(auth);
+
+    expect(identity.user_uuid).toBe('disk-user');
+    expect(identity.organization_uuid_v4).toBe('disk-org');
+    expect(identity.enterprise_uuid).toBe('ent-1');
+    expect(
+      getSafeSpy.mock.calls.filter(
+        (call: [string]) => call[0] === '/enterprises/enterprise-organizations',
+      ),
+    ).toHaveLength(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('caches confirmed-absent enterprise UUID and stops re-fetching', async () => {
+    const auth = cloudAuth('enterprise-absent-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'cloud-user' }],
+      org: [{ ok: true, uuidV4: 'cloud-org', id: 'legacy-org' }],
+      enterprise: [{ ok: true }],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(cloudAuth('enterprise-absent-token'));
+
+    expect(first.enterprise_uuid).toBeNull();
+    expect(second.enterprise_uuid).toBeNull();
+    expect(
+      getSafeSpy.mock.calls.filter(
+        (call: [string]) => call[0] === '/enterprises/enterprise-organizations',
+      ),
+    ).toHaveLength(1);
+    getSafeSpy.mockRestore();
+  });
+
+  it('retries enterprise UUID fetch after a transient API failure', async () => {
+    const auth = cloudAuth('transient-enterprise-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'cloud-user' }],
+      org: [
+        { ok: true, uuidV4: 'cloud-org', id: 'legacy-org' },
+        { ok: true, uuidV4: 'cloud-org', id: 'legacy-org' },
+      ],
+      enterprise: [{ ok: false }, { ok: true, enterpriseId: 'ent-after-retry' }],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(cloudAuth('transient-enterprise-token'));
+
+    expect(first.enterprise_uuid).toBeNull();
+    expect(second.enterprise_uuid).toBe('ent-after-retry');
+    expect(
+      getSafeSpy.mock.calls.filter(
+        (call: [string]) => call[0] === '/enterprises/enterprise-organizations',
+      ),
+    ).toHaveLength(2);
     getSafeSpy.mockRestore();
   });
 

--- a/tests/unit/core/telemetry/identity.test.ts
+++ b/tests/unit/core/telemetry/identity.test.ts
@@ -110,7 +110,7 @@ describe('identityFromConnection()', () => {
     expect(identityFromConnection(undefined)).toEqual({
       user_uuid: null,
       organization_uuid_v4: null,
-      enterprise_uuid: null,
+      enterprise_uuid: undefined,
       sqs_installation_id: null,
     });
   });
@@ -451,7 +451,7 @@ describe('resolveTelemetryIdentity()', () => {
     const first = await resolveTelemetryIdentity(auth);
     const second = await resolveTelemetryIdentity(cloudAuth('transient-enterprise-token'));
 
-    expect(first.enterprise_uuid).toBeNull();
+    expect(first.enterprise_uuid).toBeUndefined();
     expect(second.enterprise_uuid).toBe('ent-after-retry');
     expect(
       getSafeSpy.mock.calls.filter(

--- a/tests/unit/core/telemetry/telemetry.test.ts
+++ b/tests/unit/core/telemetry/telemetry.test.ts
@@ -350,6 +350,7 @@ describe('storeEvent', () => {
       });
       conn.userUuid = 'user-uuid-abc';
       conn.organizationUuidV4 = 'org-uuid-xyz';
+      conn.enterpriseUuid = null;
       loadStateSpy.mockReturnValue(state);
 
       await storeEvent(makeCommand('auth login'), true);


### PR DESCRIPTION
## Summary
- Persist SonarQube Cloud `enterpriseUuid` on the connection (and identity disk cache), resolved via `/organizations/organizations` then `/enterprises/enterprise-organizations`
- Include an `enterprise` LaunchDarkly context for Private Beta flag evaluation when the UUID is known; orgs not in an enterprise still evaluate with user + organization
- Existing Cloud connections with user + org but no enterprise field are enriched once; transient lookup failures are not stored