### PR TITLE
CLI-1003 Clean up hook stdin listeners on timeout

### DIFF
--- a/src/commands/hook/stdin.ts
+++ b/src/commands/hook/stdin.ts
@@ -89,17 +89,32 @@ function parseStdinJson(raw: string): unknown {
 }
 
 export async function readRawStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  const onData = (chunk: Buffer) => {
+    chunks.push(chunk);
+  };
+  let resolveRead!: (value: string) => void;
+  let rejectRead!: (reason: Error) => void;
+  const readPromise = new Promise<string>((resolve, reject) => {
+    resolveRead = resolve;
+    rejectRead = reject;
+  });
+  const onEnd = () => {
+    resolveRead(Buffer.concat(chunks).toString('utf-8'));
+  };
+  const onError = (err: Error) => {
+    rejectRead(err);
+  };
+
+  process.stdin.on('data', onData);
+  process.stdin.on('end', onEnd);
+  process.stdin.on('error', onError);
+
   try {
     return await Promise.race([
-      new Promise<string>((resolve, reject) => {
-        const chunks: Buffer[] = [];
-        process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
-        process.stdin.on('end', () => {
-          resolve(Buffer.concat(chunks).toString('utf-8'));
-        });
-        process.stdin.on('error', reject);
-      }),
+      readPromise,
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
           reject(new Error(`stdin read timed out after ${STDIN_TIMEOUT_MS}ms`));
@@ -108,5 +123,11 @@ export async function readRawStdin(): Promise<string> {
     ]);
   } finally {
     clearTimeout(timeoutId);
+    process.stdin.off('data', onData);
+    process.stdin.off('end', onEnd);
+    process.stdin.off('error', onError);
+    process.stdin.pause();
+    // An idle pipe otherwise keeps the event loop alive after timeout.
+    process.stdin.destroy();
   }
 }

--- a/tests/unit/commands/hook/stdin.test.ts
+++ b/tests/unit/commands/hook/stdin.test.ts
@@ -22,10 +22,13 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import { readGitPushRefs, readStdinJson } from '../../../../src/commands/hook/stdin.ts';
 
-describe('readStdinJson', () => {
-  type StdinListener = (...args: any[]) => void;
+type StdinListener = (...args: any[]) => void;
+
+function createStdinHarness() {
   const listeners: Record<string, StdinListener[]> = {};
-  let onSpy: ReturnType<typeof spyOn>;
+  const spies: Array<{ mockRestore: () => void }> = [];
+  let pauseCalls = 0;
+  let destroyCalls = 0;
 
   function captureListener(event: string, fn: StdinListener) {
     if (!listeners[event]) listeners[event] = [];
@@ -33,22 +36,73 @@ describe('readStdinJson', () => {
     return process.stdin;
   }
 
+  function dropListener(event: string, fn: StdinListener) {
+    listeners[event] = (listeners[event] ?? []).filter((registered) => registered !== fn);
+    return process.stdin;
+  }
+
   function emitStdin(event: string, ...args: unknown[]) {
-    for (const fn of listeners[event] ?? []) {
+    for (const fn of [...(listeners[event] ?? [])]) {
       fn(...args);
     }
   }
 
-  beforeEach(() => {
+  function listenerCount(event: string): number {
+    return listeners[event]?.length ?? 0;
+  }
+
+  function install() {
     for (const key of Object.keys(listeners)) {
       delete listeners[key];
     }
-    onSpy = spyOn(process.stdin, 'on').mockImplementation(captureListener);
+    pauseCalls = 0;
+    destroyCalls = 0;
+    spies.push(spyOn(process.stdin, 'on').mockImplementation(captureListener));
+    spies.push(spyOn(process.stdin, 'off').mockImplementation(dropListener));
+    spies.push(
+      spyOn(process.stdin, 'pause').mockImplementation(() => {
+        pauseCalls += 1;
+        return process.stdin;
+      }),
+    );
+    spies.push(
+      spyOn(process.stdin, 'destroy').mockImplementation(() => {
+        destroyCalls += 1;
+        return process.stdin;
+      }),
+    );
+  }
+
+  function restore() {
+    for (const spy of spies.splice(0)) {
+      spy.mockRestore();
+    }
+  }
+
+  return {
+    emitStdin,
+    install,
+    restore,
+    listenerCount,
+    pauseCalls: () => pauseCalls,
+    destroyCalls: () => destroyCalls,
+  };
+}
+
+describe('readStdinJson', () => {
+  const stdin = createStdinHarness();
+
+  beforeEach(() => {
+    stdin.install();
   });
 
   afterEach(() => {
-    onSpy.mockRestore();
+    stdin.restore();
   });
+
+  function emitStdin(event: string, ...args: unknown[]) {
+    stdin.emitStdin(event, ...args);
+  }
 
   it('parses a JSON object from stdin', async () => {
     const payload = { tool_name: 'Read', tool_input: { file_path: '/tmp/test.ts' } };
@@ -116,39 +170,45 @@ describe('readStdinJson', () => {
       const err = await promise.catch((e: unknown) => e);
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toContain('stdin read timed out');
+      expect(stdin.listenerCount('data')).toBe(0);
+      expect(stdin.listenerCount('end')).toBe(0);
+      expect(stdin.listenerCount('error')).toBe(0);
+      expect(stdin.pauseCalls()).toBeGreaterThan(0);
+      expect(stdin.destroyCalls()).toBeGreaterThan(0);
+      emitStdin('end');
     } finally {
       timeoutSpy.mockRestore();
     }
   });
+
+  it('removes stdin listeners after a successful read', async () => {
+    const payload = { ok: true };
+    const promise = readStdinJson<typeof payload>();
+    emitStdin('data', Buffer.from(JSON.stringify(payload)));
+    emitStdin('end');
+    await promise;
+    expect(stdin.listenerCount('data')).toBe(0);
+    expect(stdin.listenerCount('end')).toBe(0);
+    expect(stdin.listenerCount('error')).toBe(0);
+    expect(stdin.pauseCalls()).toBeGreaterThan(0);
+    expect(stdin.destroyCalls()).toBeGreaterThan(0);
+  });
 });
 
 describe('readGitPushRefs', () => {
-  type StdinListener = (...args: any[]) => void;
-  const listeners: Record<string, StdinListener[]> = {};
-  let onSpy: ReturnType<typeof spyOn>;
-
-  function captureListener(event: string, fn: StdinListener) {
-    if (!listeners[event]) listeners[event] = [];
-    listeners[event].push(fn);
-    return process.stdin;
-  }
-
-  function emitStdin(event: string, ...args: unknown[]) {
-    for (const fn of listeners[event] ?? []) {
-      fn(...args);
-    }
-  }
+  const stdin = createStdinHarness();
 
   beforeEach(() => {
-    for (const key of Object.keys(listeners)) {
-      delete listeners[key];
-    }
-    onSpy = spyOn(process.stdin, 'on').mockImplementation(captureListener);
+    stdin.install();
   });
 
   afterEach(() => {
-    onSpy.mockRestore();
+    stdin.restore();
   });
+
+  function emitStdin(event: string, ...args: unknown[]) {
+    stdin.emitStdin(event, ...args);
+  }
 
   it('parses valid push ref lines', async () => {
     const localSha = 'abc1234abc1234abc1234abc1234abc1234abc123';


### PR DESCRIPTION
## Summary
- `readRawStdin()` now removes `data`/`end`/`error` listeners when the read finishes
- Pause and destroy stdin so an idle pipe cannot keep the process alive after the 5s timeout
- Shared by all hooks; found during CLI-958 / #695 review but pre-existing