### PR TITLE
SONAR-31829 Implement onboard-ci gitlab command

### DIFF
--- a/src/commands/admin/onboard-ci/gitlab/dry-run.ts
+++ b/src/commands/admin/onboard-ci/gitlab/dry-run.ts
@@ -1,0 +1,49 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { RepoClassification, RepoWithBranch } from './processor.ts';
+import type { DryRunResults } from './types.ts';
+
+export interface ClassificationEntry {
+  repo: RepoWithBranch;
+  classification: RepoClassification | null;
+}
+
+export function computeDryRunResults(
+  entries: ClassificationEntry[],
+  failedRepos: { repo: string; error: string }[],
+): DryRunResults {
+  const wouldOpenMr: DryRunResults['wouldOpenMr'] = [];
+  const wouldSkip: DryRunResults['wouldSkip'] = [];
+
+  for (const { repo, classification } of entries) {
+    if (!classification) continue;
+    if (classification.outcome === 'skip') {
+      wouldSkip.push({ repo: repo.path_with_namespace, reason: classification.reason });
+    } else {
+      wouldOpenMr.push({
+        repo: repo.path_with_namespace,
+        projectKey: classification.projectKey,
+      });
+    }
+  }
+
+  return { wouldOpenMr, wouldSkip, failed: failedRepos };
+}

--- a/src/commands/admin/onboard-ci/gitlab/index.ts
+++ b/src/commands/admin/onboard-ci/gitlab/index.ts
@@ -1,0 +1,421 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
+import { CommandFailedError } from '@/core/command-error.ts';
+import { runWithConcurrencyLimit } from '@/core/concurrency/concurrency-pool.ts';
+import type { GitLabRepo } from '@/core/gitlab/client.ts';
+import { GitLabClient } from '@/core/gitlab/client.ts';
+import { SonarQubeClient } from '@/core/server/client.ts';
+import { info, intro, outro, warn, withSpinner } from '@/core/ui';
+import { ConcurrentProgress } from '@/core/ui/components/concurrent-progress.ts';
+
+import type { ClassificationEntry } from './dry-run.ts';
+import { computeDryRunResults } from './dry-run.ts';
+import type { ProcessRepoContext, RepoClassification, RepoWithBranch } from './processor.ts';
+import { classifyRepo, executeRepo } from './processor.ts';
+import { writeReportFile } from './report.ts';
+import type { DryRunResults, OnboardCiGitlabOptions, OnboardCiResults } from './types.ts';
+import { TriggerOn } from './types.ts';
+
+export type { OnboardCiGitlabOptions } from './types.ts';
+
+const SETUP_CI_CONCURRENCY_LIMIT = 10;
+// GitLab CI variable names: letters, digits, underscores only, no leading digit.
+const GITLAB_VAR_NAME_RE = /^[a-zA-Z_]\w*$/;
+// GitLab group paths: no whitespace, no leading/trailing slashes.
+const GROUP_PATH_RE = /^[^\s/]([^\s]*[^\s/])?$/;
+// GitLab stage names: alphanumeric, spaces, dots, underscores, hyphens — no YAML-significant characters.
+const GITLAB_STAGE_NAME_RE = /^[a-zA-Z0-9 ._-]+$/;
+// Scanner property key: starts with a letter, then letters/digits/dots/underscores/hyphens.
+const SCANNER_PROPERTY_KEY_RE = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
+// Scanner property value: must not be whitespace-only, contain newlines, ': ' (YAML mapping indicator), or ' #' (YAML comment).
+const SCANNER_PROPERTY_VALUE_UNSAFE_RE = /[\n\r]|: | #/;
+
+/** Commander collector for repeatable --scanner-property options. */
+export function collectScannerProperty(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+export function validateOnboardCiGitlabOptions(options: OnboardCiGitlabOptions): void {
+  if (!Object.values(TriggerOn).includes(options.triggerOn)) {
+    throw new CommandFailedError(
+      `Invalid --trigger-on value '${options.triggerOn}'. Must be one of: ${(Object.values(TriggerOn) as string[]).join(', ')}`,
+      { exitCode: 2 },
+    );
+  }
+
+  if (!GITLAB_VAR_NAME_RE.test(options.sonarTokenVarName)) {
+    throw new CommandFailedError(
+      `Invalid --sonar-token-var-name '${options.sonarTokenVarName}'. ` +
+        'Must contain only letters, digits, and underscores and must not start with a digit.',
+      { exitCode: 2 },
+    );
+  }
+
+  if (!GROUP_PATH_RE.test(options.group)) {
+    throw new CommandFailedError(
+      `Invalid --group value '${options.group}'. Must be a non-empty path without leading or trailing slashes.`,
+      { exitCode: 2 },
+    );
+  }
+
+  if (options.stage !== undefined && !GITLAB_STAGE_NAME_RE.test(options.stage)) {
+    throw new CommandFailedError(
+      `Invalid --stage value '${options.stage}'. Must be a non-empty name containing only letters, digits, spaces, '.', '_', or '-'.`,
+      { exitCode: 2 },
+    );
+  }
+
+  for (const prop of options.scannerProperty) {
+    const eqIdx = prop.indexOf('=');
+    if (eqIdx <= 0) {
+      throw new CommandFailedError(
+        `Invalid --scanner-property '${prop}'. Expected format: key=value (e.g. sonar.scanner.engineJarPath=/path/to/jar).`,
+        { exitCode: 2 },
+      );
+    }
+    const key = prop.slice(0, eqIdx);
+    const value = prop.slice(eqIdx + 1);
+    if (!SCANNER_PROPERTY_KEY_RE.test(key)) {
+      throw new CommandFailedError(
+        `Invalid --scanner-property key '${key}'. Keys must start with a letter and contain only letters, digits, dots, underscores, or hyphens.`,
+        { exitCode: 2 },
+      );
+    }
+    if (value.trim().length === 0 || SCANNER_PROPERTY_VALUE_UNSAFE_RE.test(value)) {
+      throw new CommandFailedError(
+        `Invalid --scanner-property value for '${key}'. Values must be non-empty and must not contain newlines, ': ', or ' #'.`,
+        { exitCode: 2 },
+      );
+    }
+  }
+}
+
+async function resolveDopSetting(
+  sqs: SonarQubeClient,
+  bindingName?: string,
+): Promise<{ dopSettingId: string; dopSettingKey: string; gitlabUrl: string }> {
+  const settings = await sqs.listGitlabDopSettings();
+
+  if (settings.length === 0) {
+    throw new CommandFailedError(
+      'No GitLab configuration found in SonarQube.\n' +
+        '  → Configure one at Administration > DevOps Platform Integrations > GitLab.',
+    );
+  }
+
+  if (bindingName) {
+    const setting = settings.find((s) => s.key === bindingName);
+    if (!setting) {
+      const available = settings.map((s) => `  ${s.key}  (${s.url})`).join('\n');
+      throw new CommandFailedError(
+        `GitLab configuration '${bindingName}' not found. Available configurations:\n${available}`,
+        { exitCode: 2 },
+      );
+    }
+    return { dopSettingId: setting.id, dopSettingKey: setting.key, gitlabUrl: setting.url };
+  }
+
+  if (settings.length === 1) {
+    return {
+      dopSettingId: settings[0].id,
+      dopSettingKey: settings[0].key,
+      gitlabUrl: settings[0].url,
+    };
+  }
+
+  const list = settings.map((s) => `  ${s.key}  (${s.url})`).join('\n');
+  throw new CommandFailedError(
+    `Multiple GitLab configurations found. Specify one with --binding-name:\n${list}`,
+    { exitCode: 2 },
+  );
+}
+
+function applyReposFileFilter<T extends GitLabRepo>(
+  allRepos: GitLabRepo[],
+  repos: T[],
+  reposFile: string,
+  group: string,
+): T[] {
+  let fileContent: string;
+  try {
+    fileContent = readFileSync(reposFile, 'utf8');
+  } catch {
+    throw new CommandFailedError(`--repos-file: file not found or unreadable: ${reposFile}`, {
+      exitCode: 2,
+    });
+  }
+  const entries = new Set(
+    fileContent
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith('#')),
+  );
+
+  const groupPrefix = `${group}/`;
+  const relativePath = (r: GitLabRepo) =>
+    r.path_with_namespace.startsWith(groupPrefix)
+      ? r.path_with_namespace.slice(groupPrefix.length)
+      : r.path_with_namespace;
+
+  for (const e of entries) {
+    if (repos.some((r) => relativePath(r) === e)) continue;
+    if (allRepos.some((r) => relativePath(r) === e)) {
+      warn(
+        `→ '${e}' from --repos-file is not eligible (empty repository or pending deletion) — skipped`,
+      );
+    } else {
+      warn(`→ '${e}' from --repos-file not found in group — skipped`);
+    }
+  }
+
+  return repos.filter((r) => entries.has(relativePath(r)));
+}
+
+async function preflight(
+  auth: ResolvedAuth,
+  gitlabToken: string,
+  options: OnboardCiGitlabOptions,
+): Promise<{
+  sqsClient: SonarQubeClient;
+  gitlabClient: GitLabClient;
+  dopSettingId: string;
+  dopSettingKey: string;
+  gitlabUrl: string;
+}> {
+  if (auth.connectionType !== 'on-premise') {
+    throw new CommandFailedError(
+      'sonar admin onboard-ci gitlab requires a SonarQube Server connection.',
+      {
+        remediationHint: "Authenticate against SonarQube Server with 'sonar auth login' and retry.",
+      },
+    );
+  }
+
+  const sqsClient = new SonarQubeClient(auth.serverUrl, auth.token);
+  if (!(await sqsClient.hasProvisionProjectsPermission())) {
+    throw new CommandFailedError(
+      'This command requires the "Provision Projects" global permission in SonarQube.',
+    );
+  }
+
+  const { dopSettingId, dopSettingKey, gitlabUrl } = await resolveDopSetting(
+    sqsClient,
+    options.bindingName,
+  );
+  const gitlabClient = new GitLabClient(gitlabUrl, gitlabToken);
+
+  return { sqsClient, gitlabClient, dopSettingId, dopSettingKey, gitlabUrl };
+}
+
+async function fetchGroupData(
+  sqsClient: SonarQubeClient,
+  gitlabClient: GitLabClient,
+  dopSettingId: string,
+  options: OnboardCiGitlabOptions,
+): Promise<{ repos: RepoWithBranch[]; bindingMap: Map<string, string> }> {
+  const bindingMap = await withSpinner('Fetching SonarQube project bindings...', () =>
+    sqsClient.getAllProjectBindings(dopSettingId),
+  );
+  const allRepos = await withSpinner('Fetching GitLab repositories...', () =>
+    gitlabClient.listGroupRepos(options.group),
+  );
+
+  let repos = allRepos.filter(
+    (r): r is RepoWithBranch => r.default_branch != null && r.marked_for_deletion_at == null,
+  );
+
+  if (options.reposFile) {
+    repos = applyReposFileFilter(allRepos, repos, options.reposFile, options.group);
+  }
+
+  return { repos, bindingMap };
+}
+
+function startRepoProgress(repos: RepoWithBranch[]): ConcurrentProgress {
+  const progress = new ConcurrentProgress({
+    maxVisible: SETUP_CI_CONCURRENCY_LIMIT,
+    showResult: false,
+  });
+  progress.setTotal(repos.length);
+  progress.addItems(repos.map((r) => r.path_with_namespace));
+  progress.start();
+  return progress;
+}
+
+type SkipClassification = Extract<RepoClassification, { outcome: 'skip' }>;
+type ProceedClassification = Extract<RepoClassification, { outcome: 'proceed' }>;
+
+async function runConcurrent(
+  ctx: ProcessRepoContext,
+  repos: RepoWithBranch[],
+  bindingMap: Map<string, string>,
+  onSkip: (repo: RepoWithBranch, classification: SkipClassification) => void,
+  onProceed: (
+    repo: RepoWithBranch,
+    classification: ProceedClassification,
+    slug: string,
+    progress: ConcurrentProgress,
+  ) => Promise<void>,
+  failed: { repo: string; error: string }[],
+): Promise<void> {
+  const progress = startRepoProgress(repos);
+  await runWithConcurrencyLimit(repos, SETUP_CI_CONCURRENCY_LIMIT, async (repo) => {
+    const slug = repo.path_with_namespace;
+    progress.update(slug, 'running');
+    try {
+      const classification = await classifyRepo(ctx, repo, bindingMap);
+      if (classification.outcome === 'skip') {
+        onSkip(repo, classification);
+        progress.update(slug, 'done', classification.message);
+      } else {
+        await onProceed(repo, classification, slug, progress);
+      }
+    } catch (err) {
+      failed.push({ repo: slug, error: String(err) });
+      progress.update(slug, 'failed', err instanceof Error ? err.message : String(err));
+    }
+  });
+  progress.finish();
+}
+
+async function runDryRun(
+  ctx: ProcessRepoContext,
+  repos: RepoWithBranch[],
+  bindingMap: Map<string, string>,
+): Promise<DryRunResults> {
+  const classifications: ClassificationEntry[] = [];
+  const failedRepos: { repo: string; error: string }[] = [];
+
+  await runConcurrent(
+    ctx,
+    repos,
+    bindingMap,
+    (repo, classification) => classifications.push({ repo, classification }),
+    (repo, classification, slug, progress) => {
+      classifications.push({ repo, classification });
+      progress.update(slug, 'done', 'would open MR');
+      return Promise.resolve();
+    },
+    failedRepos,
+  );
+
+  return computeDryRunResults(classifications, failedRepos);
+}
+
+async function runLive(
+  ctx: ProcessRepoContext,
+  repos: RepoWithBranch[],
+  bindingMap: Map<string, string>,
+): Promise<OnboardCiResults> {
+  const results: OnboardCiResults = { opened: [], skipped: [], failed: [] };
+
+  await runConcurrent(
+    ctx,
+    repos,
+    bindingMap,
+    (repo, classification) =>
+      results.skipped.push({
+        repo: repo.path_with_namespace,
+        reason: classification.reason,
+        mrUrl: classification.mrUrl,
+      }),
+    async (repo, classification, slug, progress) => {
+      const result = await executeRepo(ctx, repo, classification);
+      results.opened.push({ repo: slug, projectKey: result.projectKey, mrUrl: result.mrUrl });
+      progress.update(slug, 'done', 'MR opened');
+    },
+    results.failed,
+  );
+
+  return results;
+}
+
+function buildOutroMessage(opened: number, skipped: number, failed: number): string {
+  return `Opened ${opened.toLocaleString()} MRs · ${skipped.toLocaleString()} skipped · ${failed.toLocaleString()} failed`;
+}
+
+export async function onboardCiGitlab(
+  auth: ResolvedAuth,
+  gitlabToken: string,
+  options: OnboardCiGitlabOptions,
+): Promise<void> {
+  const { sqsClient, gitlabClient, dopSettingId, dopSettingKey, gitlabUrl } = await preflight(
+    auth,
+    gitlabToken,
+    options,
+  );
+
+  intro('Onboard CI configuration', 'GitLab');
+  if (options.dryRun) info('DRY RUN — no changes will be made \n');
+
+  info(`Using GitLab configuration '${dopSettingKey}' (${gitlabUrl})`);
+  info(`Processing group: ${options.group}`);
+
+  const { repos, bindingMap } = await fetchGroupData(
+    sqsClient,
+    gitlabClient,
+    dopSettingId,
+    options,
+  );
+
+  info(`Found ${repos.length.toLocaleString()} repositories to process`);
+
+  const ctx: ProcessRepoContext = {
+    gitlab: gitlabClient,
+    sqs: sqsClient,
+    dopSettingId,
+    auth,
+    options,
+  };
+
+  if (options.dryRun) {
+    const dryRunResults = await runDryRun(ctx, repos, bindingMap);
+    const { wouldOpenMr, wouldSkip, failed } = dryRunResults;
+    outro(
+      buildOutroMessage(wouldOpenMr.length, wouldSkip.length, failed.length),
+      failed.length > 0 ? 'error' : 'success',
+      'No changes were made',
+    );
+    writeReportFile(dryRunResults, 'sonar-onboard-ci-report-dry.json');
+    if (failed.length > 0) {
+      throw new CommandFailedError(`${failed.length} repositories failed to process.`, {
+        remediationHint: 'See the per-repository errors above and the report file for details.',
+      });
+    }
+    return;
+  }
+
+  const results = await runLive(ctx, repos, bindingMap);
+  const { opened, skipped, failed } = results;
+  outro(
+    buildOutroMessage(opened.length, skipped.length, failed.length),
+    failed.length > 0 ? 'error' : 'success',
+  );
+  writeReportFile(results, 'sonar-onboard-ci-report.json');
+  if (failed.length > 0) {
+    throw new CommandFailedError(`${failed.length} repositories failed to process.`, {
+      remediationHint: 'See the per-repository errors above and the report file for details.',
+    });
+  }
+}

