### PR TITLE
CLI-1037 Add runInteractive to the test harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ The two inputs are separate because the single boolean made _collect but do not 
 
 **Writing tests that touch telemetry** — four traps, none of which lint or CI will catch:
 
-- **Spawn the CLI only through the harness** (`harness.run()`, `runCli()`) or by spreading `ISOLATED_CLI_SPAWN_ENV`. A hand-rolled `Bun.spawn` of the binary inherits production egress; the two such spawns in `tests/e2e/install-scripts.test.ts` are safe only because they spread it explicitly.
+- **Spawn the CLI only through the harness** (`harness.run()`, `harness.runInteractive()`, `runCli()`) or by spreading `ISOLATED_CLI_SPAWN_ENV`. A hand-rolled `Bun.spawn` of the binary inherits production egress; the two such spawns in `tests/e2e/install-scripts.test.ts` are safe only because they spread it explicitly.
 - **A unit test that enables telemetry must point `SONAR_USER_HOME` at a temp dir.** Egress `off` stops _that process_ transmitting, but events still land in the developer's real `~/.sonar` queue, and their next genuine `sonar` command drains and POSTs them. This is the one leak path the egress mode cannot close, because the transmitting process is legitimate.
 - **Clearing `__SQ_CLI_TELEMETRY_EGRESS`** to exercise the spawn or drain means the real code paths run: mock `Bun.spawn` and `fetch` in the same file.
 - **`flushTelemetryEvents` transmits unconditionally** — its guards are in `flushTelemetry`. Call it directly only with `fetch` mocked.
@@ -214,7 +214,7 @@ Before writing a test, find an existing spec for the same command area and follo
 
 ### Integration test harness
 
-Each test creates a fresh `TestHarness` and disposes it in `afterEach`. The harness runs the compiled binary in a fully isolated environment (temp dir, fake keychain, fake servers). For fine-grained state setup beyond `withAuth`, use `harness.state()` builder (see `tests/integration/harness/environment-builder.ts`). For git hook tests, use `initGitRepo` / `stageFile` from `tests/integration/specs/hook/git-test-helpers.ts`.
+Each test creates a fresh `TestHarness` and disposes it in `afterEach`. The harness runs the compiled binary in a fully isolated environment (temp dir, fake keychain, fake servers). For fine-grained state setup beyond `withAuth`, use `harness.state()` builder (see `tests/integration/harness/environment-builder.ts`). For git hook tests, use `initGitRepo` / `stageFile` from `tests/integration/specs/hook/git-test-helpers.ts`. Use `harness.run()` for non-interactive commands and dump-all stdin (`stdin` / `stdinChunks`). Drive prompt-by-prompt flows with `harness.runInteractive()`, which returns an `InteractiveSession` (`waitText`, `write` / `keyEnter` / `keyUp` / `keyDown` / `keySpace` / `keyCtrlC`, then `waitFinish()`). `dispose()` kills any session that is still running.
 
 ### Coverage
 

--- a/tests/integration/harness/cli-runner.ts
+++ b/tests/integration/harness/cli-runner.ts
@@ -26,7 +26,7 @@ import { join } from 'node:path';
 import { applyIsolatedSpawnEnv } from '../../_common/isolated-cli-env.js';
 import { COVERAGE_BINARY, COVERAGE_RAW_DIR } from '../../coverage/paths.js';
 import { IS_WINDOWS } from './platform';
