### PR TITLE
CLI-999 Make the context command stable

### DIFF
--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -106,7 +106,6 @@ import {
   isAlphaEnabledFromEnv,
   SonarCommand,
   SonarOption,
-  Stage,
 } from './sonar-command.ts';
 import { systemReset, type SystemResetOptions } from './system/reset.ts';
 import { systemStatus, type SystemStatusOptions } from './system/status.ts';
@@ -373,7 +372,6 @@ function buildCommandTree(runtime: CliRuntime): SonarCommand {
       category: 'data',
       label: 'context [action] [args...]',
     })
-    .stage(Stage.Beta())
     .argument('[action]', 'Action forwarded to sonar-context-augmentation')
     .argument('[args...]', 'Additional arguments forwarded to sonar-context-augmentation')
     .helpOption(false)

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -54,7 +54,7 @@ function getExpectedRootHelp(): string {
     '',
     '    list <issues|projects>                                   List issues and projects from SonarQube Cloud or Server',
     '    api <method> <endpoint>                                  Make authenticated API requests to SonarQube',
-    '    context [action] [args...]                               Augment AI agents with context from your codebase [BETA]',
+    '    context [action] [args...]                               Augment AI agents with context from your codebase',
     '',
     '    integrate <git|claude|copilot|codex|antigravity|cursor>  Setup SonarQube integration for AI coding agents, git and others.',
     '',
@@ -134,13 +134,11 @@ describe('root help', () => {
   );
 
   it(
-    'a Beta command warns on stderr only once for the current version',
+    'context does not emit a beta warning',
     async () => {
-      const firstResult = await harness.run('context');
-      const secondResult = await harness.run('context');
+      const result = await harness.run('context');
 
-      expect(stripAnsi(firstResult.stderr)).toContain("'context' is in beta and may change.");
-      expect(stripAnsi(secondResult.stderr)).not.toContain("'context' is in beta and may change.");
+      expect(stripAnsi(result.stderr)).not.toContain("'context' is in beta and may change.");
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -132,14 +132,4 @@ describe('root help', () => {
     },
     { timeout: 15000 },
   );
-
-  it(
-    'context does not emit a beta warning',
-    async () => {
-      const result = await harness.run('context');
-
-      expect(stripAnsi(result.stderr)).not.toContain("'context' is in beta and may change.");
-    },
-    { timeout: 15000 },
-  );
 });

--- a/tests/unit/core/launch-darkly/private-beta.test.ts
+++ b/tests/unit/core/launch-darkly/private-beta.test.ts
@@ -411,7 +411,7 @@ describe('Private Beta command registration', () => {
     const tree = await createCommandTree();
     const names = tree.commands.map((c) => c.name());
     expect(names).toContain('context');
-    // No Private Beta commands exist yet; default runtime keeps Open Beta and omits gated ones.
+    // No Private Beta commands exist yet; default runtime omits gated ones.
     for (const command of tree.commands as SonarCommand[]) {
       expect(command.isPrivateBeta).toBe(false);
     }


### PR DESCRIPTION
## Summary
- Promote `sonar context` from Open Beta to Stable by dropping `.stage(Stage.Beta())`
- Remove the `[BETA]` root-help tag and the one-time beta warning on invocation
- Docs site artifacts remain generated post-release