--- a/src/commands/admin/onboard-ci/gitlab/processor.ts
+++ b/src/commands/admin/onboard-ci/gitlab/processor.ts
@@ -1,0 +1,230 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import * as yaml from 'js-yaml';
+
+import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
+import type { GitLabClient, GitLabRepo, GitLabTreeEntry } from '@/core/gitlab/client.ts';
+import { GitLabApiError } from '@/core/gitlab/client.ts';
+import { HTTP_STATUS_BAD_REQUEST } from '@/core/http-constants.ts';
+import type { SonarQubeClient } from '@/core/server/client.ts';
+
+import { buildUpdatedCiYml, generateCiYml, generateMrDescription } from './templates.ts';
+import type { OnboardCiGitlabOptions } from './types.ts';
+import { GITLAB_DEFAULT_STAGES, GITLAB_IMPLICIT_STAGES, SkipReason } from './types.ts';
+
+const DEFAULT_CI_FILE = '.gitlab-ci.yml';
+const CI_BRANCH = 'sonar/add-sonar-analysis-job';
+
+enum OtherCiMarker {
+  Jenkinsfile = 'Jenkinsfile',
+  AzurePipelines = 'azure-pipelines.yml',
+  CircleCi = '.circleci',
+  TravisCi = '.travis.yml',
+}
+
+enum SonarCiMarker {
+  SonarScanner = 'sonar-scanner',
+  SonarHostUrl = 'SONAR_HOST_URL',
+  SonarqubeAnalysis = 'sonarqube-analysis:',
+}
+
+export type RepoWithBranch = GitLabRepo & { default_branch: string };
+
+export interface ProcessRepoContext {
+  gitlab: GitLabClient;
+  sqs: SonarQubeClient;
+  dopSettingId: string;
+  auth: ResolvedAuth;
+  options: OnboardCiGitlabOptions;
+}
+
+export type RepoClassification =
+  | { outcome: 'skip'; reason: SkipReason; message: string; mrUrl?: string }
+  | {
+      outcome: 'proceed';
+      ciFilePath: string;
+      existingCi: string | null;
+      projectKey: string;
+    };
+
+export type ExecuteResult = { outcome: 'opened'; projectKey: string; mrUrl: string };
+
+function isBranchAlreadyExistsError(err: unknown): boolean {
+  return (
+    err instanceof GitLabApiError &&
+    err.status === HTTP_STATUS_BAD_REQUEST &&
+    err.body.includes('Branch already exists')
+  );
+}
+
+function stageConflicts(existingCiContent: string, requestedStage: string): boolean {
+  if (GITLAB_IMPLICIT_STAGES.has(requestedStage)) return false;
+  try {
+    const parsed = yaml.load(existingCiContent);
+    if (parsed == null || typeof parsed !== 'object') return false;
+    const stages = (parsed as Record<string, unknown>).stages;
+    if (!Array.isArray(stages)) return !GITLAB_DEFAULT_STAGES.has(requestedStage);
+    return !stages.includes(requestedStage);
+  } catch {
+    return false;
+  }
+}
+
+export async function classifyRepo(
+  ctx: ProcessRepoContext,
+  repo: RepoWithBranch,
+  bindingMap: Map<string, string>,
+): Promise<RepoClassification> {
+  const existingProjectKey = bindingMap.get(String(repo.id));
+  if (!existingProjectKey) {
+    return {
+      outcome: 'skip',
+      reason: SkipReason.NotInSonarQube,
+      message: 'skipped (not bound in SonarQube)',
+    };
+  }
+
+  if (await ctx.sqs.hasProjectBeenAnalyzed(existingProjectKey)) {
+    return {
+      outcome: 'skip',
+      reason: SkipReason.AlreadyConfigured,
+      message: 'skipped (already configured)',
+    };
+  }
+
+  const ciConfigPath = await ctx.gitlab.getProjectCiConfigPath(repo.id);
+  if (ciConfigPath?.includes('@')) {
+    return {
+      outcome: 'skip',
+      reason: SkipReason.CustomCiConfigPath,
+      message: `skipped (external CI config: ${ciConfigPath})`,
+    };
+  }
+  const ciFilePath = ciConfigPath ?? DEFAULT_CI_FILE;
+
+  const rawCi = await ctx.gitlab.getFileContent(repo.id, ciFilePath, repo.default_branch);
+  const existingCi = rawCi === '' ? null : rawCi;
+
+  if (existingCi !== null) {
+    if (Object.values(SonarCiMarker).some((marker) => existingCi.includes(marker))) {
+      return {
+        outcome: 'skip',
+        reason: SkipReason.AlreadyConfigured,
+        message: 'skipped (already configured)',
+      };
+    }
+
+    const effectiveStage = ctx.options.stage ?? 'test';
+    if (stageConflicts(existingCi, effectiveStage)) {
+      return {
+        outcome: 'skip',
+        reason: SkipReason.StageNotInCi,
+        message: `skipped (stage '${effectiveStage}' not defined in ${ciFilePath})`,
+      };
+    }
+  } else {
+    const treeEntries = await ctx.gitlab.listRepoTree(repo.id, repo.default_branch);
+    const rootFiles = new Set<string>(treeEntries.map((f: GitLabTreeEntry) => f.name));
+
+    if (Object.values(OtherCiMarker).some((f) => rootFiles.has(f))) {
+      return {
+        outcome: 'skip',
+        reason: SkipReason.OtherCiDetected,
+        message: 'skipped (other CI detected)',
+      };
+    }
+
+    if (rootFiles.has('sonar-project.properties')) {
+      return {
+        outcome: 'skip',
+        reason: SkipReason.AlreadyConfigured,
+        message: 'skipped (already configured)',
+      };
+    }
+  }
+
+  const openMrs = await ctx.gitlab.listOpenMergeRequests(repo.id, CI_BRANCH);
+  if (openMrs.length > 0) {
+    return {
+      outcome: 'skip',
+      reason: SkipReason.MrAlreadyOpen,
+      message: 'skipped (MR already open)',
+      mrUrl: openMrs[0].web_url,
+    };
+  }
+
+  return { outcome: 'proceed', ciFilePath, existingCi, projectKey: existingProjectKey };
+}
+
+export async function executeRepo(
+  ctx: ProcessRepoContext,
+  repo: RepoWithBranch,
+  classification: Extract<RepoClassification, { outcome: 'proceed' }>,
+): Promise<ExecuteResult> {
+  const { ciFilePath, existingCi, projectKey } = classification;
+
+  try {
+    await ctx.gitlab.createBranch(repo.id, CI_BRANCH);
+  } catch (err) {
+    if (isBranchAlreadyExistsError(err)) {
+      await ctx.gitlab.deleteBranch(repo.id, CI_BRANCH);
+      await ctx.gitlab.createBranch(repo.id, CI_BRANCH);
+    } else {
+      throw err;
+    }
+  }
+
+  const ciYml = generateCiYml(projectKey, ctx.auth.serverUrl, ctx.options, existingCi === null);
+  const updatedCi = buildUpdatedCiYml(existingCi, ciYml);
+  if (existingCi === null) {
+    await ctx.gitlab.createFile(
+      repo.id,
+      ciFilePath,
+      CI_BRANCH,
+      updatedCi,
+      `Add ${ciFilePath} with SonarQube analysis`,
+    );
+  } else {
+    await ctx.gitlab.updateFile(
+      repo.id,
+      ciFilePath,
+      CI_BRANCH,
+      updatedCi,
+      'Add SonarQube analysis job',
+    );
+  }
+
+  const mrUrl = await ctx.gitlab.createMergeRequest(
+    repo.id,
+    CI_BRANCH,
+    repo.default_branch,
+    'Configure SonarQube CI analysis',
+    generateMrDescription(
+      projectKey,
+      ctx.auth.serverUrl,
+      ciFilePath,
+      ctx.options.sonarTokenVarName,
+      ctx.options.triggerOn,
+    ),
+  );
+
+  return { outcome: 'opened', projectKey, mrUrl };
+}

