### PR TITLE
SONAR-31828 Add GitLab API client and SonarQube Server DOP/binding methods

### DIFF
--- a/src/core/gitlab/client.ts
+++ b/src/core/gitlab/client.ts
@@ -1,0 +1,281 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { buildFetchNetworkOptions } from '@/core/host/connectivity/network-config.ts';
+import {
+  HTTP_STATUS_BAD_GATEWAY,
+  HTTP_STATUS_GATEWAY_TIMEOUT,
+  HTTP_STATUS_NOT_FOUND,
+  HTTP_STATUS_SERVICE_UNAVAILABLE,
+  HTTP_STATUS_TOO_MANY_REQUESTS,
+} from '@/core/http-constants.ts';
+import { buildFetchInit, fetchGuarded } from '@/core/server/fetch-guarded.ts';
+
+export interface GitLabRepo {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  default_branch: string | null;
+  marked_for_deletion_at: string | null | undefined;
+}
+
+export interface GitLabTreeEntry {
+  name: string;
+  type: 'blob' | 'tree';
+  path: string;
+}
+
+export interface GitLabMergeRequest {
+  iid: number;
+  web_url: string;
+  state: 'opened' | 'closed' | 'merged';
+}
+
+const GET_TIMEOUT_MS = 30_000;
+const WRITE_TIMEOUT_MS = 60_000;
+const GITLAB_PAGE_SIZE = 100;
+const RETRY_5XX_DELAY_MS = 2_000;
+const MAX_RETRIES = 5;
+const DEFAULT_RETRY_AFTER_S = 5;
+
+// Only used for idempotent GET requests — writes are issued once without retry.
+async function callWithRetry(fn: () => Promise<Response>): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    const response = await fn();
+    const retryable =
+      response.status === HTTP_STATUS_TOO_MANY_REQUESTS ||
+      response.status === HTTP_STATUS_BAD_GATEWAY ||
+      response.status === HTTP_STATUS_SERVICE_UNAVAILABLE ||
+      response.status === HTTP_STATUS_GATEWAY_TIMEOUT;
+    if (!retryable || attempt >= MAX_RETRIES) return response;
+    const parsed = Number.parseInt(response.headers.get('Retry-After') ?? '', 10);
+    const retryAfterS = Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_RETRY_AFTER_S;
+    const delayMs =
+      response.status === HTTP_STATUS_TOO_MANY_REQUESTS
+        ? (retryAfterS + 1) * 1000
+        : RETRY_5XX_DELAY_MS;
+    await new Promise<void>((r) => setTimeout(r, delayMs));
+  }
+}
+
+export class GitLabApiError extends Error {
+  constructor(
+    public readonly status: number,
+    context: string,
+    public readonly body: string,
+  ) {
+    super(`GitLab API error ${status} (${context}): ${body}`);
+  }
+}
+
+async function assertOk(response: Response, context: string): Promise<void> {
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new GitLabApiError(response.status, context, body);
+  }
+}
+
+export class GitLabClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+
+  constructor(baseUrl: string, token: string) {
+    this.baseUrl = baseUrl.replace(/\/api\/v4\/?$/, '').replace(/\/$/, '');
+    this.token = token;
+  }
+
+  private headers(): Record<string, string> {
+    return {
+      'PRIVATE-TOKEN': this.token,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private url(path: string): string {
+    return `${this.baseUrl}/api/v4${path}`;
+  }
+
+  private fetchGet(url: string): Promise<Response> {
+    return callWithRetry(() =>
+      fetchGuarded(
+        url,
+        buildFetchInit(
+          'GET',
+          this.headers(),
+          GET_TIMEOUT_MS,
+          undefined,
+          buildFetchNetworkOptions(url),
+        ),
+      ),
+    );
+  }
+
+  private fetchWrite(url: string, method: string, body?: string): Promise<Response> {
+    return fetchGuarded(
+      url,
+      buildFetchInit(method, this.headers(), WRITE_TIMEOUT_MS, body, buildFetchNetworkOptions(url)),
+    );
+  }
+
+  private async fetchAllPages<T>(
+    buildUrl: (page: number) => string,
+    context: string,
+  ): Promise<T[]> {
+    const items: T[] = [];
+    let page = 1;
+    for (;;) {
+      const response = await this.fetchGet(buildUrl(page));
+      await assertOk(response, `${context} page ${page}`);
+      const batch = (await response.json()) as T[];
+      items.push(...batch);
+      if (batch.length < GITLAB_PAGE_SIZE) break;
+      page++;
+    }
+    return items;
+  }
+
+  async getProjectCiConfigPath(projectId: number): Promise<string | null> {
+    const url = this.url(`/projects/${projectId}`);
+    const response = await this.fetchGet(url);
+    await assertOk(response, `getProjectCiConfigPath projectId=${projectId}`);
+    const data = (await response.json()) as { ci_config_path?: string | null };
+    const path = data.ci_config_path;
+    return path != null && path !== '' ? path : null;
+  }
+
+  async listGroupRepos(groupPath: string): Promise<GitLabRepo[]> {
+    return this.fetchAllPages(
+      (page) =>
+        this.url(
+          `/groups/${encodeURIComponent(groupPath)}/projects?include_subgroups=true&archived=false&per_page=${GITLAB_PAGE_SIZE}&page=${page}`,
+        ),
+      'listGroupRepos',
+    );
+  }
+
+  async listRepoTree(projectId: number, ref: string): Promise<GitLabTreeEntry[]> {
+    return this.fetchAllPages(
+      (page) =>
+        this.url(
+          `/projects/${projectId}/repository/tree?ref=${encodeURIComponent(ref)}&per_page=${GITLAB_PAGE_SIZE}&page=${page}`,
+        ),
+      `listRepoTree projectId=${projectId}`,
+    );
+  }
+
+  async getFileContent(projectId: number, filePath: string, ref: string): Promise<string | null> {
+    const encodedPath = filePath.split('/').map(encodeURIComponent).join('%2F');
+    const url = this.url(
+      `/projects/${projectId}/repository/files/${encodedPath}?ref=${encodeURIComponent(ref)}`,
+    );
+    const response = await this.fetchGet(url);
+    if (response.status === HTTP_STATUS_NOT_FOUND) return null;
+    await assertOk(response, `getFileContent projectId=${projectId} path=${filePath}`);
+    const data = (await response.json()) as { content: string; encoding: string };
+    return Buffer.from(data.content, 'base64').toString('utf8');
+  }
+
+  async createBranch(projectId: number, branchName: string): Promise<void> {
+    const url = this.url(`/projects/${projectId}/repository/branches`);
+    const response = await this.fetchWrite(
+      url,
+      'POST',
+      JSON.stringify({ branch: branchName, ref: 'HEAD' }),
+    );
+    await assertOk(response, `createBranch projectId=${projectId} branch=${branchName}`);
+  }
+
+  async createFile(
+    projectId: number,
+    filePath: string,
+    branch: string,
+    content: string,
+    commitMessage: string,
+  ): Promise<void> {
+    const encodedPath = filePath.split('/').map(encodeURIComponent).join('%2F');
+    const url = this.url(`/projects/${projectId}/repository/files/${encodedPath}`);
+    const response = await this.fetchWrite(
+      url,
+      'POST',
+      JSON.stringify({ branch, content, commit_message: commitMessage, encoding: 'text' }),
+    );
+    await assertOk(response, `createFile projectId=${projectId} path=${filePath}`);
+  }
+
+  async updateFile(
+    projectId: number,
+    filePath: string,
+    branch: string,
+    content: string,
+    commitMessage: string,
+  ): Promise<void> {
+    const encodedPath = filePath.split('/').map(encodeURIComponent).join('%2F');
+    const url = this.url(`/projects/${projectId}/repository/files/${encodedPath}`);
+    const response = await this.fetchWrite(
+      url,
+      'PUT',
+      JSON.stringify({ branch, content, commit_message: commitMessage, encoding: 'text' }),
+    );
+    await assertOk(response, `updateFile projectId=${projectId} path=${filePath}`);
+  }
+
+  async createMergeRequest(
+    projectId: number,
+    sourceBranch: string,
+    targetBranch: string,
+    title: string,
+    description: string,
+  ): Promise<string> {
+    const url = this.url(`/projects/${projectId}/merge_requests`);
+    const response = await this.fetchWrite(
+      url,
+      'POST',
+      JSON.stringify({
+        source_branch: sourceBranch,
+        target_branch: targetBranch,
+        title,
+        description,
+      }),
+    );
+    await assertOk(response, `createMergeRequest projectId=${projectId}`);
+    const data = (await response.json()) as { web_url: string };
+    return data.web_url;
+  }
+
+  async listOpenMergeRequests(
+    projectId: number,
+    sourceBranch: string,
+  ): Promise<GitLabMergeRequest[]> {
+    const url = this.url(
+      `/projects/${projectId}/merge_requests?source_branch=${encodeURIComponent(sourceBranch)}&state=opened`,
+    );
+    const response = await this.fetchGet(url);
+    await assertOk(response, `listOpenMergeRequests projectId=${projectId}`);
+    return (await response.json()) as GitLabMergeRequest[];
+  }
+
+  async deleteBranch(projectId: number, branchName: string): Promise<void> {
+    const encodedBranch = encodeURIComponent(branchName);
+    const url = this.url(`/projects/${projectId}/repository/branches/${encodedBranch}`);
+    const response = await this.fetchWrite(url, 'DELETE');
+    await assertOk(response, `deleteBranch projectId=${projectId} branch=${branchName}`);
+  }
+}

--- a/src/core/gitlab/token.ts
+++ b/src/core/gitlab/token.ts
@@ -1,0 +1,43 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { CommandFailedError } from '@/core/command-error.ts';
+import { passwordPrompt } from '@/core/ui';
+
+export async function resolveGitlabToken(): Promise<string> {
+  const canPrompt = process.stdin.isTTY || Boolean(process.env.SONARQUBE_CLI_MOCK_TTY);
+  const envToken = process.env.GITLAB_TOKEN;
+
+  if (canPrompt) {
+    const hint = envToken ? ' (press Enter to use GITLAB_TOKEN)' : '';
+    const prompted = await passwordPrompt(`GitLab personal access token${hint}:`);
+    if (prompted === null) {
+      throw new CommandFailedError('GitLab token is required.');
+    }
+    if (prompted !== '') return prompted;
+    if (envToken) return envToken;
+    throw new CommandFailedError(
+      'GitLab token required: provide one at the prompt or set the GITLAB_TOKEN environment variable.',
+    );
+  }
+
+  if (envToken) return envToken;
+  throw new CommandFailedError('GitLab token required: set the GITLAB_TOKEN environment variable.');
+}

--- a/src/core/http-constants.ts
+++ b/src/core/http-constants.ts
@@ -1,0 +1,30 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Shared HTTP status code constants used across API clients.
+
+export const HTTP_STATUS_BAD_REQUEST = 400;
+export const HTTP_STATUS_FORBIDDEN = 403;
+export const HTTP_STATUS_NOT_FOUND = 404;
+export const HTTP_STATUS_PAYLOAD_TOO_LARGE = 413;
+export const HTTP_STATUS_TOO_MANY_REQUESTS = 429;
+export const HTTP_STATUS_BAD_GATEWAY = 502;
+export const HTTP_STATUS_SERVICE_UNAVAILABLE = 503;
+export const HTTP_STATUS_GATEWAY_TIMEOUT = 504;

--- a/src/core/server/client.ts
+++ b/src/core/server/client.ts
@@ -21,6 +21,14 @@
 // SonarQube API HTTP client
 
 import { buildFetchNetworkOptions } from '@/core/host/connectivity/network-config.ts';
+import {
+  HTTP_STATUS_BAD_REQUEST,
+  HTTP_STATUS_FORBIDDEN,
+  HTTP_STATUS_NOT_FOUND,
+  HTTP_STATUS_PAYLOAD_TOO_LARGE,
+  HTTP_STATUS_SERVICE_UNAVAILABLE,
+  HTTP_STATUS_TOO_MANY_REQUESTS,
+} from '@/core/http-constants.ts';
 import { INVOCATION_ID, SONAR_INVOCATION_ID_HEADER } from '@/core/telemetry/invocation-id.ts';
 import { print } from '@/core/ui';
 
@@ -48,12 +56,6 @@ const GET_REQUEST_TIMEOUT_MS = 30000; // 30 seconds
 const POST_REQUEST_TIMEOUT_MS = 60000; // 60 seconds for analysis
 /** Best-effort token revocation should fail fast when the server is unreachable. */
 const REVOKE_USER_TOKEN_TIMEOUT_MS = 10_000;
-const HTTP_STATUS_BAD_REQUEST = 400;
-const HTTP_STATUS_FORBIDDEN = 403;
-const HTTP_STATUS_NOT_FOUND = 404;
-const HTTP_STATUS_PAYLOAD_TOO_LARGE = 413;
-const HTTP_STATUS_TOO_MANY_REQUESTS = 429;
-const HTTP_STATUS_SERVICE_UNAVAILABLE = 503;
 
 export const GENERIC_HTTP_METHODS = ['GET', 'POST', 'PATCH', 'PUT', 'DELETE'] as const;
 export const METHODS_WITH_BODY = new Set<HttpMethod>(['POST', 'PATCH', 'PUT']);
@@ -830,6 +832,58 @@ export class SonarQubeClient {
     } catch {
       return false;
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Admin / CI setup — SonarQube Server only (SQS v2 endpoints)
+  // ---------------------------------------------------------------------------
+
+  async listGitlabDopSettings(): Promise<Array<{ id: string; key: string; url: string }>> {
+    const result = await this.get<{
+      dopSettings: Array<{ id: string; key: string; type: string; url: string }>;
+    }>('/api/v2/dop-translation/dop-settings');
+    return result.dopSettings.filter((s) => s.type === 'gitlab');
+  }
+
+  // filters by dopSettingId to avoid cross-ALM collisions (GitHub, Azure also populate `repository`)
+  async getAllProjectBindings(dopSettingId: string): Promise<Map<string, string>> {
+    const bindingMap = new Map<string, string>();
+    let pageIndex = 1;
+    const pageSize = 500;
+    for (;;) {
+      const result = await this.get<{
+        projectBindings: Array<{ projectKey: string; repository: string }>;
+        page: { total: number; pageSize: number; pageIndex: number };
+      }>('/api/v2/dop-translation/project-bindings', {
+        pageSize,
+        pageIndex,
+        dopSettingId,
+      });
+      for (const binding of result.projectBindings) {
+        bindingMap.set(binding.repository, binding.projectKey);
+      }
+      const effectivePageSize = result.page.pageSize || pageSize;
+      if (result.projectBindings.length === 0 || pageIndex * effectivePageSize >= result.page.total)
+        break;
+      pageIndex++;
+    }
+    return bindingMap;
+  }
+
+  async hasProjectBeenAnalyzed(projectKey: string): Promise<boolean> {
+    const { response, value } = await this.getSafe<{ analyses: unknown[] }>(
+      '/api/project_analyses/search',
+      { project: projectKey, ps: 1 },
+    );
+    if (response.status === HTTP_STATUS_NOT_FOUND) return false;
+    await this.raiseForStatus(response, 'GET');
+    return (value?.analyses.length ?? 0) > 0;
+  }
+
+  async hasProvisionProjectsPermission(): Promise<boolean> {
+    const result = await this.get<{ permissions?: { global?: string[] } }>('/api/users/current');
+
+    return result.permissions?.global?.includes('provisioning') ?? false;
   }
 
   /**

--- a/tests/integration/harness/fake-gitlab-server.ts
+++ b/tests/integration/harness/fake-gitlab-server.ts
@@ -1,0 +1,320 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Lightweight in-process fake GitLab API server (Bun.serve).
+// Implements the subset of the GitLab v4 API used by GitLabClient.
+
+import type { RecordedRequest } from './types.js';
+
+export interface FakeGitLabProject {
+  id: number;
+  name: string;
+  path_with_namespace: string;
+  default_branch: string | null;
+  /** Root-level files present in the default branch. */
+  rootFiles?: Array<{ name: string; content?: string }>;
+  /** Whether there is already an open MR from the sonar/add-sonar-analysis-job branch. */
+  hasOpenSonarMr?: boolean;
+  /** Custom CI config path (GitLab project setting). Omit for default .gitlab-ci.yml. */
+  ciConfigPath?: string;
+  /** Branches that already exist on the project (e.g. an orphaned CI branch from a prior run). */
+  existingBranches?: string[];
+}
+
+interface CreatedMr {
+  projectId: number;
+  sourceBranch: string;
+  targetBranch: string;
+  title: string;
+  description: string;
+  webUrl: string;
+}
+
+interface CommittedFile {
+  projectId: number;
+  path: string;
+  branch: string;
+  content: string;
+}
+
+export class FakeGitLabServer {
+  private readonly server: ReturnType<typeof Bun.serve>;
+  private readonly requests: RecordedRequest[];
+  readonly createdMrs: CreatedMr[];
+  readonly committedFiles: CommittedFile[];
+  readonly createdBranches: Array<{ projectId: number; branch: string }>;
+  readonly deletedBranches: Array<{ projectId: number; branch: string }>;
+
+  constructor(
+    server: ReturnType<typeof Bun.serve>,
+    requests: RecordedRequest[],
+    createdMrs: CreatedMr[],
+    committedFiles: CommittedFile[],
+    createdBranches: Array<{ projectId: number; branch: string }>,
+    deletedBranches: Array<{ projectId: number; branch: string }>,
+  ) {
+    this.server = server;
+    this.requests = requests;
+    this.createdMrs = createdMrs;
+    this.committedFiles = committedFiles;
+    this.createdBranches = createdBranches;
+    this.deletedBranches = deletedBranches;
+  }
+
+  baseUrl(): string {
+    return `http://localhost:${this.server.port}`;
+  }
+
+  getRecordedRequests(): RecordedRequest[] {
+    return [...this.requests];
+  }
+
+  async stop(): Promise<void> {
+    await this.server.stop(true);
+  }
+}
+
+export class FakeGitLabServerBuilder {
+  private readonly projects: FakeGitLabProject[] = [];
+  private readonly projectsByGroup = new Map<string, FakeGitLabProject[]>();
+
+  withGroup(groupPath: string, projects: FakeGitLabProject[]): this {
+    this.projectsByGroup.set(groupPath, projects);
+    for (const p of projects) {
+      if (!this.projects.some((existing) => existing.id === p.id)) {
+        this.projects.push(p);
+      }
+    }
+    return this;
+  }
+
+  start(): Promise<FakeGitLabServer> {
+    const requests: RecordedRequest[] = [];
+    const createdMrs: CreatedMr[] = [];
+    const committedFiles: CommittedFile[] = [];
+    const preExistingBranches: Array<{ projectId: number; branch: string }> = this.projects.flatMap(
+      (p) => (p.existingBranches ?? []).map((branch) => ({ projectId: p.id, branch })),
+    );
+    const createdBranches: Array<{ projectId: number; branch: string }> = [];
+    const deletedBranches: Array<{ projectId: number; branch: string }> = [];
+    const branchExists = (projectId: number, branch: string): boolean =>
+      [...preExistingBranches, ...createdBranches].some(
+        (b) => b.projectId === projectId && b.branch === branch,
+      );
+    const projects = this.projects;
+    const projectsByGroup = this.projectsByGroup;
+
+    let mrCounter = 1;
+
+    const server = Bun.serve({
+      port: 0,
+      hostname: '::',
+      ipv6Only: false,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const path = url.pathname;
+        const query: Record<string, string> = {};
+        url.searchParams.forEach((v, k) => {
+          query[k] = v;
+        });
+        const headers: Record<string, string> = {};
+        req.headers.forEach((v, k) => {
+          headers[k] = v;
+        });
+        const body = req.method === 'POST' || req.method === 'PUT' ? await req.text() : undefined;
+
+        requests.push({
+          method: req.method,
+          url: req.url,
+          path,
+          query,
+          headers,
+          timestamp: Date.now(),
+        });
+
+        const json = (data: unknown, status = 200): Response =>
+          new Response(JSON.stringify(data), {
+            status,
+            headers: { 'Content-Type': 'application/json' },
+          });
+
+        // GET /api/v4/projects/{id}
+        const projectMatch = /^\/api\/v4\/projects\/(\d+)$/.exec(path);
+        if (projectMatch && req.method === 'GET') {
+          const projectId = Number.parseInt(projectMatch[1], 10);
+          const project = projects.find((p) => p.id === projectId);
+          if (!project) return json({ message: 'Not Found' }, 404);
+          return json({ id: project.id, ci_config_path: project.ciConfigPath ?? '' });
+        }
+
+        // GET /api/v4/groups/{group}/projects
+        const groupProjectsMatch = /^\/api\/v4\/groups\/([^/]+)\/projects$/.exec(path);
+        if (groupProjectsMatch && req.method === 'GET') {
+          const groupPath = decodeURIComponent(groupProjectsMatch[1]);
+          const groupProjects = projectsByGroup.get(groupPath) ?? [];
+          const pageSize = Number.parseInt(query.per_page ?? '100', 10);
+          const page = Number.parseInt(query.page ?? '1', 10);
+          const start = (page - 1) * pageSize;
+          const paged = groupProjects.slice(start, start + pageSize).map((p) => ({
+            id: p.id,
+            name: p.name,
+            path_with_namespace: p.path_with_namespace,
+            default_branch: p.default_branch,
+          }));
+          return json(paged);
+        }
+
+        // GET /api/v4/projects/{id}/repository/tree
+        const treeMatch = /^\/api\/v4\/projects\/(\d+)\/repository\/tree$/.exec(path);
+        if (treeMatch && req.method === 'GET') {
+          const projectId = Number.parseInt(treeMatch[1], 10);
+          const project = projects.find((p) => p.id === projectId);
+          if (!project) return json({ message: 'Not Found' }, 404);
+          const allEntries = (project.rootFiles ?? []).map((f) => ({
+            name: f.name,
+            type: 'blob',
+            path: f.name,
+          }));
+          const pageSize = Number.parseInt(query.per_page ?? '100', 10);
+          const page = Number.parseInt(query.page ?? '1', 10);
+          const start = (page - 1) * pageSize;
+          return json(allEntries.slice(start, start + pageSize));
+        }
+
+        // GET /api/v4/projects/{id}/repository/files/{encoded_path}
+        const fileMatch = /^\/api\/v4\/projects\/(\d+)\/repository\/files\/(.+)$/.exec(path);
+        if (fileMatch && req.method === 'GET') {
+          const projectId = Number.parseInt(fileMatch[1], 10);
+          const filePath = decodeURIComponent(fileMatch[2].replace(/%2F/gi, '/'));
+          const project = projects.find((p) => p.id === projectId);
+          if (!project) return json({ message: 'Not Found' }, 404);
+          const rootFile = project.rootFiles?.find((f) => f.name === filePath);
+          if (!rootFile) return json({ message: 'Not Found' }, 404);
+          const content = Buffer.from(rootFile.content ?? '').toString('base64');
+          return json({ content, encoding: 'base64' });
+        }
+
+        // POST /api/v4/projects/{id}/repository/branches
+        const createBranchMatch = /^\/api\/v4\/projects\/(\d+)\/repository\/branches$/.exec(path);
+        if (createBranchMatch && req.method === 'POST') {
+          const projectId = Number.parseInt(createBranchMatch[1], 10);
+          const payload = JSON.parse(body ?? '{}') as { branch: string };
+          if (branchExists(projectId, payload.branch)) {
+            return json({ message: 'Branch already exists' }, 400);
+          }
+          createdBranches.push({ projectId, branch: payload.branch });
+          return json({ name: payload.branch }, 201);
+        }
+
+        // DELETE /api/v4/projects/{id}/repository/branches/{branch}
+        const deleteBranchMatch = /^\/api\/v4\/projects\/(\d+)\/repository\/branches\/(.+)$/.exec(
+          path,
+        );
+        if (deleteBranchMatch && req.method === 'DELETE') {
+          const projectId = Number.parseInt(deleteBranchMatch[1], 10);
+          const branch = decodeURIComponent(deleteBranchMatch[2]);
+          deletedBranches.push({ projectId, branch });
+          for (const list of [preExistingBranches, createdBranches]) {
+            const idx = list.findIndex((b) => b.projectId === projectId && b.branch === branch);
+            if (idx >= 0) list.splice(idx, 1);
+          }
+          return new Response(null, { status: 204 });
+        }
+
+        // POST /api/v4/projects/{id}/repository/files/{encoded_path}
+        const createFileMatch = /^\/api\/v4\/projects\/(\d+)\/repository\/files\/(.+)$/.exec(path);
+        if (createFileMatch && req.method === 'POST') {
+          const projectId = Number.parseInt(createFileMatch[1], 10);
+          const filePath = decodeURIComponent(createFileMatch[2].replace(/%2F/gi, '/'));
+          const payload = JSON.parse(body ?? '{}') as { branch: string; content: string };
+          committedFiles.push({
+            projectId,
+            path: filePath,
+            branch: payload.branch,
+            content: payload.content,
+          });
+          return json({ file_path: filePath }, 201);
+        }
+
+        // PUT /api/v4/projects/{id}/repository/files/{encoded_path}
+        const updateFileMatch = /^\/api\/v4\/projects\/(\d+)\/repository\/files\/(.+)$/.exec(path);
+        if (updateFileMatch && req.method === 'PUT') {
+          const projectId = Number.parseInt(updateFileMatch[1], 10);
+          const filePath = decodeURIComponent(updateFileMatch[2].replace(/%2F/gi, '/'));
+          const payload = JSON.parse(body ?? '{}') as { branch: string; content: string };
+          committedFiles.push({
+            projectId,
+            path: filePath,
+            branch: payload.branch,
+            content: payload.content,
+          });
+          return json({ file_path: filePath });
+        }
+
+        // GET /api/v4/projects/{id}/merge_requests
+        const listMrMatch = /^\/api\/v4\/projects\/(\d+)\/merge_requests$/.exec(path);
+        if (listMrMatch && req.method === 'GET') {
+          const projectId = Number.parseInt(listMrMatch[1], 10);
+          const sourceBranch = query.source_branch;
+          const project = projects.find((p) => p.id === projectId);
+          if (project?.hasOpenSonarMr && sourceBranch === 'sonar/add-sonar-analysis-job') {
+            return json([{ iid: 1, web_url: `http://localhost/mr/1`, state: 'opened' }]);
+          }
+          return json([]);
+        }
+
+        // POST /api/v4/projects/{id}/merge_requests
+        const createMrMatch = /^\/api\/v4\/projects\/(\d+)\/merge_requests$/.exec(path);
+        if (createMrMatch && req.method === 'POST') {
+          const projectId = Number.parseInt(createMrMatch[1], 10);
+          const payload = JSON.parse(body ?? '{}') as {
+            source_branch: string;
+            target_branch: string;
+            title: string;
+            description: string;
+          };
+          const webUrl = `${url.origin}/mr/${mrCounter++}`;
+          createdMrs.push({
+            projectId,
+            sourceBranch: payload.source_branch,
+            targetBranch: payload.target_branch,
+            title: payload.title,
+            description: payload.description,
+            webUrl,
+          });
+          return json({ web_url: webUrl }, 201);
+        }
+
+        return json({ message: `Unknown GitLab endpoint: ${path}` }, 404);
+      },
+    });
+
+    return Promise.resolve(
+      new FakeGitLabServer(
+        server,
+        requests,
+        createdMrs,
+        committedFiles,
+        createdBranches,
+        deletedBranches,
+      ),
+    );
+  }
+}

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -257,6 +257,13 @@ export class FakeSonarQubeServerBuilder {
   private provisionProjectsDelayMs?: number;
   private autoscanEligibilityStatusCode?: number;
   private autoscanEligibilityStatusBody?: string;
+  private dopSettings: Array<{ id: string; key: string; type: string; url: string }> = [];
+  private projectBindings: Array<{ projectKey: string; repository: string; dopSettingId: string }> =
+    [];
+  private hasProvisionProjects = true;
+  private boundProjectsStatusCode?: number;
+  private analyzedProjectKeys = new Set<string>();
+
   private metrics: Metric[] = [];
 
   /** Configure the server-wide metric catalog `GET /api/metrics/search` returns. */
@@ -545,6 +552,35 @@ export class FakeSonarQubeServerBuilder {
     return this;
   }
 
+  withDopSettings(settings: Array<{ id: string; key: string; type: string; url: string }>): this {
+    this.dopSettings = settings;
+    return this;
+  }
+
+  withProjectBindings(
+    bindings: Array<{ projectKey: string; repository: string; dopSettingId: string }>,
+  ): this {
+    this.projectBindings = bindings;
+    return this;
+  }
+
+  withProvisionProjectsPermission(has: boolean): this {
+    this.hasProvisionProjects = has;
+    return this;
+  }
+
+  withBoundProjectsError(statusCode: number): this {
+    this.boundProjectsStatusCode = statusCode;
+    return this;
+  }
+
+  withAnalyzedProjects(projectKeys: string[]): this {
+    for (const key of projectKeys) {
+      this.analyzedProjectKeys.add(key);
+    }
+    return this;
+  }
+
   start(): Promise<FakeSonarQubeServer> {
     const projects = new Map([...this.projectBuilders.entries()].map(([k, v]) => [k, v.getData()]));
     const {
@@ -586,6 +622,11 @@ export class FakeSonarQubeServerBuilder {
       autoscanEligibilityStatusCode,
       autoscanEligibilityStatusBody,
       metrics,
+      dopSettings,
+      projectBindings,
+      hasProvisionProjects,
+      boundProjectsStatusCode,
+      analyzedProjectKeys,
     } = this;
     const memberOrganizationsTotal = rawMemberOrganizationsTotal ?? memberOrganizations.length;
     const requests: RecordedRequest[] = [];
@@ -1264,6 +1305,77 @@ export class FakeSonarQubeServerBuilder {
             }),
             { headers: { 'Content-Type': 'application/json' } },
           );
+        }
+
+        if (path === '/api/users/current') {
+          const global = hasProvisionProjects ? ['provisioning'] : [];
+          return new Response(
+            JSON.stringify({ id: 'fake-user-uuid', login: 'fake-user', permissions: { global } }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+
+        if (path === '/api/v2/dop-translation/dop-settings') {
+          return new Response(JSON.stringify({ dopSettings }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+
+        if (path === '/api/v2/dop-translation/project-bindings' && req.method === 'GET') {
+          const { dopSettingId, pageSize: pageSizeStr, pageIndex: pageIndexStr } = query;
+          const pageSize = Number.parseInt(pageSizeStr ?? '500', 10);
+          const pageIndex = Number.parseInt(pageIndexStr ?? '1', 10);
+          const filtered = dopSettingId
+            ? projectBindings.filter((b) => b.dopSettingId === dopSettingId)
+            : projectBindings;
+          const start = (pageIndex - 1) * pageSize;
+          const page = filtered.slice(start, start + pageSize);
+          return new Response(
+            JSON.stringify({
+              projectBindings: page.map(({ projectKey, repository }) => ({
+                projectKey,
+                repository,
+              })),
+              page: { total: filtered.length, pageSize, pageIndex },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+
+        if (path === '/api/project_analyses/search' && req.method === 'GET') {
+          const projectKey = query.project ?? '';
+          const hasAnalysis = analyzedProjectKeys.has(projectKey);
+          const analyses = hasAnalysis ? [{ key: 'AX1', date: '2024-01-01T00:00:00+0000' }] : [];
+          return new Response(
+            JSON.stringify({
+              paging: { pageIndex: 1, pageSize: 1, total: analyses.length },
+              analyses,
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+
+        if (path === '/api/v2/dop-translation/bound-projects' && req.method === 'POST') {
+          if (boundProjectsStatusCode !== undefined) {
+            return new Response(JSON.stringify({ errors: [{ msg: 'Bound project error' }] }), {
+              status: boundProjectsStatusCode,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+          const payload = JSON.parse(body ?? '{}') as {
+            projectKey: string;
+            repositoryIdentifier: string;
+            devOpsPlatformSettingId: string;
+          };
+          projectBindings.push({
+            projectKey: payload.projectKey,
+            repository: payload.repositoryIdentifier,
+            dopSettingId: payload.devOpsPlatformSettingId,
+          });
+          return new Response(JSON.stringify({}), {
+            status: 201,
+            headers: { 'Content-Type': 'application/json' },
+          });
         }
 
         return new Response(JSON.stringify({ errors: [{ msg: `Unknown endpoint: ${path}` }] }), {

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -33,12 +33,14 @@ import { getCliBinaryPath, runCli } from './cli-runner.js';
 import { Dir } from './dir';
 import { EnvironmentBuilder } from './environment-builder.js';
 import { FakeBinariesServer, FakeBinariesServerBuilder } from './fake-binaries-server.js';
+import { FakeGitLabServer, FakeGitLabServerBuilder } from './fake-gitlab-server.js';
 import { FakeSonarQubeServer, FakeSonarQubeServerBuilder } from './fake-sonarqube-server.js';
 import { FakeUpdateScriptServer } from './fake-update-script-server.js';
 import { File } from './file';
 import { buildHomeEnv, IS_WINDOWS } from './platform';
 import type { CliResult, RunOptions } from './types.js';
 
+export { FakeGitLabServer, FakeGitLabServerBuilder } from './fake-gitlab-server.js';
 export { FakeSonarQubeServer, FakeSonarQubeServerBuilder } from './fake-sonarqube-server.js';
 export { hookScriptName, hookScriptPath, IS_WINDOWS, normalizePath } from './platform';
 export type { CliResult, RecordedRequest } from './types.js';
@@ -53,6 +55,7 @@ export class TestHarness {
   private readonly tempDir: Dir;
   private readonly servers: FakeSonarQubeServer[] = [];
   private readonly binariesServers: FakeBinariesServer[] = [];
+  private readonly gitlabServers: FakeGitLabServer[] = [];
   private readonly updateScriptServers: FakeUpdateScriptServer[] = [];
   private _envBuilder?: EnvironmentBuilder;
   private systemEnvVars: Record<string, string> = {};
@@ -160,6 +163,20 @@ export class TestHarness {
       return server;
     };
 
+    return builder;
+  }
+
+  /** Creates a fake GitLab server. Call .start() on the result; stopped automatically on dispose(). */
+  newFakeGitLabServer(): FakeGitLabServerBuilder & {
+    start: () => Promise<FakeGitLabServer>;
+  } {
+    const builder = new FakeGitLabServerBuilder();
+    const originalStart = builder.start.bind(builder);
+    builder.start = async () => {
+      const server = await originalStart();
+      this.gitlabServers.push(server);
+      return server;
+    };
     return builder;
   }
 
@@ -277,7 +294,7 @@ export class TestHarness {
    */
   async dispose(): Promise<void> {
     await Promise.all(
-      [...this.servers, ...this.binariesServers].map((s) =>
+      [...this.servers, ...this.binariesServers, ...this.gitlabServers].map((s) =>
         s.stop().catch(() => {
           /* ignore stop errors */
         }),

--- a/tests/unit/core/gitlab/client.test.ts
+++ b/tests/unit/core/gitlab/client.test.ts
@@ -1,0 +1,402 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { GitLabApiError, GitLabClient } from '@/core/gitlab/client.ts';
+
+import {
+  fakeResponse,
+  lastFetchInit,
+  lastFetchUrl,
+  mockFetch,
+  mockFetchSeq,
+  nthFetchUrl,
+} from '../../helpers/mock-fetch.ts';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_URL = 'https://gitlab.example.com';
+const TOKEN = 'glpat-test-token';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitLabClient', () => {
+  let client: GitLabClient;
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    client = new GitLabClient(BASE_URL, TOKEN);
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // Constructor — base URL normalisation
+  // -------------------------------------------------------------------------
+
+  describe('constructor', () => {
+    it('strips trailing /api/v4/ from the base URL', async () => {
+      const c = new GitLabClient(`${BASE_URL}/api/v4/`, TOKEN);
+      fetchSpy = mockFetch({ ci_config_path: null });
+      await c.getProjectCiConfigPath(1);
+      expect(lastFetchUrl(fetchSpy)).toBe(`${BASE_URL}/api/v4/projects/1`);
+    });
+
+    it('strips trailing slash from the base URL', async () => {
+      const c = new GitLabClient(`${BASE_URL}/`, TOKEN);
+      fetchSpy = mockFetch({ ci_config_path: null });
+      await c.getProjectCiConfigPath(1);
+      expect(lastFetchUrl(fetchSpy)).toBe(`${BASE_URL}/api/v4/projects/1`);
+    });
+
+    it('sends PRIVATE-TOKEN header on every request', async () => {
+      fetchSpy = mockFetch({ ci_config_path: null });
+      await client.getProjectCiConfigPath(1);
+      const headers = lastFetchInit(fetchSpy).headers as Record<string, string>;
+      expect(headers['PRIVATE-TOKEN']).toBe(TOKEN);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getProjectCiConfigPath
+  // -------------------------------------------------------------------------
+
+  describe('getProjectCiConfigPath', () => {
+    it('returns the ci_config_path string when present', async () => {
+      fetchSpy = mockFetch({ ci_config_path: 'ci/custom.yml' });
+      const result = await client.getProjectCiConfigPath(42);
+      expect(result).toBe('ci/custom.yml');
+      expect(lastFetchUrl(fetchSpy)).toContain('/projects/42');
+    });
+
+    it('returns null when ci_config_path is null', async () => {
+      fetchSpy = mockFetch({ ci_config_path: null });
+      expect(await client.getProjectCiConfigPath(1)).toBeNull();
+    });
+
+    it('returns null when ci_config_path is empty string', async () => {
+      fetchSpy = mockFetch({ ci_config_path: '' });
+      expect(await client.getProjectCiConfigPath(1)).toBeNull();
+    });
+
+    it('returns null when ci_config_path is absent', async () => {
+      fetchSpy = mockFetch({});
+      expect(await client.getProjectCiConfigPath(1)).toBeNull();
+    });
+
+    it('throws on non-ok response', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getProjectCiConfigPath(1)).rejects.toThrow('GitLab API error 403');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listGroupRepos
+  // -------------------------------------------------------------------------
+
+  describe('listGroupRepos', () => {
+    const repo = {
+      id: 1,
+      name: 'repo',
+      path_with_namespace: 'group/repo',
+      default_branch: 'main',
+      marked_for_deletion_at: null,
+    };
+
+    it('returns repos from a single page', async () => {
+      fetchSpy = mockFetch([repo]);
+      const result = await client.listGroupRepos('my-group');
+      expect(result).toEqual([repo]);
+      expect(lastFetchUrl(fetchSpy)).toContain('/groups/my-group/projects');
+    });
+
+    it('encodes the group path in the URL', async () => {
+      fetchSpy = mockFetch([]);
+      await client.listGroupRepos('my-org/sub-group');
+      expect(lastFetchUrl(fetchSpy)).toContain('/groups/my-org%2Fsub-group/projects');
+    });
+
+    it('paginates and returns all repos across pages', async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) => ({ ...repo, id: i + 1 }));
+      const page2 = [{ ...repo, id: 101 }];
+      fetchSpy = mockFetchSeq(fakeResponse(page1), fakeResponse(page2));
+      const result = await client.listGroupRepos('group');
+      expect(result).toHaveLength(101);
+      expect(nthFetchUrl(fetchSpy, 0)).toContain('page=1');
+      expect(nthFetchUrl(fetchSpy, 1)).toContain('page=2');
+    });
+
+    it('stops pagination when page is smaller than page size', async () => {
+      fetchSpy = mockFetch([repo]);
+      await client.listGroupRepos('group');
+      expect(fetchSpy.mock.calls).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listRepoTree
+  // -------------------------------------------------------------------------
+
+  describe('listRepoTree', () => {
+    const entry = { name: 'README.md', type: 'blob' as const, path: 'README.md' };
+
+    it('returns tree entries from a single page', async () => {
+      fetchSpy = mockFetch([entry]);
+      const result = await client.listRepoTree(1, 'main');
+      expect(result).toEqual([entry]);
+      expect(lastFetchUrl(fetchSpy)).toContain('/projects/1/repository/tree');
+      expect(lastFetchUrl(fetchSpy)).toContain('ref=main');
+    });
+
+    it('paginates and returns all entries across pages', async () => {
+      const page1 = Array.from({ length: 100 }, (_, i) => ({ ...entry, name: `file${i}` }));
+      const page2 = [entry];
+      fetchSpy = mockFetchSeq(fakeResponse(page1), fakeResponse(page2));
+      const result = await client.listRepoTree(1, 'main');
+      expect(result).toHaveLength(101);
+      expect(nthFetchUrl(fetchSpy, 1)).toContain('page=2');
+    });
+
+    it('encodes the ref in the URL', async () => {
+      fetchSpy = mockFetch([]);
+      await client.listRepoTree(1, 'feature/my-branch');
+      expect(lastFetchUrl(fetchSpy)).toContain('ref=feature%2Fmy-branch');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getFileContent
+  // -------------------------------------------------------------------------
+
+  describe('getFileContent', () => {
+    it('decodes base64 file content', async () => {
+      const content = Buffer.from('hello world').toString('base64');
+      fetchSpy = mockFetch({ content, encoding: 'base64' });
+      const result = await client.getFileContent(1, '.gitlab-ci.yml', 'main');
+      expect(result).toBe('hello world');
+    });
+
+    it('returns null on 404', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
+      expect(await client.getFileContent(1, 'missing.yml', 'main')).toBeNull();
+    });
+
+    it('encodes path segments with %2F', async () => {
+      const content = Buffer.from('x').toString('base64');
+      fetchSpy = mockFetch({ content, encoding: 'base64' });
+      await client.getFileContent(1, 'ci/sub/file.yml', 'main');
+      expect(lastFetchUrl(fetchSpy)).toContain('ci%2Fsub%2Ffile.yml');
+    });
+
+    it('throws on non-404 error', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 500 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getFileContent(1, 'file.yml', 'main')).rejects.toThrow(
+        'GitLab API error 500',
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createBranch
+  // -------------------------------------------------------------------------
+
+  describe('createBranch', () => {
+    it('POSTs to the branches endpoint with branch name and HEAD ref', async () => {
+      fetchSpy = mockFetch({});
+      await client.createBranch(1, 'feature/my-branch');
+      const init = lastFetchInit(fetchSpy);
+      expect(init.method).toBe('POST');
+      expect(lastFetchUrl(fetchSpy)).toContain('/projects/1/repository/branches');
+      const body = JSON.parse(init.body as string);
+      expect(body.branch).toBe('feature/my-branch');
+      expect(body.ref).toBe('HEAD');
+    });
+
+    it('throws GitLabApiError with body exposed when the server returns an error', async () => {
+      fetchSpy = mockFetch({ message: 'Branch already exists' }, { ok: false, status: 400 });
+
+      const err = await client.createBranch(1, 'bad').catch((e: unknown) => e);
+      expect(err).toBeInstanceOf(GitLabApiError);
+      expect((err as GitLabApiError).status).toBe(400);
+      expect((err as GitLabApiError).body).toContain('Branch already exists');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createFile / updateFile
+  // -------------------------------------------------------------------------
+
+  describe('createFile', () => {
+    it('POSTs with correct body fields', async () => {
+      fetchSpy = mockFetch({});
+      await client.createFile(1, '.gitlab-ci.yml', 'my-branch', 'content', 'Add CI');
+      const body = JSON.parse(lastFetchInit(fetchSpy).body as string);
+      expect(body.branch).toBe('my-branch');
+      expect(body.content).toBe('content');
+      expect(body.commit_message).toBe('Add CI');
+      expect(body.encoding).toBe('text');
+      expect(lastFetchInit(fetchSpy).method).toBe('POST');
+    });
+  });
+
+  describe('updateFile', () => {
+    it('PUTs with correct body fields', async () => {
+      fetchSpy = mockFetch({});
+      await client.updateFile(1, '.gitlab-ci.yml', 'my-branch', 'updated', 'Update CI');
+      const body = JSON.parse(lastFetchInit(fetchSpy).body as string);
+      expect(body.branch).toBe('my-branch');
+      expect(body.content).toBe('updated');
+      expect(lastFetchInit(fetchSpy).method).toBe('PUT');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // createMergeRequest
+  // -------------------------------------------------------------------------
+
+  describe('createMergeRequest', () => {
+    it('POSTs and returns web_url from response', async () => {
+      fetchSpy = mockFetch({ web_url: 'https://gitlab.example.com/mr/1' });
+      const url = await client.createMergeRequest(1, 'feature', 'main', 'Title', 'Desc');
+      expect(url).toBe('https://gitlab.example.com/mr/1');
+      const body = JSON.parse(lastFetchInit(fetchSpy).body as string);
+      expect(body.source_branch).toBe('feature');
+      expect(body.target_branch).toBe('main');
+      expect(body.title).toBe('Title');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listOpenMergeRequests
+  // -------------------------------------------------------------------------
+
+  describe('listOpenMergeRequests', () => {
+    it('returns open MRs for the source branch', async () => {
+      const mr = { iid: 1, web_url: 'https://gitlab.example.com/mr/1', state: 'opened' as const };
+      fetchSpy = mockFetch([mr]);
+      const result = await client.listOpenMergeRequests(1, 'feature/branch');
+      expect(result).toEqual([mr]);
+      expect(lastFetchUrl(fetchSpy)).toContain('source_branch=feature%2Fbranch');
+      expect(lastFetchUrl(fetchSpy)).toContain('state=opened');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // deleteBranch
+  // -------------------------------------------------------------------------
+
+  describe('deleteBranch', () => {
+    it('DELETEs the encoded branch URL', async () => {
+      fetchSpy = mockFetch({});
+      await client.deleteBranch(1, 'feature/my-branch');
+      expect(lastFetchInit(fetchSpy).method).toBe('DELETE');
+      expect(lastFetchUrl(fetchSpy)).toContain('feature%2Fmy-branch');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // callWithRetry — GET retries
+  // -------------------------------------------------------------------------
+
+  describe('callWithRetry', () => {
+    let setTimeoutSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      setTimeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((fn: () => void) => {
+        fn();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout);
+    });
+
+    afterEach(() => {
+      setTimeoutSpy.mockRestore();
+    });
+
+    it('retries a 429 and succeeds on the next attempt', async () => {
+      fetchSpy = mockFetchSeq(
+        fakeResponse({}, { ok: false, status: 429, headers: { 'Retry-After': '1' } }),
+        fakeResponse({ ci_config_path: null }),
+      );
+      const result = await client.getProjectCiConfigPath(1);
+      expect(result).toBeNull();
+      expect(fetchSpy.mock.calls).toHaveLength(2);
+    });
+
+    it('uses DEFAULT_RETRY_AFTER_S when Retry-After is an HTTP-date (NaN)', async () => {
+      fetchSpy = mockFetchSeq(
+        fakeResponse(
+          {},
+          { ok: false, status: 429, headers: { 'Retry-After': 'Wed, 21 Oct 2015 07:28:00 GMT' } },
+        ),
+        fakeResponse({ ci_config_path: null }),
+      );
+      await client.getProjectCiConfigPath(1);
+      const delayCall = setTimeoutSpy.mock.calls[0];
+      // (DEFAULT_RETRY_AFTER_S=5 + 1) * 1000 = 6000
+      expect(delayCall[1]).toBe(6000);
+    });
+
+    it('stops retrying after MAX_RETRIES (5) attempts and returns the last response', async () => {
+      const responses = Array.from({ length: 6 }, () =>
+        fakeResponse({}, { ok: false, status: 429, headers: { 'Retry-After': '0' } }),
+      );
+      fetchSpy = mockFetchSeq(...responses);
+      // Should return the 429 without throwing after MAX_RETRIES exceeded
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getProjectCiConfigPath(1)).rejects.toThrow('GitLab API error 429');
+      expect(fetchSpy.mock.calls).toHaveLength(6); // attempt 0-5, then return
+    });
+
+    it('retries 5xx errors on GETs', async () => {
+      fetchSpy = mockFetchSeq(
+        fakeResponse({}, { ok: false, status: 503 }),
+        fakeResponse({ ci_config_path: null }),
+      );
+      const result = await client.getProjectCiConfigPath(1);
+      expect(result).toBeNull();
+      expect(fetchSpy.mock.calls).toHaveLength(2);
+    });
+
+    it('does NOT retry writes on 5xx — throws immediately', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 503 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.createBranch(1, 'branch')).rejects.toThrow('GitLab API error 503');
+      expect(fetchSpy.mock.calls).toHaveLength(1);
+    });
+
+    it('does NOT retry createMergeRequest on 5xx', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 502 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.createMergeRequest(1, 'src', 'main', 'T', 'D')).rejects.toThrow(
+        'GitLab API error 502',
+      );
+      expect(fetchSpy.mock.calls).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/core/server/client.test.ts
+++ b/tests/unit/core/server/client.test.ts
@@ -37,25 +37,7 @@ import { INVOCATION_ID } from '@/core/telemetry/invocation-id.ts';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 
 import { version as VERSION } from '../../../../package.json';
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function mockFetch(body: unknown, ok = true, status = 200): ReturnType<typeof spyOn> {
-  const statusText = ok ? 'OK' : 'Internal Server Error';
-  return spyOn(globalThis, 'fetch').mockResolvedValue({
-    ok,
-    status,
-    statusText,
-    json: () => Promise.resolve(body),
-    text: () => Promise.resolve(JSON.stringify(body)),
-  } as Response);
-}
-
-function lastFetchUrl(fetchSpy: ReturnType<typeof spyOn>): string {
-  return (fetchSpy.mock.calls[0][0] as URL).toString();
-}
+import { lastFetchInit, lastFetchUrl, mockFetch } from '../../helpers/mock-fetch.ts';
 
 function fetchPathnames(fetchSpy: ReturnType<typeof spyOn>): string[] {
   const paths: string[] = [];
@@ -63,10 +45,6 @@ function fetchPathnames(fetchSpy: ReturnType<typeof spyOn>): string[] {
     paths.push(new URL(fetchSpy.mock.calls[index][0] as URL).pathname);
   }
   return paths;
-}
-
-function lastFetchInit(fetchSpy: ReturnType<typeof spyOn>): RequestInit {
-  return fetchSpy.mock.calls[0][1] as RequestInit;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,7 +126,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('throws when response is not ok', async () => {
-      fetchSpy = mockFetch({}, false, 401);
+      fetchSpy = mockFetch({}, { ok: false, status: 401 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.get('/api/authentication/validate')).rejects.toThrow(
         'SonarQube API error: 401',
@@ -182,7 +160,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('postForm uses redirect: manual so the runtime cannot auto-follow', async () => {
-      fetchSpy = mockFetch({}, true, 204);
+      fetchSpy = mockFetch({}, { status: 204 });
       await client.postForm('/api/endpoint', { k: 'v' });
       expect(lastFetchInit(fetchSpy).redirect).toBe('manual');
     });
@@ -415,7 +393,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns response with undefined value on non-ok status (does not throw)', async () => {
-      fetchSpy = mockFetch({ errors: [{ msg: 'Not found' }] }, false, 404);
+      fetchSpy = mockFetch({ errors: [{ msg: 'Not found' }] }, { ok: false, status: 404 });
       const result = await client.getSafe('/api/settings/values', { component: 'missing' });
       expect(result.response.ok).toBe(false);
       expect(result.response.status).toBe(404);
@@ -464,7 +442,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('throws "Project ... not found" on 404', async () => {
-      fetchSpy = mockFetch({ errors: [{ msg: 'Not found' }] }, false, 404);
+      fetchSpy = mockFetch({ errors: [{ msg: 'Not found' }] }, { ok: false, status: 404 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.getProjectSettings('missing')).rejects.toThrow(
         "Project 'missing' not found",
@@ -472,7 +450,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('throws a generic API error on other non-ok statuses', async () => {
-      fetchSpy = mockFetch({}, false, 500);
+      fetchSpy = mockFetch({}, { ok: false, status: 500 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.getProjectSettings('demo')).rejects.toThrow('SonarQube API error: 500');
     });
@@ -500,7 +478,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('throws with error body text when response is not ok', async () => {
-      fetchSpy = mockFetch({ message: 'Not found' }, false, 404);
+      fetchSpy = mockFetch({ message: 'Not found' }, { ok: false, status: 404 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.post('/api/some/endpoint', {})).rejects.toThrow('404');
     });
@@ -512,7 +490,7 @@ describe('SonarQubeClient', () => {
 
   describe('postForm', () => {
     it('sends a form-encoded POST with URL-encoded body', async () => {
-      fetchSpy = mockFetch({}, true, 204);
+      fetchSpy = mockFetch({}, { status: 204 });
       await client.postForm('/api/some/form', { foo: 'bar baz', qux: 'a&b' });
       const init = lastFetchInit(fetchSpy);
       expect(init.method).toBe('POST');
@@ -520,7 +498,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('sets Content-Type: application/x-www-form-urlencoded and Bearer auth', async () => {
-      fetchSpy = mockFetch({}, true, 204);
+      fetchSpy = mockFetch({}, { status: 204 });
       await client.postForm('/api/some/form', { name: 'test' });
       expect(lastFetchInit(fetchSpy).headers).toMatchObject({
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -529,13 +507,13 @@ describe('SonarQubeClient', () => {
     });
 
     it('targets the exact endpoint on the configured server URL', async () => {
-      fetchSpy = mockFetch({}, true, 204);
+      fetchSpy = mockFetch({}, { status: 204 });
       await client.postForm('/api/some/form', { name: 'test' });
       expect(lastFetchUrl(fetchSpy)).toBe(`${SERVER_URL}/api/some/form`);
     });
 
     it('throws with error body text when response is not ok', async () => {
-      fetchSpy = mockFetch({ message: 'boom' }, false, 500);
+      fetchSpy = mockFetch({ message: 'boom' }, { ok: false, status: 500 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.postForm('/api/some/form', { name: 'test' })).rejects.toThrow(
         'SonarQube API error: 500 Internal Server Error',
@@ -545,7 +523,7 @@ describe('SonarQubeClient', () => {
 
   describe('revokeUserToken', () => {
     it('POSTs name=<tokenName> to /api/user_tokens/revoke', async () => {
-      fetchSpy = mockFetch({}, true, 204);
+      fetchSpy = mockFetch({}, { status: 204 });
       await client.revokeUserToken('cli-token-name');
       expect(lastFetchUrl(fetchSpy)).toBe(`${SERVER_URL}/api/user_tokens/revoke`);
       const init = lastFetchInit(fetchSpy);
@@ -558,13 +536,13 @@ describe('SonarQubeClient', () => {
     });
 
     it('URL-encodes special characters in the token name', async () => {
-      fetchSpy = mockFetch({}, true, 204);
+      fetchSpy = mockFetch({}, { status: 204 });
       await client.revokeUserToken('cli token+with/special&chars');
       expect(lastFetchInit(fetchSpy).body).toBe('name=cli+token%2Bwith%2Fspecial%26chars');
     });
 
     it('propagates server errors to the caller', async () => {
-      fetchSpy = mockFetch('revocation boom', false, 500);
+      fetchSpy = mockFetch('revocation boom', { ok: false, status: 500 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.revokeUserToken('cli-token-name')).rejects.toThrow(
         'SonarQube API error: 500 Internal Server Error',
@@ -625,7 +603,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns null on error', async () => {
-      fetchSpy = mockFetch({}, false, 401);
+      fetchSpy = mockFetch({}, { ok: false, status: 401 });
       expect(await client.getCurrentUser()).toBeNull();
     });
   });
@@ -665,7 +643,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns null on error', async () => {
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect(await client.getOrganizationId('unknown-org')).toBeNull();
     });
 
@@ -712,22 +690,22 @@ describe('SonarQubeClient', () => {
     });
 
     it("returns 'check_failed' when the entitlement API errors out", async () => {
-      fetchSpy = mockFetch({}, false, 500);
+      fetchSpy = mockFetch({}, { ok: false, status: 500 });
       expect((await cloudClient['checkHubEntitlement'](CLOUD_CAG)).status).toBe('check_failed');
     });
 
     it("returns 'check_failed' when a Cloud hub is missing (HTTP 404)", async () => {
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect((await cloudClient['checkHubEntitlement'](CLOUD_SQAA)).status).toBe('check_failed');
     });
 
     it("returns 'not_applicable' when a Server hub is absent (HTTP 404)", async () => {
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect((await client['checkHubEntitlement'](SERVER_SQAA)).status).toBe('not_applicable');
     });
 
     it("returns 'check_failed' when the hub is unavailable (HTTP 503)", async () => {
-      fetchSpy = mockFetch({}, false, 503);
+      fetchSpy = mockFetch({}, { ok: false, status: 503 });
       expect((await cloudClient['checkHubEntitlement'](CLOUD_CAG)).status).toBe('check_failed');
     });
 
@@ -815,7 +793,7 @@ describe('SonarQubeClient', () => {
 
     it("returns 'not_applicable' when both Server hubs are absent", async () => {
       const serverClient = new SonarQubeClient(SERVER_URL, TOKEN);
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect((await serverClient.hasVortexEntitlement()).status).toBe('not_applicable');
     });
 
@@ -842,12 +820,12 @@ describe('SonarQubeClient', () => {
 
     it("returns 'check_failed' when the Server Hub is unavailable", async () => {
       const serverClient = new SonarQubeClient(SERVER_URL, TOKEN);
-      fetchSpy = mockFetch({}, false, 503);
+      fetchSpy = mockFetch({}, { ok: false, status: 503 });
       expect((await serverClient.hasVortexEntitlement()).status).toBe('check_failed');
     });
 
     it('returns check_failed when org UUID cannot be resolved', async () => {
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect((await cloudClient.hasVortexEntitlement('unknown-org')).status).toBe('check_failed');
     });
 
@@ -929,7 +907,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns false when component is not found', async () => {
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect(await client.checkComponent('missing-project')).toBe(false);
     });
 
@@ -952,24 +930,24 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns false when component is not found (404)', async () => {
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect(await client.componentExists('missing-project')).toBe(false);
     });
 
     it('propagates a rate-limit error instead of reporting the component as missing', async () => {
-      fetchSpy = mockFetch({}, false, 429);
+      fetchSpy = mockFetch({}, { ok: false, status: 429 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.componentExists('my-project')).rejects.toThrow(RateLimitError);
     });
 
     it('propagates a service-unavailable error instead of reporting the component as missing', async () => {
-      fetchSpy = mockFetch({}, false, 503);
+      fetchSpy = mockFetch({}, { ok: false, status: 503 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.componentExists('my-project')).rejects.toThrow(ServiceUnavailableError);
     });
 
     it('propagates a forbidden/auth failure instead of reporting the component as missing', async () => {
-      fetchSpy = mockFetch({}, false, 403);
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.componentExists('my-project')).rejects.toThrow('Access denied');
     });
@@ -991,7 +969,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns false on error', async () => {
-      fetchSpy = mockFetch({}, false, 500);
+      fetchSpy = mockFetch({}, { ok: false, status: 500 });
       expect(await client.checkOrganization('my-org')).toBe(false);
     });
   });
@@ -1028,7 +1006,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns false on error', async () => {
-      fetchSpy = mockFetch({}, false, 403);
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
       expect(await client.checkQualityProfiles('my-project')).toBe(false);
     });
   });
@@ -1132,7 +1110,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('throws BadRequestError on non-ok POST response', async () => {
-      fetchSpy = mockFetch({ message: 'Bad request' }, false, 400);
+      fetchSpy = mockFetch({ message: 'Bad request' }, { ok: false, status: 400 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(
         client.genericRequest('POST', '/api/issues/do_transition', '{"k":"v"}', 'form'),
@@ -1140,7 +1118,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('preserves raw body for non-SQAA POST 400 responses', async () => {
-      fetchSpy = mockFetch({ errors: [{ msg: 'Transition failed' }] }, false, 400);
+      fetchSpy = mockFetch({ errors: [{ msg: 'Transition failed' }] }, { ok: false, status: 400 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(
         client.genericRequest('POST', '/api/issues/do_transition', '{"k":"v"}', 'form'),
@@ -1151,7 +1129,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('throws access denied on GET 403', async () => {
-      fetchSpy = mockFetch({}, false, 403);
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.genericRequest('GET', '/api/system/status')).rejects.toThrow(
         'Access denied',
@@ -1302,8 +1280,7 @@ describe('SonarQubeClient', () => {
     it('throws BadRequestError on structured 400 response', async () => {
       fetchSpy = mockFetch(
         { message: 'Invalid request body', code: 'INVALID_FILE_PATH' },
-        false,
-        400,
+        { ok: false, status: 400 },
       );
 
       // eslint-disable-next-line @typescript-eslint/await-thenable
@@ -1321,8 +1298,7 @@ describe('SonarQubeClient', () => {
           code: 'REQUEST_TOO_LARGE',
           meta: { maxRequestSize: 512_000 },
         },
-        false,
-        413,
+        { ok: false, status: 413 },
       );
 
       // eslint-disable-next-line @typescript-eslint/await-thenable
@@ -1346,7 +1322,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns null when component is not found', async () => {
-      fetchSpy = mockFetch({}, false, 404);
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
       expect(await client.getComponentId('missing-project')).toBeNull();
     });
 
@@ -1421,7 +1397,7 @@ describe('SonarQubeClient', () => {
 
     it('throws ForbiddenApiError on 403 response', async () => {
       const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
-      fetchSpy = mockFetch({ message: 'Insufficient privileges' }, false, 403);
+      fetchSpy = mockFetch({ message: 'Insufficient privileges' }, { ok: false, status: 403 });
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(
         cloudClient.scheduleAgentJob({
@@ -1476,7 +1452,7 @@ describe('SonarQubeClient', () => {
     });
 
     it('returns null when SQS project-bindings request fails', async () => {
-      fetchSpy = mockFetch({ message: 'not found' }, false, 404);
+      fetchSpy = mockFetch({ message: 'not found' }, { ok: false, status: 404 });
       expect(await client.getProjectKeyByGitRemote(remoteUrl)).toBeNull();
     });
 
@@ -1560,7 +1536,7 @@ describe('SonarQubeClient', () => {
 
     it('returns null when SonarCloud project-bindings request fails', async () => {
       const cloudClient = new SonarQubeClient(SONARCLOUD_URL, TOKEN);
-      fetchSpy = mockFetch({ message: 'not found' }, false, 404);
+      fetchSpy = mockFetch({ message: 'not found' }, { ok: false, status: 404 });
       expect(await cloudClient.getProjectKeyByGitRemote(remoteUrl, 'my-org')).toBeNull();
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
@@ -1645,6 +1621,134 @@ describe('SonarQubeClient', () => {
       } as Response);
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(client.getServerMode()).rejects.toThrow();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // listGitlabDopSettings
+  // -------------------------------------------------------------------------
+
+  describe('listGitlabDopSettings', () => {
+    it('returns only gitlab-type settings', async () => {
+      fetchSpy = mockFetch({
+        dopSettings: [
+          { id: 'g1', key: 'my-gitlab', type: 'gitlab', url: 'https://gitlab.com' },
+          { id: 'gh1', key: 'my-github', type: 'github', url: 'https://github.com' },
+        ],
+      });
+      const result = await client.listGitlabDopSettings();
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({ id: 'g1', key: 'my-gitlab', url: 'https://gitlab.com' });
+    });
+
+    it('returns empty array when no gitlab settings exist', async () => {
+      fetchSpy = mockFetch({ dopSettings: [] });
+      expect(await client.listGitlabDopSettings()).toEqual([]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getAllProjectBindings
+  // -------------------------------------------------------------------------
+
+  describe('getAllProjectBindings', () => {
+    it('returns a map of repository → projectKey for a single page', async () => {
+      fetchSpy = mockFetch({
+        projectBindings: [{ projectKey: 'my-project', repository: '123' }],
+        page: { total: 1, pageSize: 500, pageIndex: 1 },
+      });
+      const result = await client.getAllProjectBindings('dop-id');
+      expect(result.get('123')).toBe('my-project');
+      expect(result.size).toBe(1);
+    });
+
+    it('paginates using the server-returned pageSize', async () => {
+      // Server caps at 2 items per page even though we request 500
+      const page1 = {
+        projectBindings: [
+          { projectKey: 'p1', repository: '1' },
+          { projectKey: 'p2', repository: '2' },
+        ],
+        page: { total: 3, pageSize: 2, pageIndex: 1 },
+      };
+      const page2 = {
+        projectBindings: [{ projectKey: 'p3', repository: '3' }],
+        page: { total: 3, pageSize: 2, pageIndex: 2 },
+      };
+      fetchSpy = spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(page1),
+          text: () => Promise.resolve(''),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(page2),
+          text: () => Promise.resolve(''),
+        } as Response);
+      const result = await client.getAllProjectBindings('dop-id');
+      expect(result.size).toBe(3);
+      expect(result.get('3')).toBe('p3');
+    });
+
+    it('passes dopSettingId as a query parameter', async () => {
+      fetchSpy = mockFetch({
+        projectBindings: [],
+        page: { total: 0, pageSize: 500, pageIndex: 1 },
+      });
+      await client.getAllProjectBindings('my-dop-id');
+      const url = new URL(lastFetchUrl(fetchSpy));
+      expect(url.searchParams.get('dopSettingId')).toBe('my-dop-id');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // hasProjectBeenAnalyzed
+  // -------------------------------------------------------------------------
+
+  describe('hasProjectBeenAnalyzed', () => {
+    it('returns true when analyses array is non-empty', async () => {
+      fetchSpy = mockFetch({ analyses: [{ key: 'abc' }] });
+      expect(await client.hasProjectBeenAnalyzed('my-project')).toBe(true);
+    });
+
+    it('returns false when analyses array is empty', async () => {
+      fetchSpy = mockFetch({ analyses: [] });
+      expect(await client.hasProjectBeenAnalyzed('my-project')).toBe(false);
+    });
+
+    it('returns false on 404 (project has no analysis history)', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 404 });
+      expect(await client.hasProjectBeenAnalyzed('my-project')).toBe(false);
+    });
+
+    it('throws on 403 so access errors are not silently treated as unanalyzed', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.hasProjectBeenAnalyzed('my-project')).rejects.toThrow('403');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // hasProvisionProjectsPermission
+  // -------------------------------------------------------------------------
+
+  describe('hasProvisionProjectsPermission', () => {
+    it('returns true when provisioning is in global permissions', async () => {
+      fetchSpy = mockFetch({ permissions: { global: ['provisioning', 'scan'] } });
+      expect(await client.hasProvisionProjectsPermission()).toBe(true);
+    });
+
+    it('returns false when provisioning is absent', async () => {
+      fetchSpy = mockFetch({ permissions: { global: ['scan'] } });
+      expect(await client.hasProvisionProjectsPermission()).toBe(false);
+    });
+
+    it('returns false when permissions field is absent', async () => {
+      fetchSpy = mockFetch({});
+      expect(await client.hasProvisionProjectsPermission()).toBe(false);
     });
   });
 });

--- a/tests/unit/helpers/mock-fetch.ts
+++ b/tests/unit/helpers/mock-fetch.ts
@@ -1,0 +1,64 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Shared fetch mock helpers for unit tests of API clients.
+
+import { spyOn } from 'bun:test';
+
+export interface FakeResponseOpts {
+  ok?: boolean;
+  status?: number;
+  headers?: Record<string, string>;
+}
+
+export function fakeResponse(body: unknown, opts: FakeResponseOpts = {}): Response {
+  const status = opts.status ?? 200;
+  const ok = opts.ok ?? status < 400;
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Internal Server Error',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(opts.headers ?? {}),
+  } as Response;
+}
+
+export function mockFetch(body: unknown, opts: FakeResponseOpts = {}): ReturnType<typeof spyOn> {
+  return spyOn(globalThis, 'fetch').mockResolvedValue(fakeResponse(body, opts));
+}
+
+export function mockFetchSeq(...responses: Response[]): ReturnType<typeof spyOn> {
+  const spy = spyOn(globalThis, 'fetch');
+  for (const r of responses) spy.mockResolvedValueOnce(r);
+  return spy;
+}
+
+export function lastFetchUrl(spy: ReturnType<typeof spyOn>): string {
+  return (spy.mock.calls[0][0] as string | URL).toString();
+}
+
+export function nthFetchUrl(spy: ReturnType<typeof spyOn>, n: number): string {
+  return (spy.mock.calls[n][0] as string | URL).toString();
+}
+
+export function lastFetchInit(spy: ReturnType<typeof spyOn>): RequestInit {
+  return spy.mock.calls[0][1] as RequestInit;
+}


### PR DESCRIPTION
Part 2/3 of the MMF-5886 CI Config Automation stack. Depends on #721.
Full validation done here: https://github.com/SonarSource/sonarqube-cli/pull/723

----
## Summary by Gitar

- **GitLab API integration:**
    - Added `GitLabClient` for interacting with GitLab v4 APIs including repositories, branches, files, and merge requests
    - Added `resolveGitlabToken` utility for prompting or reading `GITLAB_TOKEN`
- **SonarQube Server bindings:**
    - Added SQS v2 admin and CI setup methods to `SonarQubeClient` for DOP settings and project bindings
- **UI components:**
    - Added `withUpdatableSpinner` utility in `src/core/ui/components/spinner.ts` for dynamic progress updates

<sub>This will update automatically on new commits.</sub>