### PR TITLE
CLI-1018 A shortcut alias for quality-gate

### DIFF
--- a/build-scripts/docs/generate-docs.ts
+++ b/build-scripts/docs/generate-docs.ts
@@ -74,6 +74,7 @@ interface ClidocCommand {
   id: string;
   name: string;
   fullName: string;
+  aliases: string[];
   description: string;
   isGroup: boolean;
   isRoot: boolean;
@@ -148,6 +149,7 @@ function serializeCommand(
     id,
     name: cmd.name(),
     fullName,
+    aliases: cmd.aliases(),
     description: descriptionWithoutBetaTag(cmd),
     isGroup: visibleChildren.length > 0,
     isRoot: depth === 0,
@@ -181,6 +183,7 @@ const rootEntry: ClidocCommand = {
   id: rootId,
   name: 'sonar',
   fullName: 'sonar',
+  aliases: [],
   description: COMMAND_TREE.description() ?? 'SonarQube CLI',
   isGroup: true,
   isRoot: true,
@@ -210,6 +213,10 @@ mkdirSync(OUT_DIR, { recursive: true });
 writeFileSync(join(OUT_DIR, 'commands.json'), JSON.stringify(data, null, 2));
 
 // ── llms.txt ─────────────────────────────────────────────────
+function aliasSuffix(cmd: ClidocCommand): string {
+  return cmd.aliases.length > 0 ? `|${cmd.aliases.join('|')}` : '';
+}
+
 function buildLlmsTxt(): string {
   const template = readFileSync(join(__dirname, 'llms.txt.template'), 'utf-8');
   const commandLines: string[] = [];
@@ -219,7 +226,7 @@ function buildLlmsTxt(): string {
     if (cmd.isRoot) continue;
 
     const authMarker = cmd.requiresAuth ? ' *' : '';
-    commandLines.push(`### ${cmd.fullName}${authMarker}`);
+    commandLines.push(`### ${cmd.fullName}${aliasSuffix(cmd)}${authMarker}`);
     if (cmd.description) {
       const betaTag = cmd.stage === 'beta' ? ` ${BETA_HELP_TAG}` : '';
       commandLines.push(`${cmd.description}${betaTag}`);

--- a/build-scripts/docs/llms.txt.template
+++ b/build-scripts/docs/llms.txt.template
@@ -17,6 +17,7 @@ sonar integrate claude -g
 Use `sonar list issues --format toon` to output issues in a format optimized for LLM consumption.
 Use `sonar list projects` to discover available projects before running analysis.
 Commands marked with * require prior authentication via `sonar auth login`.
+Aliases are shown next to a command name as `name|alias`.
 
 ## Commands
 

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1218,6 +1218,15 @@ body.commands-page { height: 100%; overflow: hidden; }
 }
 .detail-badge.group { background: var(--orange-dim); color: var(--orange); }
 .detail-badge.cmd { background: var(--green-dim); color: var(--green); }
+.detail-alias {
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+  padding: 1px 7px;
+  border-radius: 4px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
 
 /* ─── Stage badges ─────────────────────────────────────────────────── */
 /* Color driver — a single --stage-c custom property varies per stage

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -154,6 +154,7 @@ function renderTree(filter) {
     const matches = data.commands.filter(c =>
       c.fullName.toLowerCase().includes(q) ||
       c.description.toLowerCase().includes(q) ||
+      (c.aliases && c.aliases.some(a => a.toLowerCase().includes(q))) ||
       (c.stage && c.stage !== 'stable' && c.stage.toLowerCase().includes(q))
     );
     for (const cmd of matches) {
@@ -174,6 +175,10 @@ function renderTree(filter) {
       }
     }
   }
+}
+
+function nameWithAliases(cmd) {
+  return cmd.name + ((cmd.aliases || []).length ? `|${cmd.aliases.join('|')}` : '');
 }
 
 // ── Pill tree node (tree mode) ────────────────────────────────
@@ -198,7 +203,7 @@ function buildPillNode(cmd, flat) {
     + (isSelected ? ' selected' : '')
     + (!isSelected && isOnPath ? ' path-highlight' : '')
     + (cmd.stage === 'beta' ? ' stage-beta' : '');
-  pill.textContent = cmd.name;
+  pill.textContent = nameWithAliases(cmd);
   row.appendChild(pill);
 
   if (!cmd.isRoot) {
@@ -238,7 +243,7 @@ function renderTreeNode(cmd, flat) {
 
   const label = document.createElement('span');
   label.className = 'tree-label ' + (cmd.isRoot ? 'root' : (cmd.isGroup || cmd.depth === 1) ? 'group' : 'leaf');
-  label.textContent = cmd.name;
+  label.textContent = nameWithAliases(cmd);
   row.appendChild(label);
 
   row.addEventListener('click', () => { navigateToCommand(cmd.id); });
@@ -325,7 +330,7 @@ function buildColumnView(root) {
           + (isSelected ? ' selected' : '')
           + (isOnPath   ? ' path-highlight' : '')
           + (entry.stage === 'beta' ? ' stage-beta' : '');
-        pill.textContent = entry.name;
+        pill.textContent = nameWithAliases(entry);
         pill.dataset.id = entry.id;
 
 
@@ -484,6 +489,9 @@ function renderDetail(cmd) {
   // Header
   parts.push(`<div class="detail-header">`);
   parts.push(`<span class="detail-title"><code>${escHtml(cmd.fullName)}</code></span>`);
+  for (const alias of cmd.aliases || []) {
+    parts.push(`<code class="detail-alias">${escHtml(alias)}</code>`);
+  }
   if (cmd.stage === 'beta') {
     parts.push(`<span class="stage-badge stage-${escHtml(cmd.stage)}">${escHtml(cmd.stage)}</span>`);
   }
@@ -569,6 +577,9 @@ function renderDetail(cmd) {
       if (!child) continue;
       parts.push(`<div class="subcmd-item" data-target="${escAttr(child.id)}">`);
       parts.push(`<span class="subcmd-name">${escHtml(child.fullName)}</span>`);
+      for (const alias of child.aliases || []) {
+        parts.push(`<code class="detail-alias">${escHtml(alias)}</code>`);
+      }
       parts.push(`<span class="subcmd-desc">${escHtml(child.description)}</span>`);
       parts.push(`<span class="subcmd-arrow">→</span>`);
       parts.push(`</div>`);

--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -270,6 +270,7 @@ function buildCommandTree(runtime: CliRuntime): SonarCommand {
     .authenticatedAction((ctx, options: ListProjectsOptions) => listProjects(options, ctx));
 
   const qualityGate = COMMAND_TREE.command('quality-gate')
+    .alias('qg')
     .description('Fetch quality gate status from SonarQube Cloud or Server')
     .rootHelp({
       category: 'data',

--- a/src/commands/root-help.ts
+++ b/src/commands/root-help.ts
@@ -83,17 +83,23 @@ function getVisibleChildCommands(command: SonarCommand, helper: Help): SonarComm
   );
 }
 
+function getCommandNameWithAlias(command: SonarCommand): string {
+  const alias = command.alias();
+  return alias ? `${command.name()}|${alias}` : command.name();
+}
+
 function getRootCommandLabel(command: SonarCommand, helper: Help): string {
   if (command.rootHelpMetadata.label) {
     return command.rootHelpMetadata.label;
   }
+  const nameWithAlias = getCommandNameWithAlias(command);
   if (command.rootHelpMetadata.expandSubcommands) {
-    return command.name();
+    return nameWithAlias;
   }
 
   const visibleChildren = getVisibleChildCommands(command, helper);
   if (visibleChildren.length === 0) {
-    return command.name();
+    return nameWithAlias;
   }
 
   const childLabels = visibleChildren.map((child) => {
@@ -105,7 +111,7 @@ function getRootCommandLabel(command: SonarCommand, helper: Help): string {
     }
     return `${child.name()}${tag}`;
   });
-  return `${command.name()} <${childLabels.join('|')}>`;
+  return `${nameWithAlias} <${childLabels.join('|')}>`;
 }
 
 function getRootCommandCategory(command: SonarCommand): CommandCategory {
@@ -118,7 +124,7 @@ function getRootCommandSubcommandEntries(command: SonarCommand, helper: Help): H
   }
 
   return getVisibleChildCommands(command, helper).map((child) => ({
-    label: `${command.name()} ${child.name()}`,
+    label: `${getCommandNameWithAlias(command)} ${getCommandNameWithAlias(child)}`,
     summary: child.description(),
   }));
 }

--- a/tests/integration/specs/help/root-help.test.ts
+++ b/tests/integration/specs/help/root-help.test.ts
@@ -53,7 +53,7 @@ function getExpectedRootHelp(): string {
     '    remediate                                                Trigger AI agent remediation for eligible issues (SonarQube Cloud only)',
     '',
     '    list <issues|projects>                                   List issues and projects from SonarQube Cloud or Server',
-    '    quality-gate <show>                                      Fetch quality gate status from SonarQube Cloud or Server',
+    '    quality-gate|qg <show>                                   Fetch quality gate status from SonarQube Cloud or Server',
     '    api <method> <endpoint>                                  Make authenticated API requests to SonarQube',
     '    context [action] [args...]                               Augment AI agents with context from your codebase',
     '',

--- a/tests/integration/specs/quality-gate/show.test.ts
+++ b/tests/integration/specs/quality-gate/show.test.ts
@@ -60,6 +60,30 @@ describe('quality-gate show', () => {
   );
 
   it(
+    'resolves via the qg alias',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) => p.withProjectStatus('OK'))
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`qg show --project my-project --format json`);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate).toEqual({
+        status: 'OK',
+        project: 'my-project',
+        branch: 'main',
+        conditions: [],
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'defaults to table format when --format is omitted',
     async () => {
       const server = await harness


### PR DESCRIPTION
----
## Summary by Gitar

- **New features:**
    - Added `qg` alias for the `quality-gate` command in `command-tree.ts`
- **Documentation & Tests:**
    - Updated root help display to show command aliases and added integration tests for `qg`

<sub>This will update automatically on new commits.</sub>