--- a/src/commands/admin/onboard-ci/gitlab/report.ts
+++ b/src/commands/admin/onboard-ci/gitlab/report.ts
@@ -1,0 +1,37 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { CommandFailedError } from '@/core/command-error.ts';
+import { print } from '@/core/ui';
+
+import type { DryRunResults, OnboardCiResults } from './types.ts';
+
+export function writeReportFile(results: OnboardCiResults | DryRunResults, filename: string): void {
+  const dest = join(process.cwd(), filename);
+  try {
+    writeFileSync(dest, JSON.stringify(results, null, 2), 'utf8');
+  } catch (err) {
+    throw new CommandFailedError(`Failed to write report to ${dest}: ${String(err)}`);
+  }
+  print(`Full report: ${filename}  (written to current directory)`);
+}

--- a/src/commands/admin/onboard-ci/gitlab/templates.ts
+++ b/src/commands/admin/onboard-ci/gitlab/templates.ts
@@ -1,0 +1,116 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type { OnboardCiGitlabOptions } from './types.ts';
+import { GITLAB_DEFAULT_STAGES, TriggerOn } from './types.ts';
+
+const SCANNER_IMAGE = 'sonarsource/sonar-scanner-cli:latest';
+
+export function generateCiYml(
+  projectKey: string,
+  serverUrl: string,
+  options: Pick<
+    OnboardCiGitlabOptions,
+    'sonarTokenVarName' | 'triggerOn' | 'stage' | 'allowFailure' | 'scannerProperty'
+  >,
+  isNewFile = false,
+): string {
+  const rules: string[] = [];
+  if (options.triggerOn === TriggerOn.Mr || options.triggerOn === TriggerOn.Both) {
+    rules.push("    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'");
+  }
+  if (options.triggerOn === TriggerOn.Main || options.triggerOn === TriggerOn.Both) {
+    rules.push('    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH');
+  }
+
+  const stageLine = options.stage != null ? `\n  stage: ${options.stage}` : '';
+  const allowFailureLine = options.allowFailure ? '\n  allow_failure: true' : '';
+
+  const tokenLine =
+    options.sonarTokenVarName !== 'SONAR_TOKEN'
+      ? `\n    SONAR_TOKEN: $${options.sonarTokenVarName}`
+      : '';
+
+  const stagesBlock =
+    options.stage && isNewFile && !GITLAB_DEFAULT_STAGES.has(options.stage)
+      ? `stages:\n  - ${options.stage}\n\n`
+      : '';
+
+  const extraProps =
+    options.scannerProperty.length > 0
+      ? options.scannerProperty
+          .map((p) => {
+            const eqIdx = p.indexOf('=');
+            const key = p.slice(0, eqIdx);
+            const value = p.slice(eqIdx + 1).replaceAll("'", "'\\''");
+            return ` -D${key}='${value}'`;
+          })
+          .join('')
+      : '';
+
+  return `${stagesBlock}sonarqube-analysis:
+  image: ${SCANNER_IMAGE}${stageLine}
+  script:
+    - sonar-scanner -Dsonar.projectKey="${projectKey}"${extraProps}
+  variables:
+    SONAR_HOST_URL: "${serverUrl}"
+    GIT_DEPTH: "0"${tokenLine}
+  rules:
+${rules.join('\n')}${allowFailureLine}
+`;
+}
+
+export function buildUpdatedCiYml(existingCi: string | null, ciYml: string): string {
+  if (!existingCi) {
+    return ciYml;
+  }
+  // Strip trailing YAML document-start markers so the appended job isn't silently placed
+  // in a second document that GitLab ignores.
+  const normalized = existingCi.trimEnd().replace(/(\n---)+$/, '');
+  return `${normalized}\n\n${ciYml}`;
+}
+
+function triggerDescription(triggerOn: TriggerOn): string {
+  if (triggerOn === TriggerOn.Mr) return 'merge request pipelines';
+  if (triggerOn === TriggerOn.Main) return 'pushes to the default branch';
+  return 'merge request pipelines and pushes to the default branch';
+}
+
+export function generateMrDescription(
+  projectKey: string,
+  serverUrl: string,
+  ciFilePath: string,
+  sonarTokenVarName: string,
+  triggerOn: TriggerOn,
+): string {
+  return `## Add SonarQube CI analysis
+
+This MR configures SonarQube analysis for this repository by adding a \`sonarqube-analysis\` job to \`${ciFilePath}\`.
+
+**Before merging:** ensure \`${sonarTokenVarName}\` is set as a CI/CD variable on your GitLab group (Group → Settings → CI/CD → Variables). All repos in the group inherit it automatically.
+
+The job runs on ${triggerDescription(triggerOn)}, and reports results back to SonarQube.
+
+- SonarQube project key: \`${projectKey}\`
+- SonarQube instance: ${serverUrl}
+
+[SonarQube CI integration docs](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/ci-integration/gitlab-cicd-integration/)
+`;
+}

