### PR TITLE
CLI-1008 Remove unused dependencyType from installed dependency state

### DIFF
--- a/src/commands/integrate/_common/context-augmentation-dependency.ts
+++ b/src/commands/integrate/_common/context-augmentation-dependency.ts
@@ -43,7 +43,6 @@ export type ContextAugmentationBinaryDependencyOptions = BaseDependencyOptions;
 export class ContextAugmentationBinaryDependency implements DependencyDeclaration {
   readonly id: string;
   readonly displayName?: string;
-  readonly dependencyType = 'context-augmentation-binary';
   readonly version: string;
 
   constructor(options: ContextAugmentationBinaryDependencyOptions) {
@@ -62,7 +61,6 @@ export class ContextAugmentationBinaryDependency implements DependencyDeclaratio
     const binaryPath = await installContextAugmentationBinary();
     return {
       id: this.id,
-      dependencyType: this.dependencyType,
       version: this.version,
       path: binaryPath,
     };

--- a/src/core/framework/dependencies/common.ts
+++ b/src/core/framework/dependencies/common.ts
@@ -34,7 +34,6 @@ export interface BaseDependencyOptions {
 export interface DependencyDeclaration {
   id: string;
   displayName?: string;
-  dependencyType: string;
   version?: string;
   installOrUpdate: (context: DependencyInstallContext) => MaybePromise<InstalledDependency>;
   isInstalled: (context: IntegrationContext) => MaybePromise<boolean>;

--- a/src/core/framework/dependencies/sonarsource-binary.ts
+++ b/src/core/framework/dependencies/sonarsource-binary.ts
@@ -47,7 +47,6 @@ export function sonarSourceBinary(
 export class SonarSourceBinaryDependency implements DependencyDeclaration {
   readonly id: string;
   readonly displayName?: string;
-  readonly dependencyType = 'sonarsource-binary';
   readonly version: string;
 
   constructor(private readonly options: SonarSourceBinaryDependencyOptions) {
@@ -60,7 +59,6 @@ export class SonarSourceBinaryDependency implements DependencyDeclaration {
     const result = await installBinary(this.options.spec);
     return {
       id: this.id,
-      dependencyType: this.dependencyType,
       version: this.version,
       path: result.binaryPath,
     };

--- a/src/core/framework/features/types.ts
+++ b/src/core/framework/features/types.ts
@@ -194,7 +194,6 @@ export interface AppliedFeature {
 
 export interface InstalledDependency {
   id: string;
-  dependencyType: string;
   version?: string;
   path?: string;
 }

--- a/src/core/state/state.ts
+++ b/src/core/state/state.ts
@@ -291,8 +291,6 @@ export interface ToolsState {
 export interface InstalledIntegrationDependency {
   /** Stable dependency identifier from the integration declaration */
   id: string;
-  /** Dependency type from the integration declaration */
-  dependencyType: string;
   /** Dependency declaration version, when versioned */
   version?: string;
   /** Resolved path for dependencies materialized on disk */

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -494,7 +494,6 @@ export class EnvironmentBuilder {
       });
       installedDependencies.push({
         id: SECRETS_SPEC.name,
-        dependencyType: 'sonarsource-binary',
         version: SECRETS_SPEC.version,
         path: binaryPath,
         updatedAt: new Date().toISOString(),
@@ -512,7 +511,6 @@ export class EnvironmentBuilder {
       });
       installedDependencies.push({
         id: CONTEXT_AUGMENTATION_BINARY_NAME,
-        dependencyType: 'context-augmentation-binary',
         version: SONAR_CONTEXT_AUGMENTATION_VERSION,
         path: binaryPath,
         updatedAt: new Date().toISOString(),

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -160,7 +160,6 @@ describe('integrate claude', () => {
       expect(state.dependencies.installed).toMatchObject([
         {
           id: 'sonar-secrets',
-          dependencyType: 'sonarsource-binary',
         },
       ]);
     },

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -181,7 +181,6 @@ describe('integrate copilot', () => {
         expect(state.dependencies.installed).toMatchObject([
           {
             id: 'sonar-secrets',
-            dependencyType: 'sonarsource-binary',
           },
         ]);
       },

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -132,7 +132,6 @@ type InstalledStateJson = {
   dependencies: {
     installed: Array<{
       id: string;
-      dependencyType: string;
     }>;
   };
   integrations: {
@@ -170,14 +169,9 @@ function getInstalledIntegration(state: InstalledStateJson, integrationId: strin
   return integration!;
 }
 
-function expectInstalledDependency(
-  state: InstalledStateJson,
-  id: string,
-  dependencyType: string,
-): void {
+function expectInstalledDependency(state: InstalledStateJson, id: string): void {
   const dependency = state.dependencies.installed.find((entry) => entry.id === id);
   expect(dependency).toBeDefined();
-  expect(dependency?.dependencyType).toBe(dependencyType);
 }
 
 function expectFeatureDependency(feature: InstalledFeatureJson, id: string): void {
@@ -526,7 +520,7 @@ describe('integrate git (native hooks)', () => {
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'whole-file');
       expect(feature.operations).toEqual([]);
-      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sonar-secrets');
     },
     { timeout: 15000 },
   );
@@ -776,8 +770,8 @@ describe('integrate git (native hooks)', () => {
       expect(feature.attrs?.projectKey).toBe('auto-project');
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectSubfeatureHasDependency(feature, 'pre-commit-dependency-risks', 'sca-scanner-cli');
-      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
-      expectInstalledDependency(state, 'sca-scanner-cli', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sonar-secrets');
+      expectInstalledDependency(state, 'sca-scanner-cli');
     },
     { timeout: 30000 },
   );
@@ -951,8 +945,8 @@ describe('integrate git (native hooks)', () => {
       expect(feature.featureId).toBe('pre-commit-hook');
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectSubfeatureHasDependency(feature, 'pre-commit-dependency-risks', 'sca-scanner-cli');
-      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
-      expectInstalledDependency(state, 'sca-scanner-cli', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sonar-secrets');
+      expectInstalledDependency(state, 'sca-scanner-cli');
     },
     { timeout: 15000 },
   );
@@ -1019,7 +1013,7 @@ describe('integrate git (husky)', () => {
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
       expect(feature.operations).toEqual([]);
-      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sonar-secrets');
     },
     { timeout: 15000 },
   );
@@ -1084,7 +1078,7 @@ describe('integrate git (husky)', () => {
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-file', 'text-snippet');
       expect(feature.operations).toEqual([]);
-      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sonar-secrets');
     },
     { timeout: 15000 },
   );
@@ -1112,7 +1106,7 @@ describe('integrate git (husky)', () => {
       expect(feature.featureId).toBe('pre-commit-hook');
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectSubfeatureHasDependency(feature, 'pre-commit-dependency-risks', 'sca-scanner-cli');
-      expectInstalledDependency(state, 'sca-scanner-cli', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sca-scanner-cli');
     },
     { timeout: 15000 },
   );
@@ -1207,7 +1201,7 @@ describe('integrate git (pre-commit framework)', () => {
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
       expectInstalledOperation(feature, 'activate-hook');
-      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sonar-secrets');
     },
     { timeout: 15000 },
   );
@@ -1254,7 +1248,7 @@ describe('integrate git (pre-commit framework)', () => {
       expectFeatureDependency(feature, 'sonar-secrets');
       expectInstalledResource(feature, 'hook-config', 'yaml-patch');
       expectInstalledOperation(feature, 'activate-hook');
-      expectInstalledDependency(state, 'sonar-secrets', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sonar-secrets');
     },
     { timeout: 15000 },
   );
@@ -1450,7 +1444,7 @@ describe('integrate git (pre-commit framework)', () => {
       expect(feature.featureId).toBe('pre-commit-hook');
       expectSubfeatureHasDependency(feature, 'pre-commit-secrets', 'sonar-secrets');
       expectSubfeatureHasDependency(feature, 'pre-commit-dependency-risks', 'sca-scanner-cli');
-      expectInstalledDependency(state, 'sca-scanner-cli', 'sonarsource-binary');
+      expectInstalledDependency(state, 'sca-scanner-cli');
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -554,7 +554,6 @@ describe('system reset --force', () => {
             installed: [
               {
                 id: 'sonar-secrets',
-                dependencyType: 'binary',
                 path: outside,
                 updatedByCliVersion: '0.0.0',
                 updatedAt: new Date().toISOString(),
@@ -608,7 +607,6 @@ describe('system reset --force', () => {
             installed: [
               {
                 id: 'sonar-secrets',
-                dependencyType: 'binary',
                 path: stalePath,
                 updatedByCliVersion: '0.0.0',
                 updatedAt: new Date().toISOString(),

--- a/tests/integration/specs/system/system-status.test.ts
+++ b/tests/integration/specs/system/system-status.test.ts
@@ -770,7 +770,6 @@ describe('system status', () => {
               installed: [
                 {
                   id: 'sonar-context-augmentation',
-                  dependencyType: 'binary',
                   version: '0.12.0.1451',
                   path: '/fake/bin/sonar-context-augmentation',
                   updatedByCliVersion: '0.14.0',
@@ -778,7 +777,6 @@ describe('system status', () => {
                 },
                 {
                   id: 'sca-scanner-cli',
-                  dependencyType: 'binary',
                   version: '2025.6.0.14965',
                   path: '/fake/bin/sca-scanner-cli',
                   updatedByCliVersion: '0.14.0',

--- a/tests/integration/specs/update/post-update.test.ts
+++ b/tests/integration/specs/update/post-update.test.ts
@@ -261,7 +261,6 @@ describe('post-update migration', () => {
             installed: [
               {
                 id: CONTEXT_AUGMENTATION_BINARY_NAME,
-                dependencyType: 'context-augmentation-binary',
                 version: staleCagVersion,
                 path: installedBinaryPath,
                 updatedByCliVersion: '0.5.0',

--- a/tests/unit/commands/integrate/_common/installer.test.ts
+++ b/tests/unit/commands/integrate/_common/installer.test.ts
@@ -175,11 +175,9 @@ describe('generic integration installer', () => {
     loadStateSpy.mockReturnValue(state);
     const dependency: DependencyDeclaration = {
       id: 'shared-binary',
-      dependencyType: 'binary',
       version: '2',
       installOrUpdate: () => ({
         id: 'shared-binary',
-        dependencyType: 'binary',
         version: '2',
         path: '/opt/sonar/shared-binary',
       }),
@@ -216,7 +214,6 @@ describe('generic integration installer', () => {
     expect(state.dependencies.installed).toMatchObject([
       {
         id: 'shared-binary',
-        dependencyType: 'binary',
         version: '2',
         path: '/opt/sonar/shared-binary',
       },
@@ -302,11 +299,9 @@ describe('generic integration installer', () => {
     loadStateSpy.mockReturnValue(state);
     const dependency: DependencyDeclaration = {
       id: 'unnamed-binary',
-      dependencyType: 'binary',
       version: '1',
       installOrUpdate: () => ({
         id: 'unnamed-binary',
-        dependencyType: 'binary',
         version: '1',
         path: '/opt/sonar/unnamed-binary',
       }),

--- a/tests/unit/commands/integrate/git/integrate-git.test.ts
+++ b/tests/unit/commands/integrate/git/integrate-git.test.ts
@@ -497,7 +497,6 @@ describe('integrateGit', () => {
       expect(state.dependencies.installed).toMatchObject([
         {
           id: 'sonar-secrets',
-          dependencyType: 'sonarsource-binary',
         },
       ]);
     } finally {
@@ -542,7 +541,6 @@ describe('integrateGit', () => {
       expect(state.dependencies.installed).toMatchObject([
         {
           id: 'sonar-secrets',
-          dependencyType: 'sonarsource-binary',
         },
       ]);
     } finally {
@@ -576,7 +574,6 @@ describe('integrateGit', () => {
       expect(state.dependencies.installed).toMatchObject([
         {
           id: 'sonar-secrets',
-          dependencyType: 'sonarsource-binary',
         },
       ]);
     } finally {

--- a/tests/unit/core/framework/features/reconcile.test.ts
+++ b/tests/unit/core/framework/features/reconcile.test.ts
@@ -187,14 +187,12 @@ describe('reconcileInstalledIntegrations', () => {
 
     const sharedDependency: DependencyDeclaration = {
       id: 'shared-dependency',
-      dependencyType: 'binary',
       version: '2',
       installOrUpdate: ({ existingDependency }) => {
         existingDependencyPaths.push(existingDependency?.path ?? 'missing');
         installCalls.push('install');
         return {
           id: 'shared-dependency',
-          dependencyType: 'binary',
           version: '2',
           path: '/new/shared-dependency',
         };
@@ -240,7 +238,6 @@ describe('reconcileInstalledIntegrations', () => {
     });
     state.dependencies.installed.push({
       id: sharedDependency.id,
-      dependencyType: sharedDependency.dependencyType,
       version: '1',
       path: '/old/shared-dependency',
       updatedByCliVersion: '0.9.0',

--- a/tests/unit/core/framework/features/registry-resources.test.ts
+++ b/tests/unit/core/framework/features/registry-resources.test.ts
@@ -431,7 +431,6 @@ describe('declarative integration framework - resources and state recording', ()
     expect(installBinarySpy).toHaveBeenCalledWith(SECRETS_SPEC);
     expect(applied).toEqual({
       id: 'binary',
-      dependencyType: 'sonarsource-binary',
       version: SECRETS_SPEC.version,
       path: binaryPath,
     });

--- a/tests/unit/core/framework/features/registry.test.ts
+++ b/tests/unit/core/framework/features/registry.test.ts
@@ -1298,7 +1298,6 @@ describe('declarative integration framework', () => {
     expect(state.dependencies.installed).toMatchObject([
       {
         id: 'binary',
-        dependencyType: 'sonarsource-binary',
         version: SECRETS_SPEC.version,
         path: join(tempDir, 'bin', 'sonar-secrets'),
       },


### PR DESCRIPTION
----
## Summary by Gitar

- **State management:**
    - Removed unused `dependencyType` property from installed dependency state and related tests

<sub>This will update automatically on new commits.</sub>