### PR TITLE
CLI-1005 Use sonar instead of sonar.exe as the MCP command on Windows

### DIFF
--- a/src/commands/integrate/antigravity/declaration.ts
+++ b/src/commands/integrate/antigravity/declaration.ts
@@ -28,7 +28,6 @@ import {
   ANTIGRAVITY_PROJECT_RULES_DIR,
   ANTIGRAVITY_PROMPT_SECRETS_RULE_FILE,
   ANTIGRAVITY_SQAA_RULE_FILE,
-  CLI_COMMAND,
 } from '@/core/config-constants.ts';
 import type { IntegrationContext, IntegrationDeclaration } from '@/core/framework/features';
 import {
@@ -162,8 +161,7 @@ export const antigravityIntegration: IntegrationDeclaration<AntigravityIntegrati
           displayName: 'Antigravity MCP configuration',
           targetPath: () => ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON,
           defaultValue: {},
-          patch: (document) =>
-            upsertJsonMcpServer(document, getMcpConfig(CLI_COMMAND, { withFsMount: false })),
+          patch: (document) => upsertJsonMcpServer(document, getMcpConfig({ withFsMount: false })),
           removePatch: (document) => removeJsonMcpServer(document),
         }),
       ],

--- a/src/commands/integrate/claude/declaration.ts
+++ b/src/commands/integrate/claude/declaration.ts
@@ -21,7 +21,6 @@
 import { join } from 'node:path';
 
 import { CONTEXT_AUGMENTATION_TOOL_MATCHER } from '@/commands/hook/context-augmentation-hook-subscriber.ts';