--- a/src/commands/admin/onboard-ci/gitlab/types.ts
+++ b/src/commands/admin/onboard-ci/gitlab/types.ts
@@ -1,0 +1,93 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+export const GITLAB_DEFAULT_STAGES = new Set(['.pre', 'build', 'test', 'deploy', '.post']);
+export const GITLAB_IMPLICIT_STAGES = new Set(['.pre', '.post']);
+
+export enum TriggerOn {
+  Mr = 'mr',
+  Main = 'main',
+  Both = 'both',
+}
+
+export enum SkipReason {
+  AlreadyConfigured = 'ALREADY_CONFIGURED',
+  OtherCiDetected = 'OTHER_CI_DETECTED',
+  MrAlreadyOpen = 'MR_ALREADY_OPEN',
+  StageNotInCi = 'STAGE_NOT_IN_CI',
+  CustomCiConfigPath = 'CUSTOM_CI_CONFIG_PATH',
+  NotInSonarQube = 'NOT_IN_SONARQUBE',
+}
+
+export interface OnboardCiGitlabOptions {
+  group: string;
+  bindingName?: string;
+  reposFile?: string;
+  sonarTokenVarName: string;
+  triggerOn: TriggerOn;
+  stage?: string;
+  allowFailure: boolean;
+  dryRun: boolean;
+  scannerProperty: string[];
+}
+
+export interface OpenedResult {
+  repo: string;
+  projectKey: string;
+  mrUrl: string;
+}
+
+export interface SkippedResult {
+  repo: string;
+  reason: SkipReason;
+  mrUrl?: string;
+}
+
+export interface FailedResult {
+  repo: string;
+  error: string;
+}
+
+export interface OnboardCiResults {
+  opened: OpenedResult[];
+  skipped: SkippedResult[];
+  failed: FailedResult[];
+}
+
+export interface DryRunEntry {
+  repo: string;
+  projectKey: string;
+}
+
+export interface DryRunSkippedEntry {
+  repo: string;
+  reason: SkipReason;
+}
+
+export interface DryRunFailedEntry {
+  repo: string;
+  error: string;
+}
+
+export interface DryRunResults {
+  wouldOpenMr: DryRunEntry[];
+  wouldSkip: DryRunSkippedEntry[];
+  failed: DryRunFailedEntry[];
+}

--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -33,6 +33,7 @@ import {
   SonarOption,
   Stage,
 } from '@/core/commands/sonar-command.ts';
+import { resolveGitlabToken } from '@/core/gitlab/token.ts';
 import { CURRENT_DISTRIBUTION } from '@/core/host/distribution.ts';
 import { initSentry } from '@/core/observability/sentry.ts';
 import { GENERIC_HTTP_METHODS } from '@/core/server/client.ts';
@@ -44,6 +45,12 @@ import { blank, error } from '@/core/ui';
 import { parseInteger } from '@/core/ui/parsing.ts';
 
 import { version as VERSION } from '../../package.json';
+import {
+  collectScannerProperty,
+  onboardCiGitlab,
+  type OnboardCiGitlabOptions,
+  validateOnboardCiGitlabOptions,
+} from './admin/onboard-ci/gitlab/index.ts';
 import { analyzeAll, type AnalyzeAllOptions } from './analyze/analyze-all.ts';
 import type { Severity } from './analyze/dependency-risk-helpers/sca-scanner.ts';
 import { SEVERITIES } from './analyze/dependency-risk-helpers/view-model/build/severity.ts';
