### PR TITLE
CLI-1023 Upload per-platform binary artifacts in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,11 +108,48 @@ jobs:
             bun build-scripts/sign.ts "$binary"
           done < <(find dist -maxdepth 1 -type f \( -name '*.bin' -o -name '*.exe' \) -print0)
 
-      - name: Upload all binaries
+      - name: Stage per-platform artifacts
+        shell: bash
+        env:
+          PROJECT_VERSION: ${{ needs.prepare.outputs.PROJECT_VERSION }}
+        run: |
+          set -euo pipefail
+          stage() {
+            local classifier="$1"
+            local ext="$2"
+            local dest="artifacts/${classifier}"
+            mkdir -p "${dest}"
+            cp "dist/sonarqube-cli-${PROJECT_VERSION}-${classifier}.${ext}" "${dest}/"
+            cp "dist/sonarqube-cli-${PROJECT_VERSION}-${classifier}.${ext}.asc" "${dest}/"
+          }
+          stage linux-x86-64 bin
+          stage linux-arm64 bin
+          stage macos-arm64 bin
+          stage windows-x86-64 exe
+
+      - name: Upload linux-x86-64 binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: binaries
-          path: dist/
+          name: binary-linux-x86-64
+          path: artifacts/linux-x86-64/
+
+      - name: Upload linux-arm64 binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-linux-arm64
+          path: artifacts/linux-arm64/
+
+      - name: Upload macos-arm64 binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-macos-arm64
+          path: artifacts/macos-arm64/
+
+      - name: Upload windows-x86-64 binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-windows-x86-64
+          path: artifacts/windows-x86-64/
 
   sign-macos:
     name: Sign and Notarize macOS Binaries
@@ -125,10 +162,10 @@ jobs:
       - name: Setup Cloudflare WARP
         uses: SonarSource/gh-action_setup-cloudflare-warp@fe31a2b2f31595cffdef290985700732cb3469d6 # v2.1.0
 
-      - name: Download binaries
+      - name: Download macos binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: binaries
+          name: binary-macos-arm64
           path: dist/
 
       - name: Vault Secrets
@@ -249,7 +286,8 @@ jobs:
       - name: Download all binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: binaries
+          pattern: binary-*
+          merge-multiple: true
           path: dist/
 
       - name: Download signed macOS binaries
@@ -383,8 +421,10 @@ jobs:
         include:
           - os: linux
             runner: github-ubuntu-latest-m
+            binary_artifact: binary-linux-x86-64
           - os: windows
             runner: warp-custom-windows-2022-s
+            binary_artifact: binary-windows-x86-64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -409,10 +449,10 @@ jobs:
           artifactory-username: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_USER }}
           artifactory-password: ${{ fromJSON(steps.secrets.outputs.vault).ARTIFACTORY_ACCESS_TOKEN }}
 
-      - name: Download cross-compiled binaries
+      - name: Download platform binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: binaries
+          name: ${{ matrix.binary_artifact }}
           path: dist/
 
       - name: Place platform binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,48 +108,37 @@ jobs:
             bun build-scripts/sign.ts "$binary"
           done < <(find dist -maxdepth 1 -type f \( -name '*.bin' -o -name '*.exe' \) -print0)
 
-      - name: Stage per-platform artifacts
-        shell: bash
-        env:
-          PROJECT_VERSION: ${{ needs.prepare.outputs.PROJECT_VERSION }}
-        run: |
-          set -euo pipefail
-          stage() {
-            local classifier="$1"
-            local ext="$2"
-            local dest="artifacts/${classifier}"
-            mkdir -p "${dest}"
-            cp "dist/sonarqube-cli-${PROJECT_VERSION}-${classifier}.${ext}" "${dest}/"
-            cp "dist/sonarqube-cli-${PROJECT_VERSION}-${classifier}.${ext}.asc" "${dest}/"
-          }
-          stage linux-x86-64 bin
-          stage linux-arm64 bin
-          stage macos-arm64 bin
-          stage windows-x86-64 exe
-
       - name: Upload linux-x86-64 binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-linux-x86-64
-          path: artifacts/linux-x86-64/
+          path: |
+            dist/*-linux-x86-64.bin
+            dist/*-linux-x86-64.bin.asc
 
       - name: Upload linux-arm64 binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-linux-arm64
-          path: artifacts/linux-arm64/
+          path: |
+            dist/*-linux-arm64.bin
+            dist/*-linux-arm64.bin.asc
 
       - name: Upload macos-arm64 binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-macos-arm64
-          path: artifacts/macos-arm64/
+          path: |
+            dist/*-macos-arm64.bin
+            dist/*-macos-arm64.bin.asc
 
       - name: Upload windows-x86-64 binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-windows-x86-64
-          path: artifacts/windows-x86-64/
+          path: |
+            dist/*-windows-x86-64.exe
+            dist/*-windows-x86-64.exe.asc
 
   sign-macos:
     name: Sign and Notarize macOS Binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-linux-x86-64
+          if-no-files-found: error
           path: |
             dist/*-linux-x86-64.bin
             dist/*-linux-x86-64.bin.asc
@@ -120,6 +121,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-linux-arm64
+          if-no-files-found: error
           path: |
             dist/*-linux-arm64.bin
             dist/*-linux-arm64.bin.asc
@@ -128,6 +130,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-macos-arm64
+          if-no-files-found: error
           path: |
             dist/*-macos-arm64.bin
             dist/*-macos-arm64.bin.asc
@@ -136,6 +139,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-windows-x86-64
+          if-no-files-found: error
           path: |
             dist/*-windows-x86-64.exe
             dist/*-windows-x86-64.exe.asc

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev": "bun run src/index.ts",
     "test:unit": "bun test --parallel ./tests/unit/",
     "pretest:integration": "bun build:binary && bun build-scripts/setup-integration-resources.ts",
-    "test:integration": "bun test ./tests/integration/",
+    "test:integration": "bun test --parallel=4 ./tests/integration/",
     "test:all": "bun run test:unit && bun run test:integration",
     "test:e2e": "bun test ./tests/e2e/",
     "test:coverage:unit": "COVERAGE_RAW_UNIT_DIR=tests/coverage/reports/raw-unit bun test ./tests/unit/",


### PR DESCRIPTION
## Summary
- Split the CI `binaries` artifact into per-platform uploads so test jobs download only the binary they need
- Run integration tests with `bun test --parallel=4` ([CLI-1022](https://sonarsource.atlassian.net/browse/CLI-1022))

[CLI-1022]: https://sonarsource.atlassian.net/browse/CLI-1022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