### PR TITLE
CLI-1016 Stop parsing the version reported by installed binaries

### DIFF
--- a/src/core/host/install/binary.ts
+++ b/src/core/host/install/binary.ts
@@ -33,7 +33,7 @@ import {
   verifyBinarySignature,
 } from '@/core/host/install/sonarsource-releases.ts';
 import { recordInstalledDependency } from '@/core/state/state-manager.ts';
-import { type OutputChannel, print, text, withSpinner } from '@/core/ui';
+import { type OutputChannel, text, withSpinner } from '@/core/ui';
 
 import {
   cleanupOldVersionBinaries,
@@ -139,12 +139,7 @@ async function downloadAndInstall(
     await makeExecutable(binaryPath);
   }
 
-  const installedVersion = await withSpinner(
-    'Verifying installation',
-    () => verifyInstallation(binaryPath),
-    channel,
-  );
-  print(`     ${spec.name} ${installedVersion}`, channel);
+  await withSpinner('Verifying installation', () => verifyInstallation(binaryPath), channel);
 
   recordInstalledDependency(spec.name, spec.version, binaryPath);
   cleanupOldVersionBinaries(resolvedBinDir, spec.name, binaryName);

--- a/src/core/host/install/install-utils.ts
+++ b/src/core/host/install/install-utils.ts
@@ -20,8 +20,8 @@
 
 // Shared installation filesystem helpers used by multiple binary installers
 // (sonar-secrets, sonar-context-augmentation). Lives separately so installers
-// with different download/verify pipelines can still share cleanup and version
-// probing.
+// with different download/verify pipelines can still share cleanup and
+// post-install probing.
 
 import { existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -31,13 +31,11 @@ import { BIN_DIR } from '@/core/config-constants.ts';
 import logger from '@/core/observability/logger.ts';
 import { spawnProcess } from '@/core/process/process.ts';
 
-const VERSION_REGEX_MAX_SEGMENT = 20;
-
 /**
  * Verify the installation by probing the binary; throws with captured stdout/stderr
  * when the binary does not respond to `--version` or exits non-zero.
  */
-export async function verifyInstallation(path: string): Promise<string> {
+export async function verifyInstallation(path: string): Promise<void> {
   let result: Awaited<ReturnType<typeof spawnProcess>>;
   try {
     result = await spawnProcess(path, ['--version'], { stdout: 'pipe', stderr: 'pipe' });
@@ -53,16 +51,6 @@ export async function verifyInstallation(path: string): Promise<string> {
         formatSpawnOutput(result.stdout, result.stderr),
     );
   }
-
-  const pattern = String.raw`(\d{1,${VERSION_REGEX_MAX_SEGMENT}}(?:\.\d{1,${VERSION_REGEX_MAX_SEGMENT}}){2,3})`;
-  const match = new RegExp(pattern).exec(result.stdout);
-  if (!match) {
-    throw new CommandFailedError(
-      `Installation verification failed: could not parse version from --version output.\n` +
-        formatSpawnOutput(result.stdout, result.stderr),
-    );
-  }
-  return match[1];
 }
 
 export function formatSpawnOutput(stdout: string, stderr: string): string {

--- a/tests/integration/resources/cag-stub.ts
+++ b/tests/integration/resources/cag-stub.ts
@@ -41,7 +41,7 @@ import { appendFileSync } from 'node:fs';
 const args = process.argv.slice(2);
 
 if (args[0] === '--version') {
-  // Match what verifyInstallation() expects (3- or 4-segment dotted version).
+  // verifyInstallation() requires a zero exit code.
   console.log('sonar-context-augmentation 0.0.0-test');
   process.exit(0);
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactoring:**
    - Removed version parsing and regex matching from `verifyInstallation` in `install-utils.ts`
    - Updated callers and tests to no longer expect a returned version string

<sub>This will update automatically on new commits.</sub>