@@ -793,6 +800,46 @@ function buildCommandTree(runtime: CliRuntime): SonarCommand {
     .description('git pre-push handler: scan files in new commits for secrets')
     .argument('[files...]', 'Changed files passed by pre-commit (pass_filenames: true)')
     .anonymousAction((ctx, files: string[] | undefined) => gitPrePush(files ?? [], ctx));
+
+  COMMAND_TREE.command('admin')
+    .stage(Stage.Alpha)
+    .description('Administrative operations for platform engineers')
+    .command('onboard-ci')
+    .description('Open CI configuration MRs across repositories')
+    .command('gitlab')
+    .description('Open CI configuration MRs across GitLab repositories')
+    .requiredOption(
+      '--group <group>',
+      'GitLab group or subgroup path to process (all nested subgroups included)',
+    )
+    .option(
+      '--binding-name <name>',
+      'Name of the GitLab configuration in SonarQube (auto-detected if only one exists)',
+    )
+    .option(
+      '--repos-file <file>',
+      'Path to a file listing repositories to process, one per line, relative to --group (e.g. subgroup/my-repo); omit to process all repositories in the group',
+    )
+    .option(
+      '--sonar-token-var-name <name>',
+      'Name of the GitLab CI/CD variable that holds the SonarQube analysis token (default: SONAR_TOKEN)',
+      'SONAR_TOKEN',
+    )
+    .option('--trigger-on <events>', 'Pipeline triggers: mr | main | both', 'both')
+    .option('--stage <name>', 'GitLab CI stage for the generated job (omit to use no stage)')
+    .option('--allow-failure', 'Add allow_failure: true to the generated job', false)
+    .option(
+      '--scanner-property <key=value>',
+      'Additional scanner property to inject into the CI script (repeatable; e.g. --scanner-property sonar.scanner.engineJarPath=/path/to/jar)',
+      collectScannerProperty,
+      [] as string[],
+    )
+    .option('--dry-run', 'Preview what would be processed without making any changes', false)
+    .authenticatedAction(async (ctx, options: OnboardCiGitlabOptions) => {
+      validateOnboardCiGitlabOptions(options);
+      const gitlabToken = await resolveGitlabToken();
+      return onboardCiGitlab(ctx.auth, gitlabToken, options);
+    });
 
   // Hidden flush command — only registered when running as a telemetry worker.
   if (process.env[TELEMETRY_FLUSH_MODE_ENV]) {

--- a/src/core/server/client.ts
+++ b/src/core/server/client.ts
@@ -860,13 +860,13 @@ export class SonarQubeClient {
   }
 
   async hasProjectBeenAnalyzed(projectKey: string): Promise<boolean> {
-    const { response, value } = await this.getSafe<{ analyses: unknown[] }>(
+    const { response, value } = await this.getSafe<{ analyses?: unknown[] }>(
       '/api/project_analyses/search',
       { project: projectKey, ps: 1 },
     );
     if (response.status === HTTP_STATUS_NOT_FOUND) return false;
     await this.raiseForStatus(response, 'GET');
-    return (value?.analyses.length ?? 0) > 0;
+    return (value?.analyses?.length ?? 0) > 0;
   }
 
   async hasProvisionProjectsPermission(): Promise<boolean> {

--- a/src/core/ui/components/concurrent-progress.ts
+++ b/src/core/ui/components/concurrent-progress.ts
@@ -138,7 +138,7 @@ export class ConcurrentProgress {
         const state = this.items.get(slug);
         return phaseItem(slug, toPhaseStatus(state?.status), state?.detail);
       });
-      if (this.showResult) phase(this.resultTitle, phaseItems);
+      phase(this.resultTitle, phaseItems);
     }
 
     return { succeeded, failed };

--- a/tests/integration/harness/fake-gitlab-server.ts
+++ b/tests/integration/harness/fake-gitlab-server.ts
@@ -94,6 +94,7 @@ export class FakeGitLabServer {
 export class FakeGitLabServerBuilder {
   private readonly projects: FakeGitLabProject[] = [];
   private readonly projectsByGroup = new Map<string, FakeGitLabProject[]>();
+  private readonly createBranchFailProjectIds = new Set<number>();
 
   withGroup(groupPath: string, projects: FakeGitLabProject[]): this {
     this.projectsByGroup.set(groupPath, projects);
@@ -102,6 +103,12 @@ export class FakeGitLabServerBuilder {
         this.projects.push(p);
       }
     }
+    return this;
+  }
+
+  /** Makes createBranch return 503 for the given project ID, simulating a GitLab outage. */
+  withCreateBranchFailure(projectId: number): this {
+    this.createBranchFailProjectIds.add(projectId);
     return this;
   }
 
@@ -120,6 +127,7 @@ export class FakeGitLabServerBuilder {
       );
     const projects = this.projects;
     const projectsByGroup = this.projectsByGroup;
+    const createBranchFailProjectIds = this.createBranchFailProjectIds;
 
     let mrCounter = 1;
 
@@ -215,6 +223,9 @@ export class FakeGitLabServerBuilder {
         const createBranchMatch = /^\/api\/v4\/projects\/(\d+)\/repository\/branches$/.exec(path);
         if (createBranchMatch && req.method === 'POST') {
           const projectId = Number.parseInt(createBranchMatch[1], 10);
+          if (createBranchFailProjectIds.has(projectId)) {
+            return json({ message: 'Service Unavailable' }, 503);
+          }
           const payload = JSON.parse(body ?? '{}') as { branch: string };
           if (branchExists(projectId, payload.branch)) {
             return json({ message: 'Branch already exists' }, 400);

--- a/tests/integration/specs/admin/onboard-ci-gitlab.test.ts
+++ b/tests/integration/specs/admin/onboard-ci-gitlab.test.ts
@@ -1,0 +1,1145 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { ALPHA_ENV_VAR } from '@/core/commands/stage.ts';
+
+import type { FakeGitLabProject, FakeGitLabServer } from '../../harness/fake-gitlab-server.js';
+import type { FakeSonarQubeServer } from '../../harness/fake-sonarqube-server.js';
+import { TestHarness } from '../../harness/index.js';
+
+const GROUP = 'mycompany';
+const DOP_SETTING_ID = 'dop-uuid-1';
+const DOP_SETTING_KEY = 'my-gitlab';
+
+function dopSettings(gitlabUrl: string) {
+  return [{ id: DOP_SETTING_ID, key: DOP_SETTING_KEY, type: 'gitlab', url: gitlabUrl }];
+}
+
+async function startServers(
+  harness: TestHarness,
+  opts: {
+    gitlabProjects?: FakeGitLabProject[];
+    bindings?: Array<{ projectKey: string; repository: string; dopSettingId: string }>;
+    hasProvisionProjects?: boolean;
+    analyzedProjectKeys?: string[];
+    branchFailureProjectIds?: number[];
+  } = {},
+): Promise<{ sqsServer: FakeSonarQubeServer; gitlabServer: FakeGitLabServer }> {
+  let gitlabBuilder = harness.newFakeGitLabServer().withGroup(GROUP, opts.gitlabProjects ?? []);
+  for (const id of opts.branchFailureProjectIds ?? []) {
+    gitlabBuilder = gitlabBuilder.withCreateBranchFailure(id);
+  }
+  const gitlabServer = await gitlabBuilder.start();
+
+  const sqsServer = await harness
+    .newFakeServer()
+    .withAuthToken('test-token')
+    .withDopSettings(dopSettings(gitlabServer.baseUrl()))
+    .withProjectBindings(opts.bindings ?? [])
+    .withProvisionProjectsPermission(opts.hasProvisionProjects ?? true)
+    .withAnalyzedProjects(opts.analyzedProjectKeys ?? [])
+    .start();
+
+  harness.withAuth(sqsServer.baseUrl(), 'test-token');
+  return { sqsServer, gitlabServer };
+}
+
+describe('sonar admin onboard-ci gitlab', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+    harness.withExtraEnv({ [ALPHA_ENV_VAR]: 'true', GITLAB_TOKEN: 'gl-token' });
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  describe('validation', () => {
+    it('exits 1 when no GitLab token is provided', async () => {
+      const { sqsServer } = await startServers(harness);
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`, {
+        extraEnv: { GITLAB_TOKEN: '' },
+      });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('GitLab token required');
+      expect(sqsServer.getRecordedRequests().some((r) => r.path.includes('dop-translation'))).toBe(
+        false,
+      );
+    });
+
+    it('exits 2 for invalid --trigger-on value', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --trigger-on weekly`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("Invalid --trigger-on value 'weekly'");
+    });
+
+    it('exits 1 when connected to SonarQube Cloud', async () => {
+      const sqsServer = await harness.newFakeServer().withAuthToken('test-token').start();
+      harness.withAuth(sqsServer.baseUrl(), 'test-token', 'my-org');
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('SonarQube Server');
+    });
+
+    it('exits 2 for invalid --sonar-token-var-name', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --sonar-token-var-name 1INVALID`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('Invalid --sonar-token-var-name');
+    });
+
+    it('exits 2 for --repos-file pointing to non-existent file', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --repos-file /no/such/file.txt`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('file not found or unreadable');
+    });
+
+    it('exits 2 for invalid --stage value', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --stage 'foo: bar'`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("Invalid --stage value 'foo: bar'");
+    });
+
+    it('exits 2 for invalid --scanner-property (missing =)', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --scanner-property sonar.scanner.engineJarPath`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("Invalid --scanner-property 'sonar.scanner.engineJarPath'");
+    });
+
+    it('exits 2 for invalid --scanner-property (missing key)', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --scanner-property '=value'`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("Invalid --scanner-property '=value'");
+    });
+
+    it('exits 2 for invalid --scanner-property (key starts with -D)', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --scanner-property '-Dsonar.foo=bar'`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("Invalid --scanner-property key '-Dsonar.foo'");
+    });
+
+    it('exits 2 for invalid --scanner-property (value contains ": ")', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --scanner-property 'sonar.projectName=My App: v2'`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("Invalid --scanner-property value for 'sonar.projectName'");
+    });
+
+    it('exits 2 for invalid --scanner-property (value contains " #")', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --scanner-property 'sonar.foo=bar #x'`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("Invalid --scanner-property value for 'sonar.foo'");
+    });
+  });
+
+  describe('preflight checks', () => {
+    it('exits 1 when user lacks PROVISION_PROJECTS permission', async () => {
+      await startServers(harness, { hasProvisionProjects: false });
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Provision Projects');
+    });
+
+    it('exits 1 when no GitLab DOP settings are configured in SonarQube', async () => {
+      const sqsServer = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withDopSettings([])
+        .withProvisionProjectsPermission(true)
+        .start();
+      harness.withAuth(sqsServer.baseUrl(), 'test-token');
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('No GitLab configuration found');
+    });
+
+    it('exits 2 when --binding-name does not match any configured setting', async () => {
+      await startServers(harness);
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --binding-name unknown-key`,
+      );
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain("GitLab configuration 'unknown-key' not found");
+      expect(result.stderr).toContain(DOP_SETTING_KEY);
+    });
+
+    it('exits 2 when multiple DOP settings exist and --binding-name is not given', async () => {
+      const gitlabServer = await harness.newFakeGitLabServer().withGroup(GROUP, []).start();
+      const sqsServer = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withDopSettings([
+          { id: 'id-1', key: 'gitlab-one', type: 'gitlab', url: gitlabServer.baseUrl() },
+          { id: 'id-2', key: 'gitlab-two', type: 'gitlab', url: gitlabServer.baseUrl() },
+        ])
+        .withProvisionProjectsPermission(true)
+        .start();
+      harness.withAuth(sqsServer.baseUrl(), 'test-token');
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain('Multiple GitLab configurations found');
+      expect(result.stderr).toContain('gitlab-one');
+      expect(result.stderr).toContain('gitlab-two');
+    });
+  });
+
+  describe('skip conditions', () => {
+    it('skips repo when Jenkinsfile is present (OTHER_CI_DETECTED)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 1,
+            name: 'jenkins-repo',
+            path_with_namespace: `${GROUP}/jenkins-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: 'Jenkinsfile' }],
+          },
+        ],
+        bindings: [
+          { projectKey: 'jenkins-repo-key', repository: '1', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('other CI detected');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+
+    it('skips repo when .gitlab-ci.yml already references SONAR_HOST_URL (ALREADY_CONFIGURED)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 2,
+            name: 'configured-repo',
+            path_with_namespace: `${GROUP}/configured-repo`,
+            default_branch: 'main',
+            rootFiles: [
+              {
+                name: '.gitlab-ci.yml',
+                content:
+                  'include:\n  - local: other.yml\nvariables:\n  SONAR_HOST_URL: https://sonar.example.com\n',
+              },
+            ],
+          },
+        ],
+        bindings: [
+          { projectKey: 'configured-repo-key', repository: '2', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('already configured');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+
+    it('skips repo when sonar-project.properties is present (ALREADY_CONFIGURED)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 3,
+            name: 'sonar-props-repo',
+            path_with_namespace: `${GROUP}/sonar-props-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: 'sonar-project.properties' }],
+          },
+        ],
+        bindings: [
+          { projectKey: 'sonar-props-repo-key', repository: '3', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('already configured');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+
+    it('skips repos not bound in SonarQube (NOT_IN_SONARQUBE)', async () => {
+      const { gitlabServer, sqsServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 4,
+            name: 'new-repo',
+            path_with_namespace: `${GROUP}/new-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('not bound in SonarQube');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+      const boundProjectReq = sqsServer
+        .getRecordedRequests()
+        .find((r) => r.path === '/api/v2/dop-translation/bound-projects' && r.method === 'POST');
+      expect(boundProjectReq).toBeUndefined();
+    });
+
+    it('skips repo when sonar/add-sonar-analysis-job MR is already open (MR_ALREADY_OPEN)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 5,
+            name: 'open-mr-repo',
+            path_with_namespace: `${GROUP}/open-mr-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+            hasOpenSonarMr: true,
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_open-mr-repo', repository: '5', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('MR already open');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+
+    it('skips repo whose SonarQube project already has analyses (ALREADY_CONFIGURED)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 6,
+            name: 'analyzed-repo',
+            path_with_namespace: `${GROUP}/analyzed-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_analyzed-repo', repository: '6', dopSettingId: DOP_SETTING_ID },
+        ],
+        analyzedProjectKeys: ['mycompany_analyzed-repo'],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('already configured');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+
+    it('prints a neutral message when all repos are skipped and no failures occurred', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 7,
+            name: 'jenkins-only',
+            path_with_namespace: `${GROUP}/jenkins-only`,
+            default_branch: 'main',
+            rootFiles: [{ name: 'Jenkinsfile' }],
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Opened 0 MRs');
+      expect(result.stdout).not.toContain('❌');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+  });
+
+  describe('--stage flag', () => {
+    it('skips repo when --stage is not defined in existing stages list (STAGE_NOT_IN_CI)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 10,
+            name: 'staged-repo',
+            path_with_namespace: `${GROUP}/staged-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab-ci.yml', content: 'stages:\n  - build\n  - test\n' }],
+          },
+        ],
+        bindings: [
+          { projectKey: 'staged-repo-key', repository: '10', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP} --stage sonar`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('not defined in');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+
+    it('skips when --stage is omitted and the implicit test stage is absent from a custom stages list', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 11,
+            name: 'no-test-stage-repo',
+            path_with_namespace: `${GROUP}/no-test-stage-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab-ci.yml', content: 'stages:\n  - compile\n  - release\n' }],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_no-test-stage-repo',
+            repository: '11',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("stage 'test' not defined in");
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+
+    it('does not skip when --stage is .post or .pre (GitLab implicit stages)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 12,
+            name: 'implicit-stage-repo',
+            path_with_namespace: `${GROUP}/implicit-stage-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab-ci.yml', content: 'stages:\n  - build\n  - deploy\n' }],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_implicit-stage-repo',
+            repository: '12',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP} --stage .post`);
+
+      expect(result.exitCode).toBe(0);
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+    });
+
+    it('does not skip when --stage is already in the existing stages list', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 13,
+            name: 'staged-ok-repo',
+            path_with_namespace: `${GROUP}/staged-ok-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab-ci.yml', content: 'stages:\n  - build\n  - sonar\n' }],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_staged-ok-repo',
+            repository: '13',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP} --stage sonar`);
+
+      expect(result.exitCode).toBe(0);
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+    });
+  });
+
+  describe('--trigger-on flag', () => {
+    it('commits only the MR pipeline rule when --trigger-on mr', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 20,
+            name: 'trigger-mr-repo',
+            path_with_namespace: `${GROUP}/trigger-mr-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_trigger-mr-repo',
+            repository: '20',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      await harness.run(`admin onboard-ci gitlab --group ${GROUP} --trigger-on mr`);
+
+      const ciYml = gitlabServer.committedFiles.find((f) => f.path === '.gitlab-ci.yml');
+      expect(ciYml).toBeDefined();
+      expect(ciYml!.content).toContain("$CI_PIPELINE_SOURCE == 'merge_request_event'");
+      expect(ciYml!.content).not.toContain('$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH');
+    });
+
+    it('commits only the default branch rule when --trigger-on main', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 21,
+            name: 'trigger-main-repo',
+            path_with_namespace: `${GROUP}/trigger-main-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_trigger-main-repo',
+            repository: '21',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      await harness.run(`admin onboard-ci gitlab --group ${GROUP} --trigger-on main`);
+
+      const ciYml = gitlabServer.committedFiles.find((f) => f.path === '.gitlab-ci.yml');
+      expect(ciYml).toBeDefined();
+      expect(ciYml!.content).toContain('$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH');
+      expect(ciYml!.content).not.toContain("$CI_PIPELINE_SOURCE == 'merge_request_event'");
+    });
+
+    it('commits both rules when --trigger-on both (default)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 22,
+            name: 'trigger-both-repo',
+            path_with_namespace: `${GROUP}/trigger-both-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_trigger-both-repo',
+            repository: '22',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      const ciYml = gitlabServer.committedFiles.find((f) => f.path === '.gitlab-ci.yml');
+      expect(ciYml).toBeDefined();
+      expect(ciYml!.content).toContain("$CI_PIPELINE_SOURCE == 'merge_request_event'");
+      expect(ciYml!.content).toContain('$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH');
+    });
+  });
+
+  describe('--dry-run', () => {
+    it('prints repo counts without writing to GitLab', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 30,
+            name: 'repo-a',
+            path_with_namespace: `${GROUP}/repo-a`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+          {
+            id: 31,
+            name: 'repo-b',
+            path_with_namespace: `${GROUP}/repo-b`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_repo-a', repository: '30', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP} --dry-run`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('DRY RUN');
+      expect(result.stdout).toContain('would open MR');
+      expect(result.stdout).toContain('No changes were made');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+      expect(gitlabServer.committedFiles).toHaveLength(0);
+      expect(gitlabServer.createdBranches).toHaveLength(0);
+    });
+
+    it('writes a report file', async () => {
+      await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 32,
+            name: 'some-repo',
+            path_with_namespace: `${GROUP}/some-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP} --dry-run`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('sonar-onboard-ci-report-dry.json');
+      expect(harness.cwd.exists('sonar-onboard-ci-report-dry.json')).toBe(true);
+    });
+  });
+
+  describe('--repos-file', () => {
+    it('limits which repos are processed', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 40,
+            name: 'repo-one',
+            path_with_namespace: `${GROUP}/repo-one`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+          {
+            id: 41,
+            name: 'repo-two',
+            path_with_namespace: `${GROUP}/repo-two`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+          {
+            id: 42,
+            name: 'repo-three',
+            path_with_namespace: `${GROUP}/repo-three`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_repo-one', repository: '40', dopSettingId: DOP_SETTING_ID },
+          { projectKey: 'mycompany_repo-three', repository: '42', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      harness.cwd.writeFile('repos.txt', `repo-one\nrepo-three\n`);
+
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --repos-file repos.txt`,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(gitlabServer.createdMrs).toHaveLength(2);
+      const openedRepos = gitlabServer.createdMrs.map((mr) => mr.projectId);
+      expect(openedRepos).toContain(40);
+      expect(openedRepos).toContain(42);
+      expect(openedRepos).not.toContain(41);
+    });
+
+    it('warns for paths not found in group', async () => {
+      await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 43,
+            name: 'repo-one',
+            path_with_namespace: `${GROUP}/repo-one`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+      });
+
+      harness.cwd.writeFile('repos.txt', `repo-one\nnonexistent\n`);
+
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --repos-file repos.txt`,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('nonexistent');
+      expect(result.stderr).toContain('not found in group');
+    });
+
+    it('warns "not eligible" (not "not found") for repos in group with no default branch', async () => {
+      await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 44,
+            name: 'empty-repo',
+            path_with_namespace: `${GROUP}/empty-repo`,
+            default_branch: null,
+            rootFiles: [],
+          },
+        ],
+      });
+
+      harness.cwd.writeFile('repos.txt', `empty-repo\n`);
+
+      const result = await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --repos-file repos.txt`,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain('empty-repo');
+      expect(result.stderr).toContain('not eligible');
+      expect(result.stderr).not.toContain('not found in group');
+    });
+  });
+
+  describe('MR content', () => {
+    it('appends the sonarqube-analysis job directly into .gitlab-ci.yml', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 50,
+            name: 'ci-repo',
+            path_with_namespace: `${GROUP}/ci-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab-ci.yml', content: 'stages:\n  - test\n' }],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_ci-repo', repository: '50', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(
+        gitlabServer.committedFiles.find((f) => f.path === '.gitlab/sonar.yml'),
+      ).toBeUndefined();
+      const ciYml = gitlabServer.committedFiles.find((f) => f.path === '.gitlab-ci.yml');
+      expect(ciYml).toBeDefined();
+      expect(ciYml!.content).toContain('sonarqube-analysis:');
+      expect(ciYml!.content).toContain('-Dsonar.projectKey=');
+      expect(ciYml!.content).toContain('stages:\n  - test');
+    });
+
+    it('uses custom local CI config path when set', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 51,
+            name: 'custom-path-repo',
+            path_with_namespace: `${GROUP}/custom-path-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab/ci.yml', content: 'stages:\n  - test\n' }],
+            ciConfigPath: '.gitlab/ci.yml',
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_custom-path-repo',
+            repository: '51',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+      const committed = gitlabServer.committedFiles.find((f) => f.path === '.gitlab/ci.yml');
+      expect(committed).toBeDefined();
+      expect(committed!.content).toContain('sonarqube-analysis:');
+    });
+
+    it('MR description references custom --sonar-token-var-name, not the default SONAR_TOKEN', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 52,
+            name: 'custom-token-repo',
+            path_with_namespace: `${GROUP}/custom-token-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_custom-token-repo',
+            repository: '52',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP} --sonar-token-var-name MY_SONAR_TOKEN`,
+      );
+
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+      expect(gitlabServer.createdMrs[0].description).toContain('`MY_SONAR_TOKEN`');
+      expect(gitlabServer.createdMrs[0].description).not.toContain('`SONAR_TOKEN`');
+    });
+
+    it('skips repo with external CI config path (CUSTOM_CI_CONFIG_PATH)', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 53,
+            name: 'external-ci-repo',
+            path_with_namespace: `${GROUP}/external-ci-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+            ciConfigPath: 'ci/config.yml@infra/ci-templates',
+          },
+        ],
+        bindings: [
+          { projectKey: 'external-ci-repo-key', repository: '53', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('external CI config');
+      expect(gitlabServer.createdMrs).toHaveLength(0);
+    });
+  });
+
+  describe('happy path', () => {
+    it('opens an MR for a repo bound in SonarQube', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 60,
+            name: 'my-repo',
+            path_with_namespace: `${GROUP}/my-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_my-repo', repository: '60', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Opened 1 MRs');
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+      expect(gitlabServer.createdMrs[0].projectId).toBe(60);
+      expect(gitlabServer.createdMrs[0].sourceBranch).toBe('sonar/add-sonar-analysis-job');
+      const sqsRequests = gitlabServer.getRecordedRequests();
+      expect(sqsRequests.some((r) => r.path.includes('bound-projects'))).toBe(false);
+    });
+
+    it('recovers from an orphaned CI branch by deleting and recreating it', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 70,
+            name: 'orphan-branch-repo',
+            path_with_namespace: `${GROUP}/orphan-branch-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+            existingBranches: ['sonar/add-sonar-analysis-job'],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_orphan-branch-repo',
+            repository: '70',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('Opened 1 MRs');
+      expect(gitlabServer.deletedBranches).toHaveLength(1);
+      expect(gitlabServer.deletedBranches[0]).toEqual({
+        projectId: 70,
+        branch: 'sonar/add-sonar-analysis-job',
+      });
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+    });
+
+    it('handles a mix of repos: opens MRs, skips others, and prints summary', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 61,
+            name: 'clean-repo',
+            path_with_namespace: `${GROUP}/clean-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+          {
+            id: 62,
+            name: 'jenkins-repo',
+            path_with_namespace: `${GROUP}/jenkins-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: 'Jenkinsfile' }],
+          },
+          {
+            id: 63,
+            name: 'sonar-repo',
+            path_with_namespace: `${GROUP}/sonar-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab-ci.yml', content: 'variables:\n  SONAR_HOST_URL: x\n' }],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_clean-repo', repository: '61', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+      expect(result.stdout).toContain('Opened 1 MRs');
+      expect(result.stdout).toContain('skipped');
+      expect(result.stdout).toContain('failed');
+    });
+
+    it('writes a report file', async () => {
+      await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 64,
+            name: 'my-repo',
+            path_with_namespace: `${GROUP}/my-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_my-repo', repository: '64', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('sonar-onboard-ci-report.json');
+      expect(harness.cwd.exists('sonar-onboard-ci-report.json')).toBe(true);
+      const report = harness.cwd.file('sonar-onboard-ci-report.json').asJson() as {
+        opened: Array<{ repo: string; projectKey: string; mrUrl: string }>;
+      };
+      expect(report.opened).toHaveLength(1);
+      expect(report.opened[0].repo).toBe(`${GROUP}/my-repo`);
+    });
+
+    it('injects --scanner-property values into the generated CI script', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 66,
+            name: 'scanner-prop-repo',
+            path_with_namespace: `${GROUP}/scanner-prop-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_scanner-prop-repo',
+            repository: '66',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      await harness.run(
+        `admin onboard-ci gitlab --group ${GROUP}` +
+          ` --scanner-property sonar.scanner.engineJarPath=/path/to/engine.jar` +
+          ` --scanner-property sonar.buildsystem.autoconfig.disabled=false`,
+      );
+
+      const ciYml = gitlabServer.committedFiles.find((f) => f.path === '.gitlab-ci.yml');
+      expect(ciYml).toBeDefined();
+      expect(ciYml!.content).toContain(
+        `-Dsonar.projectKey="mycompany_scanner-prop-repo" -Dsonar.scanner.engineJarPath='/path/to/engine.jar' -Dsonar.buildsystem.autoconfig.disabled='false'`,
+      );
+    });
+
+    it('accepts token from GITLAB_TOKEN env var', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 65,
+            name: 'env-repo',
+            path_with_namespace: `${GROUP}/env-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_env-repo', repository: '65', dopSettingId: DOP_SETTING_ID },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`, {
+        extraEnv: { GITLAB_TOKEN: 'env-gl-token' },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('exits 1 when at least one repo fails to process', async () => {
+      await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 90,
+            name: 'ok-repo',
+            path_with_namespace: `${GROUP}/ok-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+          {
+            id: 91,
+            name: 'broken-repo',
+            path_with_namespace: `${GROUP}/broken-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_ok-repo', repository: '90', dopSettingId: DOP_SETTING_ID },
+          { projectKey: 'mycompany_broken-repo', repository: '91', dopSettingId: DOP_SETTING_ID },
+        ],
+        branchFailureProjectIds: [91],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('1 repositories failed to process');
+    });
+
+    it('exits 1 even when some repos succeed alongside failures', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 92,
+            name: 'good-repo',
+            path_with_namespace: `${GROUP}/good-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+          {
+            id: 93,
+            name: 'bad-repo',
+            path_with_namespace: `${GROUP}/bad-repo`,
+            default_branch: 'main',
+            rootFiles: [],
+          },
+        ],
+        bindings: [
+          { projectKey: 'mycompany_good-repo', repository: '92', dopSettingId: DOP_SETTING_ID },
+          { projectKey: 'mycompany_bad-repo', repository: '93', dopSettingId: DOP_SETTING_ID },
+        ],
+        branchFailureProjectIds: [93],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).toContain('Opened 1 MRs');
+      expect(result.stderr).toContain('1 repositories failed to process');
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+    });
+  });
+
+  describe('empty CI file', () => {
+    it('uses updateFile (not createFile) when existing .gitlab-ci.yml is empty', async () => {
+      const { gitlabServer } = await startServers(harness, {
+        gitlabProjects: [
+          {
+            id: 82,
+            name: 'empty-ci-repo',
+            path_with_namespace: `${GROUP}/empty-ci-repo`,
+            default_branch: 'main',
+            rootFiles: [{ name: '.gitlab-ci.yml', content: '' }],
+          },
+        ],
+        bindings: [
+          {
+            projectKey: 'mycompany_empty-ci-repo',
+            repository: '82',
+            dopSettingId: DOP_SETTING_ID,
+          },
+        ],
+      });
+
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
+
+      expect(result.exitCode).toBe(0);
+      expect(gitlabServer.createdMrs).toHaveLength(1);
+      const committed = gitlabServer.committedFiles.find((f) => f.path === '.gitlab-ci.yml');
+      expect(committed).toBeDefined();
+      expect(committed?.content).toContain('sonarqube-analysis:');
+    });
+  });
+});

--- a/tests/unit/commands/admin/onboard-ci/gitlab/dry-run.test.ts
+++ b/tests/unit/commands/admin/onboard-ci/gitlab/dry-run.test.ts
@@ -1,0 +1,165 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import type { ClassificationEntry } from '@/commands/admin/onboard-ci/gitlab/dry-run.ts';
+import { computeDryRunResults } from '@/commands/admin/onboard-ci/gitlab/dry-run.ts';
+import type {
+  RepoClassification,
+  RepoWithBranch,
+} from '@/commands/admin/onboard-ci/gitlab/processor.ts';
+import { SkipReason } from '@/commands/admin/onboard-ci/gitlab/types.ts';
+
+function makeRepo(id: number, path: string): RepoWithBranch {
+  return {
+    id,
+    name: path.split('/').at(-1) ?? path,
+    path_with_namespace: path,
+    default_branch: 'main',
+    marked_for_deletion_at: null,
+  };
+}
+
+function proceed(repo: RepoWithBranch, projectKey: string): ClassificationEntry {
+  return {
+    repo,
+    classification: {
+      outcome: 'proceed',
+      ciFilePath: '.gitlab-ci.yml',
+      existingCi: null,
+      projectKey,
+    } satisfies RepoClassification,
+  };
+}
+
+function skip(
+  repo: RepoWithBranch,
+  reason: RepoClassification & { outcome: 'skip' },
+): ClassificationEntry {
+  return { repo, classification: reason };
+}
+
+describe('computeDryRunResults', () => {
+  it('marks repo as would open MR when bound in SonarQube', () => {
+    const repo = makeRepo(1, 'org/repo-one');
+    const result = computeDryRunResults([proceed(repo, 'org_repo-one')], []);
+
+    expect(result.wouldOpenMr).toHaveLength(1);
+    expect(result.wouldOpenMr[0]).toEqual({
+      repo: 'org/repo-one',
+      projectKey: 'org_repo-one',
+    });
+    expect(result.wouldSkip).toHaveLength(0);
+  });
+
+  it('places skipped repos in wouldSkip with their reason', () => {
+    const repo = makeRepo(3, 'org/jenkins-repo');
+    const result = computeDryRunResults(
+      [
+        skip(repo, {
+          outcome: 'skip',
+          reason: SkipReason.OtherCiDetected,
+          message: 'skipped (other CI detected)',
+        }),
+      ],
+      [],
+    );
+
+    expect(result.wouldOpenMr).toHaveLength(0);
+    expect(result.wouldSkip).toHaveLength(1);
+    expect(result.wouldSkip[0]).toEqual({
+      repo: 'org/jenkins-repo',
+      reason: SkipReason.OtherCiDetected,
+    });
+  });
+
+  it('places repos not in SonarQube in wouldSkip with NotInSonarQube reason', () => {
+    const repo = makeRepo(4, 'org/unbound-repo');
+    const result = computeDryRunResults(
+      [skip(repo, { outcome: 'skip', reason: SkipReason.NotInSonarQube, message: '' })],
+      [],
+    );
+
+    expect(result.wouldSkip).toHaveLength(1);
+    expect(result.wouldSkip[0].reason).toBe(SkipReason.NotInSonarQube);
+    expect(result.wouldOpenMr).toHaveLength(0);
+  });
+
+  it('handles a mix of proceed and skip classifications', () => {
+    const bound = makeRepo(1, 'org/bound-repo');
+    const jenkins = makeRepo(2, 'org/jenkins-repo');
+    const unbound = makeRepo(3, 'org/unbound-repo');
+
+    const result = computeDryRunResults(
+      [
+        proceed(bound, 'org_bound-repo'),
+        skip(jenkins, { outcome: 'skip', reason: SkipReason.OtherCiDetected, message: '' }),
+        skip(unbound, { outcome: 'skip', reason: SkipReason.NotInSonarQube, message: '' }),
+      ],
+      [],
+    );
+
+    expect(result.wouldOpenMr).toHaveLength(1);
+    expect(result.wouldOpenMr[0].projectKey).toBe('org_bound-repo');
+    expect(result.wouldSkip).toHaveLength(2);
+  });
+
+  it('ignores entries where classification failed (null)', () => {
+    const repo = makeRepo(4, 'org/failed-repo');
+    const result = computeDryRunResults([{ repo, classification: null }], []);
+
+    expect(result.wouldOpenMr).toHaveLength(0);
+    expect(result.wouldSkip).toHaveLength(0);
+  });
+
+  it('places failed repos in the failed bucket', () => {
+    const repo = makeRepo(5, 'org/errored-repo');
+    const failed = [{ repo: repo.path_with_namespace, error: 'GitLab API error 500' }];
+    const result = computeDryRunResults([{ repo, classification: null }], failed);
+
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]).toEqual({ repo: 'org/errored-repo', error: 'GitLab API error 500' });
+    expect(result.wouldOpenMr).toHaveLength(0);
+    expect(result.wouldSkip).toHaveLength(0);
+  });
+
+  it('includes failed repos in the total when mixed with successes', () => {
+    const good = makeRepo(1, 'org/good-repo');
+    const bad = makeRepo(2, 'org/bad-repo');
+    const failed = [{ repo: bad.path_with_namespace, error: 'timeout' }];
+
+    const result = computeDryRunResults(
+      [proceed(good, 'org_good-repo'), { repo: bad, classification: null }],
+      failed,
+    );
+
+    expect(result.wouldOpenMr).toHaveLength(1);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0].repo).toBe('org/bad-repo');
+  });
+
+  it('returns empty results for empty list', () => {
+    const result = computeDryRunResults([], []);
+    expect(result.wouldOpenMr).toHaveLength(0);
+    expect(result.wouldSkip).toHaveLength(0);
+    expect(result.failed).toHaveLength(0);
+  });
+});

--- a/tests/unit/commands/admin/onboard-ci/gitlab/templates.test.ts
+++ b/tests/unit/commands/admin/onboard-ci/gitlab/templates.test.ts
@@ -1,0 +1,265 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildUpdatedCiYml,
+  generateCiYml,
+  generateMrDescription,
+} from '@/commands/admin/onboard-ci/gitlab/templates.ts';
+import { TriggerOn } from '@/commands/admin/onboard-ci/gitlab/types.ts';
+
+describe('generateCiYml', () => {
+  const base = {
+    sonarTokenVarName: 'SONAR_TOKEN',
+    triggerOn: TriggerOn.Both,
+    allowFailure: true,
+    scannerProperty: [] as string[],
+  };
+
+  it('omits the stage line when stage is not provided', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', base);
+    expect(yml).not.toContain('stage:');
+  });
+
+  it('includes the stage line when stage is provided', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      stage: 'quality',
+    });
+    expect(yml).toContain('  stage: quality');
+  });
+
+  it('emits a stages block for a custom stage when creating a new file', () => {
+    const yml = generateCiYml(
+      'my_project',
+      'https://sonar.example.com',
+      { ...base, stage: 'security' },
+      true,
+    );
+    expect(yml).toMatch(/^stages:\n  - security\n/);
+    expect(yml).toContain('  stage: security');
+  });
+
+  it('does not emit a stages block for a GitLab default stage even when creating a new file', () => {
+    for (const stage of ['build', 'test', 'deploy', '.pre', '.post']) {
+      const yml = generateCiYml(
+        'my_project',
+        'https://sonar.example.com',
+        { ...base, stage },
+        true,
+      );
+      expect(yml).not.toContain('stages:');
+    }
+  });
+
+  it('does not emit a stages block for a custom stage when appending to an existing file', () => {
+    const yml = generateCiYml(
+      'my_project',
+      'https://sonar.example.com',
+      { ...base, stage: 'security' },
+      false,
+    );
+    expect(yml).not.toContain('stages:');
+    expect(yml).toContain('  stage: security');
+  });
+
+  it('includes both MR and main branch rules for trigger-on both', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', base);
+    expect(yml).toContain("$CI_PIPELINE_SOURCE == 'merge_request_event'");
+    expect(yml).toContain('$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH');
+  });
+
+  it('includes only MR rule for trigger-on mr', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      triggerOn: TriggerOn.Mr,
+    });
+    expect(yml).toContain("$CI_PIPELINE_SOURCE == 'merge_request_event'");
+    expect(yml).not.toContain('$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH');
+  });
+
+  it('includes only main branch rule for trigger-on main', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      triggerOn: TriggerOn.Main,
+    });
+    expect(yml).not.toContain("$CI_PIPELINE_SOURCE == 'merge_request_event'");
+    expect(yml).not.toContain('$CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS');
+    expect(yml).toContain('$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH');
+    expect(yml).not.toContain('$CI_COMMIT_BRANCH\n');
+  });
+
+  it('includes allow_failure: true when enabled', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', base);
+    expect(yml).toContain('allow_failure: true');
+  });
+
+  it('omits allow_failure when disabled', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      allowFailure: false,
+    });
+    expect(yml).not.toContain('allow_failure');
+  });
+
+  it('injects project key and server URL', () => {
+    const yml = generateCiYml('mygroup_myrepo', 'https://sonar.example.com', base);
+    expect(yml).toContain('-Dsonar.projectKey="mygroup_myrepo"');
+    expect(yml).toContain('SONAR_HOST_URL: "https://sonar.example.com"');
+  });
+
+  it('uses custom sonar token variable name', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      sonarTokenVarName: 'MY_SONAR_TOKEN',
+    });
+    expect(yml).toContain('SONAR_TOKEN: $MY_SONAR_TOKEN');
+  });
+
+  it('always includes GIT_DEPTH 0', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', base);
+    expect(yml).toContain('GIT_DEPTH: "0"');
+  });
+
+  it('appends no extra properties when scannerProperty is empty', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', base);
+    expect(yml).toContain('- sonar-scanner -Dsonar.projectKey="my_project"\n');
+  });
+
+  it('appends a single scanner property after the project key, shell-quoted', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      scannerProperty: ['sonar.scanner.engineJarPath=/path/to/engine.jar'],
+    });
+    expect(yml).toContain(
+      `-Dsonar.projectKey="my_project" -Dsonar.scanner.engineJarPath='/path/to/engine.jar'`,
+    );
+  });
+
+  it('appends multiple scanner properties in order, each shell-quoted', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      scannerProperty: [
+        'sonar.scanner.engineJarPath=/path/to/engine.jar',
+        'sonar.buildsystem.autoconfig.disabled=false',
+      ],
+    });
+    expect(yml).toContain(
+      `-Dsonar.projectKey="my_project" -Dsonar.scanner.engineJarPath='/path/to/engine.jar' -Dsonar.buildsystem.autoconfig.disabled='false'`,
+    );
+  });
+
+  it('escapes single quotes inside a property value', () => {
+    const yml = generateCiYml('my_project', 'https://sonar.example.com', {
+      ...base,
+      scannerProperty: [`sonar.projectName=It's a test`],
+    });
+    expect(yml).toContain(`-Dsonar.projectName='It'\\''s a test'`);
+  });
+});
+
+describe('generateMrDescription', () => {
+  const base = {
+    projectKey: 'mygroup_myrepo',
+    serverUrl: 'https://sonar.example.com',
+    ciFilePath: '.gitlab-ci.yml',
+    sonarTokenVarName: 'SONAR_TOKEN',
+  };
+
+  it('mentions only merge request pipelines for trigger-on mr', () => {
+    const desc = generateMrDescription(
+      base.projectKey,
+      base.serverUrl,
+      base.ciFilePath,
+      base.sonarTokenVarName,
+      TriggerOn.Mr,
+    );
+    expect(desc).toContain('merge request pipelines');
+    expect(desc).not.toContain('pushes to the default branch');
+  });
+
+  it('mentions only default branch pushes for trigger-on main', () => {
+    const desc = generateMrDescription(
+      base.projectKey,
+      base.serverUrl,
+      base.ciFilePath,
+      base.sonarTokenVarName,
+      TriggerOn.Main,
+    );
+    expect(desc).toContain('pushes to the default branch');
+    expect(desc).not.toContain('merge request pipelines');
+  });
+
+  it('mentions both triggers for trigger-on both', () => {
+    const desc = generateMrDescription(
+      base.projectKey,
+      base.serverUrl,
+      base.ciFilePath,
+      base.sonarTokenVarName,
+      TriggerOn.Both,
+    );
+    expect(desc).toContain('merge request pipelines and pushes to the default branch');
+  });
+});
+
+describe('buildUpdatedCiYml', () => {
+  const jobYml = 'sonarqube-analysis:\n  script:\n    - sonar-scanner\n';
+
+  it('returns the job YAML directly when no CI file exists', () => {
+    const result = buildUpdatedCiYml(null, jobYml);
+    expect(result).toBe(jobYml);
+  });
+
+  it('appends the job to an existing CI file with a blank line separator', () => {
+    const existing = 'stages:\n  - test\n';
+    const result = buildUpdatedCiYml(existing, jobYml);
+    expect(result).toBe(`stages:\n  - test\n\n${jobYml}`);
+  });
+
+  it('trims trailing whitespace from existing CI before appending', () => {
+    const existing = 'stages:\n  - test\n\n\n';
+    const result = buildUpdatedCiYml(existing, jobYml);
+    expect(result).toBe(`stages:\n  - test\n\n${jobYml}`);
+  });
+
+  it('preserves existing CI content', () => {
+    const existing = 'build:\n  script:\n    - make\n';
+    const result = buildUpdatedCiYml(existing, jobYml);
+    expect(result).toContain('build:');
+    expect(result).toContain('sonarqube-analysis:');
+    expect(result.indexOf('build:')).toBeLessThan(result.indexOf('sonarqube-analysis:'));
+  });
+
+  it('strips a trailing --- document-start marker before appending', () => {
+    const existing = 'stages:\n  - test\n---';
+    const result = buildUpdatedCiYml(existing, jobYml);
+    expect(result).not.toContain('---');
+    expect(result).toContain('sonarqube-analysis:');
+  });
+
+  it('strips multiple trailing --- markers before appending', () => {
+    const existing = 'stages:\n  - test\n---\n---';
+    const result = buildUpdatedCiYml(existing, jobYml);
+    expect(result).not.toContain('---');
+    expect(result).toContain('sonarqube-analysis:');
+  });
+});