-import type { CliResult } from './types.js';
+import type { CliResult, InteractiveProcessHandle, SessionStdin } from './types.js';
 
 const PROJECT_ROOT = join(import.meta.dir, '../../..');
 const DEFAULT_BINARY = join(
@@ -34,7 +34,7 @@ const DEFAULT_BINARY = join(
   'dist',
   IS_WINDOWS ? 'sonarqube-cli.exe' : 'sonarqube-cli',
 );
-const DEFAULT_TIMEOUT_MS = 30000;
+export const DEFAULT_CLI_TIMEOUT_MS = 30000;
 
 function getBinaryPath(coverageMode: boolean, overridePath?: string): string {
   const binaryPath = overridePath ?? (coverageMode ? COVERAGE_BINARY : DEFAULT_BINARY);
@@ -49,6 +49,77 @@ function getBinaryPath(coverageMode: boolean, overridePath?: string): string {
 /** Same executable `runCli` uses (coverage binary when `SONARQUBE_CLI_USE_COVERAGE=1`). */
 export function getCliBinaryPath(): string {
   return getBinaryPath(process.env.SONARQUBE_CLI_USE_COVERAGE === '1');
+}
+
+export type SpawnedCliProcess = {
+  proc: InteractiveProcessHandle;
+  timeoutMs: number;
+  startedAt: number;
+};
+
+export function spawnCliProcess(
+  command: string,
+  env: Record<string, string>,
+  options: {
+    cwd: string;
+    timeoutMs?: number;
+    binaryPath?: string;
+    stdin: 'pipe' | 'ignore';
+  },
+): SpawnedCliProcess {
+  const coverageMode = process.env.SONARQUBE_CLI_USE_COVERAGE === '1';
+  const binaryPath = getBinaryPath(coverageMode, options.binaryPath);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CLI_TIMEOUT_MS;
+  const startedAt = Date.now();
+  mkdirSync(options.cwd, { recursive: true });
+
+  const spawnEnv = applyIsolatedSpawnEnv(env);
+  if (coverageMode) {
+    mkdirSync(COVERAGE_RAW_DIR, { recursive: true });
+    const unique = `${Date.now()}-${crypto.randomUUID()}`;
+    spawnEnv.COVERAGE_OUTPUT_FILE = join(COVERAGE_RAW_DIR, `coverage-${unique}.json`);
+  }
+
+  const args = tokenize(command);
+  const proc = wrapSpawnedProcess(
+    Bun.spawn([binaryPath, ...args], {
+      env: spawnEnv,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      stdin: options.stdin,
+      cwd: options.cwd,
+    }),
+  );
+
+  return { proc, timeoutMs, startedAt };
+}
+
+function wrapSpawnedProcess(proc: ReturnType<typeof Bun.spawn>): InteractiveProcessHandle {
+  return {
+    stdin: isSessionStdin(proc.stdin) ? proc.stdin : null,
+    stdout: requirePipedStream(proc.stdout, 'stdout'),
+    stderr: requirePipedStream(proc.stderr, 'stderr'),
+    kill() {
+      proc.kill();
+    },
+    get exited() {
+      return proc.exited;
+    },
+  };
+}
+
+function isSessionStdin(stdin: unknown): stdin is SessionStdin {
+  return typeof stdin === 'object' && stdin !== null && 'write' in stdin && 'end' in stdin;
+}
+
+function requirePipedStream(
+  stream: number | ReadableStream<Uint8Array> | undefined,
+  name: string,
+): ReadableStream<Uint8Array> {
+  if (typeof stream === 'object' && stream !== null) {
+    return stream;
+  }
+  throw new Error(`Expected piped ${name}`);
 }
 
 const STDIN_CHUNK_DELAY_MS = 300;
@@ -67,48 +138,28 @@ export async function runCli(
     binaryPath?: string;
   },
 ): Promise<CliResult> {
-  const coverageMode = process.env.SONARQUBE_CLI_USE_COVERAGE === '1';
-  const binaryPath = getBinaryPath(coverageMode, options.binaryPath);
-  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  const startTime = Date.now();
-  mkdirSync(options.cwd, { recursive: true });
-
-  const spawnEnv = applyIsolatedSpawnEnv(env);
-  if (coverageMode) {
-    mkdirSync(COVERAGE_RAW_DIR, { recursive: true });
-    const unique = `${Date.now()}-${crypto.randomUUID()}`;
-    spawnEnv.COVERAGE_OUTPUT_FILE = join(COVERAGE_RAW_DIR, `coverage-${unique}.json`);
-  }
-
-  const args = tokenize(command);
   const hasStdin = options.stdin !== undefined || (options.stdinChunks?.length ?? 0) > 0;
-  const proc = Bun.spawn([binaryPath, ...args], {
-    env: spawnEnv,
-    stdout: 'pipe',
-    stderr: 'pipe',
-    stdin: hasStdin ? 'pipe' : 'ignore',
+  const { proc, timeoutMs, startedAt } = spawnCliProcess(command, env, {
     cwd: options.cwd,
+    timeoutMs: options.timeoutMs,
+    binaryPath: options.binaryPath,
+    stdin: hasStdin ? 'pipe' : 'ignore',
   });
 
   if (options.stdin !== undefined && proc.stdin) {
-    // proc.stdin is a Bun FileSink (not a Web WritableStream)
-    const sink = proc.stdin as { write(data: Uint8Array): void; end(): void };
-    sink.write(new TextEncoder().encode(options.stdin));
-    sink.end();
+    proc.stdin.write(new TextEncoder().encode(options.stdin));
+    proc.stdin.end();
   }
 
   if (options.stdinChunks !== undefined && proc.stdin) {
-    const sink = proc.stdin as { write(data: Uint8Array): void; end(): void };
     const encoder = new TextEncoder();
-    // Write each chunk with a delay so readline in the CLI process finishes
-    // handling one prompt before the next chunk arrives for the next prompt.
     const chunkDelayMs = options.stdinChunkDelayMs ?? STDIN_CHUNK_DELAY_MS;
     await (async () => {
       for (const chunk of options.stdinChunks ?? []) {
         await new Promise((r) => setTimeout(r, chunkDelayMs));
-        sink.write(encoder.encode(chunk));
+        proc.stdin?.write(encoder.encode(chunk));
       }
-      sink.end();
+      proc.stdin?.end();
     })();
   }
 
@@ -142,7 +193,7 @@ export async function runCli(
     exitCode,
     stdout,
     stderr,
-    durationMs: Date.now() - startTime,
+    durationMs: Date.now() - startedAt,
   };
 }
 
@@ -150,7 +201,7 @@ export async function runCli(
  * Extracts the loopback port from accumulated stdout and POSTs the token to it.
  * Returns true if the token was delivered, false if the port was not found yet.
  */
-function tryDeliverToken(accumulated: string, token: string, tokenName?: string): boolean {
+export function tryDeliverToken(accumulated: string, token: string, tokenName?: string): boolean {
   const match = /[?&]port=(\d+)/.exec(accumulated);
   if (!match) return false;
   const port = match[1];

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -37,13 +37,15 @@ import { FakeGitLabServer, FakeGitLabServerBuilder } from './fake-gitlab-server.
 import { FakeSonarQubeServer, FakeSonarQubeServerBuilder } from './fake-sonarqube-server.js';
 import { FakeUpdateScriptServer } from './fake-update-script-server.js';
 import { File } from './file';
+import { type InteractiveSession, startInteractiveSession } from './interactive-session.js';
 import { buildHomeEnv, IS_WINDOWS } from './platform';
-import type { CliResult, RunOptions } from './types.js';
+import type { CliResult, RunInteractiveOptions, RunOptions } from './types.js';
 
 export { FakeGitLabServer, FakeGitLabServerBuilder } from './fake-gitlab-server.js';
 export { FakeSonarQubeServer, FakeSonarQubeServerBuilder } from './fake-sonarqube-server.js';
+export { InteractiveSession } from './interactive-session.js';
 export { hookScriptName, hookScriptPath, IS_WINDOWS, normalizePath } from './platform';
-export type { CliResult, RecordedRequest } from './types.js';
+export type { CliResult, RecordedRequest, RunInteractiveOptions } from './types.js';
 
 export class TestHarness {
   public readonly cwd: Dir;
@@ -59,6 +61,7 @@ export class TestHarness {
   private readonly updateScriptServers: FakeUpdateScriptServer[] = [];
   private _envBuilder?: EnvironmentBuilder;
   private systemEnvVars: Record<string, string> = {};
+  private readonly sessions: InteractiveSession[] = [];
 
   private constructor(tempDir: string) {
     this.tempDir = new Dir(tempDir);
@@ -232,6 +235,23 @@ export class TestHarness {
   }
 
   /**
+   * Spawns the CLI and returns a session the test drives prompt-by-prompt.
+   * Use `run()` when the command is non-interactive or only needs dump-all stdin.
+   */
+  runInteractive(command: string, options?: RunInteractiveOptions): InteractiveSession {
+    const session = startInteractiveSession(command, this.env(options), {
+      cwd: options?.cwd ?? this.cwd.path,
+      timeoutMs: options?.timeoutMs,
+      waitTimeoutMs: options?.waitTimeoutMs,
+      binaryPath: options?.binaryPath,
+      browserToken: options?.browserToken,
+      browserTokenName: options?.browserTokenName,
+    });
+    this.sessions.push(session);
+    return session;
+  }
+
+  /**
    * Builds the environment used to run the CLI from this harness.
    */
   env(options?: Pick<RunOptions, 'extraEnv'>): Record<string, string> {
@@ -293,6 +313,11 @@ export class TestHarness {
    * Stops all fake servers and removes the temporary directory.
    */
   async dispose(): Promise<void> {
+    for (const session of this.sessions) {
+      session.kill();
+    }
+    await Promise.all(this.sessions.map((session) => session.waitFinish().catch(() => undefined)));
+
     await Promise.all(
       [...this.servers, ...this.binariesServers, ...this.gitlabServers].map((s) =>
         s.stop().catch(() => {

--- a/tests/integration/harness/interactive-session.ts
+++ b/tests/integration/harness/interactive-session.ts
@@ -146,8 +146,8 @@ export class InteractiveSession {
   private readonly browserTokenName?: string;
   private readonly encoder = new TextEncoder();
   private readonly waiters: Array<() => void> = [];
-  private readonly readersDone: Promise<void>;
-  private readonly timer: ReturnType<typeof setTimeout>;
+  private readersDone!: Promise<void>;
+  private timer!: ReturnType<typeof setTimeout>;
 
   private rawStdout = '';
   private rawStderr = '';
@@ -166,7 +166,9 @@ export class InteractiveSession {
     proc: InteractiveProcessHandle,
     options: InteractiveSessionOptions = {},
   ): InteractiveSession {
-    return new InteractiveSession(proc, options);
+    const session = new InteractiveSession(proc, options);
+    session.start();
+    return session;
   }
 
   private constructor(proc: InteractiveProcessHandle, options: InteractiveSessionOptions) {
@@ -176,9 +178,11 @@ export class InteractiveSession {
     this.startedAt = options.startedAt ?? Date.now();
     this.browserToken = options.browserToken;
     this.browserTokenName = options.browserTokenName;
+  }
 
+  private start(): void {
     this.readersDone = Promise.all([
-      this.consume(proc.stdout, (chunk) => {
+      this.consume(this.proc.stdout, (chunk) => {
         this.rawStdout += chunk;
         if (this.browserToken && !this.tokenDelivered) {
           this.tokenDelivered = tryDeliverToken(
@@ -189,13 +193,13 @@ export class InteractiveSession {
         }
         this.notify();
       }),
-      this.consume(proc.stderr, (chunk) => {
+      this.consume(this.proc.stderr, (chunk) => {
         this.rawStderr += chunk;
         this.notify();
       }),
     ]).then(() => undefined);
 
-    void proc.exited.then((code) => {
+    void this.proc.exited.then((code) => {
       this.exitCode = code;
       clearTimeout(this.timer);
       this.notify();

--- a/tests/integration/harness/interactive-session.ts
+++ b/tests/integration/harness/interactive-session.ts
@@ -54,10 +54,34 @@ export function formatPrompt(prompt: PromptText): string {
 
 /** Clack paints a submitted prompt (and `discreetSuccess`) as `  ✓  …`; such a line is never a live wait target. */
 const SUBMITTED_PROMPT_PREFIX = '✓  ';
+const LIVE_PROMPT_PREFIX = '?  ';
 
 function isSubmittedPrompt(window: string, matchIndex: number): boolean {
   const lineStart = window.lastIndexOf('\n', matchIndex) + 1;
-  return window.slice(lineStart, matchIndex).trimStart().startsWith(SUBMITTED_PROMPT_PREFIX);
+  const prefix = window.slice(lineStart, matchIndex);
+  const submittedAt = prefix.lastIndexOf(SUBMITTED_PROMPT_PREFIX);
+  const liveAt = prefix.lastIndexOf(LIVE_PROMPT_PREFIX);
+  if (submittedAt === -1) {
+    return prefix.trimStart().startsWith(SUBMITTED_PROMPT_PREFIX);
+  }
+  return submittedAt > liveAt;
+}
+
+/** Raw index at `rawStart` plus enough bytes for `strippedCount` visible characters. */
+export function rawOffsetAfterStripped(
+  raw: string,
+  rawStart: number,
+  strippedCount: number,
+): number {
+  if (strippedCount <= 0) {
+    return rawStart;
+  }
+  for (let rawEnd = rawStart + 1; rawEnd <= raw.length; rawEnd++) {
+    if (stripControlSequences(raw.slice(rawStart, rawEnd)).length >= strippedCount) {
+      return rawEnd;
+    }
+  }
+  return raw.length;
 }
 
 export function findPromptMatch(window: string, prompt: PromptText): number | null {
@@ -173,6 +197,7 @@ export class InteractiveSession {
 
     void proc.exited.then((code) => {
       this.exitCode = code;
+      clearTimeout(this.timer);
       this.notify();
     });
 
@@ -185,11 +210,11 @@ export class InteractiveSession {
   async waitText(prompt: PromptText, timeoutMs = this.waitTimeoutMs): Promise<void> {
     const deadline = Date.now() + timeoutMs;
     while (true) {
-      const window = stripControlSequences(
-        this.rawStdout.slice(Math.max(this.consumed, this.barrier)),
-      );
-      if (findPromptMatch(window, prompt) !== null) {
-        this.consumed = this.rawStdout.length;
+      const rawStart = Math.max(this.consumed, this.barrier);
+      const window = stripControlSequences(this.rawStdout.slice(rawStart));
+      const matchEnd = findPromptMatch(window, prompt);
+      if (matchEnd !== null) {
+        this.consumed = rawOffsetAfterStripped(this.rawStdout, rawStart, matchEnd);
         return;
       }
       if (this.timedOut) {
@@ -245,6 +270,7 @@ export class InteractiveSession {
       return;
     }
     this.killed = true;
+    clearTimeout(this.timer);
     try {
       this.proc.kill();
     } catch {
@@ -271,6 +297,14 @@ export class InteractiveSession {
   private assertWritable(): SessionStdin {
     if (this.exitCode !== undefined) {
       throw new Error('Cannot write to an interactive session that has already exited');
+    }
+    if (this.timedOut) {
+      throw new Error(
+        `Cannot write to an interactive session killed by the ${this.timeoutMs}ms timeout`,
+      );
+    }
+    if (this.killed) {
+      throw new Error('Cannot write to an interactive session after kill()');
     }
     if (this.stdinEnded || !this.proc.stdin) {
       throw new Error('Cannot write to an interactive session after waitFinish()');

--- a/tests/integration/harness/interactive-session.ts
+++ b/tests/integration/harness/interactive-session.ts
@@ -1,0 +1,352 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Interactive CLI session — wait for prompt text, type, then waitFinish or kill
+
+import { DEFAULT_CLI_TIMEOUT_MS, spawnCliProcess, tryDeliverToken } from './cli-runner.js';
+import type { CliResult, InteractiveProcessHandle, SessionStdin } from './types.js';
+
+export type { InteractiveProcessHandle, SessionStdin } from './types.js';
+
+const ENTER = '\r';
+const CTRL_C = '\x03';
+const ARROW_UP = '\x1b[A';
+const ARROW_DOWN = '\x1b[B';
+const SPACE = ' ';
+
+export type PromptText = string | RegExp;
+
+export type InteractiveSessionOptions = {
+  timeoutMs?: number;
+  waitTimeoutMs?: number;
+  startedAt?: number;
+  browserToken?: string;
+  browserTokenName?: string;
+};
+
+/** CSI / OSC / leftover ESC plus CR, so clack cursor codes do not hide prompt text. */
+const CONTROL_SEQUENCE = /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b.|[\r]/g;
+
+export function stripControlSequences(s: string): string {
+  return s.replaceAll(CONTROL_SEQUENCE, '');
+}
+
+export function formatPrompt(prompt: PromptText): string {
+  return typeof prompt === 'string' ? `"${prompt}"` : String(prompt);
+}
+
+/** Clack paints a submitted prompt (and `discreetSuccess`) as `  ✓  …`; such a line is never a live wait target. */
+const SUBMITTED_PROMPT_PREFIX = '✓  ';
+
+function isSubmittedPrompt(window: string, matchIndex: number): boolean {
+  const lineStart = window.lastIndexOf('\n', matchIndex) + 1;
+  return window.slice(lineStart, matchIndex).trimStart().startsWith(SUBMITTED_PROMPT_PREFIX);
+}
+
+export function findPromptMatch(window: string, prompt: PromptText): number | null {
+  if (typeof prompt === 'string') {
+    let searchFrom = 0;
+    while (searchFrom <= window.length) {
+      const index = window.indexOf(prompt, searchFrom);
+      if (index === -1) {
+        return null;
+      }
+      if (!isSubmittedPrompt(window, index)) {
+        return index + prompt.length;
+      }
+      searchFrom = index + prompt.length;
+    }
+    return null;
+  }
+  const flags = prompt.flags.replaceAll('g', '').replaceAll('y', '');
+  const matcher = new RegExp(prompt.source, `${flags}g`);
+  for (let match = matcher.exec(window); match !== null; match = matcher.exec(window)) {
+    if (!isSubmittedPrompt(window, match.index)) {
+      return match.index + match[0].length;
+    }
+    matcher.lastIndex = match.index + Math.max(match[0].length, 1);
+  }
+  return null;
+}
+
+export function startInteractiveSession(
+  command: string,
+  env: Record<string, string>,
+  options: {
+    cwd: string;
+    timeoutMs?: number;
+    waitTimeoutMs?: number;
+    binaryPath?: string;
+    browserToken?: string;
+    browserTokenName?: string;
+  },
+): InteractiveSession {
+  const spawned = spawnCliProcess(command, env, {
+    cwd: options.cwd,
+    timeoutMs: options.timeoutMs,
+    binaryPath: options.binaryPath,
+    stdin: 'pipe',
+  });
+  return InteractiveSession.fromProcess(spawned.proc, {
+    timeoutMs: spawned.timeoutMs,
+    startedAt: spawned.startedAt,
+    waitTimeoutMs: options.waitTimeoutMs,
+    browserToken: options.browserToken,
+    browserTokenName: options.browserTokenName,
+  });
+}
+
+export class InteractiveSession {
+  private readonly proc: InteractiveProcessHandle;
+  private readonly timeoutMs: number;
+  private readonly waitTimeoutMs: number;
+  private readonly startedAt: number;
+  private readonly browserToken?: string;
+  private readonly browserTokenName?: string;
+  private readonly encoder = new TextEncoder();
+  private readonly waiters: Array<() => void> = [];
+  private readonly readersDone: Promise<void>;
+  private readonly timer: ReturnType<typeof setTimeout>;
+
+  private rawStdout = '';
+  private rawStderr = '';
+  /** Byte offset into `rawStdout` (monotonic — that buffer only grows). */
+  private consumed = 0;
+  /** Raw-stdout offset at the last write; next waitText ignores output already on screen. */
+  private barrier = 0;
+  private tokenDelivered = false;
+  private stdinEnded = false;
+  private killed = false;
+  private timedOut = false;
+  private exitCode: number | undefined;
+  private resultPromise: Promise<CliResult> | undefined;
+
+  static fromProcess(
+    proc: InteractiveProcessHandle,
+    options: InteractiveSessionOptions = {},
+  ): InteractiveSession {
+    return new InteractiveSession(proc, options);
+  }
+
+  private constructor(proc: InteractiveProcessHandle, options: InteractiveSessionOptions) {
+    this.proc = proc;
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_CLI_TIMEOUT_MS;
+    this.waitTimeoutMs = options.waitTimeoutMs ?? this.timeoutMs;
+    this.startedAt = options.startedAt ?? Date.now();
+    this.browserToken = options.browserToken;
+    this.browserTokenName = options.browserTokenName;
+
+    this.readersDone = Promise.all([
+      this.consume(proc.stdout, (chunk) => {
+        this.rawStdout += chunk;
+        if (this.browserToken && !this.tokenDelivered) {
+          this.tokenDelivered = tryDeliverToken(
+            this.rawStdout,
+            this.browserToken,
+            this.browserTokenName,
+          );
+        }
+        this.notify();
+      }),
+      this.consume(proc.stderr, (chunk) => {
+        this.rawStderr += chunk;
+        this.notify();
+      }),
+    ]).then(() => undefined);
+
+    void proc.exited.then((code) => {
+      this.exitCode = code;
+      this.notify();
+    });
+
+    this.timer = setTimeout(() => {
+      this.timedOut = true;
+      this.kill();
+    }, this.timeoutMs);
+  }
+
+  async waitText(prompt: PromptText, timeoutMs = this.waitTimeoutMs): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (true) {
+      const window = stripControlSequences(
+        this.rawStdout.slice(Math.max(this.consumed, this.barrier)),
+      );
+      if (findPromptMatch(window, prompt) !== null) {
+        this.consumed = this.rawStdout.length;
+        return;
+      }
+      if (this.timedOut) {
+        throw this.waitError(`CLI process timed out after ${this.timeoutMs}ms waiting for`, prompt);
+      }
+      if (this.exitCode !== undefined) {
+        throw this.waitError('CLI exited before', prompt, 'appeared');
+      }
+      if (Date.now() >= deadline) {
+        throw this.waitError('Timed out waiting for', prompt);
+      }
+      await this.waitUntilChange(deadline);
+    }
+  }
+
+  write(keys: string): void {
+    const stdin = this.assertWritable();
+    this.barrier = this.rawStdout.length;
+    stdin.write(this.encoder.encode(keys));
+  }
+
+  keyEnter(): void {
+    this.write(ENTER);
+  }
+
+  keyUp(): void {
+    this.write(ARROW_UP);
+  }
+
+  keyDown(): void {
+    this.write(ARROW_DOWN);
+  }
+
+  keySpace(): void {
+    this.write(SPACE);
+  }
+
+  keyCtrlC(): void {
+    this.write(CTRL_C);
+  }
+
+  output(): string {
+    return stripControlSequences(this.rawStdout + this.rawStderr);
+  }
+
+  async waitFinish(): Promise<CliResult> {
+    this.resultPromise ??= this.collectResult();
+    return this.resultPromise;
+  }
+
+  kill(): void {
+    if (this.killed) {
+      return;
+    }
+    this.killed = true;
+    try {
+      this.proc.kill();
+    } catch {
+      /* process may already have exited */
+    }
+    this.endStdin();
+  }
+
+  private async collectResult(): Promise<CliResult> {
+    this.endStdin();
+    const [exitCode] = await Promise.all([this.proc.exited, this.readersDone]);
+    clearTimeout(this.timer);
+    if (this.timedOut) {
+      throw new Error(`CLI process timed out after ${this.timeoutMs}ms`);
+    }
+    return {
+      exitCode,
+      stdout: this.rawStdout,
+      stderr: this.rawStderr,
+      durationMs: Date.now() - this.startedAt,
+    };
+  }
+
+  private assertWritable(): SessionStdin {
+    if (this.exitCode !== undefined) {
+      throw new Error('Cannot write to an interactive session that has already exited');
+    }
+    if (this.stdinEnded || !this.proc.stdin) {
+      throw new Error('Cannot write to an interactive session after waitFinish()');
+    }
+    return this.proc.stdin;
+  }
+
+  private endStdin(): void {
+    if (this.stdinEnded) {
+      return;
+    }
+    this.stdinEnded = true;
+    try {
+      this.proc.stdin?.end();
+    } catch {
+      /* stdin may already be closed */
+    }
+  }
+
+  private waitError(prefix: string, prompt: PromptText, suffix = ''): Error {
+    const after = suffix === '' ? '' : ` ${suffix}`;
+    return new Error(
+      `${prefix} ${formatPrompt(prompt)}${after} on stdout\n--- stdout ---\n${stripControlSequences(this.rawStdout)}\n--- stderr ---\n${stripControlSequences(this.rawStderr)}`,
+    );
+  }
+
+  private notify(): void {
+    const waiters = this.waiters.splice(0);
+    for (const waiter of waiters) {
+      waiter();
+    }
+  }
+
+  private waitUntilChange(deadlineMs: number): Promise<void> {
+    if (this.exitCode !== undefined || this.timedOut) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(
+        () => {
+          const index = this.waiters.indexOf(onChange);
+          if (index >= 0) {
+            this.waiters.splice(index, 1);
+          }
+          resolve();
+        },
+        Math.max(0, deadlineMs - Date.now()),
+      );
+      const onChange = (): void => {
+        clearTimeout(timer);
+        resolve();
+      };
+      this.waiters.push(onChange);
+    });
+  }
+
+  private async consume(
+    stream: ReadableStream<Uint8Array>,
+    onChunk: (text: string) => void,
+  ): Promise<void> {
+    const decoder = new TextDecoder();
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        onChunk(decoder.decode(value, { stream: true }));
+      }
+      const tail = decoder.decode();
+      if (tail) {
+        onChunk(tail);
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/tests/integration/harness/types.ts
+++ b/tests/integration/harness/types.ts
@@ -20,6 +20,19 @@
 
 // Integration test harness — shared types
 
+export type SessionStdin = {
+  write(data: Uint8Array): number | void;
+  end(): void;
+};
+
+export type InteractiveProcessHandle = {
+  stdin: SessionStdin | null;
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  kill(): void;
+  readonly exited: Promise<number>;
+};
+
 export interface CliResult {
   exitCode: number;
   stdout: string;
@@ -57,6 +70,12 @@ export interface RunOptions {
   /** Override the compiled CLI binary path for this invocation. */
   binaryPath?: string;
 }
+
+/** Options for `harness.runInteractive()`. Stdin is driven by the session. */
+export type RunInteractiveOptions = RunOptions & {
+  /** Per-`waitText` timeout. Defaults to `timeoutMs`. */
+  waitTimeoutMs?: number;
+};
 
 export interface RecordedRequest {
   method: string;

--- a/tests/integration/harness/types.ts
+++ b/tests/integration/harness/types.ts
@@ -72,7 +72,10 @@ export interface RunOptions {
 }
 
 /** Options for `harness.runInteractive()`. Stdin is driven by the session. */
-export type RunInteractiveOptions = RunOptions & {
+export type RunInteractiveOptions = Omit<
+  RunOptions,
+  'stdin' | 'stdinChunks' | 'stdinChunkDelayMs'
+> & {
   /** Per-`waitText` timeout. Defaults to `timeoutMs`. */
   waitTimeoutMs?: number;
 };

--- a/tests/unit/integration-harness/interactive-session.test.ts
+++ b/tests/unit/integration-harness/interactive-session.test.ts
@@ -1,0 +1,304 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  findPromptMatch,
+  formatPrompt,
+  type InteractiveProcessHandle,
+  InteractiveSession,
+  stripControlSequences,
+} from '../../integration/harness/interactive-session.ts';
+
+function createFakeProcess(): {
+  writes: string[];
+  ended: boolean;
+  killCount: number;
+  pushStdout: (text: string) => void;
+  pushStderr: (text: string) => void;
+  close: (code?: number) => void;
+  handle: InteractiveProcessHandle;
+} {
+  const writes: string[] = [];
+  let ended = false;
+  let killCount = 0;
+  let stdoutCtrl: ReadableStreamDefaultController<Uint8Array>;
+  let stderrCtrl: ReadableStreamDefaultController<Uint8Array>;
+  let resolveExit: (code: number) => void;
+  let exitCode: number | undefined;
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const exited = new Promise<number>((resolve) => {
+    resolveExit = resolve;
+  });
+
+  const close = (code = 0): void => {
+    if (exitCode !== undefined) {
+      return;
+    }
+    exitCode = code;
+    try {
+      stdoutCtrl.close();
+    } catch {
+      /* already closed */
+    }
+    try {
+      stderrCtrl.close();
+    } catch {
+      /* already closed */
+    }
+    resolveExit(code);
+  };
+
+  const handle: InteractiveProcessHandle = {
+    stdin: {
+      write(data) {
+        writes.push(decoder.decode(data));
+      },
+      end() {
+        ended = true;
+      },
+    },
+    stdout: new ReadableStream<Uint8Array>({
+      start(controller) {
+        stdoutCtrl = controller;
+      },
+    }),
+    stderr: new ReadableStream<Uint8Array>({
+      start(controller) {
+        stderrCtrl = controller;
+      },
+    }),
+    kill() {
+      killCount += 1;
+      close(1);
+    },
+    get exited() {
+      return exited;
+    },
+  };
+
+  return {
+    writes,
+    get ended() {
+      return ended;
+    },
+    get killCount() {
+      return killCount;
+    },
+    pushStdout(text) {
+      stdoutCtrl.enqueue(encoder.encode(text));
+    },
+    pushStderr(text) {
+      stderrCtrl.enqueue(encoder.encode(text));
+    },
+    close,
+    handle,
+  };
+}
+
+describe('prompt matching', () => {
+  it('formats string and regexp prompts', () => {
+    expect(formatPrompt('Scope')).toBe('"Scope"');
+    expect(formatPrompt(/hook/i)).toBe('/hook/i');
+  });
+
+  it('finds a string or regexp in the window', () => {
+    expect(findPromptMatch('Install Vortex?', 'Vortex')).toBe(14);
+    expect(findPromptMatch('Install Vortex?', /vortex/i)).toBe(14);
+    expect(findPromptMatch('Install Vortex?', 'missing')).toBeNull();
+  });
+
+  it('skips a submitted prompt line and matches the live one', () => {
+    expect(findPromptMatch('✓  Enter server URL bad-url', 'Enter server URL')).toBeNull();
+    expect(findPromptMatch('?  Enter server URL', 'Enter server URL')).toBe(19);
+    expect(
+      findPromptMatch('✓  Enter server URL bad\n?  Enter server URL', 'Enter server URL'),
+    ).toBe('✓  Enter server URL bad\n?  Enter server URL'.length);
+  });
+
+  it('skips a submitted line even when the wait text is not a prefix', () => {
+    const submitted = '  ✓  MCP server (currently installed)  Keep? No';
+    const live = '  ?  MCP server (currently installed)  Keep?';
+    expect(findPromptMatch(submitted, 'Keep?')).toBeNull();
+    expect(findPromptMatch(live, 'Keep?')).toBe(live.length);
+    expect(findPromptMatch(`${submitted}\n${live}`, 'Keep?')).toBe(`${submitted}\n${live}`.length);
+    expect(findPromptMatch(submitted, /Keep\?/)).toBeNull();
+    expect(findPromptMatch(live, /Keep\?/)).toBe(live.length);
+  });
+
+  it('does not re-anchor a regexp at the next search offset', () => {
+    expect(findPromptMatch('✓  Keep?prompt', /Keep\?|^prompt/)).toBeNull();
+    expect(findPromptMatch('✓  Keep?\nprompt', /Keep\?|^prompt/m)).toBe('✓  Keep?\nprompt'.length);
+    expect(findPromptMatch('✓  KeepXfoo', /KeepX|\bfoo/)).toBeNull();
+  });
+
+  it('strips CSI sequences so prompt text is visible', () => {
+    expect(stripControlSequences('\x1b[?25lSelect the tool\x1b[2K\r')).toBe('Select the tool');
+  });
+});
+
+describe('InteractiveSession', () => {
+  it('waits for new text, writes keys, and waitFinish is idempotent', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    const waiting = session.waitText('Select a tool');
+    fake.pushStdout('\x1b[1mSelect a tool\x1b[0m');
+    await waiting;
+
+    session.write('n');
+    session.keyEnter();
+    session.keyDown();
+    session.keyUp();
+    session.keySpace();
+    expect(fake.writes).toEqual(['n', '\r', '\x1b[B', '\x1b[A', ' ']);
+    expect(session.output()).toContain('Select a tool');
+
+    fake.close(0);
+    const first = await session.waitFinish();
+    const second = await session.waitFinish();
+    expect(first.exitCode).toBe(0);
+    expect(second).toBe(first);
+    expect(fake.ended).toBe(true);
+  });
+
+  it('does not rematch text that was already consumed', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    fake.pushStdout('Scope then Hook');
+    await session.waitText('Scope');
+
+    let rematchError: unknown;
+    try {
+      await session.waitText('Hook', 50);
+    } catch (error) {
+      rematchError = error;
+    }
+    expect(rematchError).toBeInstanceOf(Error);
+    expect(String(rematchError)).toContain('Timed out waiting for "Hook" on stdout');
+    expect(String(rematchError)).toContain('--- stdout ---');
+    expect(String(rematchError)).toContain('--- stderr ---');
+
+    const later = session.waitText('Hook');
+    fake.pushStdout(' Hook again');
+    await later;
+
+    session.kill();
+    await session.waitFinish().catch(() => undefined);
+  });
+
+  it('does not lose later text when an escape sequence splits across chunks', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    fake.pushStdout('Scope\x1b');
+    await session.waitText('Scope');
+    const later = session.waitText('Hook');
+    fake.pushStdout('[2KHook the repo');
+    await later;
+    expect(session.output()).toContain('Hook the repo');
+
+    session.kill();
+    await session.waitFinish().catch(() => undefined);
+  });
+
+  it('waits for a repeated prompt only after a write', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    fake.pushStdout('Enter server URL');
+    await session.waitText('Enter server URL');
+    session.write('bad');
+    session.keyEnter();
+
+    const again = session.waitText('Enter server URL');
+    fake.pushStdout('Enter server URL');
+    await again;
+    expect(fake.writes).toEqual(['bad', '\r']);
+
+    session.kill();
+    await session.waitFinish().catch(() => undefined);
+  });
+
+  it('does not treat a submitted prompt line as the next live prompt', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    fake.pushStdout('?  Enter server URL\n');
+    await session.waitText('Enter server URL');
+    session.write('bad-url');
+    session.keyEnter();
+
+    const submitted = session.waitText('Enter server URL', 50);
+    fake.pushStdout('✓  Enter server URL bad-url\n');
+    let rematchError: unknown;
+    try {
+      await submitted;
+    } catch (error) {
+      rematchError = error;
+    }
+    expect(rematchError).toBeInstanceOf(Error);
+    expect(String(rematchError)).toContain('Timed out waiting for "Enter server URL" on stdout');
+
+    const live = session.waitText('Enter server URL');
+    fake.pushStdout('?  Enter server URL');
+    await live;
+
+    session.kill();
+    await session.waitFinish().catch(() => undefined);
+  });
+
+  it('throws when the process exits before the prompt appears', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    const waiting = session.waitText('never shown');
+    fake.close(1);
+    let exitError: unknown;
+    try {
+      await waiting;
+    } catch (error) {
+      exitError = error;
+    }
+    expect(exitError).toBeInstanceOf(Error);
+    expect(String(exitError)).toContain('CLI exited before "never shown" appeared on stdout');
+  });
+
+  it('sends Ctrl+C on keyCtrlC and treats kill as idempotent', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    fake.pushStdout('pick one');
+    await session.waitText('pick one');
+    session.keyCtrlC();
+    expect(fake.writes).toEqual(['\x03']);
+
+    session.kill();
+    session.kill();
+    expect(fake.killCount).toBe(1);
+
+    const result = await session.waitFinish();
+    expect(result.exitCode).toBe(1);
+    expect(session.output()).toContain('pick one');
+  });
+});

--- a/tests/unit/integration-harness/interactive-session.test.ts
+++ b/tests/unit/integration-harness/interactive-session.test.ts
@@ -145,6 +145,12 @@ describe('prompt matching', () => {
     expect(findPromptMatch(live, /Keep\?/)).toBe(live.length);
   });
 
+  it('skips a submitted frame concatenated onto the previous paint', () => {
+    const painted = '  › No  ✓  Keep? No  ?  Install Vortex?';
+    expect(findPromptMatch(painted, 'Keep?')).toBeNull();
+    expect(findPromptMatch(painted, 'Install Vortex?')).toBe(painted.length);
+  });
+
   it('does not re-anchor a regexp at the next search offset', () => {
     expect(findPromptMatch('✓  Keep?prompt', /Keep\?|^prompt/)).toBeNull();
     expect(findPromptMatch('✓  Keep?\nprompt', /Keep\?|^prompt/m)).toBe('✓  Keep?\nprompt'.length);
@@ -181,27 +187,36 @@ describe('InteractiveSession', () => {
     expect(fake.ended).toBe(true);
   });
 
-  it('does not rematch text that was already consumed', async () => {
+  it('keeps unread stdout for a later waitText', async () => {
     const fake = createFakeProcess();
     const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
 
     fake.pushStdout('Scope then Hook');
     await session.waitText('Scope');
+    await session.waitText('Hook');
+    expect(session.output()).toContain('Scope then Hook');
+
+    session.kill();
+    await session.waitFinish().catch(() => undefined);
+  });
+
+  it('does not rematch the same occurrence', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    fake.pushStdout('Scope');
+    await session.waitText('Scope');
 
     let rematchError: unknown;
     try {
-      await session.waitText('Hook', 50);
+      await session.waitText('Scope', 50);
     } catch (error) {
       rematchError = error;
     }
     expect(rematchError).toBeInstanceOf(Error);
-    expect(String(rematchError)).toContain('Timed out waiting for "Hook" on stdout');
+    expect(String(rematchError)).toContain('Timed out waiting for "Scope" on stdout');
     expect(String(rematchError)).toContain('--- stdout ---');
     expect(String(rematchError)).toContain('--- stderr ---');
-
-    const later = session.waitText('Hook');
-    fake.pushStdout(' Hook again');
-    await later;
 
     session.kill();
     await session.waitFinish().catch(() => undefined);
@@ -296,6 +311,7 @@ describe('InteractiveSession', () => {
     session.kill();
     session.kill();
     expect(fake.killCount).toBe(1);
+    expect(() => session.write('x')).toThrow('after kill()');
 
     const result = await session.waitFinish();
     expect(result.exitCode).toBe(1);


### PR DESCRIPTION
## Summary
- Adds `harness.runInteractive()` and an `InteractiveSession` (`waitText`, keystrokes, `waitFinish`, `kill`)
- Leaves `run()` and `stdin` / `stdinChunks` in place so existing tests keep working