### PR TITLE
CLI-970 Unified project-resolution

### DIFF
--- a/src/commands/analyze/sqaa-auth.ts
+++ b/src/commands/analyze/sqaa-auth.ts
@@ -22,31 +22,11 @@
 
 import { isSonarQubeCloud, type ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { CommandFailedError } from '@/core/command-error.ts';
-import { selectRecordedFeatureForDir } from '@/core/host/recorded-feature-resolver.ts';
 import logger from '@/core/observability/logger.ts';
-import type { InstalledIntegrationFeature, IntegrationStateAttribute } from '@/core/state/state.ts';
-import { loadState } from '@/core/state/state-repository.ts';
+import { discoverProject } from '@/core/project-info.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import { blank, confirmPrompt, text, warn } from '@/core/ui';
 import { printAgentNonInteractiveAlternativeHint } from '@/core/ui/components/agent-prompt-hint.ts';
-
-import { SQAA_HOOK_FEATURE_ID } from '../integrate/_common/features/sqaa-instructions-feature.ts';
-import { isProjectVortexFeature } from '../integrate/_common/vortex.ts';
-
-function isProjectSqaaFeature(feature: InstalledIntegrationFeature): boolean {
-  return (
-    isProjectVortexFeature(feature) ||
-    (feature.featureId === SQAA_HOOK_FEATURE_ID && feature.scope === 'project')
-  );
-}
-
-function getOptionalStringAttr(
-  attrs: Record<string, IntegrationStateAttribute> | undefined,
-  key: string,
-): string | undefined {
-  const value = attrs?.[key];
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
 
 const LARGE_CHANGESET_HINT =
   'For faster feedback, try targeting your changes:\n' +
@@ -96,7 +76,7 @@ export async function resolveSqaaAuthAndProject(
   const sqaaAuth = resolveSqaaAuth(auth, explicitProject);
   if (!sqaaAuth) return { kind: 'no-org' };
 
-  const projectKey = explicitProject ?? (await resolveSqaaProjectKey(projectRoot));
+  const projectKey = explicitProject ?? (await resolveSqaaProjectKey(auth, projectRoot));
   if (!projectKey) return { kind: 'no-project' };
 
   noteProject(auth, projectKey);
@@ -134,40 +114,21 @@ export function resolveSqaaAuth(
 }
 
 /**
- * Look up the project key for the current project from the declarative
- * integration state (`integrations.installed`).
- *
- * Delegates the worktree-aware matching to the shared resolver (see
- * `selectRecordedFeatureForDir`): the current directory is mapped to its working
- * tree — and, from a linked worktree, to the main working tree — then matched
- * against the recorded Vortex features, preferring a `targetRoot` (physical
- * install dir) match over a `repoRoot`-only one. Falls back to `process.cwd()`
- * when no `projectRoot` is given so the single-file path still works, including
- * from a subdirectory or outside git.
+ * Look up the project key for the current project via the shared project-discovery
+ * pipeline (`discoverProject`): the known-server-project-mapping cache, local config
+ * files, then a git-remote-binding lookup against the server. Falls back to
+ * `process.cwd()` when no `projectRoot` is given so the single-file path still
+ * works, including from a subdirectory or outside git.
  */
-export async function resolveSqaaProjectKey(projectRoot?: string): Promise<string | null> {
-  try {
-    const candidates = loadState().integrations.installed.flatMap((integration) =>
-      integration.features.filter(isProjectSqaaFeature).map((feature) => ({
-        feature,
-        targetRoot: feature.targetRoot,
-        repoRoot: getOptionalStringAttr(feature.attrs, 'repoRoot'),
-        updatedAt: feature.updatedAt,
-      })),
-    );
-    const sqaaFeature = await selectRecordedFeatureForDir(projectRoot ?? process.cwd(), candidates);
-
-    const projectKey = sqaaFeature?.attrs?.projectKey;
-    if (typeof projectKey !== 'string' || projectKey.length === 0) {
-      logger.debug('Vortex analysis skipped: no project key found in integration state');
-      return null;
-    }
-
-    return projectKey;
-  } catch {
-    logger.debug('Vortex analysis skipped: failed to resolve integration state');
-    return null;
+export async function resolveSqaaProjectKey(
+  auth: ResolvedAuth,
+  projectRoot?: string,
+): Promise<string | null> {
+  const discovered = await discoverProject(projectRoot ?? process.cwd(), true, { auth });
+  if (!discovered.projectKey) {
+    logger.debug('Vortex analysis skipped: no project key found');
   }
+  return discovered.projectKey ?? null;
 }
 
 /**

--- a/src/commands/analyze/sqaa-auth.ts
+++ b/src/commands/analyze/sqaa-auth.ts
@@ -124,7 +124,7 @@ export async function resolveSqaaProjectKey(
   auth: ResolvedAuth,
   projectRoot?: string,
 ): Promise<string | null> {
-  const discovered = await discoverProject(projectRoot ?? process.cwd(), true, { auth });
+  const discovered = await discoverProject(projectRoot ?? process.cwd(), { auth, silent: true });
   if (!discovered.projectKey) {
     logger.debug('Vortex analysis skipped: no project key found');
   }

--- a/src/commands/context/index.ts
+++ b/src/commands/context/index.ts
@@ -89,7 +89,7 @@ async function resolveRecordedContextAugmentationConfig(
   cwd: string,
   auth: ResolvedAuth,
 ): Promise<RecordedContextAugmentationConfig> {
-  const discovered = await discoverProject(cwd, true, { auth });
+  const discovered = await discoverProject(cwd, { auth, silent: true });
   if (!discovered.projectKey) {
     return {};
   }

--- a/src/commands/context/index.ts
+++ b/src/commands/context/index.ts
@@ -20,20 +20,13 @@
 
 import { spawn } from 'node:child_process';
 
-import { CONTEXT_AUGMENTATION_FEATURE_ID } from '@/commands/integrate/_common/features/context-augmentation-feature.ts';
-import { isProjectVortexFeature } from '@/commands/integrate/_common/vortex.ts';
 import { resolveAuth, type ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { CommandFailedError } from '@/core/command-error.ts';
 import { SONAR_CONTEXT_INVOCATION } from '@/core/config-constants.ts';
 import { buildContextAugmentationEnv } from '@/core/host/context-augmentation-env.ts';
-import { resolveContextWorkspaceRoot } from '@/core/host/git/worktree.ts';
 import { resolveContextAugmentationBinaryPath } from '@/core/host/install/context-augmentation.ts';
 import { getToken } from '@/core/host/keychain.ts';
-import { selectRecordedFeatureForDir } from '@/core/host/recorded-feature-resolver.ts';
-import { canonicalizePath } from '@/core/io/fs-utils.ts';
-import logger from '@/core/observability/logger.ts';
-import type { InstalledIntegrationFeature, IntegrationStateAttribute } from '@/core/state/state.ts';
-import { loadState } from '@/core/state/state-manager.ts';
+import { discoverProject } from '@/core/project-info.ts';
 
 // Commander may assign --help/-h to the optional [action] positional on some platforms.
 function buildForwardedArgs(
@@ -81,59 +74,31 @@ interface RecordedContextAugmentationConfig {
   organization?: string;
   projectKey?: string;
   serverUrl?: string;
-  /** Git working tree root containing the current invocation; set only when a recorded integration matched. */
+  /** The discovered project's own directory; set only when a project actually resolved. */
   workspaceDir?: string;
 }
 
-function isProjectContextAugmentationFeature(feature: InstalledIntegrationFeature): boolean {
-  return (
-    isProjectVortexFeature(feature) ||
-    (feature.featureId === CONTEXT_AUGMENTATION_FEATURE_ID && feature.scope === 'project')
-  );
-}
-
-function getOptionalStringAttr(
-  attrs: Record<string, IntegrationStateAttribute> | undefined,
-  key: string,
-): string | undefined {
-  const value = attrs?.[key];
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
-}
-
+/**
+ * Resolve org/project/server via the shared project-discovery pipeline (`discoverProject`),
+ * the same one SQAA's project-key lookup uses (see resolveSqaaProjectKey). `workspaceDir` is
+ * `discovered.projectRoot` directly — `discoverProject()` itself always anchors it to the
+ * current worktree (never a different one a matched mapping happens to point at), so no
+ * extra resolution is needed here.
+ */
 async function resolveRecordedContextAugmentationConfig(
   cwd: string,
+  auth: ResolvedAuth,
 ): Promise<RecordedContextAugmentationConfig> {
-  try {
-    // Worktree-aware matching (current worktree, then main tree; targetRoot before
-    // repoRoot; nearest ancestor; most recent) is owned by the shared resolver, so
-    // this stays identical to SQAA's project-key lookup (see resolveSqaaProjectKey).
-    const candidates = loadState().integrations.installed.flatMap((integration) =>
-      integration.features.filter(isProjectContextAugmentationFeature).map((feature) => ({
-        feature,
-        targetRoot: feature.targetRoot,
-        repoRoot: getOptionalStringAttr(feature.attrs, 'repoRoot'),
-        updatedAt: feature.updatedAt,
-      })),
-    );
-    const match = await selectRecordedFeatureForDir(cwd, candidates);
-    if (!match) {
-      return {};
-    }
-    return {
-      organization: getOptionalStringAttr(match.attrs, 'orgKey'),
-      projectKey: getOptionalStringAttr(match.attrs, 'projectKey'),
-      serverUrl: getOptionalStringAttr(match.attrs, 'serverUrl'),
-      // CAG daemon folder: git working-tree root (climbs up from subdirs), or the
-      // physical integrate targetRoot outside a git repo. Project metadata above
-      // comes from recorded state matched via targetRoot / repoRoot.
-      workspaceDir: canonicalizePath(await resolveContextWorkspaceRoot(cwd, match.targetRoot)),
-    };
-  } catch (err) {
-    logger.debug(
-      `Failed to resolve recorded context augmentation config: ${(err as Error).message}`,
-    );
+  const discovered = await discoverProject(cwd, true, { auth });
+  if (!discovered.projectKey) {
     return {};
   }
+  return {
+    organization: discovered.organization,
+    projectKey: discovered.projectKey,
+    serverUrl: discovered.serverUrl,
+    workspaceDir: discovered.projectRoot,
+  };
 }
 
 async function resolveContextToken(
@@ -182,7 +147,7 @@ export async function runContextPassthrough(
         remediationHint: 'Run: sonar auth login',
       });
     }
-    const recordedConfig = await resolveRecordedContextAugmentationConfig(process.cwd());
+    const recordedConfig = await resolveRecordedContextAugmentationConfig(process.cwd(), auth);
     const serverUrl = recordedConfig.serverUrl ?? auth.serverUrl;
     const organization = recordedConfig.organization ?? auth.orgKey;
     env = buildContextAugmentationEnv({

--- a/src/commands/hook/agent-post-tool-use.ts
+++ b/src/commands/hook/agent-post-tool-use.ts
@@ -76,7 +76,7 @@ async function handleSqaaPostToolUse(
   }
 
   const projectKey =
-    explicitProjectKey ?? (await discoverProject(process.cwd(), true, { auth })).projectKey;
+    explicitProjectKey ?? (await discoverProject(process.cwd(), { auth, silent: true })).projectKey;
   if (!projectKey) {
     return { decision: 'none' };
   }

--- a/src/commands/hook/agent-post-tool-use.ts
+++ b/src/commands/hook/agent-post-tool-use.ts
@@ -33,6 +33,7 @@ import { isSonarQubeCloud, resolveAuth } from '@/core/auth/auth-resolver.ts';
 import { canonicalizePath, toRelativePosixPath } from '@/core/io/fs-utils.ts';
 import logger from '@/core/observability/logger.ts';
 import { timed } from '@/core/observability/timed.ts';
+import { discoverProject } from '@/core/project-info.ts';
 import { SqaaForbiddenError } from '@/core/server/errors.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 
@@ -56,7 +57,7 @@ export interface AgentPostToolUseOptions {
 
 async function handleSqaaPostToolUse(
   payload: ClaudePostToolUsePayload,
-  projectKey: string | undefined,
+  explicitProjectKey: string | undefined,
   ctx: CommandInvocationContext,
 ): Promise<ClaudePostToolUseResult> {
   const filePath = payload.tool_input?.file_path;
@@ -65,12 +66,18 @@ async function handleSqaaPostToolUse(
   }
 
   const auth = await resolveAuth().catch(() => null);
-  if (!auth || !projectKey) {
+  if (!auth) {
     return { decision: 'none' };
   }
 
   // Cloud addresses an organization; Server has none and resolves it from the instance.
   if (isSonarQubeCloud(auth.serverUrl) && !auth.orgKey) {
+    return { decision: 'none' };
+  }
+
+  const projectKey =
+    explicitProjectKey ?? (await discoverProject(process.cwd(), true, { auth })).projectKey;
+  if (!projectKey) {
     return { decision: 'none' };
   }
 

--- a/src/commands/hook/codex-post-tool-use.ts
+++ b/src/commands/hook/codex-post-tool-use.ts
@@ -30,6 +30,7 @@ import type { SqaaJsonReport } from '@/commands/analyze/sqaa-display.ts';
 import type { CommandInvocationContext } from '@/commands/command-invocation-context.ts';
 import { isSonarQubeCloud, resolveAuth } from '@/core/auth/auth-resolver.ts';
 import logger from '@/core/observability/logger.ts';
+import { discoverProject } from '@/core/project-info.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 
 import {
@@ -64,14 +65,16 @@ export async function codexPostToolUse(
       // ignore
     }
   }
-  const projectKey = options.project;
-  if (!projectKey) return { agentSessionId: fromHook };
 
   const auth = await resolveAuth().catch(() => null);
   // Cloud addresses an organization; Server has none and resolves it from the instance.
   if (!auth || (isSonarQubeCloud(auth.serverUrl) && !auth.orgKey)) {
     return { agentSessionId: fromHook };
   }
+
+  const projectKey =
+    options.project ?? (await discoverProject(process.cwd(), true, { auth })).projectKey;
+  if (!projectKey) return { agentSessionId: fromHook };
 
   noteProject(auth, projectKey);
 

--- a/src/commands/hook/codex-post-tool-use.ts
+++ b/src/commands/hook/codex-post-tool-use.ts
@@ -73,7 +73,7 @@ export async function codexPostToolUse(
   }
 
   const projectKey =
-    options.project ?? (await discoverProject(process.cwd(), true, { auth })).projectKey;
+    options.project ?? (await discoverProject(process.cwd(), { auth, silent: true })).projectKey;
   if (!projectKey) return { agentSessionId: fromHook };
 
   noteProject(auth, projectKey);

--- a/src/commands/hook/git-pre-commit.ts
+++ b/src/commands/hook/git-pre-commit.ts
@@ -23,9 +23,10 @@
 // Replaces the shell logic that was previously embedded in the git hook script.
 
 import type { CommandInvocationContext } from '@/commands/command-invocation-context.ts';
-import { resolveAuth } from '@/core/auth/auth-resolver.ts';
+import { resolveAuth, type ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { InvalidOptionError } from '@/core/command-error.ts';
 import { spawnProcess } from '@/core/process/process.ts';
+import { discoverProject } from '@/core/project-info.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 
 import { runDepRisksStage } from './git-pre-commit-dependency-risks.ts';
@@ -37,19 +38,44 @@ export interface GitPreCommitOptions {
   dependencyRisks?: boolean;
 }
 
+/**
+ * Resolves the project key for --dependency-risks, falling back to project
+ * discovery when `-p` was not passed. A secrets-only pre-commit hook is
+ * intentionally project-agnostic and never bakes a `-p`, so the fallback is
+ * skipped entirely when --dependency-risks is not set.
+ */
+async function resolveDepRisksProjectKey(
+  options: GitPreCommitOptions,
+  auth: ResolvedAuth | null,
+): Promise<string | undefined> {
+  if (options.project) {
+    return options.project;
+  }
+  if (!options.dependencyRisks || !auth) {
+    return undefined;
+  }
+  const discovered = await discoverProject(process.cwd(), true, { auth });
+  return discovered.projectKey;
+}
+
 export async function gitPreCommit(
   options: GitPreCommitOptions,
   files: string[],
   ctx: CommandInvocationContext,
 ): Promise<void> {
-  if (options.dependencyRisks && !options.project) {
+  const auth = await resolveAuth().catch(() => null);
+
+  // Validated up front, independent of staged files, so a misconfigured hook
+  // (--dependency-risks with no way to resolve a project) always fails loudly.
+  const projectKey = await resolveDepRisksProjectKey(options, auth);
+
+  if (options.dependencyRisks && !projectKey) {
     throw new InvalidOptionError('--dependency-risks requires -p <projectKey>.');
   }
 
   const stagedFiles = files.length > 0 ? files : await getStagedFiles();
   if (stagedFiles.length === 0) return;
 
-  const auth = await resolveAuth().catch(() => null);
   if (!auth) {
     throw new MissingDependenciesError(HOOK_INACTIVE_UNAUTHENTICATED);
   }
@@ -57,13 +83,13 @@ export async function gitPreCommit(
   // Noted before the stages, not inside the dependency-risks one, so a `-p` passed without
   // --dependency-risks is still reported. In practice integrate only bakes `-p` into the hook
   // alongside --dependency-risks, so a secrets-only pre-commit correctly reports null.
-  noteProject(auth, options.project);
+  noteProject(auth, projectKey);
 
   await runCommitSecretsStage(stagedFiles, auth, ctx);
 
-  if (options.dependencyRisks && options.project) {
+  if (options.dependencyRisks && projectKey) {
     await runDepRisksStage({
-      project: options.project,
+      project: projectKey,
       changedFiles: stagedFiles,
       auth,
       ctx,

--- a/src/commands/hook/git-pre-commit.ts
+++ b/src/commands/hook/git-pre-commit.ts
@@ -54,7 +54,7 @@ async function resolveDepRisksProjectKey(
   if (!options.dependencyRisks || !auth) {
     return undefined;
   }
-  const discovered = await discoverProject(process.cwd(), true, { auth });
+  const discovered = await discoverProject(process.cwd(), { auth, silent: true });
   return discovered.projectKey;
 }
 

--- a/src/commands/integrate/_common/agent-integrate-postlude.ts
+++ b/src/commands/integrate/_common/agent-integrate-postlude.ts
@@ -68,11 +68,12 @@ export async function finalizeAgentInstall<TOptions extends IntegrateAgentOption
   });
   const { installRoot, installScope } = resolveIntegrateInstallTarget(
     context.isGlobal,
-    context.project.rootDir,
+    context.project.projectRoot,
   );
-  const attrs = await buildRecordedIntegrationAttrs({
+  const attrs = buildRecordedIntegrationAttrs({
     baseAttrs: { projectKey: context.projectKey ?? null },
-    projectRoot: context.project.rootDir,
+    projectRoot: context.project.projectRoot,
+    mainRepoRoot: context.project.mainRepoRoot,
     serverUrl: context.serverUrl,
     orgKey: context.organization,
     contextAugmentation: vortex,
@@ -83,7 +84,7 @@ export async function finalizeAgentInstall<TOptions extends IntegrateAgentOption
     options: {
       ...options,
       ...params.featureOptions,
-      projectRoot: context.project.rootDir,
+      projectRoot: context.project.projectRoot,
       vortexDisposition: vortex.disposition,
     },
     targetRoot: installRoot,

--- a/src/commands/integrate/_common/agent-integrate-prelude.ts
+++ b/src/commands/integrate/_common/agent-integrate-prelude.ts
@@ -141,7 +141,7 @@ export async function displayAgentIntegratePrelude(
   });
   const scope = await resolveIntegrateScope({
     ...options,
-    projectRoot: project.rootDir,
+    projectRoot: project.projectRoot,
     projectKey: options.project,
   });
   const isGlobal = isGlobalIntegrateScope(scope);

--- a/src/commands/integrate/_common/agent-integrate-prelude.ts
+++ b/src/commands/integrate/_common/agent-integrate-prelude.ts
@@ -58,7 +58,7 @@ export function introAgentIntegration(agentDisplayName: string): void {
 
 export async function discoverIntegrateProject(auth: ResolvedAuth): Promise<DiscoveredProject> {
   return withSpinner('Discovering project...', () =>
-    discoverProject(process.cwd(), true, { auth }),
+    discoverProject(process.cwd(), { auth, silent: true }),
   );
 }
 

--- a/src/commands/integrate/_common/context-augmentation.ts
+++ b/src/commands/integrate/_common/context-augmentation.ts
@@ -24,7 +24,6 @@ import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { CommandFailedError } from '@/core/command-error.ts';
 import { SONAR_CONTEXT_INVOCATION } from '@/core/config-constants.ts';
 import { buildContextAugmentationEnv } from '@/core/host/context-augmentation-env.ts';
-import { resolveRecordedRepoRoot } from '@/core/host/git/worktree.ts';
 import { SONAR_CONTEXT_AUGMENTATION_VERSION } from '@/core/host/install/signatures.ts';
 import logger from '@/core/observability/logger.ts';
 import type { IntegrationStateAttribute } from '@/core/state/state.ts';
@@ -64,25 +63,18 @@ export function buildContextAugmentationAttrs(
   };
 }
 
-/**
- * Assemble the attrs persisted on an agent integration's features, shared by
- * every agent handler. Records the repository's main working tree as `repoRoot`
- * (resolved once from `projectRoot`) so `sonar analyze`/`sonar context` can match
- * the integration from any linked worktree — including ones created after
- * integrate ran; falls back to `projectRoot` outside a git repo. Layers the
- * agent's `baseAttrs` first, then the Context Augmentation connection attrs when
- * CAG was set up.
- */
-export async function buildRecordedIntegrationAttrs(params: {
+/** Assembles the attrs persisted on an agent integration's features, shared by every agent handler. `mainRepoRoot` should come from the caller's own `DiscoveredProject`; falls back to `projectRoot` when absent. */
+export function buildRecordedIntegrationAttrs(params: {
   baseAttrs: Record<string, IntegrationStateAttribute>;
   projectRoot: string;
+  mainRepoRoot?: string;
   serverUrl: string;
   orgKey: string | undefined;
   contextAugmentation: ResolvedVortexSetup | null;
-}): Promise<Record<string, IntegrationStateAttribute>> {
+}): Record<string, IntegrationStateAttribute> {
   return {
     ...params.baseAttrs,
-    repoRoot: await resolveRecordedRepoRoot(params.projectRoot),
+    repoRoot: params.mainRepoRoot ?? params.projectRoot,
     ...(params.contextAugmentation?.disposition === 'install'
       ? buildContextAugmentationAttrs(
           params.serverUrl,

--- a/src/commands/integrate/_common/preflight-summary.ts
+++ b/src/commands/integrate/_common/preflight-summary.ts
@@ -120,9 +120,9 @@ async function buildProjectItems(
   options: AgentPreflightSummaryOptions,
   tokenStatus: TokenStatus,
 ): Promise<PhaseItem[]> {
-  const items: PhaseItem[] = [phaseItem('Root', 'done', options.project.rootDir)];
+  const items: PhaseItem[] = [phaseItem('Root', 'done', options.project.projectRoot)];
 
-  if (options.project.isGitRepo) {
+  if (options.project.repoRoot) {
     items.push(phaseItem('Git repository', 'done', 'detected'));
   } else {
     items.push(phaseItem('Git repository', 'warn', 'not detected'));

--- a/src/commands/integrate/antigravity/index.ts
+++ b/src/commands/integrate/antigravity/index.ts
@@ -60,7 +60,7 @@ export async function integrateAntigravity(
 
   const { installRoot: targetRoot, installScope: scope } = resolveAntigravityInstallTarget(
     integrateCtx.isGlobal,
-    integrateCtx.project.rootDir,
+    integrateCtx.project.projectRoot,
   );
   const existingGlobalHookPath = integrateCtx.isGlobal
     ? undefined
@@ -69,14 +69,15 @@ export async function integrateAntigravity(
 
   const integrationOptions: AntigravityIntegrationOptions = {
     ...options,
-    projectRoot: integrateCtx.project.rootDir,
+    projectRoot: integrateCtx.project.projectRoot,
     globalSecretsHookExists,
     vortexDisposition: vortex.disposition,
   };
 
-  const attrs = await buildRecordedIntegrationAttrs({
+  const attrs = buildRecordedIntegrationAttrs({
     baseAttrs: buildIntegrationAttrs(integrateCtx),
-    projectRoot: integrateCtx.project.rootDir,
+    projectRoot: integrateCtx.project.projectRoot,
+    mainRepoRoot: integrateCtx.project.mainRepoRoot,
     serverUrl: integrateCtx.serverUrl,
     orgKey: integrateCtx.organization,
     contextAugmentation: vortex,

--- a/src/commands/integrate/claude/index.ts
+++ b/src/commands/integrate/claude/index.ts
@@ -77,20 +77,21 @@ export async function integrateClaude(
     projectKey: integrateCtx.projectKey,
     isGlobal: integrateCtx.isGlobal,
   });
-  const featureAttrs = await buildRecordedIntegrationAttrs({
+  const featureAttrs = buildRecordedIntegrationAttrs({
     baseAttrs: buildIntegrationAttrs(config),
-    projectRoot: integrateCtx.project.rootDir,
+    projectRoot: integrateCtx.project.projectRoot,
+    mainRepoRoot: integrateCtx.project.mainRepoRoot,
     serverUrl: config.serverURL,
     orgKey: config.organization,
     contextAugmentation: vortex,
   });
   const { installRoot, installScope } = resolveIntegrateInstallTarget(
     integrateCtx.isGlobal,
-    integrateCtx.project.rootDir,
+    integrateCtx.project.projectRoot,
   );
   const integrationOptions = {
     ...options,
-    projectRoot: integrateCtx.project.rootDir,
+    projectRoot: integrateCtx.project.projectRoot,
     globalSecretsHookExists: skipSecretsHooks,
     vortexDisposition: vortex.disposition,
   } satisfies ClaudeIntegrationOptions;
@@ -119,7 +120,7 @@ export async function integrateClaude(
   } catch (error) {
     installError = error instanceof Error ? error : new Error(String(error));
   }
-  await removeObsoleteHookArtifacts(integrateCtx.project.rootDir);
+  await removeObsoleteHookArtifacts(integrateCtx.project.projectRoot);
   if (installError) {
     throw installError;
   }

--- a/src/commands/integrate/git/index.ts
+++ b/src/commands/integrate/git/index.ts
@@ -204,7 +204,7 @@ async function resolveProjectKey(
     return options;
   }
 
-  const discovered = await discoverProject(root, true, { auth });
+  const discovered = await discoverProject(root, { auth, silent: true });
   if (discovered.projectKey) {
     phase('Project', [phaseItem('Key', 'done', discovered.projectKey)]);
     return { ...options, project: discovered.projectKey };

--- a/src/commands/remediate/index.ts
+++ b/src/commands/remediate/index.ts
@@ -142,7 +142,7 @@ async function resolveProjectKey(options: RemediateOptions, auth: ResolvedAuth):
   if (options.project) {
     return options.project;
   }
-  const discovered = await discoverProject(process.cwd(), false, { auth });
+  const discovered = await discoverProject(process.cwd(), { auth });
   if (!discovered.projectKey) {
     throw new CommandFailedError('Could not determine project key.', {
       remediationHint: 'Use --project <key> to specify it.',

--- a/src/commands/run/mcp.ts
+++ b/src/commands/run/mcp.ts
@@ -78,8 +78,8 @@ export async function runMcp(
     );
   }
   const discoveredRootIsHomeDir =
-    discovered && canonicalizePath(discovered.rootDir) === canonicalizePath(homedir());
-  const projectRoot = discoveredRootIsHomeDir ? undefined : discovered?.rootDir;
+    discovered && canonicalizePath(discovered.projectRoot) === canonicalizePath(homedir());
+  const projectRoot = discoveredRootIsHomeDir ? undefined : discovered?.projectRoot;
 
   const context: McpServerContext = projectRoot
     ? { withFsMount: true, projectRoot, projectKey }

--- a/src/commands/run/mcp.ts
+++ b/src/commands/run/mcp.ts
@@ -66,7 +66,7 @@ export async function runMcp(
 
   const cwd = process.cwd();
   const cwdIsHomeDir = canonicalizePath(cwd) === canonicalizePath(homedir());
-  const discovered = cwdIsHomeDir ? undefined : await discoverProject(cwd, true, { auth });
+  const discovered = cwdIsHomeDir ? undefined : await discoverProject(cwd, { auth, silent: true });
   // Deliberately does NOT call `noteProject` (telemetry/project-uuid.ts), unlike the other
   // commands that resolve a project key: this starts a long-running server, and
   // CliCommandExecuted is only emitted from the postAction hook once it exits — or never, if

--- a/src/core/host/git/lookup-path-resolver.ts
+++ b/src/core/host/git/lookup-path-resolver.ts
@@ -68,15 +68,16 @@ function asLookupPaths(paths: string[]): LookupPath[] {
 }
 
 /**
- * Nearest-first directories to check for `startDir`: climbs to the repo root (or the
- * filesystem root outside git); from a linked worktree, also appends the main tree's
- * offset-equivalent climb so a mapping recorded only there still resolves.
+ * Nearest-first directories to check for `startDir`: climbs to the repo root, or — outside
+ * git, where nothing bounds a climb to a project — just `startDir` itself; from a linked
+ * worktree, also appends the main tree's offset-equivalent climb so a mapping recorded only
+ * there still resolves.
  */
 export async function resolveLookupPaths(startDir: string): Promise<LookupPath[]> {
   const canonicalStart = canonicalizePath(startDir);
   const currentRepoRoot = await resolveGitRepoRoot(canonicalStart);
   if (!currentRepoRoot) {
-    return asLookupPaths(buildDirectoryClimb(canonicalStart));
+    return asLookupPaths(buildDirectoryClimb(canonicalStart, canonicalStart));
   }
 
   const climb = buildDirectoryClimb(canonicalStart, currentRepoRoot);

--- a/src/core/host/git/lookup-path-resolver.ts
+++ b/src/core/host/git/lookup-path-resolver.ts
@@ -1,0 +1,103 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Resolves the explicit, ordered list of directories to check for a recorded per-project
+// mapping, handling git/non-git and current-vs-main-worktree internally.
+
+import { dirname, isAbsolute, join, relative, sep } from 'node:path';
+
+import { canonicalizePath, pathComparisonKey } from '@/core/io/fs-utils.ts';
+
+import { resolveGitRepoRoot, resolveMainWorktreeRoot } from './worktree.ts';
+
+/** Pure, git-free: walks `dirname()` from `from` up to `upToInclusive` (or the filesystem root when omitted). */
+export function buildDirectoryClimb(from: string, upToInclusive?: string): string[] {
+  const boundKey = upToInclusive === undefined ? undefined : pathComparisonKey(upToInclusive);
+  const climb: string[] = [];
+
+  let current = canonicalizePath(from);
+  for (;;) {
+    climb.push(current);
+    if (boundKey !== undefined && pathComparisonKey(current) === boundKey) {
+      break;
+    }
+    const parent = dirname(current);
+    if (pathComparisonKey(parent) === pathComparisonKey(current)) {
+      break; // reached the filesystem/drive root
+    }
+    current = parent;
+  }
+
+  return climb;
+}
+
+/** Maps `dir`'s offset inside `fromRoot` onto the equivalent location under `toRoot`. */
+function mapOffset(dir: string, fromRoot: string, toRoot: string): string | undefined {
+  const rel = relative(fromRoot, dir);
+  if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
+    return undefined;
+  }
+  return rel === '' ? toRoot : canonicalizePath(join(toRoot, rel));
+}
+
+/** A directory to check candidates against (`checkPath`), and the `projectRoot` to use if it matches — these differ only for the main-tree-equivalent climb, where `projectRoot` stays in the current worktree instead of pointing at the main one. */
+export interface LookupPath {
+  checkPath: string;
+  projectRoot: string;
+}
+
+function asLookupPaths(paths: string[]): LookupPath[] {
+  return paths.map((checkPath) => ({ checkPath, projectRoot: checkPath }));
+}
+
+/**
+ * Nearest-first directories to check for `startDir`: climbs to the repo root (or the
+ * filesystem root outside git); from a linked worktree, also appends the main tree's
+ * offset-equivalent climb so a mapping recorded only there still resolves.
+ */
+export async function resolveLookupPaths(startDir: string): Promise<LookupPath[]> {
+  const canonicalStart = canonicalizePath(startDir);
+  const currentRepoRoot = await resolveGitRepoRoot(canonicalStart);
+  if (!currentRepoRoot) {
+    return asLookupPaths(buildDirectoryClimb(canonicalStart));
+  }
+
+  const climb = buildDirectoryClimb(canonicalStart, currentRepoRoot);
+
+  const mainRepoRoot = await resolveMainWorktreeRoot(canonicalStart);
+  if (!mainRepoRoot || pathComparisonKey(mainRepoRoot) === pathComparisonKey(currentRepoRoot)) {
+    return asLookupPaths(climb);
+  }
+
+  const mappedStart = mapOffset(canonicalStart, currentRepoRoot, mainRepoRoot);
+  if (mappedStart === undefined) {
+    return asLookupPaths(climb);
+  }
+
+  // climb[i] and mainTreeClimb[i] are the same relative depth, so climb[i] is the
+  // current-worktree equivalent of whatever mainTreeClimb[i] checks in the main tree.
+  const mainTreeClimb = buildDirectoryClimb(mappedStart, mainRepoRoot);
+  const mainTreeLookupPaths = mainTreeClimb.map((checkPath, i) => ({
+    checkPath,
+    projectRoot: climb[i] ?? checkPath,
+  }));
+
+  return [...asLookupPaths(climb), ...mainTreeLookupPaths];
+}

--- a/src/core/host/git/lookup-path-resolver.ts
+++ b/src/core/host/git/lookup-path-resolver.ts
@@ -23,7 +23,7 @@
 
 import { dirname, isAbsolute, join, relative, sep } from 'node:path';
 
-import { canonicalizePath, pathComparisonKey } from '@/core/io/fs-utils.ts';
+import { canonicalizePath, isAncestorOrSelf, pathComparisonKey } from '@/core/io/fs-utils.ts';
 
 import { resolveGitRepoRoot, resolveMainWorktreeRoot } from './worktree.ts';
 
@@ -67,17 +67,31 @@ function asLookupPaths(paths: string[]): LookupPath[] {
   return paths.map((checkPath) => ({ checkPath, projectRoot: checkPath }));
 }
 
-/**
- * Nearest-first directories to check for `startDir`: climbs to the repo root, or — outside
- * git, where nothing bounds a climb to a project — just `startDir` itself; from a linked
- * worktree, also appends the main tree's offset-equivalent climb so a mapping recorded only
- * there still resolves.
- */
-export async function resolveLookupPaths(startDir: string): Promise<LookupPath[]> {
+/** Shallowest ancestor-or-self of `dir` among the raw, un-deduplicated `knownRoots`. */
+function findBoundingKnownRoot(dir: string, knownRoots: string[]): string | undefined {
+  let shallowest: string | undefined;
+  for (const root of knownRoots) {
+    const canonicalRoot = canonicalizePath(root);
+    if (
+      isAncestorOrSelf(canonicalRoot, dir) &&
+      (shallowest === undefined || canonicalRoot.length < shallowest.length)
+    ) {
+      shallowest = canonicalRoot;
+    }
+  }
+  return shallowest;
+}
+
+/** Nearest-first directories to check for `startDir`: repo-root climb in git, else bounded by the shallowest matching `knownRoots` entry (or `startDir` itself); appends the main-tree-equivalent climb from a linked worktree. */
+export async function resolveLookupPaths(
+  startDir: string,
+  knownRoots: string[] = [],
+): Promise<LookupPath[]> {
   const canonicalStart = canonicalizePath(startDir);
   const currentRepoRoot = await resolveGitRepoRoot(canonicalStart);
   if (!currentRepoRoot) {
-    return asLookupPaths(buildDirectoryClimb(canonicalStart, canonicalStart));
+    const bound = findBoundingKnownRoot(canonicalStart, knownRoots) ?? canonicalStart;
+    return asLookupPaths(buildDirectoryClimb(canonicalStart, bound));
   }
 
   const climb = buildDirectoryClimb(canonicalStart, currentRepoRoot);

--- a/src/core/host/git/worktree.ts
+++ b/src/core/host/git/worktree.ts
@@ -18,34 +18,20 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Git worktree awareness: map a path inside a linked worktree back to the
-// equivalent path in the repository's main working tree, so per-project state
-// recorded by `sonar integrate` in the main checkout can still be found after a
-// worktree is created (e.g. for SQAA project-key and CAG context lookups).
-//
-// `resolveGitRepoRoot` is also the single source of truth for "resolve the git
-// top-level for a path" used by branch resolution (branch.ts) and other
-// callers that only need the plain repository root, not worktree mapping.
+// Git worktree awareness: resolves a repository's main working tree root for a given
+// directory (see also the worktree-aware climb in `lookup-path-resolver.ts`).
 
 import { statSync } from 'node:fs';
-import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 
-import { canonicalizePath, pathComparisonKey } from '../../io/fs-utils.ts';
+import { canonicalizePath } from '../../io/fs-utils.ts';
 import { tryRunGit } from './exec.ts';
 
-interface WorktreeMapping {
-  /** git top-level of the input path (the linked worktree root when inside one). */
-  currentRoot: string;
-  /** Main working tree root; differs from currentRoot only inside a linked worktree. */
-  mainRoot: string;
-}
-
-// Per-process cache of `git` stdout keyed by (cwd, args). A single CLI
-// invocation resolves worktree topology for the same directory several times
-// (e.g. `sonar context` maps cwd both to match recorded features and to derive
-// the workspace root), and that topology cannot change mid-invocation — so we
-// spawn `git` at most once per distinct command. Each CLI run is a fresh
-// process, so the cache never outlives a single invocation.
+// Per-process cache of `git` stdout keyed by (cwd, args). A single CLI invocation can
+// resolve worktree topology for the same directory more than once (e.g. the lookup-path
+// climb checks both the current and main worktree), and that topology cannot change
+// mid-invocation — so we spawn `git` at most once per distinct command. Each CLI run is
+// a fresh process, so the cache never outlives a single invocation.
 const gitStdoutCache = new Map<string, Promise<string | null>>();
 
 function runGitStdout(args: string[], cwd: string): Promise<string | null> {
@@ -120,75 +106,4 @@ async function listWorktreeRoots(dir: string): Promise<string[] | null> {
 export async function resolveMainWorktreeRoot(dir: string): Promise<string | null> {
   const roots = await listWorktreeRoots(dir);
   return roots?.[0] ?? null;
-}
-
-/**
- * Resolve the current git top-level and the repository's main working tree root
- * for the given directory. The current root comes from `resolveGitRepoRoot`
- * (climbs up from subdirectories automatically). The main root is the first
- * `git worktree list` entry when available, otherwise the current root. Returns
- * null when git is unavailable or the directory is not inside a repository;
- * when not inside a linked worktree, currentRoot equals mainRoot.
- */
-async function resolveWorktreeMapping(dir: string): Promise<WorktreeMapping | null> {
-  const currentRoot = await resolveGitRepoRoot(dir);
-  if (!currentRoot) {
-    return null;
-  }
-  const roots = await listWorktreeRoots(dir);
-  const mainRoot = roots?.[0] ?? currentRoot;
-  return { currentRoot, mainRoot };
-}
-
-/**
- * Given a filesystem `path` inside a git working tree, return the de-duplicated
- * list of equivalent paths to consult for per-project state lookups: `path`
- * itself, plus its equivalent inside the repository's main working tree when
- * `path` is inside a linked worktree. Order is [current, main].
- *
- * Preserves the in-worktree offset (a subdirectory maps to the same subdirectory
- * under the main tree), so callers that match by prefix keep subfolder precision.
- * Falls back to `[path]` when git is unavailable, `path` is not inside a linked
- * worktree, or `path` is outside the current worktree root.
- */
-export async function resolveWorktreeEquivalentPaths(path: string): Promise<string[]> {
-  const mapping = await resolveWorktreeMapping(path);
-  const canonicalPath = canonicalizePath(path);
-  if (!mapping || mapping.currentRoot === mapping.mainRoot) {
-    return [canonicalPath];
-  }
-
-  const rel = relative(mapping.currentRoot, canonicalPath);
-  if (rel.startsWith('..') || isAbsolute(rel)) {
-    return [canonicalPath];
-  }
-
-  const mapped = rel === '' ? mapping.mainRoot : canonicalizePath(join(mapping.mainRoot, rel));
-  return pathComparisonKey(mapped) === pathComparisonKey(canonicalPath)
-    ? [canonicalPath]
-    : [canonicalPath, mapped];
-}
-
-/**
- * Stable repository identity key for per-project integration state: the main
- * working tree when inside a git repo, otherwise `projectRoot` itself.
- */
-export async function resolveRecordedRepoRoot(projectRoot: string): Promise<string> {
-  return (await resolveMainWorktreeRoot(projectRoot)) ?? projectRoot;
-}
-
-/**
- * Workspace root for CAG: the git working-tree root containing `cwd` when inside a
- * repository (climbs up from subdirectories), otherwise the physical integrate
- * `targetRoot` supplied by the caller.
- */
-export async function resolveContextWorkspaceRoot(
-  cwd: string,
-  integratedTargetRoot: string,
-): Promise<string> {
-  const mapping = await resolveWorktreeMapping(cwd);
-  if (mapping) {
-    return mapping.currentRoot;
-  }
-  return integratedTargetRoot;
 }

--- a/src/core/host/recorded-feature-resolver.ts
+++ b/src/core/host/recorded-feature-resolver.ts
@@ -18,17 +18,12 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Shared worktree-aware resolution of a recorded per-project integration feature
-// for a working directory. Both `sonar analyze agentic` (SQAA project-key lookup)
-// and the `sonar context` passthrough (CAG connection lookup) map the current
-// directory to the recorded feature that governs it, so they share this single
-// selection policy to guarantee identical behavior.
-
-import { sep } from 'node:path';
-
-import { resolveWorktreeEquivalentPaths } from '@/core/host/git/worktree.ts';
+// Shared worktree-aware resolution of a recorded per-project feature; `discoverProject()`
+// is the sole caller, so SQAA and CAG project lookups share one selection policy.
 
 import { pathComparisonKey } from '../io/fs-utils.ts';
+import { parseTimestampMillis } from '../time/timestamp.ts';
+import type { LookupPath } from './git/lookup-path-resolver.ts';
 
 /**
  * A recorded feature paired with the roots used to match it to a directory.
@@ -52,70 +47,28 @@ interface KeyedCandidate<T> {
   updatedAt: string | undefined;
 }
 
-function updatedAtMillis(iso: string | undefined): number {
-  if (iso === undefined) {
-    return 0;
-  }
-  const parsed = Date.parse(iso);
-  return Number.isNaN(parsed) ? 0 : parsed;
+/** A selected candidate plus the project root to use — always in the caller's own worktree, never a different one. */
+export interface FeatureMatch<T> {
+  feature: T;
+  matchedPath: string;
 }
 
-/**
- * True when `parent` equals or is an ancestor of `child`. Both arguments must
- * already be canonical comparison keys (see `pathComparisonKey`): absolute,
- * `..`-free, and case-folded consistently. That invariant is what makes a plain
- * boundary-aware prefix check correct and robust:
- *  - canonicalization has already collapsed any real `..` traversal, so there is
- *    no relative-path string to misread — a child literally named `..config`
- *    stays inside `parent` (`/a/..config` starts with `/a/`);
- *  - appending the separator keeps `/a` from matching a sibling `/ab`.
- */
-function isPathInside(parent: string, child: string): boolean {
-  if (parent === child) {
-    return true;
-  }
-  const boundary = parent.endsWith(sep) ? parent : parent + sep;
-  return child.startsWith(boundary);
-}
-
-/**
- * Among features whose given root is an ancestor of (or equal to) a lookup path,
- * pick the most specific (longest root), then the most recently updated.
- */
-function pickBest<T>(matches: { candidate: KeyedCandidate<T>; root: string }[]): T | undefined {
+/** Among candidates tied on an exact match, the most recently updated wins. */
+function pickBest<T>(matches: KeyedCandidate<T>[]): T | undefined {
   return matches
     .slice()
-    .sort(
-      (a, b) =>
-        b.root.length - a.root.length ||
-        updatedAtMillis(b.candidate.updatedAt) - updatedAtMillis(a.candidate.updatedAt),
-    )
-    .at(0)?.candidate.feature;
+    .sort((a, b) => parseTimestampMillis(b.updatedAt) - parseTimestampMillis(a.updatedAt))
+    .at(0)?.feature;
 }
 
 /**
- * Pure selection over already-resolved lookup paths (ordered current-worktree
- * first, then main working tree). Exposed separately from
- * `selectRecordedFeatureForDir` so the policy can be unit-tested without git.
- *
- * For each lookup path in order:
- *  1. an exact/ancestor `targetRoot` match (the physical install dir) wins over
- *     a `repoRoot`-only match, so two worktrees integrated with different project
- *     keys resolve to the one actually installed here rather than a sibling that
- *     merely shares the same main working tree;
- *  2. among same-kind matches the longest (most specific) root wins, then the
- *     most recently updated feature, so nested (monorepo) integrations resolve to
- *     the nearest ancestor.
- *
- * Consulting the current worktree before the main tree means a call from a linked
- * worktree prefers that worktree's own integration but still falls back to the
- * main checkout's when the worktree itself was never integrated.
+ * Pure, git-free exact-match selection over an already-resolved, nearest-first lookup-path
+ * list. Per path: exact `targetRoot` match wins over `repoRoot`-only; ties broken by recency.
  */
 export function selectFeatureForLookupPaths<T>(
   candidates: RecordedFeatureCandidate<T>[],
-  lookupPaths: string[],
-): T | undefined {
-  const keyedPaths = lookupPaths.map((path) => pathComparisonKey(path));
+  lookupPaths: LookupPath[],
+): FeatureMatch<T> | undefined {
   const keyed: KeyedCandidate<T>[] = candidates.map((candidate) => ({
     feature: candidate.feature,
     targetRoot: pathComparisonKey(candidate.targetRoot),
@@ -123,41 +76,18 @@ export function selectFeatureForLookupPaths<T>(
     updatedAt: candidate.updatedAt,
   }));
 
-  for (const path of keyedPaths) {
-    const byTarget = pickBest(
-      keyed.flatMap((candidate) =>
-        isPathInside(candidate.targetRoot, path) ? [{ candidate, root: candidate.targetRoot }] : [],
-      ),
-    );
+  for (const { checkPath, projectRoot } of lookupPaths) {
+    const keyedPath = pathComparisonKey(checkPath);
+
+    const byTarget = pickBest(keyed.filter((candidate) => candidate.targetRoot === keyedPath));
     if (byTarget) {
-      return byTarget;
+      return { feature: byTarget, matchedPath: projectRoot };
     }
 
-    const byRepo = pickBest(
-      keyed.flatMap((candidate) =>
-        candidate.repoRoot !== undefined && isPathInside(candidate.repoRoot, path)
-          ? [{ candidate, root: candidate.repoRoot }]
-          : [],
-      ),
-    );
+    const byRepo = pickBest(keyed.filter((candidate) => candidate.repoRoot === keyedPath));
     if (byRepo) {
-      return byRepo;
+      return { feature: byRepo, matchedPath: projectRoot };
     }
   }
   return undefined;
-}
-
-/**
- * Worktree-aware selection of the recorded feature governing `dir`. Resolves the
- * lookup paths for `dir` (`dir` itself, plus its equivalent in the main working
- * tree when inside a linked worktree) via a single `git worktree list` call, then
- * applies {@link selectFeatureForLookupPaths}. Returns undefined when nothing
- * matches (including when git is unavailable and no candidate contains `dir`).
- */
-export async function selectRecordedFeatureForDir<T>(
-  dir: string,
-  candidates: RecordedFeatureCandidate<T>[],
-): Promise<T | undefined> {
-  const lookupPaths = await resolveWorktreeEquivalentPaths(dir);
-  return selectFeatureForLookupPaths(candidates, lookupPaths);
 }

--- a/src/core/io/fs-utils.ts
+++ b/src/core/io/fs-utils.ts
@@ -93,3 +93,12 @@ export function toRelativePosixPath(file: string, base: string = process.cwd()):
   if (isAbsolute(rel) || rel.split('/').includes('..')) return null;
   return rel;
 }
+
+/** True when `path` is `ancestor` itself or nested under it. Both args must already be canonicalized. */
+export function isAncestorOrSelf(ancestor: string, path: string): boolean {
+  if (pathComparisonKey(ancestor) === pathComparisonKey(path)) {
+    return true;
+  }
+  const rel = relative(ancestor, path);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}

--- a/src/core/io/fs-utils.ts
+++ b/src/core/io/fs-utils.ts
@@ -19,7 +19,7 @@
  */
 
 import { realpathSync } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
 
 export const normalizePath = (p: string): string => p.replaceAll('\\', '/');
 
@@ -96,9 +96,6 @@ export function toRelativePosixPath(file: string, base: string = process.cwd()):
 
 /** True when `path` is `ancestor` itself or nested under it. Both args must already be canonicalized. */
 export function isAncestorOrSelf(ancestor: string, path: string): boolean {
-  if (pathComparisonKey(ancestor) === pathComparisonKey(path)) {
-    return true;
-  }
   const rel = relative(ancestor, path);
-  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel));
 }

--- a/src/core/known-server-project-mappings.ts
+++ b/src/core/known-server-project-mappings.ts
@@ -1,0 +1,127 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Derives targetRoot/repoRoot -> SonarQube project/server mappings live from every
+// currently project-scoped `integrations.installed` feature, for discoverProject()'s
+// known-mapping source. targetRoot/repoRoot are copied verbatim from the feature's
+// attrs (never collapsed into one value) so worktree-aware matching can prefer the
+// precise location over the worktree-wide fallback — see `resolveLookupPaths` /
+// `selectFeatureForLookupPaths`.
+
+import { pathComparisonKey } from '@/core/io/fs-utils.ts';
+import type {
+  CliState,
+  InstalledIntegrationFeature,
+  IntegrationStateAttribute,
+} from '@/core/state/state.ts';
+import { parseTimestampMillis } from '@/core/time/timestamp.ts';
+
+/**
+ * A folder known to be bound to a SonarQube project, derived from a project-scoped
+ * integration feature's attrs. Keeps `targetRoot`/`repoRoot` as two distinct signals
+ * (never collapsed into one) so worktree-aware matching can prefer the precise
+ * physical location over a worktree-wide fallback — see `resolveLookupPaths` /
+ * `selectFeatureForLookupPaths`.
+ */
+export interface KnownServerProjectMapping {
+  /** Physical location this was recorded from — the precise, most-specific signal. */
+  targetRoot: string;
+  /** Repository's main working tree root, when known — the worktree-wide fallback signal. */
+  repoRoot?: string;
+  /** SonarQube project key bound to this mapping. */
+  projectKey: string;
+  /**
+   * Server URL for this binding, when the feature actually recorded one (Vortex-entitled
+   * agent integrations). Left undefined when it didn't (e.g. `git` integrate never records a
+   * connection) — deliberately NOT backfilled here from whichever connection happened to be
+   * active at derive time, since that is a point-in-time snapshot that can go stale (e.g.
+   * env-var auth switching server/org per invocation). Callers matching this mapping
+   * substitute the connection active *at match time* instead — see `discoverProject()`.
+   */
+  serverUrl?: string;
+  /** Organization key (SonarQube Cloud only), same recorded-only precedence as `serverUrl`. */
+  orgKey?: string;
+  /** ISO timestamp of the contributing feature's last update; used to resolve conflicts when merging. */
+  updatedAt: string;
+}
+
+function getOptionalStringAttr(
+  attrs: Record<string, IntegrationStateAttribute> | undefined,
+  key: string,
+): string | undefined {
+  const value = attrs?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function deriveMappingForFeature(
+  feature: InstalledIntegrationFeature,
+): KnownServerProjectMapping | undefined {
+  if (feature.scope !== 'project') {
+    return undefined;
+  }
+
+  const projectKey = getOptionalStringAttr(feature.attrs, 'projectKey');
+  if (!projectKey) {
+    return undefined;
+  }
+
+  // serverUrl/orgKey are recorded-only — never backfilled from the active connection, which
+  // would go stale by the time a future, possibly different-environment invocation matches
+  // this mapping. Callers resolve the connection fresh at match time — see `discoverProject()`.
+  return {
+    targetRoot: feature.targetRoot,
+    repoRoot: getOptionalStringAttr(feature.attrs, 'repoRoot'),
+    projectKey,
+    serverUrl: getOptionalStringAttr(feature.attrs, 'serverUrl'),
+    orgKey: getOptionalStringAttr(feature.attrs, 'orgKey'),
+    updatedAt: feature.updatedAt,
+  };
+}
+
+/**
+ * Derives targetRoot/repoRoot -> project mappings by parsing `attrs.projectKey`/`serverUrl`/
+ * `orgKey` off every currently project-scoped `integrations.installed` feature, for
+ * `discoverProject()`'s known-mapping source.
+ */
+export function buildKnownServerProjectMappings(state: CliState): KnownServerProjectMapping[] {
+  const byTargetRoot = new Map<string, KnownServerProjectMapping>();
+
+  for (const integration of state.integrations.installed) {
+    for (const feature of integration.features) {
+      const mapping = deriveMappingForFeature(feature);
+      if (!mapping) {
+        continue;
+      }
+
+      const key = pathComparisonKey(mapping.targetRoot);
+      const existing = byTargetRoot.get(key);
+      if (
+        existing &&
+        parseTimestampMillis(existing.updatedAt) >= parseTimestampMillis(mapping.updatedAt)
+      ) {
+        continue;
+      }
+
+      byTargetRoot.set(key, mapping);
+    }
+  }
+
+  return [...byTargetRoot.values()];
+}

--- a/src/core/project-info.ts
+++ b/src/core/project-info.ts
@@ -95,13 +95,13 @@ export interface SonarProperties {
   organization: string;
 }
 
-/** Same nearest-first climb as discoverProject()'s local-config source — no known-mapping table, no git-remote API call, since this also runs pre-login (no token yet). */
+/** Same nearest-first, known-root-bounded climb as discoverProject()'s local-config source — no known-mapping match, no git-remote API call, since this also runs pre-login (no token yet). */
 async function discoverLocalConfig(
   startDir: string,
   silent: boolean,
 ): Promise<Pick<DiscoveredProject, 'serverUrl' | 'organization'>> {
   const config: DiscoveredProject = { projectRoot: canonicalizePath(startDir), configSources: [] };
-  const lookupPaths = await resolveLookupPaths(startDir);
+  const lookupPaths = await resolveLookupPaths(startDir, collectKnownRoots(loadKnownMappings()));
   await applyLocalConfigAcrossLookupPaths(config, lookupPaths, { silent });
   return config;
 }

--- a/src/core/project-info.ts
+++ b/src/core/project-info.ts
@@ -21,27 +21,40 @@
 // Project workspace: git root, sonar-project.properties, SonarLint connected mode
 
 import { existsSync } from 'node:fs';
-import { basename, join } from 'node:path';
+import { join } from 'node:path';
 
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { resolveAuth } from '@/core/auth/auth-resolver.ts';
 import { CommandFailedError } from '@/core/command-error.ts';
 import { findGitRoot, getGitRemote } from '@/core/host/git/discover.ts';
+import { type LookupPath, resolveLookupPaths } from '@/core/host/git/lookup-path-resolver.ts';
+import { resolveMainWorktreeRoot } from '@/core/host/git/worktree.ts';
+import {
+  type FeatureMatch,
+  type RecordedFeatureCandidate,
+  selectFeatureForLookupPaths,
+} from '@/core/host/recorded-feature-resolver.ts';
+import {
+  buildKnownServerProjectMappings,
+  type KnownServerProjectMapping,
+} from '@/core/known-server-project-mappings.ts';
 import {
   discoverProjectKeyByGitRemote,
   GIT_REMOTE_BINDING_SOURCE,
 } from '@/core/server/discover-project-by-remote.ts';
+import type { CliState } from '@/core/state/state.ts';
+import { getActiveConnection } from '@/core/state/state-manager.ts';
+import { loadState } from '@/core/state/state-repository.ts';
 import { print } from '@/core/ui';
 
 import { loadSonarLintConfig, type SonarLintConfig } from './host/sonarlint-connected-mode.ts';
 import { canonicalizePath } from './io/fs-utils.ts';
 import logger from './observability/logger.ts';
 
-export interface ProjectInfo {
-  root: string;
-  name: string;
-  isGitRepo: boolean;
-  gitRemote: string;
+export const KNOWN_SERVER_PROJECT_MAPPING_SOURCE = 'known project mapping';
+
+/** Local config files found at exactly one directory — no git, no root resolution. */
+interface LocalProjectConfig {
   hasSonarProps: boolean;
   sonarPropsData: SonarProperties | null;
   hasSonarLintConfig: boolean;
@@ -51,11 +64,17 @@ export interface ProjectInfo {
 }
 
 export interface DiscoveredProject {
-  rootDir: string;
-  isGitRepo: boolean;
+  /** Where the discovered project is anchored — what nearly every caller should use. */
+  projectRoot: string;
+  projectKey?: string;
   serverUrl?: string;
   organization?: string;
-  projectKey?: string;
+  /** Current git worktree root, or undefined outside git. Not a stand-in for `projectRoot` — a monorepo's project is routinely a subdirectory of the repo. */
+  repoRoot?: string;
+  /** The repository's main working tree, or undefined outside git — same regardless of which worktree resolved it. */
+  mainRepoRoot?: string;
+  /** Where `sonar integrate` was run for the matched mapping/feature (its own `targetRoot`), possibly a different worktree; undefined when nothing in state matched. */
+  integrationDir?: string;
   /** Config files that contributed to the discovered project, in order found. */
   configSources: string[];
 }
@@ -74,76 +93,44 @@ export interface SonarProperties {
   organization: string;
 }
 
-/**
- * Try to find server URL from project configs
- */
+/** Same nearest-first climb as discoverProject()'s local-config source — no known-mapping table, no git-remote API call, since this also runs pre-login (no token yet). */
+async function discoverLocalConfig(
+  startDir: string,
+  silent: boolean,
+): Promise<Pick<DiscoveredProject, 'serverUrl' | 'organization'>> {
+  const config: DiscoveredProject = { projectRoot: canonicalizePath(startDir), configSources: [] };
+  const lookupPaths = await resolveLookupPaths(startDir);
+  await applyLocalConfigAcrossLookupPaths(config, lookupPaths, silent);
+  return config;
+}
+
+/** Try to find server URL from project configs. */
 export async function discoverServer(): Promise<string | null> {
   try {
-    const projectInfo = await discoverProjectInfo(process.cwd());
-
-    // Check sonar-project.properties first
-    if (projectInfo.sonarPropsData?.hostURL) {
-      const url = projectInfo.sonarPropsData.hostURL;
-      print(`Found server in sonar-project.properties: ${url}`);
-      return url;
-    }
-
-    // Check .sonarlint config
-    if (projectInfo.sonarLintData?.serverURL) {
-      const url = projectInfo.sonarLintData.serverURL;
-      print(`Found server in .sonarlint config: ${url}`);
-      return url;
-    }
-
-    return null;
+    const { serverUrl } = await discoverLocalConfig(process.cwd(), false);
+    return serverUrl ?? null;
   } catch (error) {
     logger.debug(`Error finding server in configs: ${(error as Error).message}`);
     return null;
   }
 }
 
-/**
- * Try to find organization from project configs
- */
+/** Try to find organization from project configs. */
 export async function discoverOrganization(): Promise<string | null> {
   try {
-    const projectInfo = await discoverProjectInfo(process.cwd());
-
-    // Check sonar-project.properties
-    if (projectInfo.sonarPropsData?.organization) {
-      return projectInfo.sonarPropsData.organization;
-    }
-
-    // Check .sonarlint config
-    if (projectInfo.sonarLintData?.organization) {
-      return projectInfo.sonarLintData.organization;
-    }
-
-    return null;
+    const { organization } = await discoverLocalConfig(process.cwd(), true);
+    return organization ?? null;
   } catch {
     return null;
   }
 }
 
-export async function discoverProjectInfo(startDir: string): Promise<ProjectInfo> {
-  const { gitRoot, isGit } = findGitRoot(startDir);
-
-  const projectRoot = canonicalizePath(isGit ? gitRoot : startDir);
-  const projectName = basename(projectRoot);
-
-  let gitRemote = '';
-  if (isGit) {
-    gitRemote = await getGitRemote(projectRoot);
-  }
-
-  const sonarProps = await loadSonarProperties(projectRoot);
-  const sonarLintLoaded = await loadSonarLintConfig(projectRoot);
+/** Loads sonar-project.properties/.sonarlint from exactly `dir` — no git, no root resolution. */
+async function loadLocalProjectConfig(dir: string): Promise<LocalProjectConfig> {
+  const sonarProps = await loadSonarProperties(dir);
+  const sonarLintLoaded = await loadSonarLintConfig(dir);
 
   return {
-    root: projectRoot,
-    name: projectName,
-    isGitRepo: isGit,
-    gitRemote,
     hasSonarProps: sonarProps !== null,
     sonarPropsData: sonarProps,
     hasSonarLintConfig: sonarLintLoaded !== null,
@@ -152,53 +139,50 @@ export async function discoverProjectInfo(startDir: string): Promise<ProjectInfo
   };
 }
 
+/**
+ * Tries each source in turn — known-server-project-mapping, then local config files, then
+ * git-remote binding (a single repo-level last resort) — with the first two walking the
+ * same nearest-first `resolveLookupPaths` list, so "closer wins" uniformly.
+ */
 export async function discoverProject(
   startDir: string,
   silent = false,
   options: DiscoverProjectOptions = {},
 ): Promise<DiscoveredProject> {
-  const projectInfo = await discoverProjectInfo(startDir);
+  const invocationDir = canonicalizePath(startDir);
   const config: DiscoveredProject = {
-    rootDir: projectInfo.root,
-    isGitRepo: projectInfo.isGitRepo,
+    projectRoot: invocationDir, // stay in place unless a source below resolves something more specific
     configSources: [],
   };
 
-  if (projectInfo.hasSonarProps && projectInfo.sonarPropsData) {
-    config.configSources.push('sonar-project.properties');
-    config.serverUrl = projectInfo.sonarPropsData.hostURL;
-    config.projectKey = projectInfo.sonarPropsData.projectKey;
-    config.organization = projectInfo.sonarPropsData.organization;
-    if (!silent) {
-      const fields = formatConfigFields(config.serverUrl, config.projectKey, config.organization);
-      if (fields) {
-        print(`Found sonar-project.properties: ${fields}`);
-      }
-    }
-  }
+  try {
+    const { gitRoot, isGit } = findGitRoot(startDir);
+    const repoRoot = isGit ? canonicalizePath(gitRoot) : undefined;
+    config.repoRoot = repoRoot;
 
-  if (
-    projectInfo.hasSonarLintConfig &&
-    projectInfo.sonarLintData &&
-    projectInfo.sonarLintConfigPath
-  ) {
-    config.configSources.push(projectInfo.sonarLintConfigPath);
-    config.serverUrl = config.serverUrl || projectInfo.sonarLintData.serverURL;
-    config.projectKey = config.projectKey || projectInfo.sonarLintData.projectKey;
-    config.organization = config.organization || projectInfo.sonarLintData.organization;
-    if (!silent) {
-      const fields = formatConfigFields(
-        projectInfo.sonarLintData.serverURL,
-        projectInfo.sonarLintData.projectKey,
-        projectInfo.sonarLintData.organization,
-      );
-      if (fields) {
-        print(`Found ${projectInfo.sonarLintConfigPath}: ${fields}`);
-      }
-    }
-  }
+    const lookupPaths = await resolveLookupPaths(startDir);
+    logger.debug(
+      `Project discovery lookup paths (nearest first): ${lookupPaths.map((p) => p.checkPath).join(', ')}`,
+    );
 
-  await applyGitRemoteBindingFromRemote(config, projectInfo, options, silent);
+    // Cache hit, not a second spawn: resolveLookupPaths() already resolved this above.
+    config.mainRepoRoot = isGit
+      ? ((await resolveMainWorktreeRoot(invocationDir)) ?? repoRoot)
+      : undefined;
+
+    const resolved =
+      applyKnownServerProjectMapping(config, lookupPaths, silent, options.auth) ||
+      (await applyLocalConfigAcrossLookupPaths(config, lookupPaths, silent));
+
+    if (!resolved) {
+      const gitRemote = repoRoot ? await getGitRemote(repoRoot) : '';
+      await applyGitRemoteBindingFromRemote(config, gitRemote, options, silent);
+    }
+  } catch (error) {
+    // No caller treats this as fallible — degrade to whatever was already resolved
+    // rather than throwing out of a git hook, agent hook, or long-running MCP server.
+    logger.debug(`Project discovery failed, returning partial result: ${(error as Error).message}`);
+  }
 
   return config;
 }
@@ -235,14 +219,175 @@ export async function resolveProjectKey(
   });
 }
 
+function applyLocalSonarProperties(
+  config: DiscoveredProject,
+  local: LocalProjectConfig,
+  silent: boolean,
+): void {
+  if (!local.hasSonarProps || !local.sonarPropsData) {
+    return;
+  }
+
+  config.configSources.push('sonar-project.properties');
+  config.serverUrl = local.sonarPropsData.hostURL;
+  config.projectKey = local.sonarPropsData.projectKey;
+  config.organization = local.sonarPropsData.organization;
+
+  if (silent) {
+    return;
+  }
+  const fields = formatConfigFields(config.serverUrl, config.projectKey, config.organization);
+  if (fields) {
+    print(`Found sonar-project.properties: ${fields}`);
+  }
+}
+
+/** Returns true once `config.projectKey` is resolved, so the caller can stop checking further sources. */
+function applySonarLintConfig(
+  config: DiscoveredProject,
+  local: LocalProjectConfig,
+  silent: boolean,
+): boolean {
+  if (!local.hasSonarLintConfig || !local.sonarLintData || !local.sonarLintConfigPath) {
+    return !!config.projectKey;
+  }
+
+  config.configSources.push(local.sonarLintConfigPath);
+  config.serverUrl = config.serverUrl || local.sonarLintData.serverURL;
+  config.projectKey = config.projectKey || local.sonarLintData.projectKey;
+  config.organization = config.organization || local.sonarLintData.organization;
+
+  if (!silent) {
+    const fields = formatConfigFields(
+      local.sonarLintData.serverURL,
+      local.sonarLintData.projectKey,
+      local.sonarLintData.organization,
+    );
+    if (fields) {
+      print(`Found ${local.sonarLintConfigPath}: ${fields}`);
+    }
+  }
+
+  return !!config.projectKey;
+}
+
+/** Walks `lookupPaths` nearest-first for a `sonar-project.properties`/`.sonarlint` hit; a partial match doesn't stop the climb. */
+async function applyLocalConfigAcrossLookupPaths(
+  config: DiscoveredProject,
+  lookupPaths: LookupPath[],
+  silent: boolean,
+): Promise<boolean> {
+  for (const { checkPath, projectRoot } of lookupPaths) {
+    let local: LocalProjectConfig;
+    try {
+      local = await loadLocalProjectConfig(checkPath);
+    } catch (error) {
+      // e.g. EACCES on a directory further up the climb — don't let one unreadable
+      // path abort discovery for the whole call, same as the other two sources.
+      logger.debug(`Local config lookup skipped for ${checkPath}: ${(error as Error).message}`);
+      continue;
+    }
+    if (!local.hasSonarProps && !local.hasSonarLintConfig) {
+      continue;
+    }
+
+    applyLocalSonarProperties(config, local, silent);
+    if (applySonarLintConfig(config, local, silent)) {
+      config.projectRoot = projectRoot;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function matchKnownServerProjectMapping(
+  lookupPaths: LookupPath[],
+  mappings: KnownServerProjectMapping[],
+): FeatureMatch<KnownServerProjectMapping> | undefined {
+  if (mappings.length === 0) {
+    return undefined;
+  }
+
+  const candidates: RecordedFeatureCandidate<KnownServerProjectMapping>[] = mappings.map(
+    (mapping) => ({
+      feature: mapping,
+      targetRoot: mapping.targetRoot,
+      repoRoot: mapping.repoRoot,
+      updatedAt: mapping.updatedAt,
+    }),
+  );
+
+  return selectFeatureForLookupPaths(candidates, lookupPaths);
+}
+
+/** Prefers the caller's own resolved auth over state, so per-invocation env-var auth resolves correctly even if it hasn't been persisted yet. */
+function resolveMappingConnection(
+  mapping: KnownServerProjectMapping,
+  state: CliState,
+  auth?: ResolvedAuth | null,
+): { serverUrl: string | undefined; orgKey: string | undefined } {
+  if (mapping.serverUrl) {
+    return { serverUrl: mapping.serverUrl, orgKey: mapping.orgKey };
+  }
+  if (auth) {
+    return { serverUrl: auth.serverUrl, orgKey: auth.orgKey };
+  }
+  const activeConnection = getActiveConnection(state);
+  return { serverUrl: activeConnection?.serverUrl, orgKey: activeConnection?.orgKey };
+}
+
+/** Derives mappings live from installed features, then matches once so the nearest wins. */
+function applyKnownServerProjectMapping(
+  config: DiscoveredProject,
+  lookupPaths: LookupPath[],
+  silent: boolean,
+  auth?: ResolvedAuth | null,
+): boolean {
+  let state: CliState;
+  try {
+    state = loadState();
+  } catch (error) {
+    logger.debug(`Known project mapping lookup skipped: ${(error as Error).message}`);
+    return false;
+  }
+
+  const mappings = buildKnownServerProjectMappings(state);
+  const match = matchKnownServerProjectMapping(lookupPaths, mappings);
+  if (!match) {
+    return false;
+  }
+
+  const { serverUrl, orgKey } = resolveMappingConnection(match.feature, state, auth);
+  if (!serverUrl) {
+    return false;
+  }
+
+  config.configSources.push(KNOWN_SERVER_PROJECT_MAPPING_SOURCE);
+  config.projectKey = match.feature.projectKey;
+  config.serverUrl = serverUrl;
+  config.organization = orgKey;
+  config.projectRoot = match.matchedPath;
+  config.integrationDir = match.feature.targetRoot;
+
+  if (!silent) {
+    const fields = formatConfigFields(config.serverUrl, config.projectKey, config.organization);
+    if (fields) {
+      print(`Found ${KNOWN_SERVER_PROJECT_MAPPING_SOURCE}: ${fields}`);
+    }
+  }
+
+  return true;
+}
+
 async function applyGitRemoteBindingFromRemote(
   config: DiscoveredProject,
-  projectInfo: ProjectInfo,
+  gitRemote: string,
   options: DiscoverProjectOptions,
   silent: boolean,
 ): Promise<void> {
   const tryGitRemoteBinding = options.tryGitRemoteBinding !== false;
-  if (!tryGitRemoteBinding || config.projectKey || !projectInfo.gitRemote) {
+  if (!tryGitRemoteBinding || !gitRemote) {
     return;
   }
 
@@ -251,7 +396,7 @@ async function applyGitRemoteBindingFromRemote(
     return;
   }
 
-  const remoteBinding = await discoverProjectKeyByGitRemote(auth, projectInfo.gitRemote);
+  const remoteBinding = await discoverProjectKeyByGitRemote(auth, gitRemote);
   if (!remoteBinding) {
     return;
   }

--- a/src/core/project-info.ts
+++ b/src/core/project-info.ts
@@ -84,6 +84,8 @@ export interface DiscoverProjectOptions {
   auth?: ResolvedAuth | null;
   /** When false, skips server lookup even if a git remote is present. Defaults to true. */
   tryGitRemoteBinding?: boolean;
+  /** Suppresses the "Found ..." stderr hints. Defaults to false. */
+  silent?: boolean;
 }
 
 export interface SonarProperties {
@@ -100,7 +102,7 @@ async function discoverLocalConfig(
 ): Promise<Pick<DiscoveredProject, 'serverUrl' | 'organization'>> {
   const config: DiscoveredProject = { projectRoot: canonicalizePath(startDir), configSources: [] };
   const lookupPaths = await resolveLookupPaths(startDir);
-  await applyLocalConfigAcrossLookupPaths(config, lookupPaths, silent);
+  await applyLocalConfigAcrossLookupPaths(config, lookupPaths, { silent });
   return config;
 }
 
@@ -146,7 +148,6 @@ async function loadLocalProjectConfig(dir: string): Promise<LocalProjectConfig> 
  */
 export async function discoverProject(
   startDir: string,
-  silent = false,
   options: DiscoverProjectOptions = {},
 ): Promise<DiscoveredProject> {
   const invocationDir = canonicalizePath(startDir);
@@ -173,12 +174,12 @@ export async function discoverProject(
 
     const resolved =
       (knownMappings !== undefined &&
-        applyKnownServerProjectMapping(config, lookupPaths, knownMappings, silent, options.auth)) ||
-      (await applyLocalConfigAcrossLookupPaths(config, lookupPaths, silent));
+        applyKnownServerProjectMapping(config, lookupPaths, knownMappings, options)) ||
+      (await applyLocalConfigAcrossLookupPaths(config, lookupPaths, options));
 
     if (!resolved) {
       const gitRemote = repoRoot ? await getGitRemote(repoRoot) : '';
-      await applyGitRemoteBindingFromRemote(config, gitRemote, options, silent);
+      await applyGitRemoteBindingFromRemote(config, gitRemote, options);
     }
   } catch (error) {
     // No caller treats this as fallible — degrade to whatever was already resolved
@@ -207,7 +208,7 @@ export async function resolveProjectKey(
     return explicitProject;
   }
 
-  const discovered = await discoverProject(process.cwd(), true, { auth });
+  const discovered = await discoverProject(process.cwd(), { auth, silent: true });
   if (discovered.projectKey) {
     if (!silent) {
       print(`     Using auto-detected project key: ${discovered.projectKey}`, 'stderr');
@@ -224,7 +225,7 @@ export async function resolveProjectKey(
 function applyLocalSonarProperties(
   config: DiscoveredProject,
   local: LocalProjectConfig,
-  silent: boolean,
+  options: DiscoverProjectOptions,
 ): void {
   if (!local.hasSonarProps || !local.sonarPropsData) {
     return;
@@ -235,7 +236,7 @@ function applyLocalSonarProperties(
   config.projectKey = local.sonarPropsData.projectKey;
   config.organization = local.sonarPropsData.organization;
 
-  if (silent) {
+  if (options.silent) {
     return;
   }
   const fields = formatConfigFields(config.serverUrl, config.projectKey, config.organization);
@@ -248,7 +249,7 @@ function applyLocalSonarProperties(
 function applySonarLintConfig(
   config: DiscoveredProject,
   local: LocalProjectConfig,
-  silent: boolean,
+  options: DiscoverProjectOptions,
 ): boolean {
   if (!local.hasSonarLintConfig || !local.sonarLintData || !local.sonarLintConfigPath) {
     return !!config.projectKey;
@@ -259,7 +260,7 @@ function applySonarLintConfig(
   config.projectKey = config.projectKey || local.sonarLintData.projectKey;
   config.organization = config.organization || local.sonarLintData.organization;
 
-  if (!silent) {
+  if (!options.silent) {
     const fields = formatConfigFields(
       local.sonarLintData.serverURL,
       local.sonarLintData.projectKey,
@@ -277,7 +278,7 @@ function applySonarLintConfig(
 async function applyLocalConfigAcrossLookupPaths(
   config: DiscoveredProject,
   lookupPaths: LookupPath[],
-  silent: boolean,
+  options: DiscoverProjectOptions,
 ): Promise<boolean> {
   for (const { checkPath, projectRoot } of lookupPaths) {
     let local: LocalProjectConfig;
@@ -293,8 +294,8 @@ async function applyLocalConfigAcrossLookupPaths(
       continue;
     }
 
-    applyLocalSonarProperties(config, local, silent);
-    if (applySonarLintConfig(config, local, silent)) {
+    applyLocalSonarProperties(config, local, options);
+    if (applySonarLintConfig(config, local, options)) {
       config.projectRoot = projectRoot;
       return true;
     }
@@ -367,15 +368,14 @@ function applyKnownServerProjectMapping(
   config: DiscoveredProject,
   lookupPaths: LookupPath[],
   known: KnownMappingsResult,
-  silent: boolean,
-  auth?: ResolvedAuth | null,
+  options: DiscoverProjectOptions,
 ): boolean {
   const match = matchKnownServerProjectMapping(lookupPaths, known.mappings);
   if (!match) {
     return false;
   }
 
-  const { serverUrl, orgKey } = resolveMappingConnection(match.feature, known.state, auth);
+  const { serverUrl, orgKey } = resolveMappingConnection(match.feature, known.state, options.auth);
   if (!serverUrl) {
     return false;
   }
@@ -387,7 +387,7 @@ function applyKnownServerProjectMapping(
   config.projectRoot = match.matchedPath;
   config.integrationDir = match.feature.targetRoot;
 
-  if (!silent) {
+  if (!options.silent) {
     const fields = formatConfigFields(config.serverUrl, config.projectKey, config.organization);
     if (fields) {
       print(`Found ${KNOWN_SERVER_PROJECT_MAPPING_SOURCE}: ${fields}`);
@@ -401,7 +401,6 @@ async function applyGitRemoteBindingFromRemote(
   config: DiscoveredProject,
   gitRemote: string,
   options: DiscoverProjectOptions,
-  silent: boolean,
 ): Promise<void> {
   const tryGitRemoteBinding = options.tryGitRemoteBinding !== false;
   if (!tryGitRemoteBinding || !gitRemote) {
@@ -423,7 +422,7 @@ async function applyGitRemoteBindingFromRemote(
   config.projectKey = remoteBinding.projectKey;
   config.organization = config.organization || remoteBinding.organization;
 
-  if (silent) {
+  if (options.silent) {
     return;
   }
 

--- a/src/core/project-info.ts
+++ b/src/core/project-info.ts
@@ -160,7 +160,8 @@ export async function discoverProject(
     const repoRoot = isGit ? canonicalizePath(gitRoot) : undefined;
     config.repoRoot = repoRoot;
 
-    const lookupPaths = await resolveLookupPaths(startDir);
+    const knownMappings = loadKnownMappings();
+    const lookupPaths = await resolveLookupPaths(startDir, collectKnownRoots(knownMappings));
     logger.debug(
       `Project discovery lookup paths (nearest first): ${lookupPaths.map((p) => p.checkPath).join(', ')}`,
     );
@@ -171,7 +172,8 @@ export async function discoverProject(
       : undefined;
 
     const resolved =
-      applyKnownServerProjectMapping(config, lookupPaths, silent, options.auth) ||
+      (knownMappings !== undefined &&
+        applyKnownServerProjectMapping(config, lookupPaths, knownMappings, silent, options.auth)) ||
       (await applyLocalConfigAcrossLookupPaths(config, lookupPaths, silent));
 
     if (!resolved) {
@@ -337,28 +339,43 @@ function resolveMappingConnection(
   return { serverUrl: activeConnection?.serverUrl, orgKey: activeConnection?.orgKey };
 }
 
-/** Derives mappings live from installed features, then matches once so the nearest wins. */
+interface KnownMappingsResult {
+  state: CliState;
+  mappings: KnownServerProjectMapping[];
+}
+
+/** Loaded upfront so `discoverProject()` can derive knownRoots and share one lookupPaths list. */
+function loadKnownMappings(): KnownMappingsResult | undefined {
+  try {
+    const state = loadState();
+    return { state, mappings: buildKnownServerProjectMappings(state) };
+  } catch (error) {
+    logger.debug(`Known project mapping lookup skipped: ${(error as Error).message}`);
+    return undefined;
+  }
+}
+
+/** Passed raw to resolveLookupPaths() — it picks the shallowest matching one itself. */
+function collectKnownRoots(known: KnownMappingsResult | undefined): string[] {
+  return (known?.mappings ?? []).flatMap((mapping) =>
+    mapping.repoRoot ? [mapping.targetRoot, mapping.repoRoot] : [mapping.targetRoot],
+  );
+}
+
+/** Matches against mappings derived live from installed features, caller-loaded once above. */
 function applyKnownServerProjectMapping(
   config: DiscoveredProject,
   lookupPaths: LookupPath[],
+  known: KnownMappingsResult,
   silent: boolean,
   auth?: ResolvedAuth | null,
 ): boolean {
-  let state: CliState;
-  try {
-    state = loadState();
-  } catch (error) {
-    logger.debug(`Known project mapping lookup skipped: ${(error as Error).message}`);
-    return false;
-  }
-
-  const mappings = buildKnownServerProjectMappings(state);
-  const match = matchKnownServerProjectMapping(lookupPaths, mappings);
+  const match = matchKnownServerProjectMapping(lookupPaths, known.mappings);
   if (!match) {
     return false;
   }
 
-  const { serverUrl, orgKey } = resolveMappingConnection(match.feature, state, auth);
+  const { serverUrl, orgKey } = resolveMappingConnection(match.feature, known.state, auth);
   if (!serverUrl) {
     return false;
   }

--- a/src/core/time/timestamp.ts
+++ b/src/core/time/timestamp.ts
@@ -1,0 +1,28 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/** Parses an ISO timestamp to epoch millis; missing or unparseable sorts as oldest (0). */
+export function parseTimestampMillis(iso: string | undefined): number {
+  if (iso === undefined) {
+    return 0;
+  }
+  const parsed = Date.parse(iso);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}

--- a/tests/integration/specs/context/passthrough.test.ts
+++ b/tests/integration/specs/context/passthrough.test.ts
@@ -26,13 +26,13 @@ import { dirname, join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, setDefaultTimeout } from 'bun:test';
 
+import { CONTEXT_AUGMENTATION_FEATURE_ID } from '@/commands/integrate/_common/features/context-augmentation-feature.ts';
+import { VORTEX_FEATURE_ID } from '@/commands/integrate/_common/vortex.ts';
+import { CLAUDE_INTEGRATION_ID } from '@/commands/integrate/claude/declaration.ts';
+import { COPILOT_INTEGRATION_ID } from '@/commands/integrate/copilot/declaration.ts';
 import { canonicalizePath } from '@/core/io/fs-utils.ts';
 import type { CliState, InstalledIntegrationFeature } from '@/core/state/state.ts';
 
-import { CONTEXT_AUGMENTATION_FEATURE_ID } from '../../../../src/commands/integrate/_common/features/context-augmentation-feature';
-import { VORTEX_FEATURE_ID } from '../../../../src/commands/integrate/_common/vortex';
-import { CLAUDE_INTEGRATION_ID } from '../../../../src/commands/integrate/claude/declaration';
-import { COPILOT_INTEGRATION_ID } from '../../../../src/commands/integrate/copilot/declaration';
 import { TestHarness } from '../../harness';
 import {
   type CagInvocation,
@@ -53,6 +53,11 @@ function findInvocation(invocations: CagInvocation[], argv: string[]): CagInvoca
   return match;
 }
 
+/**
+ * Records a project-scoped installed feature so `discoverProject()`'s live known-mapping
+ * derivation (`buildKnownServerProjectMappings`, reading `integrations.installed`) picks it
+ * up — there is no persisted `state.knownServerProjectMappings` table on this branch.
+ */
 function appendRecordedCagFeature(
   state: CliState,
   args: {
@@ -267,7 +272,7 @@ describe('sonar context passthrough', () => {
   );
 
   it(
-    'resolves context from a recorded Vortex feature',
+    'resolves context from a recorded known-server-project mapping',
     async () => {
       const server = await harness.newFakeServer().start();
       const serverUrl = server.baseUrl();
@@ -300,13 +305,18 @@ describe('sonar context passthrough', () => {
   );
 
   it(
-    'matches on the recorded repoRoot when targetRoot points at a different worktree',
+    'resolves a mapping via its repoRoot signal when invoked from a linked worktree',
     async () => {
-      // Simulates integrate having run inside worktree-A (targetRoot = that worktree),
-      // while repoRoot records the stable main working tree. Running from the main
-      // tree must still resolve via repoRoot even though cwd is not inside targetRoot.
+      // The mapping's targetRoot points at a different (unrelated) physical location,
+      // so this can only resolve through the repoRoot fallback signal — proving the two
+      // stay distinct instead of collapsing into a single "folder".
       const server = await harness.newFakeServer().start();
       const serverUrl = server.baseUrl();
+      initGitRepo(harness.cwd.path);
+      commitFile(harness.cwd.path, 'README.md', '# test\n');
+      const worktreePath = join(dirname(harness.cwd.path), 'linked-worktree');
+      git(['worktree', 'add', worktreePath, '-b', 'feature/repo-root-fallback'], harness.cwd.path);
+
       const stateBuilder = harness
         .state()
         .withAuth(serverUrl, 'main-token', ORG_KEY)
@@ -314,16 +324,16 @@ describe('sonar context passthrough', () => {
       const state = stateBuilder.build();
       appendRecordedCagFeature(state, {
         integrationId: CLAUDE_INTEGRATION_ID,
-        targetRoot: join(dirname(harness.cwd.path), 'some-other-worktree'),
+        targetRoot: join(dirname(harness.cwd.path), 'other-physical-location'),
         repoRoot: harness.cwd.path,
-        updatedAt: '2026-03-01T00:00:00.000Z',
+        updatedAt: new Date().toISOString(),
         projectKey: PROJECT_KEY,
         orgKey: ORG_KEY,
         serverUrl,
       });
       stateBuilder.withRawState(JSON.stringify(state, null, 2));
 
-      const result = await harness.run('context status');
+      const result = await harness.run('context status', { cwd: worktreePath });
 
       expect(result.exitCode).toBe(0);
       const invocation = findInvocation(readInvocations(harness), ['status']);
@@ -335,53 +345,7 @@ describe('sonar context passthrough', () => {
   );
 
   it(
-    'prefers a targetRoot match over a more recent repoRoot-only match',
-    async () => {
-      // Two worktrees integrated with different project keys, both recording the
-      // same main working tree as repoRoot. Running from the main tree, the
-      // feature whose targetRoot IS the main tree must win over a sibling that
-      // only shares the repoRoot — even though the sibling was updated later, so
-      // recency alone would pick the wrong one.
-      const server = await harness.newFakeServer().start();
-      const serverUrl = server.baseUrl();
-      const stateBuilder = harness
-        .state()
-        .withAuth(serverUrl, 'main-token', ORG_KEY)
-        .withContextAugmentationBinaryInstalled();
-      const state = stateBuilder.build();
-      // repoRoot-only match, integrated in a sibling worktree, updated LATER.
-      appendRecordedCagFeature(state, {
-        integrationId: CLAUDE_INTEGRATION_ID,
-        targetRoot: join(dirname(harness.cwd.path), 'some-other-worktree'),
-        repoRoot: harness.cwd.path,
-        updatedAt: '2026-02-01T00:00:00.000Z',
-        projectKey: 'wrong-worktree-project',
-        orgKey: ORG_KEY,
-        serverUrl,
-      });
-      // Exact targetRoot match for the current directory, updated EARLIER.
-      appendRecordedCagFeature(state, {
-        integrationId: COPILOT_INTEGRATION_ID,
-        targetRoot: harness.cwd.path,
-        repoRoot: harness.cwd.path,
-        updatedAt: '2026-01-01T00:00:00.000Z',
-        projectKey: 'right-here-project',
-        orgKey: ORG_KEY,
-        serverUrl,
-      });
-      stateBuilder.withRawState(JSON.stringify(state, null, 2));
-
-      const result = await harness.run('context status');
-
-      expect(result.exitCode).toBe(0);
-      const invocation = findInvocation(readInvocations(harness), ['status']);
-      expect(invocation.env.SONAR_CONTEXT_PROJECT).toBe('right-here-project');
-    },
-    { timeout: 30000 },
-  );
-
-  it(
-    'uses the latest recorded CAG feature when multiple entries share the same project root',
+    'uses the latest recorded mapping when multiple entries share the same project root',
     async () => {
       const server = await harness.newFakeServer().start();
       const serverUrl = server.baseUrl();

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -315,7 +315,7 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness);
 
-      // No .git directory — discoverProject() sets isGitRepo: false
+      // No .git directory — discoverProject() leaves repoRoot undefined
       const result = await harness.run('integrate git --non-interactive');
 
       expect(result.exitCode).toBe(1);

--- a/tests/integration/specs/project-workspace/sonarlint-connected-mode.test.ts
+++ b/tests/integration/specs/project-workspace/sonarlint-connected-mode.test.ts
@@ -24,12 +24,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 import { SONARCLOUD_URL } from '@/core/config-constants.ts';
-import {
-  discoverOrganization,
-  discoverProject,
-  discoverProjectInfo,
-  discoverServer,
-} from '@/core/project-info.ts';
+import { discoverOrganization, discoverProject, discoverServer } from '@/core/project-info.ts';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 
 import { TestHarness } from '../../harness';
@@ -63,7 +58,7 @@ describe('Project workspace + SonarLint (harness)', () => {
   }
 
   it(
-    'discoverProjectInfo and discoverProject read SonarQube Server binding from .sonarlint',
+    'discoverProject reads SonarQube Server binding from .sonarlint',
     async () => {
       const root = projectRoot('sq-server');
       mkdirSync(join(root, '.sonarlint'), { recursive: true });
@@ -75,16 +70,6 @@ describe('Project workspace + SonarLint (harness)', () => {
         }),
       );
 
-      const info = await discoverProjectInfo(root);
-      expect(info.root).toBeDefined();
-      expect(info.hasSonarLintConfig).toBe(true);
-      expect(info.sonarLintConfigPath).toBe(join('.sonarlint', 'connectedMode.json'));
-      expect(info.sonarLintData).toMatchObject({
-        serverURL: 'https://sonarqube.example.com',
-        projectKey: 'my_server_project',
-      });
-      expect(info.sonarLintData?.organization).toBeUndefined();
-
       const discovered = await discoverProject(root);
       expect(discovered.serverUrl).toBe('https://sonarqube.example.com');
       expect(discovered.projectKey).toBe('my_server_project');
@@ -95,7 +80,7 @@ describe('Project workspace + SonarLint (harness)', () => {
   );
 
   it(
-    'discoverProjectInfo and discoverProject read SonarQube Cloud binding from .sonarlint',
+    'discoverProject reads SonarQube Cloud binding from .sonarlint',
     async () => {
       const root = projectRoot('sq-cloud');
       mkdirSync(join(root, '.sonarlint'), { recursive: true });
@@ -106,12 +91,6 @@ describe('Project workspace + SonarLint (harness)', () => {
           projectKey: 'cloud_project_key',
         }),
       );
-
-      const info = await discoverProjectInfo(root);
-      expect(info.hasSonarLintConfig).toBe(true);
-      expect(info.sonarLintData?.serverURL).toBe(SONARCLOUD_URL);
-      expect(info.sonarLintData?.organization).toBe('my-org');
-      expect(info.sonarLintData?.projectKey).toBe('cloud_project_key');
 
       const discovered = await discoverProject(root);
       expect(discovered.serverUrl).toBe(SONARCLOUD_URL);
@@ -135,11 +114,8 @@ describe('Project workspace + SonarLint (harness)', () => {
         }),
       );
 
-      const info = await discoverProjectInfo(root);
-      expect(info.sonarLintConfigPath).toBe(join('.sonarlint', 'MySolution.json'));
-      expect(info.sonarLintData?.projectKey).toBe('acme_solution');
-
       const discovered = await discoverProject(root);
+      expect(discovered.configSources).toEqual([join('.sonarlint', 'MySolution.json')]);
       expect(discovered.projectKey).toBe('acme_solution');
       expect(discovered.organization).toBe('acme');
     },
@@ -147,29 +123,30 @@ describe('Project workspace + SonarLint (harness)', () => {
   );
 
   it(
-    'discoverProjectInfo reports no SonarLint config when .sonarlint is missing',
+    'discoverProject finds no SonarLint config when .sonarlint is missing',
     async () => {
       const root = projectRoot('no-sonarlint');
       mkdirSync(root, { recursive: true });
 
-      const info = await discoverProjectInfo(root);
-      expect(info.hasSonarLintConfig).toBe(false);
-      expect(info.sonarLintData).toBeNull();
-      expect(info.sonarLintConfigPath).toBeNull();
+      const discovered = await discoverProject(root);
+      expect(discovered.serverUrl).toBeUndefined();
+      expect(discovered.projectKey).toBeUndefined();
+      expect(discovered.configSources).toEqual([]);
     },
     { timeout: 15000 },
   );
 
   it(
-    'discoverProjectInfo reports no SonarLint config when .sonarlint has no binding JSON',
+    'discoverProject finds no SonarLint config when .sonarlint has no binding JSON',
     async () => {
       const root = projectRoot('empty-sonarlint');
       mkdirSync(join(root, '.sonarlint'), { recursive: true });
       writeFileSync(join(root, '.sonarlint', 'notes.txt'), 'not json');
 
-      const info = await discoverProjectInfo(root);
-      expect(info.hasSonarLintConfig).toBe(false);
-      expect(info.sonarLintData).toBeNull();
+      const discovered = await discoverProject(root);
+      expect(discovered.serverUrl).toBeUndefined();
+      expect(discovered.projectKey).toBeUndefined();
+      expect(discovered.configSources).toEqual([]);
     },
     { timeout: 15000 },
   );
@@ -212,10 +189,13 @@ describe('Project workspace + SonarLint (harness)', () => {
       });
 
       expect(
-        getMockUiCalls().some(
-          (c) =>
-            c.method === 'print' && String(c.args[0]).includes('Found server in .sonarlint config'),
-        ),
+        getMockUiCalls().some((c) => {
+          if (c.method !== 'print') return false;
+          const message = String(c.args[0]);
+          return (
+            message.includes('.sonarlint') && message.includes('https://sonarqube.from-lint.test')
+          );
+        }),
       ).toBe(true);
     },
     { timeout: 15000 },

--- a/tests/unit/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/commands/analyze/analyze-sqaa.test.ts
@@ -20,7 +20,6 @@
 
 // Unit tests for analyzeSqaa command
 
-import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
@@ -28,16 +27,15 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { CommandAuthenticatedInvocationContext } from '@/commands/command-invocation-context.ts';
 import { CommandFailedError, InvalidOptionError } from '@/core/command-error.ts';
 import * as processLib from '@/core/process/process.ts';
+import * as projectInfo from '@/core/project-info.ts';
 import { SonarQubeClient } from '@/core/server/client.ts';
-import { CliState, getDefaultState } from '@/core/state/state.ts';
+import { getDefaultState } from '@/core/state/state.ts';
 import * as stateManager from '@/core/state/state-manager.ts';
 import * as stateRepository from '@/core/state/state-repository.ts';
 import { clearMockUiCalls, getMockUiCalls, setMockTty, setMockUi } from '@/core/ui';
 
 import { analyzeSqaa, buildSqaaJsonReport } from '../../../../src/commands/analyze/sqaa.ts';
 import * as changesetModule from '../../../../src/commands/analyze/sqaa-changeset.ts';
-import { SQAA_HOOK_FEATURE_ID } from '../../../../src/commands/integrate/_common/features/sqaa-instructions-feature.ts';
-import { CLAUDE_INTEGRATION_ID } from '../../../../src/commands/integrate/claude/declaration.ts';
 
 const SONARCLOUD_URL = 'https://sonarcloud.io';
 const TEST_ORG = 'test-org';
@@ -62,46 +60,25 @@ let statSyncSpy: ReturnType<typeof spyOn>;
 let readFileSpy: ReturnType<typeof spyOn>;
 let createAnalysisSpy: ReturnType<typeof spyOn>;
 let spawnProcessSpy: ReturnType<typeof spyOn>;
+let discoverProjectSpy: ReturnType<typeof spyOn>;
 
-/**
- * Seed a declarative Claude Code integration whose project-scoped
- * `sonar-sqaa-hook` feature carries the given `projectKey` attr (or none).
- */
-function seedClaudeSqaaFeature(state: CliState, projectKey: string | undefined) {
-  const now = new Date().toISOString();
-  state.integrations.installed.push({
-    id: randomUUID(),
-    integrationId: CLAUDE_INTEGRATION_ID,
-    installedByCliVersion: '1.0.0',
-    installedAt: now,
-    updatedByCliVersion: '1.0.0',
-    updatedAt: now,
-    features: [
-      {
-        featureId: SQAA_HOOK_FEATURE_ID,
-        scope: 'project',
-        targetRoot: process.cwd(),
-        installedByCliVersion: '1.0.0',
-        installedAt: now,
-        updatedByCliVersion: '1.0.0',
-        updatedAt: now,
-        dependencies: [],
-        resources: [],
-        operations: [],
-        attrs: projectKey === undefined ? {} : { projectKey },
-      },
-    ],
-  });
-}
-
-/** Cloud state WITH a sonar-sqaa hook feature for the current project root */
+/** Cloud state (project-key resolution is mocked separately via discoverProjectSpy) */
 function makeCloudState() {
   const state = getDefaultState('test');
   stateManager.addOrUpdateConnection(state, SONARCLOUD_URL, 'cloud', {
     orgKey: TEST_ORG,
   });
-  seedClaudeSqaaFeature(state, TEST_PROJECT);
   return state;
+}
+
+/** discoverProject result carrying just enough for resolveSqaaProjectKey to resolve `projectKey`. */
+function makeDiscoveredProject(projectKey: string | undefined) {
+  return {
+    repoRoot: process.cwd(),
+    projectRoot: process.cwd(),
+    projectKey,
+    configSources: [],
+  };
 }
 
 beforeEach(() => {
@@ -115,6 +92,10 @@ beforeEach(() => {
   existsSpy = spyOn(fs, 'existsSync').mockReturnValue(true);
   statSyncSpy = spyOn(fs, 'statSync').mockReturnValue({ isFile: () => true } as fs.Stats);
   readFileSpy = spyOn(fs, 'readFileSync').mockReturnValue(FILE_CONTENT);
+
+  discoverProjectSpy = spyOn(projectInfo, 'discoverProject').mockResolvedValue(
+    makeDiscoveredProject(TEST_PROJECT),
+  );
 
   createAnalysisSpy = spyOn(SonarQubeClient.prototype, 'createAnalysis').mockResolvedValue({
     id: 'analysis-1',
@@ -144,6 +125,7 @@ afterEach(() => {
   existsSpy.mockRestore();
   statSyncSpy.mockRestore();
   readFileSpy.mockRestore();
+  discoverProjectSpy.mockRestore();
   createAnalysisSpy.mockRestore();
   spawnProcessSpy.mockRestore();
 });
@@ -165,19 +147,9 @@ describe('analyzeSqaa: input validation', () => {
   });
 });
 
-function stateWithSqaaFeatureMissingProjectKey() {
-  const state = getDefaultState('test');
-  stateManager.addOrUpdateConnection(state, SONARCLOUD_URL, 'cloud', {
-    orgKey: TEST_ORG,
-  });
-  // Feature exists but projectKey attr is absent
-  seedClaudeSqaaFeature(state, undefined);
-  return state;
-}
-
 describe('analyzeSqaa: auth resolution', () => {
-  it('throws CommandFailedError when the SQAA feature has no projectKey (explicit agentic)', async () => {
-    loadStateSpy.mockReturnValue(stateWithSqaaFeatureMissingProjectKey());
+  it('throws CommandFailedError when no project can be discovered (explicit agentic)', async () => {
+    discoverProjectSpy.mockResolvedValue(makeDiscoveredProject(undefined));
 
     let thrown: unknown;
     await analyzeSqaa({ file: ['src/index.ts'] }, FAKE_AUTHENTICATED_CONTEXT).catch(
@@ -193,8 +165,8 @@ describe('analyzeSqaa: auth resolution', () => {
     expect(createAnalysisSpy).not.toHaveBeenCalled();
   });
 
-  it('skips SQAA and warns when the SQAA feature has no projectKey and requireProject is false (bare analyze)', async () => {
-    loadStateSpy.mockReturnValue(stateWithSqaaFeatureMissingProjectKey());
+  it('skips SQAA and warns when no project can be discovered and requireProject is false (bare analyze)', async () => {
+    discoverProjectSpy.mockResolvedValue(makeDiscoveredProject(undefined));
 
     await analyzeSqaa({ file: ['src/index.ts'] }, FAKE_AUTHENTICATED_CONTEXT, {
       requireProject: false,
@@ -210,62 +182,10 @@ describe('analyzeSqaa: auth resolution', () => {
   });
 });
 
-/**
- * Cloud state with two project-scoped SQAA features that both resolve to the
- * current directory, but via different signals: the first (array order) matches
- * only on `repoRoot` (as if a sibling worktree integrated with a different key
- * shares this main working tree); the second matches exactly on `targetRoot`
- * (the install actually rooted here). The exact targetRoot match must win.
- */
-function stateWithTargetAndRepoRootSqaaFeatures(
-  repoRootOnlyKey: string,
-  targetRootKey: string,
-): CliState {
-  const state = getDefaultState('test');
-  stateManager.addOrUpdateConnection(state, SONARCLOUD_URL, 'cloud', { orgKey: TEST_ORG });
-  const now = new Date().toISOString();
-  const makeFeature = (targetRoot: string, projectKey: string) => ({
-    featureId: SQAA_HOOK_FEATURE_ID,
-    scope: 'project' as const,
-    targetRoot,
-    installedByCliVersion: '1.0.0',
-    installedAt: now,
-    updatedByCliVersion: '1.0.0',
-    updatedAt: now,
-    dependencies: [],
-    resources: [],
-    operations: [],
-    attrs: { projectKey, repoRoot: process.cwd() },
-  });
-  state.integrations.installed.push({
-    id: randomUUID(),
-    integrationId: CLAUDE_INTEGRATION_ID,
-    installedByCliVersion: '1.0.0',
-    installedAt: now,
-    updatedByCliVersion: '1.0.0',
-    updatedAt: now,
-    features: [
-      // repoRoot-only match listed first — would win on array order under a
-      // combined targetRoot-OR-repoRoot search.
-      makeFeature('/some/other/worktree', repoRootOnlyKey),
-      makeFeature(process.cwd(), targetRootKey),
-    ],
-  });
-  return state;
-}
-
-describe('analyzeSqaa: project-key resolution across worktrees', () => {
-  it('prefers a targetRoot match over a repoRoot-only match regardless of feature order', async () => {
-    loadStateSpy.mockReturnValue(
-      stateWithTargetAndRepoRootSqaaFeatures('wrong-worktree-key', 'right-here-key'),
-    );
-
-    await analyzeSqaa({ file: ['src/index.ts'] }, FAKE_AUTHENTICATED_CONTEXT);
-
-    expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
-    expect(createAnalysisSpy.mock.calls[0][0].projectKey).toBe('right-here-key');
-  });
-});
+// Worktree-aware project-key resolution (targetRoot vs. repoRoot precedence) now
+// lives entirely inside discoverProject/selectFeatureForLookupPaths, which this
+// suite mocks away via discoverProjectSpy — see tests/unit/core/project-info.test.ts
+// and tests/unit/core/host/recorded-feature-resolver.test.ts for that coverage.
 
 describe('analyzeSqaa: API call and result display', () => {
   it('calls client.createAnalysis with correct parameters', async () => {

--- a/tests/unit/commands/hook/agent-post-tool-use.test.ts
+++ b/tests/unit/commands/hook/agent-post-tool-use.test.ts
@@ -31,6 +31,7 @@ import {
 import { CommandInvocationContext } from '@/commands/command-invocation-context.ts';
 import * as authResolver from '@/core/auth/auth-resolver.ts';
 import * as processLib from '@/core/process/process.ts';
+import * as projectInfo from '@/core/project-info.ts';
 import * as clientModule from '@/core/server/client.ts';
 
 import { agentPostToolUse } from '../../../../src/commands/hook/agent-post-tool-use.ts';
@@ -52,6 +53,7 @@ describe('agentPostToolUse', () => {
   let spawnProcessSpy: ReturnType<typeof spyOn>;
   let cagMatchesSpy: ReturnType<typeof spyOn>;
   let ctx: CommandInvocationContext;
+  let discoverProjectSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     // Deterministic git branch auto-detection (hook resolves branch from the edited file).
@@ -82,6 +84,13 @@ describe('agentPostToolUse', () => {
     );
     existsSyncSpy = spyOn(fs, 'existsSync').mockReturnValue(true);
     readFileSyncSpy = spyOn(fs, 'readFileSync').mockReturnValue('const x = 1;');
+    // Only exercised when a test omits `project` — an explicit project short-circuits it.
+    discoverProjectSpy = spyOn(projectInfo, 'discoverProject').mockResolvedValue({
+      repoRoot: process.cwd(),
+      projectRoot: process.cwd(),
+      projectKey: undefined,
+      configSources: [],
+    });
     createAnalysisSpy = spyOn(
       clientModule.SonarQubeClient.prototype,
       'createAnalysis',
@@ -103,6 +112,7 @@ describe('agentPostToolUse', () => {
     emitSqaaAnalysisTelemetrySpy.mockRestore();
     spawnProcessSpy.mockRestore();
     cagMatchesSpy.mockRestore();
+    discoverProjectSpy.mockRestore();
   });
 
   it('emits SQAA analysis telemetry after a successful PostToolUse analysis', async () => {

--- a/tests/unit/commands/hook/codex-post-tool-use.test.ts
+++ b/tests/unit/commands/hook/codex-post-tool-use.test.ts
@@ -27,6 +27,7 @@ import {
 } from '@/commands/analyze/sqaa-analysis-telemetry.ts';
 import { CommandInvocationContext } from '@/commands/command-invocation-context.ts';
 import * as authResolver from '@/core/auth/auth-resolver.ts';
+import * as projectInfo from '@/core/project-info.ts';
 
 import * as sqaaModule from '../../../../src/commands/analyze/sqaa.ts';
 import { codexPostToolUse } from '../../../../src/commands/hook/codex-post-tool-use.ts';
@@ -40,6 +41,7 @@ describe('codexPostToolUse', () => {
   let emitSqaaAnalysisTelemetrySpy: ReturnType<typeof spyOn>;
   let readStdinJsonSpy: ReturnType<typeof spyOn>;
   let ctx: CommandInvocationContext;
+  let discoverProjectSpy: ReturnType<typeof spyOn>;
   const originalStdinIsTTY = process.stdin.isTTY;
 
   beforeEach(() => {
@@ -67,6 +69,13 @@ describe('codexPostToolUse', () => {
       sqaaTelemetry,
       'recordSqaaAnalysisTelemetry',
     ).mockImplementation(() => {});
+    // Only exercised when a test omits `project` — an explicit project short-circuits it.
+    discoverProjectSpy = spyOn(projectInfo, 'discoverProject').mockResolvedValue({
+      repoRoot: process.cwd(),
+      projectRoot: process.cwd(),
+      projectKey: undefined,
+      configSources: [],
+    });
   });
 
   afterEach(() => {
@@ -75,6 +84,7 @@ describe('codexPostToolUse', () => {
     buildSqaaJsonReportSpy.mockRestore();
     emitSqaaAnalysisTelemetrySpy.mockRestore();
     readStdinJsonSpy.mockRestore();
+    discoverProjectSpy.mockRestore();
     Object.defineProperty(process.stdin, 'isTTY', {
       configurable: true,
       value: originalStdinIsTTY,

--- a/tests/unit/commands/integrate/_common/agent-integrate-prelude.test.ts
+++ b/tests/unit/commands/integrate/_common/agent-integrate-prelude.test.ts
@@ -38,8 +38,8 @@ const AUTH: ResolvedAuth = {
 };
 
 const PROJECT: DiscoveredProject = {
-  rootDir: '/workspace',
-  isGitRepo: false,
+  repoRoot: undefined,
+  projectRoot: '/workspace',
   configSources: [],
   projectKey: 'discovered-key',
 };

--- a/tests/unit/commands/integrate/_common/preflight-summary.test.ts
+++ b/tests/unit/commands/integrate/_common/preflight-summary.test.ts
@@ -33,8 +33,8 @@ import type { PhaseItem } from '@/core/ui';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 
 const BASE_PROJECT: DiscoveredProject = {
-  rootDir: '/workspace/app',
-  isGitRepo: true,
+  repoRoot: '/workspace/app',
+  projectRoot: '/workspace/app',
   configSources: [],
 };
 

--- a/tests/unit/commands/integrate/claude/integrate.test.ts
+++ b/tests/unit/commands/integrate/claude/integrate.test.ts
@@ -30,7 +30,6 @@ import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import * as token from '@/core/auth/token.ts';
 import { CommandFailedError } from '@/core/command-error.ts';
 import * as registry from '@/core/framework/features';
-import * as gitWorktree from '@/core/host/git/worktree.ts';
 import type { DiscoveredProject } from '@/core/project-info.ts';
 import * as discovery from '@/core/project-info.ts';
 import { SonarQubeClient } from '@/core/server/client.ts';
@@ -87,9 +86,6 @@ describe('integrateCommand', () => {
   let getScaEnablementSpy: Mock<
     Extract<(typeof SonarQubeClient.prototype)['getScaEnablement'], (...args: any[]) => any>
   >;
-  let resolveRecordedRepoRootSpy: Mock<
-    Extract<(typeof gitWorktree)['resolveRecordedRepoRoot'], (...args: any[]) => any>
-  >;
 
   beforeEach(() => {
     setMockUi(true);
@@ -98,9 +94,6 @@ describe('integrateCommand', () => {
     hasVortexEntitlementSpy.mockResolvedValue({ status: 'not_entitled' });
     getScaEnablementSpy = spyOn(SonarQubeClient.prototype, 'getScaEnablement').mockResolvedValue(
       'not_enabled',
-    );
-    resolveRecordedRepoRootSpy = spyOn(gitWorktree, 'resolveRecordedRepoRoot').mockImplementation(
-      (projectRoot: string) => Promise.resolve(projectRoot),
     );
 
     loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('test'));
@@ -133,7 +126,6 @@ describe('integrateCommand', () => {
     installIntegrationSpy.mockRestore();
     detectGlobalSecretsHookSpy.mockRestore();
     getScaEnablementSpy.mockRestore();
-    resolveRecordedRepoRootSpy.mockRestore();
   });
 
   it('shows intro message', async () => {
@@ -285,7 +277,7 @@ describe('integrateCommand', () => {
   });
 
   it('installs Vortex through the declarative installer in a single call', async () => {
-    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
     mockVortexEntitlement(true);
     getScaEnablementSpy.mockResolvedValue('enabled');
 
@@ -314,8 +306,27 @@ describe('integrateCommand', () => {
     );
   });
 
+  it('records the already-resolved mainRepoRoot from discovery instead of re-deriving it', async () => {
+    // attrs.repoRoot must record mainRepoRoot (main tree), not repoRoot (current worktree).
+    mockDiscoveredProject({
+      repoRoot: '/repo-worktrees/feature-x',
+      mainRepoRoot: '/repo',
+      projectKey: 'a-project',
+    });
+    mockVortexEntitlement(true);
+    getScaEnablementSpy.mockResolvedValue('enabled');
+
+    await integrateClaude({}, CLOUD_CTX);
+
+    expect(installIntegrationSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attrs: expect.objectContaining({ repoRoot: '/repo' }),
+      }),
+    );
+  });
+
   it('requests Vortex removal when the project organization is not entitled', async () => {
-    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
     mockVortexEntitlement(false);
 
     await integrateClaude({}, CLOUD_CTX);
@@ -332,7 +343,7 @@ describe('integrateCommand', () => {
   });
 
   it('rethrows Vortex installation failures', async () => {
-    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
     mockVortexEntitlement(true);
     installIntegrationSpy.mockRejectedValueOnce(new Error('print failed'));
 
@@ -352,7 +363,7 @@ describe('integrateCommand', () => {
   });
 
   it('runs migration and installs hooks when setup summary succeeds', async () => {
-    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
     mockVortexEntitlement(true);
 
     await integrateClaude({}, CLOUD_CTX);
@@ -367,7 +378,7 @@ describe('integrateCommand', () => {
   });
 
   it('runs migration and installs hooks when global option is set', async () => {
-    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
     mockVortexEntitlement(true);
 
     await integrateClaude({ global: true }, CLOUD_CTX);
@@ -384,7 +395,7 @@ describe('integrateCommand', () => {
   });
 
   it('still installs when organization access check fails in the summary', async () => {
-    mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+    mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
     mockVortexEntitlement(true);
     checkOrganizationSpy.mockResolvedValue(false);
 
@@ -400,7 +411,7 @@ describe('integrateCommand', () => {
   });
 
   it('requests Vortex removal when project key is missing and entitlement is lost', async () => {
-    mockDiscoveredProject({ rootDir: '/projectB/root' });
+    mockDiscoveredProject({ repoRoot: '/projectB/root' });
     mockVortexEntitlement(false);
 
     await integrateClaude({}, CLOUD_CTX);
@@ -430,7 +441,7 @@ describe('integrateCommand', () => {
     });
 
     it('forwards skipSecretsHooks: true to migrations and skips the declarative secrets-hooks feature', async () => {
-      mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+      mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
       hasVortexEntitlementSpy.mockResolvedValue({ status: 'not_applicable' });
 
       await integrateClaude({}, SERVER_CTX);
@@ -447,7 +458,7 @@ describe('integrateCommand', () => {
     });
 
     it('still installs project-scoped Vortex when the org is entitled', async () => {
-      mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+      mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
       mockVortexEntitlement(true);
 
       await integrateClaude({}, CLOUD_CTX);
@@ -470,7 +481,7 @@ describe('integrateCommand', () => {
     });
 
     it('falls back to a project-level install (does not skip secrets hooks)', async () => {
-      mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+      mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
       hasVortexEntitlementSpy.mockResolvedValue({ status: 'not_applicable' });
 
       await integrateClaude({}, SERVER_CTX);
@@ -505,7 +516,7 @@ describe('integrateCommand', () => {
     });
 
     it('skips Vortex (and warns) even when the org is entitled', async () => {
-      mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+      mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
       mockVortexEntitlement(true);
 
       await integrateClaude({ global: true }, CLOUD_CTX);
@@ -528,7 +539,7 @@ describe('integrateCommand', () => {
     });
 
     it('requests Vortex removal when a global run finds the org is not entitled', async () => {
-      mockDiscoveredProject({ rootDir: '/project/root', projectKey: 'a-project' });
+      mockDiscoveredProject({ repoRoot: '/project/root', projectKey: 'a-project' });
       mockVortexEntitlement(false);
 
       await integrateClaude({ global: true }, CLOUD_CTX);
@@ -546,9 +557,11 @@ describe('integrateCommand', () => {
   });
 
   function mockDiscoveredProject(project: Partial<DiscoveredProject>) {
+    const repoRoot = project.repoRoot || process.cwd();
     discoverProjectSpy.mockResolvedValue({
-      rootDir: project.rootDir || process.cwd(),
-      isGitRepo: project.isGitRepo ?? false,
+      repoRoot,
+      mainRepoRoot: project.mainRepoRoot,
+      projectRoot: project.projectRoot || repoRoot,
       serverUrl: project.serverUrl,
       organization: project.organization,
       projectKey: project.projectKey,

--- a/tests/unit/commands/integrate/codex/integrate.test.ts
+++ b/tests/unit/commands/integrate/codex/integrate.test.ts
@@ -40,8 +40,8 @@ const SERVER_AUTH: ResolvedAuth = {
 const SERVER_CTX = new CommandAuthenticatedInvocationContext(SERVER_AUTH);
 
 const BASE_PROJECT: DiscoveredProject = {
-  rootDir: '/project/root',
-  isGitRepo: true,
+  repoRoot: '/project/root',
+  projectRoot: '/project/root',
   configSources: [],
   projectKey: 'my-project',
 };

--- a/tests/unit/commands/integrate/copilot/integrate.test.ts
+++ b/tests/unit/commands/integrate/copilot/integrate.test.ts
@@ -41,8 +41,8 @@ const SERVER_AUTH: ResolvedAuth = {
 const SERVER_CTX = new CommandAuthenticatedInvocationContext(SERVER_AUTH);
 
 const BASE_PROJECT: DiscoveredProject = {
-  rootDir: '/project/root',
-  isGitRepo: true,
+  repoRoot: '/project/root',
+  projectRoot: '/project/root',
   configSources: [],
   projectKey: 'my-project',
 };

--- a/tests/unit/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/commands/integrate/git/integrate-git.test.ts
@@ -357,9 +357,9 @@ describe('integrateGit', () => {
     clearMockUiCalls();
     findGitRootSpy = spyOn(gitDiscovery, 'findGitRoot');
     discoverProjectSpy = spyOn(discovery, 'discoverProject').mockResolvedValue({
-      rootDir: TEMP_DIR,
+      repoRoot: TEMP_DIR,
+      projectRoot: TEMP_DIR,
       projectKey: undefined,
-      isGitRepo: true,
       configSources: [],
     });
     printGitPreflightSummarySpy = spyOn(
@@ -571,9 +571,9 @@ describe('integrateGit', () => {
     mkdirSync(join(TEMP_DIR, '.git', 'hooks'), { recursive: true });
     findGitRootSpy.mockReturnValue({ gitRoot: TEMP_DIR, isGit: true });
     discoverProjectSpy.mockResolvedValue({
-      rootDir: TEMP_DIR,
+      repoRoot: TEMP_DIR,
+      projectRoot: TEMP_DIR,
       projectKey: 'my-project',
-      isGitRepo: true,
       configSources: [],
     });
     const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue(NO_HOOKS_PATH);

--- a/tests/unit/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/commands/integrate/git/integrate-git.test.ts
@@ -589,7 +589,7 @@ describe('integrateGit', () => {
       spawnSpy.mockRestore();
       rmSync(TEMP_DIR, { recursive: true, force: true });
     }
-    expect(discoverProjectSpy).toHaveBeenCalledWith(TEMP_DIR, true, { auth: MOCK_AUTH });
+    expect(discoverProjectSpy).toHaveBeenCalledWith(TEMP_DIR, { auth: MOCK_AUTH, silent: true });
     expect(caughtError).toBeInstanceOf(CommandFailedError);
     expect((caughtError as Error).message).toContain('Installation cancelled');
   });

--- a/tests/unit/commands/run/mcp.test.ts
+++ b/tests/unit/commands/run/mcp.test.ts
@@ -108,8 +108,8 @@ describe('runMcp', () => {
   beforeEach(() => {
     discoverProjectSpy = spyOn(projectInfo, 'discoverProject').mockResolvedValue({
       projectKey: undefined,
-      rootDir: '/tmp/non-git-dir',
-      isGitRepo: false,
+      repoRoot: undefined,
+      projectRoot: '/tmp/non-git-dir',
       configSources: [],
     });
   });
@@ -233,8 +233,8 @@ describe('runMcp', () => {
   it('adds fs mount when --project is set and discovered root is a git repo', async () => {
     discoverProjectSpy.mockResolvedValue({
       projectKey: undefined,
-      rootDir: '/tmp/git-repo',
-      isGitRepo: true,
+      repoRoot: '/tmp/git-repo',
+      projectRoot: '/tmp/git-repo',
       configSources: [],
     });
     detectRuntimeSpy = spyOn(toolDetector, 'detectContainerRuntime').mockResolvedValue({

--- a/tests/unit/core/fake-fs-test-handle.ts
+++ b/tests/unit/core/fake-fs-test-handle.ts
@@ -1,0 +1,195 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/**
+ * Test helper that backs an in-memory filesystem for code reading the real disk via
+ * `existsSync`, `statSync`, `realpathSync.native` (node:fs) and `readFile`, `readdir`
+ * (node:fs/promises) — the exact primitives `canonicalizePath` (io/fs-utils.ts),
+ * `findGitRoot` (host/git/discover.ts), and the sonar-project.properties/.sonarlint
+ * readers (project-info.ts, host/sonarlint-connected-mode.ts) use. Build a tree with
+ * `mkdir`/`writeFile` instead of touching the real disk.
+ *
+ * Call setup() in beforeEach and teardown() in afterEach.
+ */
+
+import * as fsModule from 'node:fs';
+import * as fsPromises from 'node:fs/promises';
+import { dirname, sep } from 'node:path';
+
+import { spyOn } from 'bun:test';
+
+export interface FakeFsTestHandle {
+  mkdir(path: string): void;
+  writeFile(path: string, content: string): void;
+  /** Removes `path` and everything nested under it (files and directories alike). */
+  rm(path: string): void;
+  setup(): void;
+  teardown(): void;
+}
+
+function enoent(path: string, syscall: string): NodeJS.ErrnoException {
+  const err = new Error(
+    `ENOENT: no such file or directory, ${syscall} '${path}'`,
+  ) as NodeJS.ErrnoException;
+  err.code = 'ENOENT';
+  return err;
+}
+
+class FakeFs {
+  private readonly files = new Map<string, string>();
+  private readonly dirs = new Set<string>();
+
+  private ancestorsOf(path: string): string[] {
+    const out: string[] = [];
+    let current = path;
+    for (;;) {
+      out.push(current);
+      const parent = dirname(current);
+      if (parent === current) {
+        return out;
+      }
+      current = parent;
+    }
+  }
+
+  mkdir(path: string): void {
+    for (const ancestor of this.ancestorsOf(path)) {
+      this.dirs.add(ancestor);
+    }
+  }
+
+  writeFile(path: string, content: string): void {
+    this.files.set(path, content);
+    this.mkdir(dirname(path));
+  }
+
+  rm(path: string): void {
+    const prefix = `${path}${sep}`;
+    for (const file of [...this.files.keys()]) {
+      if (file === path || file.startsWith(prefix)) {
+        this.files.delete(file);
+      }
+    }
+    for (const dir of [...this.dirs]) {
+      if (dir === path || dir.startsWith(prefix)) {
+        this.dirs.delete(dir);
+      }
+    }
+  }
+
+  exists(path: string): boolean {
+    return this.dirs.has(path) || this.files.has(path);
+  }
+
+  isDirectory(path: string): boolean {
+    return this.dirs.has(path);
+  }
+
+  readFile(path: string): string {
+    const content = this.files.get(path);
+    if (content === undefined) {
+      throw enoent(path, 'open');
+    }
+    return content;
+  }
+
+  readdir(path: string): string[] {
+    if (!this.dirs.has(path)) {
+      throw enoent(path, 'scandir');
+    }
+    const prefix = `${path}${sep}`;
+    const names = new Set<string>();
+    for (const file of this.files.keys()) {
+      if (file.startsWith(prefix)) {
+        names.add(file.slice(prefix.length).split(sep)[0]);
+      }
+    }
+    for (const dir of this.dirs) {
+      if (dir !== path && dir.startsWith(prefix)) {
+        names.add(dir.slice(prefix.length).split(sep)[0]);
+      }
+    }
+    return [...names];
+  }
+}
+
+/**
+ * Wraps a sync, possibly-throwing fn into the shape node:fs/promises functions need — an
+ * `async` fn auto-converts a synchronous throw into a rejected promise, no manual catch needed.
+ */
+function asAsync<T>(fn: (path: fsModule.PathLike) => T): (path: fsModule.PathLike) => Promise<T> {
+  return async (path) => await Promise.resolve(fn(path));
+}
+
+interface RestorableSpy {
+  mockRestore(): void;
+}
+
+function installFakeFsSpies(vfs: FakeFs): RestorableSpy[] {
+  return [
+    spyOn(fsModule, 'existsSync').mockImplementation((path) => vfs.exists(String(path))),
+    spyOn(fsModule, 'statSync').mockImplementation(
+      ((path: fsModule.PathLike) =>
+        ({
+          isDirectory: () => vfs.isDirectory(String(path)),
+          isFile: () => vfs.exists(String(path)) && !vfs.isDirectory(String(path)),
+        }) as fsModule.Stats) as typeof fsModule.statSync,
+    ),
+    // Stays sync (unlike readFile/readdir below) — realpathSync.native must return a
+    // string directly, not a Promise, so it can't go through asAsync.
+    spyOn(fsModule.realpathSync, 'native').mockImplementation(((path: fsModule.PathLike) => {
+      const p = String(path);
+      if (!vfs.exists(p)) {
+        throw enoent(p, 'lstat');
+      }
+      return p;
+    }) as typeof fsModule.realpathSync.native),
+    spyOn(fsPromises, 'readFile').mockImplementation(
+      asAsync((path) => vfs.readFile(String(path))) as typeof fsPromises.readFile,
+    ),
+    spyOn(fsPromises, 'readdir').mockImplementation(
+      asAsync((path) => vfs.readdir(String(path))) as typeof fsPromises.readdir,
+    ),
+  ];
+}
+
+export function createFakeFsTestHandle(): FakeFsTestHandle {
+  let vfs: FakeFs;
+  let spies: RestorableSpy[] = [];
+
+  return {
+    mkdir(path) {
+      vfs.mkdir(path);
+    },
+    writeFile(path, content) {
+      vfs.writeFile(path, content);
+    },
+    rm(path) {
+      vfs.rm(path);
+    },
+    setup() {
+      vfs = new FakeFs();
+      spies = installFakeFsSpies(vfs);
+    },
+    teardown() {
+      spies.forEach((spy) => spy.mockRestore());
+    },
+  };
+}

--- a/tests/unit/core/host/git/discover.test.ts
+++ b/tests/unit/core/host/git/discover.test.ts
@@ -1,0 +1,83 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it, spyOn } from 'bun:test';
+
+import { findGitRoot, getGitRemote } from '@/core/host/git/discover.ts';
+import * as processLib from '@/core/process/process.ts';
+
+describe('getGitRemote', () => {
+  it('reads the origin remote URL when git succeeds', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
+      exitCode: 0,
+      stdout: 'https://github.com/example/test-project.git\n',
+      stderr: '',
+    });
+
+    try {
+      expect(await getGitRemote('/repo')).toBe('https://github.com/example/test-project.git');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('returns an empty string when the git spawn fails', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockRejectedValue(
+      new Error('git not available'),
+    );
+
+    try {
+      expect(await getGitRemote('/repo')).toBe('');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('returns an empty string when git exits non-zero (no origin configured)', async () => {
+    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
+      exitCode: 1,
+      stdout: '',
+      stderr: 'no origin',
+    });
+
+    try {
+      expect(await getGitRemote('/repo')).toBe('');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+});
+
+describe('findGitRoot', () => {
+  it('detects a git repository when a .git directory is present', () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-findgitroot-' + Date.now());
+    mkdirSync(join(testDir, '.git'), { recursive: true });
+
+    try {
+      expect(findGitRoot(testDir)).toEqual({ gitRoot: testDir, isGit: true });
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/core/host/git/lookup-path-resolver.test.ts
+++ b/tests/unit/core/host/git/lookup-path-resolver.test.ts
@@ -89,12 +89,46 @@ describe('resolveLookupPaths', () => {
   });
 
   it('is bounded to the start dir itself when not inside a git repository', async () => {
-    // Outside git, nothing bounds a climb to a project — climbing to the filesystem
-    // root would let a mapping/config file sitting in an unrelated ancestor directory
-    // resolve for any subdirectory below it. Restrict to the start dir alone.
     mockGitResponses({ 'rev-parse --show-toplevel': null });
 
     const paths = await resolveLookupPaths(STANDALONE_PROJECT);
+
+    expect(paths).toEqual([
+      { checkPath: canon(STANDALONE_PROJECT), projectRoot: canon(STANDALONE_PROJECT) },
+    ]);
+  });
+
+  it('bounds the non-git climb to a known root instead of the start dir', async () => {
+    mockGitResponses({ 'rev-parse --show-toplevel': null });
+
+    const paths = await resolveLookupPaths(`${STANDALONE_PROJECT}/src`, [STANDALONE_PROJECT]);
+
+    expect(paths).toEqual([
+      {
+        checkPath: canon(`${STANDALONE_PROJECT}/src`),
+        projectRoot: canon(`${STANDALONE_PROJECT}/src`),
+      },
+      { checkPath: canon(STANDALONE_PROJECT), projectRoot: canon(STANDALONE_PROJECT) },
+    ]);
+  });
+
+  it('bounds to the shallowest matching known root, given an un-deduplicated nested chain', async () => {
+    mockGitResponses({ 'rev-parse --show-toplevel': null });
+    const nested = `${STANDALONE_PROJECT}/deep`;
+
+    const paths = await resolveLookupPaths(`${nested}/src`, [nested, STANDALONE_PROJECT]);
+
+    expect(paths).toEqual([
+      { checkPath: canon(`${nested}/src`), projectRoot: canon(`${nested}/src`) },
+      { checkPath: canon(nested), projectRoot: canon(nested) },
+      { checkPath: canon(STANDALONE_PROJECT), projectRoot: canon(STANDALONE_PROJECT) },
+    ]);
+  });
+
+  it('falls back to the start dir itself when no known root is an ancestor', async () => {
+    mockGitResponses({ 'rev-parse --show-toplevel': null });
+
+    const paths = await resolveLookupPaths(STANDALONE_PROJECT, ['/unrelated/root']);
 
     expect(paths).toEqual([
       { checkPath: canon(STANDALONE_PROJECT), projectRoot: canon(STANDALONE_PROJECT) },

--- a/tests/unit/core/host/git/lookup-path-resolver.test.ts
+++ b/tests/unit/core/host/git/lookup-path-resolver.test.ts
@@ -1,0 +1,166 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Unit tests for resolving the nearest-first list of directories to check for a
+// recorded per-project mapping.
+
+import { dirname } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { buildDirectoryClimb, resolveLookupPaths } from '@/core/host/git/lookup-path-resolver.ts';
+import { clearGitStdoutCache } from '@/core/host/git/worktree.ts';
+import { canonicalizePath } from '@/core/io/fs-utils.ts';
+import * as processLib from '@/core/process/process.ts';
+
+const MAIN = '/repo';
+const WORKTREE = '/repo-worktrees/feature-x';
+const NESTED = `${MAIN}/packages/api`;
+const STANDALONE_PROJECT = '/standalone-project/nested';
+
+function canon(p: string): string {
+  return canonicalizePath(p);
+}
+
+describe('buildDirectoryClimb', () => {
+  it('climbs from a nested directory up to an inclusive bound', () => {
+    expect(buildDirectoryClimb(`${NESTED}/src`, MAIN)).toEqual([
+      canon(`${NESTED}/src`),
+      canon(NESTED),
+      canon(`${MAIN}/packages`),
+      canon(MAIN),
+    ]);
+  });
+
+  it('returns a single-element list when already at the bound', () => {
+    expect(buildDirectoryClimb(MAIN, MAIN)).toEqual([canon(MAIN)]);
+  });
+
+  it('climbs to the filesystem root when no bound is given', () => {
+    const climb = buildDirectoryClimb(MAIN);
+
+    expect(climb[0]).toBe(canon(MAIN));
+    const last = climb.at(-1) as string;
+    expect(dirname(last)).toBe(last);
+  });
+});
+
+describe('resolveLookupPaths', () => {
+  let spawnProcessSpy: ReturnType<typeof spyOn>;
+
+  function mockGitResponses(responses: Record<string, string | null>): void {
+    spawnProcessSpy.mockImplementation((_cmd: string, args: string[]) => {
+      const key = args.join(' ');
+      if (key in responses) {
+        const stdout = responses[key];
+        if (stdout === null) {
+          return Promise.resolve({ exitCode: 1, stdout: '', stderr: 'git failed' });
+        }
+        return Promise.resolve({ exitCode: 0, stdout, stderr: '' });
+      }
+      return Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
+    });
+  }
+
+  beforeEach(() => {
+    spawnProcessSpy = spyOn(processLib, 'spawnProcess');
+  });
+
+  afterEach(() => {
+    spawnProcessSpy.mockRestore();
+    clearGitStdoutCache();
+  });
+
+  it('climbs to the filesystem root when not inside a git repository', async () => {
+    mockGitResponses({ 'rev-parse --show-toplevel': null });
+
+    const paths = await resolveLookupPaths(STANDALONE_PROJECT);
+
+    expect(paths[0]).toEqual({
+      checkPath: canon(STANDALONE_PROJECT),
+      projectRoot: canon(STANDALONE_PROJECT),
+    });
+    const last = paths.at(-1);
+    expect(dirname(last!.checkPath)).toBe(last!.checkPath);
+    expect(last!.projectRoot).toBe(last!.checkPath);
+  });
+
+  it('climbs only up to the repo root on the main working tree', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': `${MAIN}\n`,
+      'worktree list --porcelain': `worktree ${MAIN}\n`,
+    });
+
+    const paths = await resolveLookupPaths(`${NESTED}/src`);
+
+    expect(paths).toEqual([
+      { checkPath: canon(`${NESTED}/src`), projectRoot: canon(`${NESTED}/src`) },
+      { checkPath: canon(NESTED), projectRoot: canon(NESTED) },
+      { checkPath: canon(`${MAIN}/packages`), projectRoot: canon(`${MAIN}/packages`) },
+      { checkPath: canon(MAIN), projectRoot: canon(MAIN) },
+    ]);
+  });
+
+  it('appends the main-tree-equivalent climb when invoked from a linked worktree, reporting projectRoot in the current worktree', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': `${WORKTREE}\n`,
+      'worktree list --porcelain': `worktree ${MAIN}\nworktree ${WORKTREE}\n`,
+    });
+
+    const paths = await resolveLookupPaths(`${WORKTREE}/src`);
+
+    expect(paths).toEqual([
+      { checkPath: canon(`${WORKTREE}/src`), projectRoot: canon(`${WORKTREE}/src`) },
+      { checkPath: canon(WORKTREE), projectRoot: canon(WORKTREE) },
+      { checkPath: canon(`${MAIN}/src`), projectRoot: canon(`${WORKTREE}/src`) },
+      { checkPath: canon(MAIN), projectRoot: canon(WORKTREE) },
+    ]);
+  });
+
+  it('still appends the main-tree climb from a directory name that merely starts with ".."', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': `${WORKTREE}\n`,
+      'worktree list --porcelain': `worktree ${MAIN}\nworktree ${WORKTREE}\n`,
+    });
+
+    const paths = await resolveLookupPaths(`${WORKTREE}/..config`);
+
+    expect(paths).toEqual([
+      { checkPath: canon(`${WORKTREE}/..config`), projectRoot: canon(`${WORKTREE}/..config`) },
+      { checkPath: canon(WORKTREE), projectRoot: canon(WORKTREE) },
+      { checkPath: canon(`${MAIN}/..config`), projectRoot: canon(`${WORKTREE}/..config`) },
+      { checkPath: canon(MAIN), projectRoot: canon(WORKTREE) },
+    ]);
+  });
+
+  it('does not append a second climb when the current worktree is already the main one', async () => {
+    mockGitResponses({
+      'rev-parse --show-toplevel': `${MAIN}\n`,
+      'worktree list --porcelain': `worktree ${MAIN}\nworktree ${WORKTREE}\n`,
+    });
+
+    const paths = await resolveLookupPaths(`${MAIN}/src`);
+
+    expect(paths).toEqual([
+      { checkPath: canon(`${MAIN}/src`), projectRoot: canon(`${MAIN}/src`) },
+      { checkPath: canon(MAIN), projectRoot: canon(MAIN) },
+    ]);
+  });
+});

--- a/tests/unit/core/host/git/lookup-path-resolver.test.ts
+++ b/tests/unit/core/host/git/lookup-path-resolver.test.ts
@@ -125,6 +125,19 @@ describe('resolveLookupPaths', () => {
     ]);
   });
 
+  it('bounds to a known root even when a directory name merely starts with ".."', async () => {
+    mockGitResponses({ 'rev-parse --show-toplevel': null });
+    const dotDir = `${STANDALONE_PROJECT}/..cache`;
+
+    const paths = await resolveLookupPaths(`${dotDir}/src`, [STANDALONE_PROJECT]);
+
+    expect(paths).toEqual([
+      { checkPath: canon(`${dotDir}/src`), projectRoot: canon(`${dotDir}/src`) },
+      { checkPath: canon(dotDir), projectRoot: canon(dotDir) },
+      { checkPath: canon(STANDALONE_PROJECT), projectRoot: canon(STANDALONE_PROJECT) },
+    ]);
+  });
+
   it('falls back to the start dir itself when no known root is an ancestor', async () => {
     mockGitResponses({ 'rev-parse --show-toplevel': null });
 

--- a/tests/unit/core/host/git/lookup-path-resolver.test.ts
+++ b/tests/unit/core/host/git/lookup-path-resolver.test.ts
@@ -88,18 +88,17 @@ describe('resolveLookupPaths', () => {
     clearGitStdoutCache();
   });
 
-  it('climbs to the filesystem root when not inside a git repository', async () => {
+  it('is bounded to the start dir itself when not inside a git repository', async () => {
+    // Outside git, nothing bounds a climb to a project — climbing to the filesystem
+    // root would let a mapping/config file sitting in an unrelated ancestor directory
+    // resolve for any subdirectory below it. Restrict to the start dir alone.
     mockGitResponses({ 'rev-parse --show-toplevel': null });
 
     const paths = await resolveLookupPaths(STANDALONE_PROJECT);
 
-    expect(paths[0]).toEqual({
-      checkPath: canon(STANDALONE_PROJECT),
-      projectRoot: canon(STANDALONE_PROJECT),
-    });
-    const last = paths.at(-1);
-    expect(dirname(last!.checkPath)).toBe(last!.checkPath);
-    expect(last!.projectRoot).toBe(last!.checkPath);
+    expect(paths).toEqual([
+      { checkPath: canon(STANDALONE_PROJECT), projectRoot: canon(STANDALONE_PROJECT) },
+    ]);
   });
 
   it('climbs only up to the repo root on the main working tree', async () => {

--- a/tests/unit/core/host/recorded-feature-resolver.test.ts
+++ b/tests/unit/core/host/recorded-feature-resolver.test.ts
@@ -18,11 +18,8 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// Unit tests for the shared worktree-aware feature-selection policy. Exercises the
-// pure selectFeatureForLookupPaths so the ranking (targetRoot before repoRoot,
-// current worktree before main, nearest ancestor, then recency) is covered
-// without spawning git. Paths are absolute and non-existent so canonicalizePath
-// falls back to a deterministic path.resolve() on every platform.
+// Unit tests for the pure exact-match selection policy over an already-expanded,
+// nearest-first lookup-path list.
 
 import { describe, expect, it } from 'bun:test';
 
@@ -31,11 +28,10 @@ import {
   selectFeatureForLookupPaths,
 } from '@/core/host/recorded-feature-resolver.ts';
 
-const BASE = '/nonexistent-sqcli-resolver-test';
-const MAIN = `${BASE}/main`;
-const WORKTREE = `${BASE}/linked-worktree`;
-const NESTED = `${MAIN}/packages/api`;
-const OUTSIDE = `${BASE}/unrelated`;
+const MAIN = '/repo';
+const MAIN_SUBDIR = `${MAIN}/src`;
+const WORKTREE = '/repo-worktrees/feature-x';
+const OUTSIDE = '/unrelated-project';
 
 function candidate(
   id: string,
@@ -45,7 +41,7 @@ function candidate(
 }
 
 describe('selectFeatureForLookupPaths', () => {
-  it('prefers a targetRoot match over a more recent repoRoot-only match', () => {
+  it('prefers a targetRoot match over a more recent repoRoot-only match at the same path', () => {
     const candidates = [
       // Sibling worktree: matches only via repoRoot, updated later.
       candidate('sibling', {
@@ -61,40 +57,71 @@ describe('selectFeatureForLookupPaths', () => {
       }),
     ];
 
-    expect(selectFeatureForLookupPaths(candidates, [MAIN])).toBe('here');
+    expect(
+      selectFeatureForLookupPaths(candidates, [{ checkPath: MAIN, projectRoot: MAIN }]),
+    ).toEqual({
+      feature: 'here',
+      matchedPath: MAIN,
+    });
   });
 
-  it('prefers the current worktree over the main working tree', () => {
+  it('checks lookup paths in order, so the current worktree wins when listed before the main tree', () => {
     const candidates = [
       candidate('main', { targetRoot: MAIN, repoRoot: MAIN }),
       candidate('worktree', { targetRoot: WORKTREE, repoRoot: MAIN }),
     ];
 
-    // Lookup order is current-worktree-first, then main.
-    expect(selectFeatureForLookupPaths(candidates, [WORKTREE, MAIN])).toBe('worktree');
+    expect(
+      selectFeatureForLookupPaths(candidates, [
+        { checkPath: WORKTREE, projectRoot: WORKTREE },
+        // Translated main-tree entry: from inside WORKTREE, this always anchors
+        // back to WORKTREE, never to MAIN itself.
+        { checkPath: MAIN, projectRoot: WORKTREE },
+      ]),
+    ).toEqual({
+      feature: 'worktree',
+      matchedPath: WORKTREE,
+    });
   });
 
-  it('falls back to the main working tree when the current worktree has no integration', () => {
+  it('falls through to a later path when an earlier one has no match', () => {
     const candidates = [candidate('main', { targetRoot: MAIN, repoRoot: MAIN })];
 
-    expect(selectFeatureForLookupPaths(candidates, [WORKTREE, MAIN])).toBe('main');
+    // Plain climb within one worktree, from a subdirectory up to the repo root.
+    expect(
+      selectFeatureForLookupPaths(candidates, [
+        { checkPath: MAIN_SUBDIR, projectRoot: MAIN_SUBDIR },
+        { checkPath: MAIN, projectRoot: MAIN },
+      ]),
+    ).toEqual({
+      feature: 'main',
+      matchedPath: MAIN,
+    });
   });
 
   it('matches via repoRoot when targetRoot points at a different worktree', () => {
     const candidates = [candidate('sibling', { targetRoot: WORKTREE, repoRoot: MAIN })];
 
-    expect(selectFeatureForLookupPaths(candidates, [MAIN])).toBe('sibling');
+    expect(
+      selectFeatureForLookupPaths(candidates, [{ checkPath: MAIN, projectRoot: MAIN }]),
+    ).toEqual({
+      feature: 'sibling',
+      matchedPath: MAIN,
+    });
   });
 
-  it('prefers the nearest ancestor (longest targetRoot) for nested integrations', () => {
-    const candidates = [
-      candidate('root', { targetRoot: MAIN }),
-      candidate('nested', { targetRoot: NESTED }),
-    ];
+  it('reports projectRoot, not checkPath, when matched via a translated main-tree entry', () => {
+    const candidates = [candidate('via-main-tree', { targetRoot: MAIN, repoRoot: MAIN })];
 
-    expect(selectFeatureForLookupPaths(candidates, [`${NESTED}/src`])).toBe('nested');
-    // Outside the nested subtree, the repo-root integration still wins.
-    expect(selectFeatureForLookupPaths(candidates, [`${MAIN}/lib`])).toBe('root');
+    expect(
+      selectFeatureForLookupPaths(candidates, [
+        { checkPath: WORKTREE, projectRoot: WORKTREE },
+        { checkPath: MAIN, projectRoot: WORKTREE },
+      ]),
+    ).toEqual({
+      feature: 'via-main-tree',
+      matchedPath: WORKTREE,
+    });
   });
 
   it('breaks ties on the same root by most recent update', () => {
@@ -103,38 +130,28 @@ describe('selectFeatureForLookupPaths', () => {
       candidate('new', { targetRoot: MAIN, updatedAt: '2026-02-01T00:00:00.000Z' }),
     ];
 
-    expect(selectFeatureForLookupPaths(candidates, [MAIN])).toBe('new');
+    expect(
+      selectFeatureForLookupPaths(candidates, [{ checkPath: MAIN, projectRoot: MAIN }])?.feature,
+    ).toBe('new');
   });
 
-  it('matches a feature recorded at an ancestor directory (subdirectory invocation)', () => {
-    const candidates = [candidate('root', { targetRoot: MAIN })];
-
-    expect(selectFeatureForLookupPaths(candidates, [`${MAIN}/deep/sub`])).toBe('root');
-  });
-
-  it('treats a directory whose name starts with ".." as inside, not a parent traversal', () => {
-    const candidates = [candidate('root', { targetRoot: MAIN })];
-
-    // `..config` is a real child of MAIN, not a `../` escape: as a canonical path
-    // it stays under MAIN (`.../main/..config` starts with `.../main/`) and must
-    // not be mistaken for a leading `..` segment.
-    expect(selectFeatureForLookupPaths(candidates, [`${MAIN}/..config`])).toBe('root');
-  });
-
-  it('returns undefined when a candidate is a sibling whose name starts with ".."', () => {
-    const candidates = [candidate('main', { targetRoot: MAIN })];
-
-    // `${BASE}/..evil` is a sibling of MAIN, not under it, so it must not match.
-    expect(selectFeatureForLookupPaths(candidates, [`${BASE}/..evil`])).toBeUndefined();
-  });
-
-  it('returns undefined when no candidate contains the directory', () => {
+  it('returns undefined when no candidate matches any lookup path', () => {
     const candidates = [candidate('main', { targetRoot: MAIN, repoRoot: MAIN })];
 
-    expect(selectFeatureForLookupPaths(candidates, [OUTSIDE])).toBeUndefined();
+    expect(
+      selectFeatureForLookupPaths(candidates, [{ checkPath: OUTSIDE, projectRoot: OUTSIDE }]),
+    ).toBeUndefined();
   });
 
   it('returns undefined when there are no candidates', () => {
-    expect(selectFeatureForLookupPaths<string>([], [MAIN])).toBeUndefined();
+    expect(
+      selectFeatureForLookupPaths<string>([], [{ checkPath: MAIN, projectRoot: MAIN }]),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when there are no lookup paths', () => {
+    const candidates = [candidate('main', { targetRoot: MAIN })];
+
+    expect(selectFeatureForLookupPaths(candidates, [])).toBeUndefined();
   });
 });

--- a/tests/unit/core/known-server-project-mappings.test.ts
+++ b/tests/unit/core/known-server-project-mappings.test.ts
@@ -1,0 +1,277 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildKnownServerProjectMappings,
+  type KnownServerProjectMapping,
+} from '@/core/known-server-project-mappings.ts';
+import type {
+  AuthConnection,
+  CliState,
+  InstalledIntegration,
+  InstalledIntegrationFeature,
+} from '@/core/state/state.ts';
+import { getDefaultState } from '@/core/state/state.ts';
+
+function makeState(): CliState {
+  return getDefaultState('1.0.0');
+}
+
+function makeMapping(
+  overrides: Partial<KnownServerProjectMapping> = {},
+): KnownServerProjectMapping {
+  return {
+    targetRoot: '/repo',
+    projectKey: 'my-project',
+    serverUrl: 'https://sonarqube.example.com',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Sets an active connection on state, for tests exercising the attrs-missing fallback. */
+function withActiveConnection(state: CliState, overrides: Partial<AuthConnection> = {}): CliState {
+  const connection: AuthConnection = {
+    id: 'conn-1',
+    type: 'cloud',
+    serverUrl: 'https://active-connection.example.com',
+    authenticatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+  state.auth.connections = [connection];
+  state.auth.activeConnectionId = connection.id;
+  return state;
+}
+
+function makeFeature(
+  overrides: Partial<InstalledIntegrationFeature> = {},
+): InstalledIntegrationFeature {
+  return {
+    featureId: 'some-feature',
+    scope: 'project',
+    targetRoot: '/repo',
+    installedByCliVersion: '1.0.0',
+    installedAt: '2026-01-01T00:00:00.000Z',
+    updatedByCliVersion: '1.0.0',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    dependencies: [],
+    resources: [],
+    operations: [],
+    ...overrides,
+  };
+}
+
+function makeIntegration(
+  features: InstalledIntegrationFeature[],
+  overrides: Partial<InstalledIntegration> = {},
+): InstalledIntegration {
+  return {
+    id: 'integration-1',
+    integrationId: 'claude-code',
+    installedByCliVersion: '1.0.0',
+    installedAt: '2026-01-01T00:00:00.000Z',
+    updatedByCliVersion: '1.0.0',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    features,
+    ...overrides,
+  };
+}
+
+/** Builds mappings from a state with a single integration holding a single feature. */
+function buildMappingsForFeature(
+  featureOverrides: Partial<InstalledIntegrationFeature>,
+  state: CliState = makeState(),
+): KnownServerProjectMapping[] {
+  state.integrations.installed = [makeIntegration([makeFeature(featureOverrides)])];
+  return buildKnownServerProjectMappings(state);
+}
+
+describe('buildKnownServerProjectMappings', () => {
+  it('skips global-scope features', () => {
+    const mappings = buildMappingsForFeature({
+      scope: 'global',
+      attrs: { projectKey: 'proj', serverUrl: 'https://sonarqube.example.com' },
+      targetRoot: '/home',
+    });
+
+    expect(mappings).toEqual([]);
+  });
+
+  it('skips features without an explicit projectKey attr', () => {
+    const state = makeState();
+    state.integrations.installed = [
+      makeIntegration([makeFeature({ attrs: undefined }), makeFeature({ attrs: {} })]),
+    ];
+
+    const mappings = buildKnownServerProjectMappings(state);
+
+    expect(mappings).toEqual([]);
+  });
+
+  it('records a mapping with serverUrl/orgKey left undefined when the feature never recorded a connection', () => {
+    // Resolved later, at match time (discoverProject), not backfilled here — see
+    // resolveMappingConnection in project-info.ts.
+    const mappings = buildMappingsForFeature({ attrs: { projectKey: 'my-project' } });
+
+    expect(mappings).toEqual([makeMapping({ serverUrl: undefined, orgKey: undefined })]);
+  });
+
+  it('records a mapping for a project-scoped feature with explicit projectKey/serverUrl attrs', () => {
+    const mappings = buildMappingsForFeature({
+      targetRoot: '/repo',
+      attrs: {
+        projectKey: 'my-project',
+        serverUrl: 'https://sonarqube.example.com',
+        orgKey: 'my-org',
+      },
+    });
+
+    expect(mappings).toEqual([
+      makeMapping({ serverUrl: 'https://sonarqube.example.com', orgKey: 'my-org' }),
+    ]);
+  });
+
+  it('never backfills serverUrl/orgKey from the active connection, even when one exists (e.g. git integrate)', () => {
+    // A stale point-in-time snapshot baked in here would go wrong once env-var auth
+    // switches server/org per invocation — the substitution happens fresh at match time
+    // in discoverProject() instead, not derivation time.
+    const state = withActiveConnection(makeState(), {
+      serverUrl: 'https://active-connection.example.com',
+      orgKey: 'active-org',
+    });
+
+    const mappings = buildMappingsForFeature({ attrs: { projectKey: 'my-project' } }, state);
+
+    expect(mappings).toEqual([makeMapping({ serverUrl: undefined, orgKey: undefined })]);
+  });
+
+  it('keeps the feature-recorded serverUrl/orgKey untouched even when a different connection is active', () => {
+    const state = withActiveConnection(makeState(), {
+      serverUrl: 'https://active-connection.example.com',
+      orgKey: 'active-org',
+    });
+
+    const mappings = buildMappingsForFeature(
+      {
+        attrs: {
+          projectKey: 'my-project',
+          serverUrl: 'https://recorded.example.com',
+          orgKey: 'recorded-org',
+        },
+      },
+      state,
+    );
+
+    expect(mappings).toEqual([
+      makeMapping({ serverUrl: 'https://recorded.example.com', orgKey: 'recorded-org' }),
+    ]);
+  });
+
+  it('copies a recorded repoRoot attr verbatim, without re-resolving or normalizing it', () => {
+    const mappings = buildMappingsForFeature({
+      targetRoot: '/linked-worktree',
+      attrs: {
+        projectKey: 'my-project',
+        serverUrl: 'https://sonarqube.example.com',
+        repoRoot: '/main',
+      },
+    });
+
+    expect(mappings).toEqual([makeMapping({ targetRoot: '/linked-worktree', repoRoot: '/main' })]);
+  });
+
+  it('leaves repoRoot undefined when no repoRoot attr is recorded', () => {
+    const mappings = buildMappingsForFeature({
+      targetRoot: '/linked/worktree',
+      attrs: { projectKey: 'my-project', serverUrl: 'https://sonarqube.example.com' },
+    });
+
+    expect(mappings).toEqual([makeMapping({ targetRoot: '/linked/worktree' })]);
+    expect(mappings[0].repoRoot).toBeUndefined();
+  });
+
+  it('keeps two features with different targetRoots that share the same repoRoot attr (two worktrees)', () => {
+    const state = makeState();
+    state.integrations.installed = [
+      makeIntegration(
+        [
+          makeFeature({
+            targetRoot: '/main',
+            attrs: {
+              projectKey: 'main-project',
+              serverUrl: 'https://sonarqube.example.com',
+              repoRoot: '/main',
+            },
+          }),
+        ],
+        { integrationId: 'claude-code-main' },
+      ),
+      makeIntegration(
+        [
+          makeFeature({
+            targetRoot: '/linked-worktree',
+            attrs: {
+              projectKey: 'worktree-project',
+              serverUrl: 'https://sonarqube.example.com',
+              repoRoot: '/main',
+            },
+          }),
+        ],
+        { integrationId: 'claude-code-worktree' },
+      ),
+    ];
+
+    const mappings = buildKnownServerProjectMappings(state);
+
+    expect(mappings.map((m) => m.projectKey).sort()).toEqual(['main-project', 'worktree-project']);
+  });
+
+  it('keeps the most recently updated feature when two features resolve to the same targetRoot', () => {
+    const state = makeState();
+    state.integrations.installed = [
+      makeIntegration(
+        [
+          makeFeature({
+            attrs: { projectKey: 'old-project', serverUrl: 'https://sonarqube.example.com' },
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          }),
+        ],
+        { integrationId: 'git' },
+      ),
+      makeIntegration(
+        [
+          makeFeature({
+            attrs: { projectKey: 'new-project', serverUrl: 'https://sonarqube.example.com' },
+            updatedAt: '2026-02-01T00:00:00.000Z',
+          }),
+        ],
+        { integrationId: 'claude-code' },
+      ),
+    ];
+
+    const mappings = buildKnownServerProjectMappings(state);
+
+    expect(mappings).toEqual([
+      makeMapping({ projectKey: 'new-project', updatedAt: '2026-02-01T00:00:00.000Z' }),
+    ]);
+  });
+});

--- a/tests/unit/core/project-info.test.ts
+++ b/tests/unit/core/project-info.test.ts
@@ -20,23 +20,26 @@
 
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
 
 import { SONARCLOUD_URL, SONARCLOUD_US_URL } from '@/core/config-constants.ts';
+import * as lookupPathResolver from '@/core/host/git/lookup-path-resolver.ts';
 import { canonicalizePath } from '@/core/io/fs-utils.ts';
+import type { KnownServerProjectMapping } from '@/core/known-server-project-mappings.ts';
 import logger from '@/core/observability/logger.ts';
 import * as processLib from '@/core/process/process.ts';
-import * as projectWorkspace from '@/core/project-info.ts';
 import {
   discoverOrganization,
   discoverProject,
-  discoverProjectInfo,
   discoverServer,
+  KNOWN_SERVER_PROJECT_MAPPING_SOURCE,
 } from '@/core/project-info.ts';
 import * as discoverByRemote from '@/core/server/discover-project-by-remote.ts';
 import { GIT_REMOTE_BINDING_SOURCE } from '@/core/server/discover-project-by-remote.ts';
+import { getDefaultState } from '@/core/state/state.ts';
+import * as stateRepository from '@/core/state/state-repository.ts';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 
 async function withCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
@@ -49,184 +52,103 @@ async function withCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
   }
 }
 
-it('discoverProjectInfo: parses sonar-project.properties (comments, empty lines, all keys)', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-props-' + Date.now());
-  mkdirSync(testDir, { recursive: true });
+function makeKnownMapping(
+  overrides: Partial<KnownServerProjectMapping> = {},
+): KnownServerProjectMapping {
+  return {
+    targetRoot: '',
+    projectKey: 'known-project',
+    serverUrl: 'https://known.example.com',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
-  try {
-    const propsContent = `
-# SonarQube properties
-sonar.host.url=https://sonarcloud.io
-
-# Another comment
-sonar.projectKey=my_project
-sonar.projectName=My Project
-sonar.organization=my-org
-`;
-    writeFileSync(join(testDir, 'sonar-project.properties'), propsContent);
-
-    const info = await discoverProjectInfo(testDir);
-
-    expect(info.hasSonarProps).toBe(true);
-    expect(info.sonarPropsData).toMatchObject({
-      hostURL: 'https://sonarcloud.io',
-      projectKey: 'my_project',
-      projectName: 'My Project',
-      organization: 'my-org',
-    });
-  } finally {
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
-
-it('discoverProjectInfo: no configuration files', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-empty-' + Date.now());
-  mkdirSync(testDir, { recursive: true });
-
-  try {
-    const info = await discoverProjectInfo(testDir);
-    expect(info.hasSonarProps).toBe(false);
-    expect(info.hasSonarLintConfig).toBe(false);
-  } finally {
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
-
-it('discoverProjectInfo: detects git repository when .git dir present', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-gitrepo-' + Date.now());
-  mkdirSync(join(testDir, '.git'), { recursive: true });
-
-  try {
-    const info = await discoverProjectInfo(testDir);
-    expect(info.isGitRepo).toBe(true);
-    expect(info.root).toBe(canonicalizePath(testDir));
-  } finally {
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
-
-it('discoverProjectInfo: reads git remote when git repository has origin', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-gitremote-' + Date.now());
-  mkdirSync(join(testDir, '.git'), { recursive: true });
-
-  const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
-    exitCode: 0,
-    stdout: 'https://github.com/example/test-project.git',
-    stderr: '',
-  });
-
-  try {
-    const info = await discoverProjectInfo(testDir);
-    expect(info.isGitRepo).toBe(true);
-    expect(info.gitRemote).toBe('https://github.com/example/test-project.git');
-  } finally {
-    spawnSpy.mockRestore();
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
-
-it('discoverProjectInfo: ignores property line without equals sign', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-noeq-' + Date.now());
-  mkdirSync(testDir, { recursive: true });
-
-  try {
-    const propsContent = `sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_key\nINVALID_LINE_NO_EQUALS\n`;
-    writeFileSync(join(testDir, 'sonar-project.properties'), propsContent);
-
-    const info = await discoverProjectInfo(testDir);
-    expect(info.hasSonarProps).toBe(true);
-    expect(info.sonarPropsData?.projectKey).toBe('my_key');
-  } finally {
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
-
-it('discoverProjectInfo: uses resolve() when startDir does not exist (canonicalizePath fallback)', async () => {
-  const ghostDir = join(tmpdir(), `sonarqube-cli-ghost-${Date.now()}`);
-  const info = await discoverProjectInfo(ghostDir);
-  expect(info.root).toBe(resolve(ghostDir));
-  expect(info.hasSonarProps).toBe(false);
-});
-
-it('discoverProjectInfo: no hostURL or projectKey in file yields no props', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-norelevantkeys-' + Date.now());
-  mkdirSync(testDir, { recursive: true });
-
-  try {
-    writeFileSync(
-      join(testDir, 'sonar-project.properties'),
-      `sonar.projectName=My Project\nsonar.organization=my-org\n`,
-    );
-
-    const info = await discoverProjectInfo(testDir);
-    expect(info.hasSonarProps).toBe(false);
-    expect(info.sonarPropsData).toBeNull();
-  } finally {
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
-
-it('discoverProjectInfo: git remote is empty when git spawn fails', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-git-spawn-fail-' + Date.now());
-  mkdirSync(join(testDir, '.git'), { recursive: true });
-
-  const spawnSpy = spyOn(processLib, 'spawnProcess').mockRejectedValue(
-    new Error('git not available'),
-  );
-
-  try {
-    const info = await discoverProjectInfo(testDir);
-    expect(info.isGitRepo).toBe(true);
-    expect(info.gitRemote).toBe('');
-  } finally {
-    spawnSpy.mockRestore();
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
-
-it('discoverProjectInfo: git remote is empty when git returns non-zero exit', async () => {
-  const testDir = join(tmpdir(), 'sonarqube-cli-test-git-exit-nz-' + Date.now());
-  mkdirSync(join(testDir, '.git'), { recursive: true });
-
-  const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
-    exitCode: 1,
-    stdout: '',
-    stderr: 'no origin',
-  });
-
-  try {
-    const info = await discoverProjectInfo(testDir);
-    expect(info.isGitRepo).toBe(true);
-    expect(info.gitRemote).toBe('');
-  } finally {
-    spawnSpy.mockRestore();
-    rmSync(testDir, { recursive: true, force: true });
-  }
-});
+/**
+ * Seeds `state.integrations.installed` with one project-scoped feature per mapping, so
+ * `buildKnownServerProjectMappings` derives each `mapping` live (there is no persisted
+ * `state.knownServerProjectMappings` table on this branch — see known-server-project-mappings.ts).
+ * Returns the built state so callers can layer further mutations (e.g. an active connection)
+ * onto the same object `loadStateSpy` is now returning.
+ */
+function mockLiveMappings(
+  loadStateSpy: Mock<typeof stateRepository.loadState>,
+  mappings: KnownServerProjectMapping[],
+): ReturnType<typeof getDefaultState> {
+  const state = getDefaultState('1.0.0');
+  state.integrations.installed = mappings.map((mapping, index) => ({
+    id: `integration-${index}`,
+    integrationId: 'claude-code',
+    installedByCliVersion: '1.0.0',
+    installedAt: mapping.updatedAt,
+    updatedByCliVersion: '1.0.0',
+    updatedAt: mapping.updatedAt,
+    features: [
+      {
+        featureId: 'vortex',
+        scope: 'project' as const,
+        targetRoot: mapping.targetRoot,
+        installedByCliVersion: '1.0.0',
+        installedAt: mapping.updatedAt,
+        updatedByCliVersion: '1.0.0',
+        updatedAt: mapping.updatedAt,
+        dependencies: [],
+        resources: [],
+        operations: [],
+        attrs: {
+          projectKey: mapping.projectKey,
+          ...(mapping.serverUrl !== undefined ? { serverUrl: mapping.serverUrl } : {}),
+          ...(mapping.orgKey !== undefined ? { orgKey: mapping.orgKey } : {}),
+          ...(mapping.repoRoot !== undefined ? { repoRoot: mapping.repoRoot } : {}),
+        },
+      },
+    ],
+  }));
+  loadStateSpy.mockReturnValue(state);
+  return state;
+}
 
 describe('discoverProject', () => {
   let testDir: string;
+  let loadStateSpy: Mock<typeof stateRepository.loadState>;
 
   beforeEach(() => {
     testDir = join(tmpdir(), `sonarqube-cli-test-discover-project-${Date.now()}`);
     mkdirSync(testDir, { recursive: true });
     setMockUi(true);
+    // Isolate from the real ~/.sonar state.json — most tests here don't care about
+    // known-project-mapping lookups, only the dedicated tests below do.
+    loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
   });
 
   afterEach(() => {
     clearMockUiCalls();
     setMockUi(false);
+    loadStateSpy.mockRestore();
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('resolves rootDir and isGitRepo from filesystem', async () => {
-    expect((await discoverProject(testDir)).rootDir).toBe(canonicalizePath(testDir));
-    expect((await discoverProject(testDir)).isGitRepo).toBe(false);
+  it('resolves repoRoot from filesystem, undefined outside a git repository', async () => {
+    expect((await discoverProject(testDir)).repoRoot).toBeUndefined();
 
     mkdirSync(join(testDir, '.git'));
     const withGit = await discoverProject(testDir);
-    expect(withGit.isGitRepo).toBe(true);
-    expect(withGit.rootDir).toBe(canonicalizePath(testDir));
+    expect(withGit.repoRoot).toBe(canonicalizePath(testDir));
+  });
+
+  it('defaults projectRoot to the invocation directory when nothing else resolves', async () => {
+    expect((await discoverProject(testDir)).projectRoot).toBe(canonicalizePath(testDir));
+  });
+
+  it('defaults projectRoot to the invocation directory, not repoRoot, even inside a git repo', async () => {
+    mkdirSync(join(testDir, '.git'));
+    const subDir = join(testDir, 'packages', 'app');
+    mkdirSync(subDir, { recursive: true });
+
+    const result = await discoverProject(subDir);
+
+    expect(result.repoRoot).toBe(canonicalizePath(testDir));
+    expect(result.projectRoot).toBe(canonicalizePath(subDir));
   });
 
   it('no config: no server fields and no text UI', async () => {
@@ -237,6 +159,53 @@ describe('discoverProject', () => {
 
     await discoverProject(testDir);
     expect(getMockUiCalls().filter((c) => c.method === 'print')).toHaveLength(0);
+  });
+
+  it('ignores comments and blank lines in sonar-project.properties', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      '\n# comment\nsonar.host.url=https://sonarcloud.io\n\n# another\nsonar.projectKey=my_project\n',
+    );
+
+    const result = await discoverProject(testDir);
+
+    expect(result.serverUrl).toBe('https://sonarcloud.io');
+    expect(result.projectKey).toBe('my_project');
+  });
+
+  it('ignores a property line without an equals sign', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_key\nINVALID_LINE_NO_EQUALS\n',
+    );
+
+    const result = await discoverProject(testDir);
+
+    expect(result.projectKey).toBe('my_key');
+  });
+
+  it('does not treat sonar-project.properties as a match when it has no hostURL or projectKey', async () => {
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.projectName=My Project\nsonar.organization=my-org\n',
+    );
+
+    const result = await discoverProject(testDir);
+
+    expect(result.serverUrl).toBeUndefined();
+    expect(result.projectKey).toBeUndefined();
+    expect(result.configSources).toEqual([]);
+  });
+
+  it('does not treat a .sonarlint dir with no usable binding file as a match', async () => {
+    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
+    writeFileSync(join(testDir, '.sonarlint', 'notes.txt'), 'not json');
+
+    const result = await discoverProject(testDir);
+
+    expect(result.serverUrl).toBeUndefined();
+    expect(result.projectKey).toBeUndefined();
+    expect(result.configSources).toEqual([]);
   });
 
   it('maps sonar-project.properties to DiscoveredProject and updates configSources', async () => {
@@ -422,6 +391,387 @@ describe('discoverProject', () => {
       remoteSpy.mockRestore();
     }
   });
+
+  it('returns a partial result instead of throwing when lookup-path resolution fails', async () => {
+    const lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockRejectedValue(
+      new Error('simulated failure'),
+    );
+
+    try {
+      const result = await discoverProject(testDir);
+
+      expect(result.projectKey).toBeUndefined();
+      expect(result.projectRoot).toBe(canonicalizePath(testDir));
+      expect(result.configSources).toEqual([]);
+    } finally {
+      lookupPathsSpy.mockRestore();
+    }
+  });
+
+  describe('known server project mapping', () => {
+    it('uses a known project mapping when no local config provides one', async () => {
+      mockLiveMappings(loadStateSpy, [
+        makeKnownMapping({ targetRoot: canonicalizePath(testDir), orgKey: 'known-org' }),
+      ]);
+
+      const result = await discoverProject(testDir);
+
+      expect(result.projectKey).toBe('known-project');
+      expect(result.serverUrl).toBe('https://known.example.com');
+      expect(result.organization).toBe('known-org');
+      expect(result.configSources).toEqual([KNOWN_SERVER_PROJECT_MAPPING_SOURCE]);
+      expect(result.projectRoot).toBe(canonicalizePath(testDir));
+      expect(result.integrationDir).toBe(canonicalizePath(testDir));
+    });
+
+    it("sets integrationDir to the matched mapping's own targetRoot, which can differ from projectRoot", async () => {
+      // Matched via the repoRoot signal: projectRoot anchors here, integrationDir stays elsewhere.
+      const otherWorktreeInstallDir = join(testDir, '..', 'other-worktree-install-dir');
+      mockLiveMappings(loadStateSpy, [
+        makeKnownMapping({
+          targetRoot: canonicalizePath(otherWorktreeInstallDir),
+          repoRoot: canonicalizePath(testDir),
+        }),
+      ]);
+
+      const result = await discoverProject(testDir);
+
+      expect(result.projectKey).toBe('known-project');
+      expect(result.projectRoot).toBe(canonicalizePath(testDir));
+      expect(result.integrationDir).toBe(canonicalizePath(otherWorktreeInstallDir));
+    });
+
+    it('matches from a subdirectory of the mapped folder', async () => {
+      const subDir = join(testDir, 'nested', 'sub');
+      mkdirSync(subDir, { recursive: true });
+      mockLiveMappings(loadStateSpy, [makeKnownMapping({ targetRoot: canonicalizePath(testDir) })]);
+
+      const result = await discoverProject(subDir);
+
+      expect(result.projectKey).toBe('known-project');
+    });
+
+    it('matches a known mapping recorded at a subdirectory below the git repo root (monorepo package)', async () => {
+      // Regression test: discoverProject() must pass the raw invocation directory
+      // (not the already-collapsed git repo root) into the known-mapping lookup, so a
+      // mapping recorded at a nested package folder still matches from inside it.
+      mkdirSync(join(testDir, '.git'), { recursive: true });
+      const packageDir = join(testDir, 'packages', 'api');
+      const invokeDir = join(packageDir, 'src');
+      mkdirSync(invokeDir, { recursive: true });
+      mockLiveMappings(loadStateSpy, [
+        makeKnownMapping({
+          targetRoot: canonicalizePath(packageDir),
+          projectKey: 'package-project',
+        }),
+      ]);
+
+      const result = await discoverProject(invokeDir);
+
+      expect(result.projectKey).toBe('package-project');
+      expect(result.projectRoot).toBe(canonicalizePath(packageDir));
+    });
+
+    it('does not match an unrelated folder', async () => {
+      mockLiveMappings(loadStateSpy, [
+        makeKnownMapping({
+          targetRoot: join(tmpdir(), 'some-other-project'),
+          projectKey: 'other-project',
+        }),
+      ]);
+
+      const result = await discoverProject(testDir);
+
+      expect(result.projectKey).toBeUndefined();
+    });
+
+    it('a known project mapping wins over sonar-project.properties and skips reading it', async () => {
+      writeFileSync(
+        join(testDir, 'sonar-project.properties'),
+        'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
+      );
+      mockLiveMappings(loadStateSpy, [makeKnownMapping({ targetRoot: canonicalizePath(testDir) })]);
+
+      const result = await discoverProject(testDir);
+
+      expect(result.projectKey).toBe('known-project');
+      expect(result.serverUrl).toBe('https://known.example.com');
+      expect(result.configSources).toEqual([KNOWN_SERVER_PROJECT_MAPPING_SOURCE]);
+    });
+
+    it('is checked before, and short-circuits, the git-remote binding network lookup', async () => {
+      mkdirSync(join(testDir, '.git'), { recursive: true });
+      mockLiveMappings(loadStateSpy, [makeKnownMapping({ targetRoot: canonicalizePath(testDir) })]);
+      const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+        projectKey: 'from-remote',
+        serverUrl: 'https://sonarcloud.io',
+      });
+
+      try {
+        const result = await discoverProject(testDir, false, {
+          auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+        });
+
+        expect(result.projectKey).toBe('known-project');
+        expect(remoteSpy).not.toHaveBeenCalled();
+      } finally {
+        remoteSpy.mockRestore();
+      }
+    });
+
+    it('falls through to git-remote binding when no known mapping matches', async () => {
+      mkdirSync(join(testDir, '.git'), { recursive: true });
+      const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
+        exitCode: 0,
+        stdout: 'https://github.com/example/remote-bound.git',
+        stderr: '',
+      });
+      const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+        projectKey: 'from-remote',
+        serverUrl: 'https://sonarcloud.io',
+      });
+
+      try {
+        const result = await discoverProject(testDir, false, {
+          auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+        });
+
+        expect(result.projectKey).toBe('from-remote');
+      } finally {
+        spawnSpy.mockRestore();
+        remoteSpy.mockRestore();
+      }
+    });
+
+    it('gracefully skips when loadState throws', async () => {
+      loadStateSpy.mockImplementation(() => {
+        throw new Error('state read failed');
+      });
+
+      const result = await discoverProject(testDir);
+
+      expect(result.projectKey).toBeUndefined();
+    });
+
+    it('derives a mapping live from a project-scoped installed feature', async () => {
+      const state = getDefaultState('1.0.0');
+      state.integrations.installed = [
+        {
+          id: 'integration-1',
+          integrationId: 'claude-code',
+          installedByCliVersion: '1.0.0',
+          installedAt: '2026-01-01T00:00:00.000Z',
+          updatedByCliVersion: '1.0.0',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          features: [
+            {
+              featureId: 'vortex',
+              scope: 'project',
+              targetRoot: canonicalizePath(testDir),
+              installedByCliVersion: '1.0.0',
+              installedAt: '2026-01-01T00:00:00.000Z',
+              updatedByCliVersion: '1.0.0',
+              updatedAt: '2026-01-01T00:00:00.000Z',
+              dependencies: [],
+              resources: [],
+              operations: [],
+              attrs: { projectKey: 'live-project', serverUrl: 'https://live.example.com' },
+            },
+          ],
+        },
+      ];
+      loadStateSpy.mockReturnValue(state);
+
+      const result = await discoverProject(testDir);
+
+      expect(result.projectKey).toBe('live-project');
+      expect(result.serverUrl).toBe('https://live.example.com');
+      expect(result.configSources).toEqual([KNOWN_SERVER_PROJECT_MAPPING_SOURCE]);
+    });
+
+    describe('connection resolution for mappings that recorded no serverUrl', () => {
+      function withActiveConnection(state: ReturnType<typeof getDefaultState>): void {
+        state.auth.connections = [
+          {
+            id: 'conn-1',
+            type: 'cloud',
+            serverUrl: 'https://active-connection.example.com',
+            orgKey: 'active-org',
+            authenticatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ];
+        state.auth.activeConnectionId = 'conn-1';
+      }
+
+      it('substitutes the currently active connection, resolved fresh, not baked in at derive time', async () => {
+        const state = mockLiveMappings(loadStateSpy, [
+          makeKnownMapping({
+            targetRoot: canonicalizePath(testDir),
+            serverUrl: undefined,
+            orgKey: undefined,
+          }),
+        ]);
+        withActiveConnection(state);
+
+        const result = await discoverProject(testDir);
+
+        expect(result.projectKey).toBe('known-project');
+        expect(result.serverUrl).toBe('https://active-connection.example.com');
+        expect(result.organization).toBe('active-org');
+      });
+
+      it('falls through to the next discovery source when no connection can be resolved at all', async () => {
+        mockLiveMappings(loadStateSpy, [
+          makeKnownMapping({
+            targetRoot: canonicalizePath(testDir),
+            serverUrl: undefined,
+            orgKey: undefined,
+          }),
+        ]);
+        // No active connection set: the mapping matches by path, but there is nothing to
+        // resolve a serverUrl from, so it must not "succeed" with an undefined serverUrl.
+        writeFileSync(
+          join(testDir, 'sonar-project.properties'),
+          'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
+        );
+
+        const result = await discoverProject(testDir);
+
+        expect(result.projectKey).toBe('props_project');
+        expect(result.configSources).toEqual(['sonar-project.properties']);
+      });
+
+      it("prefers the caller's own resolved auth over the active connection in state", async () => {
+        // Active connection in state disagrees with the auth the caller actually resolved
+        // and passed in — e.g. env-var auth that hasn't been persisted yet.
+        const state = mockLiveMappings(loadStateSpy, [
+          makeKnownMapping({
+            targetRoot: canonicalizePath(testDir),
+            serverUrl: undefined,
+            orgKey: undefined,
+          }),
+        ]);
+        withActiveConnection(state);
+
+        const result = await discoverProject(testDir, false, {
+          auth: {
+            token: 't',
+            serverUrl: 'https://env-auth.example.com',
+            orgKey: 'env-org',
+            connectionType: 'cloud',
+          },
+        });
+
+        expect(result.serverUrl).toBe('https://env-auth.example.com');
+        expect(result.organization).toBe('env-org');
+      });
+
+      it("never mixes a recorded serverUrl with the active connection's orgKey", async () => {
+        const state = mockLiveMappings(loadStateSpy, [
+          makeKnownMapping({
+            targetRoot: canonicalizePath(testDir),
+            serverUrl: 'https://recorded.example.com',
+            orgKey: undefined,
+          }),
+        ]);
+        withActiveConnection(state);
+
+        const result = await discoverProject(testDir);
+
+        expect(result.serverUrl).toBe('https://recorded.example.com');
+        expect(result.organization).toBeUndefined();
+      });
+    });
+  });
+
+  describe('local config file precedence (climbing sonar-project.properties/.sonarlint)', () => {
+    it('finds sonar-project.properties at a nested subdirectory when invoked from within it', async () => {
+      const subDir = join(testDir, 'packages', 'api');
+      mkdirSync(subDir, { recursive: true });
+      writeFileSync(
+        join(subDir, 'sonar-project.properties'),
+        'sonar.host.url=https://sub.example.com\nsonar.projectKey=sub_project\n',
+      );
+
+      const result = await discoverProject(subDir);
+
+      expect(result.projectKey).toBe('sub_project');
+      expect(result.serverUrl).toBe('https://sub.example.com');
+      expect(result.projectRoot).toBe(canonicalizePath(subDir));
+      // Resolved via a local config hint, not a recorded integration.
+      expect(result.integrationDir).toBeUndefined();
+    });
+
+    it('finds .sonarlint connected mode at a nested subdirectory when invoked from within it', async () => {
+      const subDir = join(testDir, 'packages', 'app');
+      mkdirSync(join(subDir, '.sonarlint'), { recursive: true });
+      writeFileSync(
+        join(subDir, '.sonarlint', 'connectedMode.json'),
+        JSON.stringify({
+          sonarQubeUri: 'https://sub-lint.example.com',
+          projectKey: 'sub_lint_project',
+        }),
+      );
+
+      const result = await discoverProject(subDir);
+
+      expect(result.projectKey).toBe('sub_lint_project');
+      expect(result.serverUrl).toBe('https://sub-lint.example.com');
+    });
+
+    it('prefers the nearer properties file over a farther ancestor one', async () => {
+      writeFileSync(
+        join(testDir, 'sonar-project.properties'),
+        'sonar.host.url=https://root.example.com\nsonar.projectKey=root_project\n',
+      );
+      const subDir = join(testDir, 'packages', 'api');
+      mkdirSync(subDir, { recursive: true });
+      writeFileSync(
+        join(subDir, 'sonar-project.properties'),
+        'sonar.host.url=https://sub.example.com\nsonar.projectKey=sub_project\n',
+      );
+
+      const result = await discoverProject(subDir);
+
+      expect(result.projectKey).toBe('sub_project');
+      expect(result.serverUrl).toBe('https://sub.example.com');
+    });
+
+    it('climbs past a directory with only partial local config to a farther directory with a full one', async () => {
+      const subDir = join(testDir, 'packages', 'api');
+      mkdirSync(subDir, { recursive: true });
+      // Partial: host URL only, no project key — must not stop the climb.
+      writeFileSync(
+        join(subDir, 'sonar-project.properties'),
+        'sonar.host.url=https://sub.example.com\n',
+      );
+      writeFileSync(
+        join(testDir, 'sonar-project.properties'),
+        'sonar.host.url=https://root.example.com\nsonar.projectKey=root_project\n',
+      );
+
+      const result = await discoverProject(subDir);
+
+      expect(result.projectKey).toBe('root_project');
+      expect(result.serverUrl).toBe('https://root.example.com');
+    });
+
+    it('a known-mapping match at a farther directory still wins over a nearer local properties file', async () => {
+      const subDir = join(testDir, 'packages', 'api');
+      mkdirSync(subDir, { recursive: true });
+      writeFileSync(
+        join(subDir, 'sonar-project.properties'),
+        'sonar.host.url=https://sub.example.com\nsonar.projectKey=sub_project\n',
+      );
+      mockLiveMappings(loadStateSpy, [
+        makeKnownMapping({ targetRoot: canonicalizePath(testDir), projectKey: 'mapped-project' }),
+      ]);
+
+      const result = await discoverProject(subDir);
+
+      expect(result.projectKey).toBe('mapped-project');
+    });
+  });
 });
 
 describe('discoverOrganization', () => {
@@ -485,15 +835,33 @@ describe('discoverOrganization', () => {
     }
   });
 
-  it('returns null when discoverProjectInfo throws', async () => {
-    const discoverSpy = spyOn(projectWorkspace, 'discoverProjectInfo').mockRejectedValue(
+  it('climbs from a nested monorepo package to find organization at an ancestor', async () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-org-nested-' + Date.now());
+    const subDir = join(testDir, 'packages', 'api');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://x.test\nsonar.projectKey=p\nsonar.organization=ancestor-org\n',
+    );
+
+    try {
+      await withCwd(subDir, async () => {
+        expect(await discoverOrganization()).toBe('ancestor-org');
+      });
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null when local config discovery throws', async () => {
+    const lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockRejectedValue(
       new Error('simulated failure'),
     );
 
     try {
       expect(await discoverOrganization()).toBeNull();
     } finally {
-      discoverSpy.mockRestore();
+      lookupPathsSpy.mockRestore();
     }
   });
 });
@@ -581,8 +949,26 @@ describe('discoverServer', () => {
     }
   });
 
-  it('returns null and logs when discoverProjectInfo throws', async () => {
-    const discoverSpy = spyOn(projectWorkspace, 'discoverProjectInfo').mockRejectedValue(
+  it('climbs from a nested monorepo package to find the server URL at an ancestor', async () => {
+    const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-server-nested-' + Date.now());
+    const subDir = join(testDir, 'packages', 'api');
+    mkdirSync(subDir, { recursive: true });
+    writeFileSync(
+      join(testDir, 'sonar-project.properties'),
+      'sonar.host.url=https://ancestor.example.com\nsonar.projectKey=p\n',
+    );
+
+    try {
+      await withCwd(subDir, async () => {
+        expect(await discoverServer()).toBe('https://ancestor.example.com');
+      });
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns null and logs when local config discovery throws', async () => {
+    const lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockRejectedValue(
       new Error('simulated failure'),
     );
     const debugSpy = spyOn(logger, 'debug').mockImplementation(() => undefined);
@@ -592,7 +978,7 @@ describe('discoverServer', () => {
       expect(debugSpy).toHaveBeenCalled();
       expect(String(debugSpy.mock.calls[0]?.[0] ?? '')).toContain('simulated failure');
     } finally {
-      discoverSpy.mockRestore();
+      lookupPathsSpy.mockRestore();
       debugSpy.mockRestore();
     }
   });

--- a/tests/unit/core/project-info.test.ts
+++ b/tests/unit/core/project-info.test.ts
@@ -356,7 +356,7 @@ describe('discoverProject', () => {
       organization: 'my-org',
     });
 
-    const result = await discoverProject(testDir, false, {
+    const result = await discoverProject(testDir, {
       auth: {
         token: 'token',
         serverUrl: 'https://sonarcloud.io',
@@ -384,7 +384,7 @@ describe('discoverProject', () => {
       serverUrl: 'https://sonarcloud.io',
     });
 
-    const result = await discoverProject(testDir, false, {
+    const result = await discoverProject(testDir, {
       auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
     });
     expect(result.projectKey).toBe('local_key');
@@ -398,9 +398,10 @@ describe('discoverProject', () => {
       serverUrl: 'https://sonarcloud.io',
     });
 
-    await discoverProject(testDir, true, {
+    await discoverProject(testDir, {
       auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
       tryGitRemoteBinding: false,
+      silent: true,
     });
     expect(remoteSpy).not.toHaveBeenCalled();
   });
@@ -531,7 +532,7 @@ describe('discoverProject', () => {
         serverUrl: 'https://sonarcloud.io',
       });
 
-      const result = await discoverProject(testDir, false, {
+      const result = await discoverProject(testDir, {
         auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
       });
 
@@ -547,7 +548,7 @@ describe('discoverProject', () => {
         serverUrl: 'https://sonarcloud.io',
       });
 
-      const result = await discoverProject(testDir, false, {
+      const result = await discoverProject(testDir, {
         auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
       });
 
@@ -664,7 +665,7 @@ describe('discoverProject', () => {
         ]);
         withActiveConnection(state);
 
-        const result = await discoverProject(testDir, false, {
+        const result = await discoverProject(testDir, {
           auth: {
             token: 't',
             serverUrl: 'https://env-auth.example.com',

--- a/tests/unit/core/project-info.test.ts
+++ b/tests/unit/core/project-info.test.ts
@@ -18,18 +18,18 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, Mock, spyOn } from 'bun:test';
 
 import { SONARCLOUD_URL, SONARCLOUD_US_URL } from '@/core/config-constants.ts';
+import * as gitDiscover from '@/core/host/git/discover.ts';
 import * as lookupPathResolver from '@/core/host/git/lookup-path-resolver.ts';
+import * as gitWorktree from '@/core/host/git/worktree.ts';
 import { canonicalizePath } from '@/core/io/fs-utils.ts';
 import type { KnownServerProjectMapping } from '@/core/known-server-project-mappings.ts';
 import logger from '@/core/observability/logger.ts';
-import * as processLib from '@/core/process/process.ts';
 import {
   discoverOrganization,
   discoverProject,
@@ -42,14 +42,36 @@ import { getDefaultState } from '@/core/state/state.ts';
 import * as stateRepository from '@/core/state/state-repository.ts';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 
-async function withCwd<T>(dir: string, fn: () => Promise<T>): Promise<T> {
-  const prev = process.cwd();
-  process.chdir(dir);
-  try {
-    return await fn();
-  } finally {
-    process.chdir(prev);
-  }
+import { createFakeFsTestHandle } from './fake-fs-test-handle.ts';
+
+const fakeFs = createFakeFsTestHandle();
+
+function withCwd<T>(
+  cwdSpy: Mock<typeof process.cwd>,
+  dir: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  cwdSpy.mockReturnValue(dir);
+  return fn();
+}
+
+/** Default `resolveLookupPaths` mock: bounded to the invocation dir itself, like the real non-git outcome — never falls through to a real `git` spawn. */
+function defaultLookupPaths(startDir: string): Promise<lookupPathResolver.LookupPath[]> {
+  const checkPath = canonicalizePath(startDir);
+  return Promise.resolve([{ checkPath, projectRoot: checkPath }]);
+}
+
+/** Points an already-spied `resolveLookupPaths` at the nearest-first climb `dirs` represents. */
+function mockClimb(
+  lookupPathsSpy: Mock<typeof lookupPathResolver.resolveLookupPaths>,
+  ...dirs: string[]
+): void {
+  lookupPathsSpy.mockResolvedValue(
+    dirs.map((dir) => {
+      const checkPath = canonicalizePath(dir);
+      return { checkPath, projectRoot: checkPath };
+    }),
+  );
 }
 
 function makeKnownMapping(
@@ -111,27 +133,42 @@ function mockLiveMappings(
 describe('discoverProject', () => {
   let testDir: string;
   let loadStateSpy: Mock<typeof stateRepository.loadState>;
+  let lookupPathsSpy: Mock<typeof lookupPathResolver.resolveLookupPaths>;
+  let remoteSpy: Mock<typeof discoverByRemote.discoverProjectKeyByGitRemote>;
+  let getGitRemoteSpy: Mock<typeof gitDiscover.getGitRemote>;
+  let mainWorktreeSpy: Mock<typeof gitWorktree.resolveMainWorktreeRoot>;
 
   beforeEach(() => {
+    fakeFs.setup();
     testDir = join(tmpdir(), `sonarqube-cli-test-discover-project-${Date.now()}`);
-    mkdirSync(testDir, { recursive: true });
+    fakeFs.mkdir(testDir);
     setMockUi(true);
     // Isolate from the real ~/.sonar state.json — most tests here don't care about
     // known-project-mapping lookups, only the dedicated tests below do.
     loadStateSpy = spyOn(stateRepository, 'loadState').mockReturnValue(getDefaultState('1.0.0'));
+    lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockImplementation(
+      defaultLookupPaths,
+    );
+    remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue(null);
+    getGitRemoteSpy = spyOn(gitDiscover, 'getGitRemote').mockResolvedValue('');
+    mainWorktreeSpy = spyOn(gitWorktree, 'resolveMainWorktreeRoot').mockResolvedValue(null);
   });
 
   afterEach(() => {
     clearMockUiCalls();
     setMockUi(false);
+    fakeFs.teardown();
     loadStateSpy.mockRestore();
-    rmSync(testDir, { recursive: true, force: true });
+    getGitRemoteSpy.mockRestore();
+    mainWorktreeSpy.mockRestore();
+    lookupPathsSpy.mockRestore();
+    remoteSpy.mockRestore();
   });
 
   it('resolves repoRoot from filesystem, undefined outside a git repository', async () => {
     expect((await discoverProject(testDir)).repoRoot).toBeUndefined();
 
-    mkdirSync(join(testDir, '.git'));
+    fakeFs.mkdir(join(testDir, '.git'));
     const withGit = await discoverProject(testDir);
     expect(withGit.repoRoot).toBe(canonicalizePath(testDir));
   });
@@ -141,9 +178,9 @@ describe('discoverProject', () => {
   });
 
   it('defaults projectRoot to the invocation directory, not repoRoot, even inside a git repo', async () => {
-    mkdirSync(join(testDir, '.git'));
+    fakeFs.mkdir(join(testDir, '.git'));
     const subDir = join(testDir, 'packages', 'app');
-    mkdirSync(subDir, { recursive: true });
+    fakeFs.mkdir(subDir);
 
     const result = await discoverProject(subDir);
 
@@ -162,7 +199,7 @@ describe('discoverProject', () => {
   });
 
   it('ignores comments and blank lines in sonar-project.properties', async () => {
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       '\n# comment\nsonar.host.url=https://sonarcloud.io\n\n# another\nsonar.projectKey=my_project\n',
     );
@@ -174,7 +211,7 @@ describe('discoverProject', () => {
   });
 
   it('ignores a property line without an equals sign', async () => {
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_key\nINVALID_LINE_NO_EQUALS\n',
     );
@@ -185,7 +222,7 @@ describe('discoverProject', () => {
   });
 
   it('does not treat sonar-project.properties as a match when it has no hostURL or projectKey', async () => {
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.projectName=My Project\nsonar.organization=my-org\n',
     );
@@ -198,8 +235,7 @@ describe('discoverProject', () => {
   });
 
   it('does not treat a .sonarlint dir with no usable binding file as a match', async () => {
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(join(testDir, '.sonarlint', 'notes.txt'), 'not json');
+    fakeFs.writeFile(join(testDir, '.sonarlint', 'notes.txt'), 'not json');
 
     const result = await discoverProject(testDir);
 
@@ -209,7 +245,7 @@ describe('discoverProject', () => {
   });
 
   it('maps sonar-project.properties to DiscoveredProject and updates configSources', async () => {
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=my_project\nsonar.organization=my-org\n',
     );
@@ -221,8 +257,7 @@ describe('discoverProject', () => {
   });
 
   it('maps SonarQube Server connected mode to DiscoveredProject and updates configSources', async () => {
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, '.sonarlint', 'connectedMode.json'),
       JSON.stringify({
         sonarQubeUri: 'https://sonarqube.example.com',
@@ -243,8 +278,7 @@ describe('discoverProject', () => {
       { region: 'US', url: SONARCLOUD_US_URL },
     ]) {
       clearMockUiCalls();
-      mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-      writeFileSync(
+      fakeFs.writeFile(
         join(testDir, '.sonarlint', 'connectedMode.json'),
         JSON.stringify({
           sonarCloudOrganization: 'my-org',
@@ -256,17 +290,16 @@ describe('discoverProject', () => {
       expect(result.serverUrl).toBe(url);
       expect(result.projectKey).toBe('org_project');
       expect(result.organization).toBe('my-org');
-      rmSync(join(testDir, '.sonarlint'), { recursive: true, force: true });
+      fakeFs.rm(join(testDir, '.sonarlint'));
     }
   });
 
   it('sonar-project.properties wins over SonarLint for serverUrl and projectKey', async () => {
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
     );
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, '.sonarlint', 'connectedMode.json'),
       JSON.stringify({ sonarQubeUri: 'https://sonarlint-server.com', projectKey: 'lint_project' }),
     );
@@ -276,24 +309,22 @@ describe('discoverProject', () => {
   });
 
   it('SonarLint fills projectKey or organization when properties omit them', async () => {
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://props-server.io\n',
     );
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, '.sonarlint', 'connectedMode.json'),
       JSON.stringify({ sonarQubeUri: 'https://sonarlint-server.com', projectKey: 'from_lint' }),
     );
     expect((await discoverProject(testDir)).projectKey).toBe('from_lint');
 
-    rmSync(join(testDir, '.sonarlint'), { recursive: true, force: true });
-    writeFileSync(
+    fakeFs.rm(join(testDir, '.sonarlint'));
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
     );
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, '.sonarlint', 'connectedMode.json'),
       JSON.stringify({ sonarCloudOrganization: 'lint-org', projectKey: 'lint_project' }),
     );
@@ -301,12 +332,11 @@ describe('discoverProject', () => {
   });
 
   it('updates configSources when both sonar-project.properties and .sonarlint exist', async () => {
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
     );
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, '.sonarlint', 'connectedMode.json'),
       JSON.stringify({ sonarQubeUri: 'https://sonarlint-server.com', projectKey: 'lint_project' }),
     );
@@ -318,94 +348,71 @@ describe('discoverProject', () => {
   });
 
   it('resolves projectKey from git remote when authenticated and no local project key', async () => {
-    mkdirSync(join(testDir, '.git'), { recursive: true });
-    const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
-      exitCode: 0,
-      stdout: 'https://github.com/example/remote-bound.git',
-      stderr: '',
-    });
-    const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+    fakeFs.mkdir(join(testDir, '.git'));
+    getGitRemoteSpy.mockResolvedValue('https://github.com/example/remote-bound.git');
+    remoteSpy.mockResolvedValue({
       projectKey: 'from-remote',
       serverUrl: 'https://sonarcloud.io',
       organization: 'my-org',
     });
 
-    try {
-      const result = await discoverProject(testDir, false, {
-        auth: {
-          token: 'token',
-          serverUrl: 'https://sonarcloud.io',
-          orgKey: 'my-org',
-          connectionType: 'cloud',
-        },
-      });
-      expect(result.projectKey).toBe('from-remote');
-      expect(result.organization).toBe('my-org');
-      expect(result.configSources).toEqual([GIT_REMOTE_BINDING_SOURCE]);
-      expect(remoteSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ orgKey: 'my-org' }),
-        'https://github.com/example/remote-bound.git',
-      );
-    } finally {
-      spawnSpy.mockRestore();
-      remoteSpy.mockRestore();
-    }
+    const result = await discoverProject(testDir, false, {
+      auth: {
+        token: 'token',
+        serverUrl: 'https://sonarcloud.io',
+        orgKey: 'my-org',
+        connectionType: 'cloud',
+      },
+    });
+    expect(result.projectKey).toBe('from-remote');
+    expect(result.organization).toBe('my-org');
+    expect(result.configSources).toEqual([GIT_REMOTE_BINDING_SOURCE]);
+    expect(remoteSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orgKey: 'my-org' }),
+      'https://github.com/example/remote-bound.git',
+    );
   });
 
   it('does not call git remote lookup when projectKey is already in local config', async () => {
-    mkdirSync(join(testDir, '.git'), { recursive: true });
-    writeFileSync(
+    fakeFs.mkdir(join(testDir, '.git'));
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://sonarcloud.io\nsonar.projectKey=local_key\n',
     );
-    const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+    remoteSpy.mockResolvedValue({
       projectKey: 'from-remote',
       serverUrl: 'https://sonarcloud.io',
     });
 
-    try {
-      const result = await discoverProject(testDir, false, {
-        auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
-      });
-      expect(result.projectKey).toBe('local_key');
-      expect(remoteSpy).not.toHaveBeenCalled();
-    } finally {
-      remoteSpy.mockRestore();
-    }
+    const result = await discoverProject(testDir, false, {
+      auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+    });
+    expect(result.projectKey).toBe('local_key');
+    expect(remoteSpy).not.toHaveBeenCalled();
   });
 
   it('skips git remote lookup when tryGitRemoteBinding is false', async () => {
-    mkdirSync(join(testDir, '.git'), { recursive: true });
-    const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+    fakeFs.mkdir(join(testDir, '.git'));
+    remoteSpy.mockResolvedValue({
       projectKey: 'from-remote',
       serverUrl: 'https://sonarcloud.io',
     });
 
-    try {
-      await discoverProject(testDir, true, {
-        auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
-        tryGitRemoteBinding: false,
-      });
-      expect(remoteSpy).not.toHaveBeenCalled();
-    } finally {
-      remoteSpy.mockRestore();
-    }
+    await discoverProject(testDir, true, {
+      auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+      tryGitRemoteBinding: false,
+    });
+    expect(remoteSpy).not.toHaveBeenCalled();
   });
 
   it('returns a partial result instead of throwing when lookup-path resolution fails', async () => {
-    const lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockRejectedValue(
-      new Error('simulated failure'),
-    );
+    lookupPathsSpy.mockRejectedValue(new Error('simulated failure'));
 
-    try {
-      const result = await discoverProject(testDir);
+    const result = await discoverProject(testDir);
 
-      expect(result.projectKey).toBeUndefined();
-      expect(result.projectRoot).toBe(canonicalizePath(testDir));
-      expect(result.configSources).toEqual([]);
-    } finally {
-      lookupPathsSpy.mockRestore();
-    }
+    expect(result.projectKey).toBeUndefined();
+    expect(result.projectRoot).toBe(canonicalizePath(testDir));
+    expect(result.configSources).toEqual([]);
   });
 
   describe('known server project mapping', () => {
@@ -443,8 +450,8 @@ describe('discoverProject', () => {
 
     it('matches from a subdirectory of the mapped folder', async () => {
       const subDir = join(testDir, 'nested', 'sub');
-      mkdirSync(subDir, { recursive: true });
       mockLiveMappings(loadStateSpy, [makeKnownMapping({ targetRoot: canonicalizePath(testDir) })]);
+      mockClimb(lookupPathsSpy, subDir, join(testDir, 'nested'), testDir);
 
       const result = await discoverProject(subDir);
 
@@ -455,16 +462,15 @@ describe('discoverProject', () => {
       // Regression test: discoverProject() must pass the raw invocation directory
       // (not the already-collapsed git repo root) into the known-mapping lookup, so a
       // mapping recorded at a nested package folder still matches from inside it.
-      mkdirSync(join(testDir, '.git'), { recursive: true });
       const packageDir = join(testDir, 'packages', 'api');
       const invokeDir = join(packageDir, 'src');
-      mkdirSync(invokeDir, { recursive: true });
       mockLiveMappings(loadStateSpy, [
         makeKnownMapping({
           targetRoot: canonicalizePath(packageDir),
           projectKey: 'package-project',
         }),
       ]);
+      mockClimb(lookupPathsSpy, invokeDir, packageDir, testDir);
 
       const result = await discoverProject(invokeDir);
 
@@ -486,7 +492,7 @@ describe('discoverProject', () => {
     });
 
     it('a known project mapping wins over sonar-project.properties and skips reading it', async () => {
-      writeFileSync(
+      fakeFs.writeFile(
         join(testDir, 'sonar-project.properties'),
         'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
       );
@@ -500,47 +506,34 @@ describe('discoverProject', () => {
     });
 
     it('is checked before, and short-circuits, the git-remote binding network lookup', async () => {
-      mkdirSync(join(testDir, '.git'), { recursive: true });
+      fakeFs.mkdir(join(testDir, '.git'));
       mockLiveMappings(loadStateSpy, [makeKnownMapping({ targetRoot: canonicalizePath(testDir) })]);
-      const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+      remoteSpy.mockResolvedValue({
         projectKey: 'from-remote',
         serverUrl: 'https://sonarcloud.io',
       });
 
-      try {
-        const result = await discoverProject(testDir, false, {
-          auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
-        });
+      const result = await discoverProject(testDir, false, {
+        auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+      });
 
-        expect(result.projectKey).toBe('known-project');
-        expect(remoteSpy).not.toHaveBeenCalled();
-      } finally {
-        remoteSpy.mockRestore();
-      }
+      expect(result.projectKey).toBe('known-project');
+      expect(remoteSpy).not.toHaveBeenCalled();
     });
 
     it('falls through to git-remote binding when no known mapping matches', async () => {
-      mkdirSync(join(testDir, '.git'), { recursive: true });
-      const spawnSpy = spyOn(processLib, 'spawnProcess').mockResolvedValue({
-        exitCode: 0,
-        stdout: 'https://github.com/example/remote-bound.git',
-        stderr: '',
-      });
-      const remoteSpy = spyOn(discoverByRemote, 'discoverProjectKeyByGitRemote').mockResolvedValue({
+      fakeFs.mkdir(join(testDir, '.git'));
+      getGitRemoteSpy.mockResolvedValue('https://github.com/example/remote-bound.git');
+      remoteSpy.mockResolvedValue({
         projectKey: 'from-remote',
         serverUrl: 'https://sonarcloud.io',
       });
 
-      try {
-        const result = await discoverProject(testDir, false, {
-          auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
-        });
+      const result = await discoverProject(testDir, false, {
+        auth: { token: 't', serverUrl: 'https://sonarcloud.io', connectionType: 'cloud' },
+      });
 
-        expect(result.projectKey).toBe('from-remote');
-      } finally {
-        spawnSpy.mockRestore();
-        remoteSpy.mockRestore();
-      }
+      expect(result.projectKey).toBe('from-remote');
     });
 
     it('gracefully skips when loadState throws', async () => {
@@ -630,7 +623,7 @@ describe('discoverProject', () => {
         ]);
         // No active connection set: the mapping matches by path, but there is nothing to
         // resolve a serverUrl from, so it must not "succeed" with an undefined serverUrl.
-        writeFileSync(
+        fakeFs.writeFile(
           join(testDir, 'sonar-project.properties'),
           'sonar.host.url=https://props-server.io\nsonar.projectKey=props_project\n',
         );
@@ -687,8 +680,7 @@ describe('discoverProject', () => {
   describe('local config file precedence (climbing sonar-project.properties/.sonarlint)', () => {
     it('finds sonar-project.properties at a nested subdirectory when invoked from within it', async () => {
       const subDir = join(testDir, 'packages', 'api');
-      mkdirSync(subDir, { recursive: true });
-      writeFileSync(
+      fakeFs.writeFile(
         join(subDir, 'sonar-project.properties'),
         'sonar.host.url=https://sub.example.com\nsonar.projectKey=sub_project\n',
       );
@@ -704,8 +696,7 @@ describe('discoverProject', () => {
 
     it('finds .sonarlint connected mode at a nested subdirectory when invoked from within it', async () => {
       const subDir = join(testDir, 'packages', 'app');
-      mkdirSync(join(subDir, '.sonarlint'), { recursive: true });
-      writeFileSync(
+      fakeFs.writeFile(
         join(subDir, '.sonarlint', 'connectedMode.json'),
         JSON.stringify({
           sonarQubeUri: 'https://sub-lint.example.com',
@@ -720,13 +711,12 @@ describe('discoverProject', () => {
     });
 
     it('prefers the nearer properties file over a farther ancestor one', async () => {
-      writeFileSync(
+      fakeFs.writeFile(
         join(testDir, 'sonar-project.properties'),
         'sonar.host.url=https://root.example.com\nsonar.projectKey=root_project\n',
       );
       const subDir = join(testDir, 'packages', 'api');
-      mkdirSync(subDir, { recursive: true });
-      writeFileSync(
+      fakeFs.writeFile(
         join(subDir, 'sonar-project.properties'),
         'sonar.host.url=https://sub.example.com\nsonar.projectKey=sub_project\n',
       );
@@ -737,18 +727,18 @@ describe('discoverProject', () => {
       expect(result.serverUrl).toBe('https://sub.example.com');
     });
 
-    it('climbs past a directory with only partial local config to a farther directory with a full one', async () => {
+    it('climbs past a directory with only partial local config to a farther directory with a full one, inside a git repo', async () => {
       const subDir = join(testDir, 'packages', 'api');
-      mkdirSync(subDir, { recursive: true });
       // Partial: host URL only, no project key — must not stop the climb.
-      writeFileSync(
+      fakeFs.writeFile(
         join(subDir, 'sonar-project.properties'),
         'sonar.host.url=https://sub.example.com\n',
       );
-      writeFileSync(
+      fakeFs.writeFile(
         join(testDir, 'sonar-project.properties'),
         'sonar.host.url=https://root.example.com\nsonar.projectKey=root_project\n',
       );
+      mockClimb(lookupPathsSpy, subDir, join(testDir, 'packages'), testDir);
 
       const result = await discoverProject(subDir);
 
@@ -756,16 +746,35 @@ describe('discoverProject', () => {
       expect(result.serverUrl).toBe('https://root.example.com');
     });
 
+    it('does not climb to an ancestor directory for local config outside a git repository', async () => {
+      // No .git anywhere in this tree: local-config discovery must stay pinned to the
+      // invocation dir, not silently adopt an unrelated ancestor's sonar-project.properties.
+      const subDir = join(testDir, 'packages', 'api');
+      fakeFs.writeFile(
+        join(subDir, 'sonar-project.properties'),
+        'sonar.host.url=https://sub.example.com\n',
+      );
+      fakeFs.writeFile(
+        join(testDir, 'sonar-project.properties'),
+        'sonar.host.url=https://root.example.com\nsonar.projectKey=root_project\n',
+      );
+
+      const result = await discoverProject(subDir);
+
+      expect(result.projectKey).toBeUndefined();
+      expect(result.serverUrl).toBe('https://sub.example.com');
+    });
+
     it('a known-mapping match at a farther directory still wins over a nearer local properties file', async () => {
       const subDir = join(testDir, 'packages', 'api');
-      mkdirSync(subDir, { recursive: true });
-      writeFileSync(
+      fakeFs.writeFile(
         join(subDir, 'sonar-project.properties'),
         'sonar.host.url=https://sub.example.com\nsonar.projectKey=sub_project\n',
       );
       mockLiveMappings(loadStateSpy, [
         makeKnownMapping({ targetRoot: canonicalizePath(testDir), projectKey: 'mapped-project' }),
       ]);
+      mockClimb(lookupPathsSpy, subDir, join(testDir, 'packages'), testDir);
 
       const result = await discoverProject(subDir);
 
@@ -775,128 +784,127 @@ describe('discoverProject', () => {
 });
 
 describe('discoverOrganization', () => {
+  let lookupPathsSpy: Mock<typeof lookupPathResolver.resolveLookupPaths>;
+  let cwdSpy: Mock<typeof process.cwd>;
+
+  beforeEach(() => {
+    fakeFs.setup();
+    lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockImplementation(
+      defaultLookupPaths,
+    );
+    cwdSpy = spyOn(process, 'cwd');
+  });
+
   afterEach(() => {
     clearMockUiCalls();
+    fakeFs.teardown();
+    lookupPathsSpy.mockRestore();
+    cwdSpy.mockRestore();
   });
 
   it('reads organization from sonar-project.properties under process.cwd()', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-org-props-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://x.test\nsonar.projectKey=p\nsonar.organization=from-props-org\n',
     );
 
-    try {
-      await withCwd(testDir, async () => {
-        expect(await discoverOrganization()).toBe('from-props-org');
-      });
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    await withCwd(cwdSpy, testDir, async () => {
+      expect(await discoverOrganization()).toBe('from-props-org');
+    });
   });
 
   it('reads organization from .sonarlint when properties omit sonar.organization', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-org-lint-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://x.test\nsonar.projectKey=p\n',
     );
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, '.sonarlint', 'connectedMode.json'),
       JSON.stringify({ sonarCloudOrganization: 'from-lint-org', projectKey: 'k' }),
     );
 
-    try {
-      await withCwd(testDir, async () => {
-        expect(await discoverOrganization()).toBe('from-lint-org');
-      });
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    await withCwd(cwdSpy, testDir, async () => {
+      expect(await discoverOrganization()).toBe('from-lint-org');
+    });
   });
 
   it('returns null when no organization is configured', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-org-empty-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://x.test\nsonar.projectKey=p\n',
     );
 
-    try {
-      await withCwd(testDir, async () => {
-        expect(await discoverOrganization()).toBeNull();
-      });
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    await withCwd(cwdSpy, testDir, async () => {
+      expect(await discoverOrganization()).toBeNull();
+    });
   });
 
-  it('climbs from a nested monorepo package to find organization at an ancestor', async () => {
+  it('climbs from a nested monorepo package to find organization at an ancestor, inside a git repo', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-org-nested-' + Date.now());
     const subDir = join(testDir, 'packages', 'api');
-    mkdirSync(subDir, { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://x.test\nsonar.projectKey=p\nsonar.organization=ancestor-org\n',
     );
+    mockClimb(lookupPathsSpy, subDir, join(testDir, 'packages'), testDir);
 
-    try {
-      await withCwd(subDir, async () => {
-        expect(await discoverOrganization()).toBe('ancestor-org');
-      });
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    await withCwd(cwdSpy, subDir, async () => {
+      expect(await discoverOrganization()).toBe('ancestor-org');
+    });
   });
 
   it('returns null when local config discovery throws', async () => {
-    const lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockRejectedValue(
-      new Error('simulated failure'),
-    );
+    lookupPathsSpy.mockRejectedValue(new Error('simulated failure'));
 
-    try {
-      expect(await discoverOrganization()).toBeNull();
-    } finally {
-      lookupPathsSpy.mockRestore();
-    }
+    expect(await discoverOrganization()).toBeNull();
   });
 });
 
 describe('discoverServer', () => {
-  beforeEach(() => setMockUi(true));
+  let lookupPathsSpy: Mock<typeof lookupPathResolver.resolveLookupPaths>;
+  let cwdSpy: Mock<typeof process.cwd>;
+  let debugSpy: Mock<typeof logger.debug>;
+
+  beforeEach(() => {
+    fakeFs.setup();
+    setMockUi(true);
+    lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockImplementation(
+      defaultLookupPaths,
+    );
+    cwdSpy = spyOn(process, 'cwd');
+    debugSpy = spyOn(logger, 'debug').mockImplementation(() => undefined);
+  });
+
   afterEach(() => {
     clearMockUiCalls();
     setMockUi(false);
+    fakeFs.teardown();
+    lookupPathsSpy.mockRestore();
+    cwdSpy.mockRestore();
+    debugSpy.mockRestore();
   });
 
   it('reads server URL from sonar-project.properties under process.cwd()', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-server-props-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://from-props.integration.test\nsonar.projectKey=p\n',
     );
-    mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, '.sonarlint', 'connectedMode.json'),
       JSON.stringify({ sonarQubeUri: 'https://from-lint.should-not-win', projectKey: 'k' }),
     );
 
-    try {
-      await withCwd(testDir, async () => {
-        expect(await discoverServer()).toBe('https://from-props.integration.test');
-        const prints = getMockUiCalls()
-          .filter((c) => c.method === 'print')
-          .map((c) => String(c.args[0]));
-        expect(prints.some((m) => m.includes('sonar-project.properties'))).toBe(true);
-      });
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    await withCwd(cwdSpy, testDir, async () => {
+      expect(await discoverServer()).toBe('https://from-props.integration.test');
+      const prints = getMockUiCalls()
+        .filter((c) => c.method === 'print')
+        .map((c) => String(c.args[0]));
+      expect(prints.some((m) => m.includes('sonar-project.properties'))).toBe(true);
+    });
   });
 
   it('uses SonarLint when there is no sonar-project.properties (Server or Cloud binding)', async () => {
@@ -913,73 +921,52 @@ describe('discoverServer', () => {
 
     for (let i = 0; i < cases.length; i++) {
       const testDir = join(tmpdir(), `sonarqube-cli-discover-server-lintonly-${i}-` + Date.now());
-      mkdirSync(join(testDir, '.sonarlint'), { recursive: true });
-      writeFileSync(
+      fakeFs.writeFile(
         join(testDir, '.sonarlint', 'connectedMode.json'),
         JSON.stringify(cases[i].json),
       );
 
-      try {
-        await withCwd(testDir, async () => {
-          clearMockUiCalls();
-          expect(await discoverServer()).toBe(cases[i].expectedUrl);
-          const prints = getMockUiCalls()
-            .filter((c) => c.method === 'print')
-            .map((c) => String(c.args[0]));
-          expect(prints.some((m) => m.includes('.sonarlint'))).toBe(true);
-          expect(prints.some((m) => m.includes('sonar-project.properties'))).toBe(false);
-        });
-      } finally {
-        rmSync(testDir, { recursive: true, force: true });
-      }
+      await withCwd(cwdSpy, testDir, async () => {
+        clearMockUiCalls();
+        expect(await discoverServer()).toBe(cases[i].expectedUrl);
+        const prints = getMockUiCalls()
+          .filter((c) => c.method === 'print')
+          .map((c) => String(c.args[0]));
+        expect(prints.some((m) => m.includes('.sonarlint'))).toBe(true);
+        expect(prints.some((m) => m.includes('sonar-project.properties'))).toBe(false);
+      });
     }
   });
 
   it('returns null when cwd has no server hint', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-server-empty-' + Date.now());
-    mkdirSync(testDir, { recursive: true });
+    fakeFs.mkdir(testDir);
 
-    try {
-      await withCwd(testDir, async () => {
-        expect(await discoverServer()).toBeNull();
-        expect(getMockUiCalls().filter((c) => c.method === 'print')).toHaveLength(0);
-      });
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    await withCwd(cwdSpy, testDir, async () => {
+      expect(await discoverServer()).toBeNull();
+      expect(getMockUiCalls().filter((c) => c.method === 'print')).toHaveLength(0);
+    });
   });
 
-  it('climbs from a nested monorepo package to find the server URL at an ancestor', async () => {
+  it('climbs from a nested monorepo package to find the server URL at an ancestor, inside a git repo', async () => {
     const testDir = join(tmpdir(), 'sonarqube-cli-test-discover-server-nested-' + Date.now());
     const subDir = join(testDir, 'packages', 'api');
-    mkdirSync(subDir, { recursive: true });
-    writeFileSync(
+    fakeFs.writeFile(
       join(testDir, 'sonar-project.properties'),
       'sonar.host.url=https://ancestor.example.com\nsonar.projectKey=p\n',
     );
+    mockClimb(lookupPathsSpy, subDir, join(testDir, 'packages'), testDir);
 
-    try {
-      await withCwd(subDir, async () => {
-        expect(await discoverServer()).toBe('https://ancestor.example.com');
-      });
-    } finally {
-      rmSync(testDir, { recursive: true, force: true });
-    }
+    await withCwd(cwdSpy, subDir, async () => {
+      expect(await discoverServer()).toBe('https://ancestor.example.com');
+    });
   });
 
   it('returns null and logs when local config discovery throws', async () => {
-    const lookupPathsSpy = spyOn(lookupPathResolver, 'resolveLookupPaths').mockRejectedValue(
-      new Error('simulated failure'),
-    );
-    const debugSpy = spyOn(logger, 'debug').mockImplementation(() => undefined);
+    lookupPathsSpy.mockRejectedValue(new Error('simulated failure'));
 
-    try {
-      expect(await discoverServer()).toBeNull();
-      expect(debugSpy).toHaveBeenCalled();
-      expect(String(debugSpy.mock.calls[0]?.[0] ?? '')).toContain('simulated failure');
-    } finally {
-      lookupPathsSpy.mockRestore();
-      debugSpy.mockRestore();
-    }
+    expect(await discoverServer()).toBeNull();
+    expect(debugSpy).toHaveBeenCalled();
+    expect(String(debugSpy.mock.calls[0]?.[0] ?? '')).toContain('simulated failure');
   });
 });

--- a/tests/unit/core/project-info.test.ts
+++ b/tests/unit/core/project-info.test.ts
@@ -458,6 +458,24 @@ describe('discoverProject', () => {
       expect(result.projectKey).toBe('known-project');
     });
 
+    it("passes every known mapping's targetRoot/repoRoot as the resolveLookupPaths bound, unfiltered", async () => {
+      // Deduplication/nesting is resolveLookupPaths()'s job, not discoverProject()'s.
+      const repoRoot = join(testDir, '..');
+      mockLiveMappings(loadStateSpy, [
+        makeKnownMapping({
+          targetRoot: canonicalizePath(testDir),
+          repoRoot: canonicalizePath(repoRoot),
+        }),
+      ]);
+
+      await discoverProject(testDir);
+
+      expect(lookupPathsSpy).toHaveBeenCalledWith(testDir, [
+        canonicalizePath(testDir),
+        canonicalizePath(repoRoot),
+      ]);
+    });
+
     it('matches a known mapping recorded at a subdirectory below the git repo root (monorepo package)', async () => {
       // Regression test: discoverProject() must pass the raw invocation directory
       // (not the already-collapsed git repo root) into the known-mapping lookup, so a


### PR DESCRIPTION
----
## Summary by Gitar

- **Unified project resolution:**
    - Centralized project discovery via `discoverProject` across hooks, commands, and integration steps
    - Added lookup-path resolution and installed-feature matching for known server-project mappings
    - Bound non-git lookup-path climbs and mocked discoverProject dependencies in unit tests

<sub>This will update automatically on new commits.</sub>