--- a/tests/unit/core/ui/concurrent-progress.test.ts
+++ b/tests/unit/core/ui/concurrent-progress.test.ts
@@ -180,8 +180,20 @@ describe('ConcurrentProgress — mock mode options', () => {
     expect(methods).toContain('concurrentProgress.finish');
   });
 
-  it('showResult: false suppresses the result block on finish', () => {
+  it('showResult: false still emits the item list in non-TTY', () => {
     const progress = new ConcurrentProgress({ isTTY: false, showResult: false });
+    progress.setTotal(1);
+    progress.addItems(['item']);
+    progress.start();
+    progress.update('item', 'done', 'some detail');
+    setMockUi(false);
+    const output = captureStdout(() => progress.finish());
+    expect(output).toContain('item');
+    expect(output).toContain('some detail');
+  });
+
+  it('showResult: false suppresses the Succeeded/Failed block in TTY', () => {
+    const progress = new ConcurrentProgress({ isTTY: true, showResult: false });
     progress.setTotal(1);
     progress.addItems(['item']);
     progress.start();
@@ -189,7 +201,7 @@ describe('ConcurrentProgress — mock mode options', () => {
     setMockUi(false);
     const output = captureStdout(() => progress.finish());
     expect(output).not.toContain('Succeeded');
-    expect(output).not.toContain('Result');
+    expect(output).not.toContain('Failed');
   });
 
   it('resultTitle appears in TTY result header', () => {

--- a/tests/unit/helpers/mock-fetch.ts
+++ b/tests/unit/helpers/mock-fetch.ts
@@ -52,7 +52,8 @@ export function mockFetchSeq(...responses: Response[]): ReturnType<typeof spyOn>
 }
 
 export function lastFetchUrl(spy: ReturnType<typeof spyOn>): string {
-  return (spy.mock.calls[0][0] as string | URL).toString();
+  const calls = spy.mock.calls;
+  return (calls[calls.length - 1][0] as string | URL).toString();
 }
 
 export function nthFetchUrl(spy: ReturnType<typeof spyOn>, n: number): string {
@@ -60,5 +61,6 @@ export function nthFetchUrl(spy: ReturnType<typeof spyOn>, n: number): string {
 }
 
 export function lastFetchInit(spy: ReturnType<typeof spyOn>): RequestInit {
-  return spy.mock.calls[0][1] as RequestInit;
+  const calls = spy.mock.calls;
+  return calls[calls.length - 1][1] as RequestInit;
 }


### PR DESCRIPTION
Part 3/3 of the MMF-5886 CI Config Automation stack. Depends on #722.

## Validation


Happy path with dry/real run 
https://www.loom.com/share/2029347ef8974af1830c0706a4303698
https://www.loom.com/share/3d4c6888276c4f7b94e9853331037695

### With bad token
https://www.loom.com/share/3b3722c2c4b843a3ad83145777af5d64

### With file flag
https://www.loom.com/share/dbd60fff61394a7dba2ba2545ad4a457

### With custom sonar token variable name
https://www.loom.com/share/d2b173c7585d4c6d804b09156da6db24

### Stage option
https://www.loom.com/share/a8fc5713810940aab8be0935bab7ab64

### other flags
https://www.loom.com/share/dbd60fff61394a7dba2ba2545ad4a457

### Edit: changed output feedback to align with import command (using concurrency-progress)
https://github.com/user-attachments/assets/c55012d4-82f0-4d75-b650-03c145b64d96

----

## Summary by Gitar

- **GitLab CI Onboarding Command:**
    - Implemented `sonar admin onboard-ci gitlab` command for automating CI configuration across repositories
    - Added repository classification logic to safely skip already configured repos, custom paths, or other CI files
    - Added dry-run support, JSON reporting, and concurrency limiting for processing groups

<sub>This will update automatically on new commits.</sub>