-import { CLI_COMMAND } from '@/core/config-constants.ts';
 import type {
   InstallDecision,
   IntegrationContext,
@@ -293,7 +292,6 @@ function resolveClaudeSkillPath(context: IntegrationContext): string {
 
 function getDesiredClaudeMcpConfig(context: IntegrationContext) {
   return getMcpConfig(
-    CLI_COMMAND,
     context.scope === 'global'
       ? { withFsMount: false }
       : {

--- a/src/commands/integrate/codex/declaration.ts
+++ b/src/commands/integrate/codex/declaration.ts
@@ -20,7 +20,6 @@
 
 import { join } from 'node:path';
 
-import { CLI_COMMAND } from '@/core/config-constants.ts';
 import type {
   IntegrationContext,
   IntegrationDeclaration,
@@ -250,7 +249,6 @@ function upsertCodexMcpServer(
 
 function getDesiredCodexMcpConfig(context: IntegrationContext) {
   return getMcpConfig(
-    CLI_COMMAND,
     context.scope === 'global'
       ? { withFsMount: false }
       : {

--- a/src/commands/integrate/copilot/declaration.ts
+++ b/src/commands/integrate/copilot/declaration.ts
@@ -20,7 +20,6 @@
 
 import { join, relative } from 'node:path';
 
-import { CLI_COMMAND } from '@/core/config-constants.ts';
 import type { IntegrationContext, IntegrationDeclaration } from '@/core/framework/features';
 import {
   askUser,
@@ -241,7 +240,6 @@ function createHookCommandEntry(context: IntegrationContext): HookCommandEntry {
 
 function getDesiredCopilotMcpConfig(context: IntegrationContext) {
   return getMcpConfig(
-    CLI_COMMAND,
     context.scope === 'global'
       ? { withFsMount: false }
       : {

--- a/src/commands/integrate/cursor/declaration.ts
+++ b/src/commands/integrate/cursor/declaration.ts
@@ -20,7 +20,7 @@
 
 import { join } from 'node:path';
 
-import { CLI_COMMAND, CURSOR_CONFIG_DIR } from '@/core/config-constants.ts';
+import { CURSOR_CONFIG_DIR } from '@/core/config-constants.ts';
 import type { IntegrationContext, IntegrationDeclaration } from '@/core/framework/features';
 import {
   askUser,
@@ -85,7 +85,6 @@ function resolveCursorMcpConfigPath(context: IntegrationContext): string {
 
 function getDesiredCursorMcpConfig(context: IntegrationContext) {
   return getMcpConfig(
-    CLI_COMMAND,
     context.scope === 'global'
       ? { withFsMount: false }
       : {

--- a/src/core/config-constants.ts
+++ b/src/core/config-constants.ts
@@ -36,8 +36,8 @@ import { join } from 'node:path';
 
 export const APP_NAME = 'sonarqube-cli';
 
-/** PATH command name. Windows PATHEXT resolves `sonar` to `sonar.exe`. */
-export const CLI_COMMAND = 'sonar';
+/** Name used to invoke the CLI on PATH (`sonar`), not the on-disk Windows filename (`sonar.exe`). */
+export const CLI_COMMAND_NAME = 'sonar';
 
 // ---------------------------------------------------------------------------
 // CLI data directory

--- a/src/core/config-constants.ts
+++ b/src/core/config-constants.ts
@@ -36,8 +36,8 @@ import { join } from 'node:path';
 
 export const APP_NAME = 'sonarqube-cli';
 
-/** The CLI command name as it appears on PATH after installation. */
-export const CLI_COMMAND = process.platform === 'win32' ? 'sonar.exe' : 'sonar';
+/** PATH command name. Windows PATHEXT resolves `sonar` to `sonar.exe`. */
+export const CLI_COMMAND = 'sonar';
 
 // ---------------------------------------------------------------------------
 // CLI data directory

--- a/src/core/host/mcp/mcp-helper.ts
+++ b/src/core/host/mcp/mcp-helper.ts
@@ -34,6 +34,7 @@ import { pemToPkcs12 } from '@/core/host/crypto/pkcs12.ts';
 
 import {
   ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON,
+  CLI_COMMAND,
   CLI_TMP_DIR,
   ENV_SONAR_USER_HOME,
   getSonarUserHome,
@@ -76,9 +77,6 @@ function mcpServerEnv(): Record<string, string> | undefined {
   return { [ENV_SONAR_USER_HOME]: getSonarUserHome() };
 }
 
-/** PATH command name written into MCP configs. Windows PATHEXT resolves `sonar` to `sonar.exe`. */
-export const MCP_CLI_COMMAND = 'sonar';
-
 export function getMcpConfig(
   context: McpServerContext,
   options: McpServerOptions = {},
@@ -102,9 +100,7 @@ export function getMcpConfig(
   }
 
   const env = mcpServerEnv();
-  return env === undefined
-    ? { command: MCP_CLI_COMMAND, args }
-    : { command: MCP_CLI_COMMAND, args, env };
+  return env === undefined ? { command: CLI_COMMAND, args } : { command: CLI_COMMAND, args, env };
 }
 
 // Path where update-ca-certificates picks up custom CA certs inside the MCP container (Debian/Alpine convention).

--- a/src/core/host/mcp/mcp-helper.ts
+++ b/src/core/host/mcp/mcp-helper.ts
@@ -34,7 +34,7 @@ import { pemToPkcs12 } from '@/core/host/crypto/pkcs12.ts';
 
 import {
   ANTIGRAVITY_GLOBAL_MCP_CONFIG_JSON,
-  CLI_COMMAND,
+  CLI_COMMAND_NAME,
   CLI_TMP_DIR,
   ENV_SONAR_USER_HOME,
   getSonarUserHome,
@@ -100,7 +100,9 @@ export function getMcpConfig(
   }
 
   const env = mcpServerEnv();
-  return env === undefined ? { command: CLI_COMMAND, args } : { command: CLI_COMMAND, args, env };
+  return env === undefined
+    ? { command: CLI_COMMAND_NAME, args }
+    : { command: CLI_COMMAND_NAME, args, env };
 }
 
 // Path where update-ca-certificates picks up custom CA certs inside the MCP container (Debian/Alpine convention).

--- a/src/core/host/mcp/mcp-helper.ts
+++ b/src/core/host/mcp/mcp-helper.ts
@@ -76,8 +76,10 @@ function mcpServerEnv(): Record<string, string> | undefined {
   return { [ENV_SONAR_USER_HOME]: getSonarUserHome() };
 }
 
+/** PATH command name written into MCP configs. Windows PATHEXT resolves `sonar` to `sonar.exe`. */
+export const MCP_CLI_COMMAND = 'sonar';
+
 export function getMcpConfig(
-  cliPath: string,
   context: McpServerContext,
   options: McpServerOptions = {},
 ): McpServerConfig {
@@ -100,7 +102,9 @@ export function getMcpConfig(
   }
 
   const env = mcpServerEnv();
-  return env === undefined ? { command: cliPath, args } : { command: cliPath, args, env };
+  return env === undefined
+    ? { command: MCP_CLI_COMMAND, args }
+    : { command: MCP_CLI_COMMAND, args, env };
 }
 
 // Path where update-ca-certificates picks up custom CA certs inside the MCP container (Debian/Alpine convention).

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -30,7 +30,6 @@ import {
   VORTEX_FEATURE_ID,
   VORTEX_GLOBAL_SKIP_MESSAGE,
 } from '@/commands/integrate/_common/vortex.ts';
-import { CLI_COMMAND } from '@/core/config-constants.ts';
 
 import {
   expectAgentPromptHint,
@@ -115,7 +114,7 @@ describe('integrate antigravity', () => {
         const mcp = harness.userHome.file(...GLOBAL_MCP_CONFIG_PATH).asJson() as {
           mcpServers?: { sonarqube?: { command?: string; args?: string[] } };
         };
-        expect(mcp.mcpServers?.sonarqube?.command).toBe(CLI_COMMAND);
+        expect(mcp.mcpServers?.sonarqube?.command).toBe('sonar');
         expect(mcp.mcpServers?.sonarqube?.args?.slice(0, 2)).toEqual(['run', 'mcp']);
         expect(mcp.mcpServers?.sonarqube?.args ?? []).not.toContain('--project');
         expect(findAntigravityFeature(harness, 'mcp-server')).toBeDefined();
@@ -242,7 +241,7 @@ describe('integrate antigravity', () => {
         const mcp = harness.userHome.file(...GLOBAL_MCP_CONFIG_PATH).asJson() as {
           mcpServers?: { sonarqube?: { command?: string; args?: string[] } };
         };
-        expect(mcp.mcpServers?.sonarqube?.command).toBe(CLI_COMMAND);
+        expect(mcp.mcpServers?.sonarqube?.command).toBe('sonar');
         expect(mcp.mcpServers?.sonarqube?.args?.slice(0, 2)).toEqual(['run', 'mcp']);
         expect(mcp.mcpServers?.sonarqube?.args ?? []).not.toContain('--project');
         expect(findAntigravityFeature(harness, 'mcp-server', 'global')).toBeDefined();
@@ -624,7 +623,7 @@ describe('integrate antigravity', () => {
           mcpServers?: Record<string, { command?: string }>;
         };
         expect(mcp.mcpServers?.other?.command).toBe('other-mcp');
-        expect(mcp.mcpServers?.sonarqube?.command).toBe(CLI_COMMAND);
+        expect(mcp.mcpServers?.sonarqube?.command).toBe('sonar');
       },
       { timeout: 30000 },
     );
@@ -653,7 +652,7 @@ describe('integrate antigravity', () => {
           JSON.stringify({
             mcpServers: {
               sonarqube: {
-                command: CLI_COMMAND,
+                command: 'sonar.exe',
                 args: ['run', 'mcp', '--project', 'proj-a'],
               },
             },
@@ -667,9 +666,10 @@ describe('integrate antigravity', () => {
         expect(result.exitCode).toBe(0);
 
         const mcp = harness.userHome.file(...GLOBAL_MCP_CONFIG_PATH).asJson() as {
-          mcpServers?: { sonarqube?: { args?: string[] } };
+          mcpServers?: { sonarqube?: { command?: string; args?: string[] } };
         };
         expect(mcp.mcpServers?.sonarqube?.args).toEqual(['run', 'mcp']);
+        expect(mcp.mcpServers?.sonarqube?.command).toBe('sonar');
       },
       { timeout: 30000 },
     );

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -22,8 +22,6 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import { CLI_COMMAND } from '@/core/config-constants.ts';
-
 import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
@@ -90,11 +88,11 @@ describe('integrate copilot', () => {
         );
 
         // .mcp.json: present and registers the sonarqube MCP server using
-        // the platform CLI command.
+        // the PATH command `sonar` (Windows PATHEXT resolves sonar.exe).
         expect(harness.cwd.exists('.mcp.json')).toBe(true);
         const mcp: McpJson = harness.cwd.file('.mcp.json').asJson();
         const sonar = mcp.mcpServers?.sonarqube;
-        expect(sonar?.command).toBe(CLI_COMMAND);
+        expect(sonar?.command).toBe('sonar');
         expect(sonar?.args?.slice(0, 2)).toEqual(['run', 'mcp']);
 
         // Completion summary

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -98,7 +98,7 @@ describe('integrate cursor', () => {
 
         const mcp: CursorMcpFile = harness.cwd.file(...MCP_JSON_DIRS).asJson();
         expect(mcp.mcpServers?.sonarqube).toBeDefined();
-        expect(mcp.mcpServers?.sonarqube?.command).toBeDefined();
+        expect(mcp.mcpServers?.sonarqube?.command).toBe('sonar');
         expect(mcp.mcpServers?.sonarqube?.args).toContain('mcp');
         expect(mcp.mcpServers?.sonarqube).not.toHaveProperty('env');
       },

--- a/tests/unit/core/config-constants.test.ts
+++ b/tests/unit/core/config-constants.test.ts
@@ -25,7 +25,7 @@ import { afterEach, describe, expect, it } from 'bun:test';
 
 import {
   APP_NAME,
-  CLI_COMMAND,
+  CLI_COMMAND_NAME,
   ENV_SONAR_USER_HOME,
   ENV_SQAA_RETRY_BASE_DELAY_MS,
   getCliDir,
@@ -55,8 +55,8 @@ describe('config-constants', () => {
     expect(LOG_FILE).toBe(join(LOG_DIR, `${APP_NAME}.log`));
   });
 
-  it('CLI_COMMAND is sonar on every platform', () => {
-    expect(CLI_COMMAND).toBe('sonar');
+  it('CLI_COMMAND_NAME is sonar on every platform', () => {
+    expect(CLI_COMMAND_NAME).toBe('sonar');
   });
 
   describe('path resolution', () => {

--- a/tests/unit/core/config-constants.test.ts
+++ b/tests/unit/core/config-constants.test.ts
@@ -25,6 +25,7 @@ import { afterEach, describe, expect, it } from 'bun:test';
 
 import {
   APP_NAME,
+  CLI_COMMAND,
   ENV_SONAR_USER_HOME,
   ENV_SQAA_RETRY_BASE_DELAY_MS,
   getCliDir,
@@ -52,6 +53,10 @@ describe('config-constants', () => {
 
   it('LOG_FILE should have the correct filename', () => {
     expect(LOG_FILE).toBe(join(LOG_DIR, `${APP_NAME}.log`));
+  });
+
+  it('CLI_COMMAND is sonar on every platform', () => {
+    expect(CLI_COMMAND).toBe('sonar');
   });
 
   describe('path resolution', () => {

--- a/tests/unit/core/config-constants.test.ts
+++ b/tests/unit/core/config-constants.test.ts
@@ -25,7 +25,6 @@ import { afterEach, describe, expect, it } from 'bun:test';
 
 import {
   APP_NAME,
-  CLI_COMMAND_NAME,
   ENV_SONAR_USER_HOME,
   ENV_SQAA_RETRY_BASE_DELAY_MS,
   getCliDir,
@@ -53,10 +52,6 @@ describe('config-constants', () => {
 
   it('LOG_FILE should have the correct filename', () => {
     expect(LOG_FILE).toBe(join(LOG_DIR, `${APP_NAME}.log`));
-  });
-
-  it('CLI_COMMAND_NAME is sonar on every platform', () => {
-    expect(CLI_COMMAND_NAME).toBe('sonar');
   });
 
   describe('path resolution', () => {

--- a/tests/unit/core/host/mcp/mcp-helper.test.ts
+++ b/tests/unit/core/host/mcp/mcp-helper.test.ts
@@ -20,7 +20,7 @@
 
 import { afterEach, describe, expect, it } from 'bun:test';
 
-import { CLI_COMMAND, ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
+import { CLI_COMMAND_NAME, ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
 import { getMcpConfig } from '@/core/host/mcp/mcp-helper.ts';
 
 import { restoreEnv } from '../../../../_common/isolated-cli-env.ts';
@@ -36,7 +36,7 @@ describe('getMcpConfig', () => {
     delete process.env[ENV_SONAR_USER_HOME];
 
     expect(getMcpConfig({ withFsMount: false })).toEqual({
-      command: CLI_COMMAND,
+      command: CLI_COMMAND_NAME,
       args: ['run', 'mcp'],
     });
   });
@@ -50,7 +50,7 @@ describe('getMcpConfig', () => {
   it('always uses sonar as the MCP command, not a platform-specific binary name', () => {
     delete process.env[ENV_SONAR_USER_HOME];
 
-    expect(CLI_COMMAND).toBe('sonar');
+    expect(CLI_COMMAND_NAME).toBe('sonar');
     expect(getMcpConfig({ withFsMount: false }).command).toBe('sonar');
   });
 
@@ -58,7 +58,7 @@ describe('getMcpConfig', () => {
     process.env[ENV_SONAR_USER_HOME] = '/custom/sonar-home';
 
     expect(getMcpConfig({ withFsMount: false, projectKey: 'my-project' })).toEqual({
-      command: CLI_COMMAND,
+      command: CLI_COMMAND_NAME,
       args: ['run', 'mcp', '--project', 'my-project'],
       env: { [ENV_SONAR_USER_HOME]: '/custom/sonar-home' },
     });

--- a/tests/unit/core/host/mcp/mcp-helper.test.ts
+++ b/tests/unit/core/host/mcp/mcp-helper.test.ts
@@ -20,8 +20,8 @@
 
 import { afterEach, describe, expect, it } from 'bun:test';
 
-import { ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
-import { getMcpConfig, MCP_CLI_COMMAND } from '@/core/host/mcp/mcp-helper.ts';
+import { CLI_COMMAND, ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
+import { getMcpConfig } from '@/core/host/mcp/mcp-helper.ts';
 
 import { restoreEnv } from '../../../../_common/isolated-cli-env.ts';
 
@@ -36,7 +36,7 @@ describe('getMcpConfig', () => {
     delete process.env[ENV_SONAR_USER_HOME];
 
     expect(getMcpConfig({ withFsMount: false })).toEqual({
-      command: MCP_CLI_COMMAND,
+      command: CLI_COMMAND,
       args: ['run', 'mcp'],
     });
   });
@@ -50,7 +50,7 @@ describe('getMcpConfig', () => {
   it('always uses sonar as the MCP command, not a platform-specific binary name', () => {
     delete process.env[ENV_SONAR_USER_HOME];
 
-    expect(MCP_CLI_COMMAND).toBe('sonar');
+    expect(CLI_COMMAND).toBe('sonar');
     expect(getMcpConfig({ withFsMount: false }).command).toBe('sonar');
   });
 
@@ -58,7 +58,7 @@ describe('getMcpConfig', () => {
     process.env[ENV_SONAR_USER_HOME] = '/custom/sonar-home';
 
     expect(getMcpConfig({ withFsMount: false, projectKey: 'my-project' })).toEqual({
-      command: MCP_CLI_COMMAND,
+      command: CLI_COMMAND,
       args: ['run', 'mcp', '--project', 'my-project'],
       env: { [ENV_SONAR_USER_HOME]: '/custom/sonar-home' },
     });

--- a/tests/unit/core/host/mcp/mcp-helper.test.ts
+++ b/tests/unit/core/host/mcp/mcp-helper.test.ts
@@ -20,7 +20,7 @@
 
 import { afterEach, describe, expect, it } from 'bun:test';
 
-import { CLI_COMMAND_NAME, ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
+import { ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
 import { getMcpConfig } from '@/core/host/mcp/mcp-helper.ts';
 
 import { restoreEnv } from '../../../../_common/isolated-cli-env.ts';
@@ -36,7 +36,7 @@ describe('getMcpConfig', () => {
     delete process.env[ENV_SONAR_USER_HOME];
 
     expect(getMcpConfig({ withFsMount: false })).toEqual({
-      command: CLI_COMMAND_NAME,
+      command: 'sonar',
       args: ['run', 'mcp'],
     });
   });
@@ -50,7 +50,6 @@ describe('getMcpConfig', () => {
   it('always uses sonar as the MCP command, not a platform-specific binary name', () => {
     delete process.env[ENV_SONAR_USER_HOME];
 
-    expect(CLI_COMMAND_NAME).toBe('sonar');
     expect(getMcpConfig({ withFsMount: false }).command).toBe('sonar');
   });
 
@@ -58,7 +57,7 @@ describe('getMcpConfig', () => {
     process.env[ENV_SONAR_USER_HOME] = '/custom/sonar-home';
 
     expect(getMcpConfig({ withFsMount: false, projectKey: 'my-project' })).toEqual({
-      command: CLI_COMMAND_NAME,
+      command: 'sonar',
       args: ['run', 'mcp', '--project', 'my-project'],
       env: { [ENV_SONAR_USER_HOME]: '/custom/sonar-home' },
     });

--- a/tests/unit/core/host/mcp/mcp-helper.test.ts
+++ b/tests/unit/core/host/mcp/mcp-helper.test.ts
@@ -21,7 +21,7 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 
 import { ENV_SONAR_USER_HOME } from '@/core/config-constants.ts';
-import { getMcpConfig } from '@/core/host/mcp/mcp-helper.ts';
+import { getMcpConfig, MCP_CLI_COMMAND } from '@/core/host/mcp/mcp-helper.ts';
 
 import { restoreEnv } from '../../../../_common/isolated-cli-env.ts';
 
@@ -35,8 +35,8 @@ describe('getMcpConfig', () => {
   it('omits env when SONAR_USER_HOME is unset', () => {
     delete process.env[ENV_SONAR_USER_HOME];
 
-    expect(getMcpConfig('sonar', { withFsMount: false })).toEqual({
-      command: 'sonar',
+    expect(getMcpConfig({ withFsMount: false })).toEqual({
+      command: MCP_CLI_COMMAND,
       args: ['run', 'mcp'],
     });
   });
@@ -44,14 +44,21 @@ describe('getMcpConfig', () => {
   it('omits env when SONAR_USER_HOME is blank', () => {
     process.env[ENV_SONAR_USER_HOME] = '   ';
 
-    expect(getMcpConfig('sonar', { withFsMount: false })).not.toHaveProperty('env');
+    expect(getMcpConfig({ withFsMount: false })).not.toHaveProperty('env');
+  });
+
+  it('always uses sonar as the MCP command, not a platform-specific binary name', () => {
+    delete process.env[ENV_SONAR_USER_HOME];
+
+    expect(MCP_CLI_COMMAND).toBe('sonar');
+    expect(getMcpConfig({ withFsMount: false }).command).toBe('sonar');
   });
 
   it('forwards the resolved SONAR_USER_HOME path when set', () => {
     process.env[ENV_SONAR_USER_HOME] = '/custom/sonar-home';
 
-    expect(getMcpConfig('sonar', { withFsMount: false, projectKey: 'my-project' })).toEqual({
-      command: 'sonar',
+    expect(getMcpConfig({ withFsMount: false, projectKey: 'my-project' })).toEqual({
+      command: MCP_CLI_COMMAND,
       args: ['run', 'mcp', '--project', 'my-project'],
       env: { [ENV_SONAR_USER_HOME]: '/custom/sonar-home' },
     });


### PR DESCRIPTION
## Summary
- Always write `"command": "sonar"` into MCP configs from `getMcpConfig()`, instead of Windows `sonar.exe`
- Stop passing `CLI_COMMAND` from agent integrate declarations so committed `.mcp.json` stays cross-platform
- PATHEXT already resolves `sonar` to `sonar.exe` on Windows; installers still name the on-disk binary `sonar.exe`