### PR TITLE
CLI-1037 Drive interactive tests with runInteractive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ Before writing a test, find an existing spec for the same command area and follo
 
 ### Integration test harness
 
-Each test creates a fresh `TestHarness` and disposes it in `afterEach`. The harness runs the compiled binary in a fully isolated environment (temp dir, fake keychain, fake servers). For fine-grained state setup beyond `withAuth`, use `harness.state()` builder (see `tests/integration/harness/environment-builder.ts`). For git hook tests, use `initGitRepo` / `stageFile` from `tests/integration/specs/hook/git-test-helpers.ts`. Use `harness.run()` for non-interactive commands and dump-all stdin (`stdin` / `stdinChunks`). Drive prompt-by-prompt flows with `harness.runInteractive()`, which returns an `InteractiveSession` (`waitText`, `write` / `keyEnter` / `keyUp` / `keyDown` / `keySpace` / `keyCtrlC`, then `waitFinish()`). `dispose()` kills any session that is still running.
+Each test creates a fresh `TestHarness` and disposes it in `afterEach`. The harness runs the compiled binary in a fully isolated environment (temp dir, fake keychain, fake servers). For fine-grained state setup beyond `withAuth`, use `harness.state()` builder (see `tests/integration/harness/environment-builder.ts`). For git hook tests, use `initGitRepo` / `stageFile` from `tests/integration/specs/hook/git-test-helpers.ts`. Use `harness.run()` for non-interactive commands. Drive stdin and prompt-by-prompt flows with `harness.runInteractive()`, which returns an `InteractiveSession` (`waitText`, `write` / `keyEnter` / `keyUp` / `keyDown` / `keySpace` / `keyCtrlC`, then `waitFinish()`). `dispose()` kills any session that is still running.
 
 ### Coverage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ The two inputs are separate because the single boolean made _collect but do not 
 
 **Writing tests that touch telemetry** — four traps, none of which lint or CI will catch:
 
-- **Spawn the CLI only through the harness** (`harness.run()`, `harness.runInteractive()`, `runCli()`) or by spreading `ISOLATED_CLI_SPAWN_ENV`. A hand-rolled `Bun.spawn` of the binary inherits production egress; the two such spawns in `tests/e2e/install-scripts.test.ts` are safe only because they spread it explicitly.
+- **Spawn the CLI only through the harness** (`harness.run()`, `harness.runInteractive()`, `harness.runWithStdin()`) or by spreading `ISOLATED_CLI_SPAWN_ENV`. A hand-rolled `Bun.spawn` of the binary inherits production egress; the two such spawns in `tests/e2e/install-scripts.test.ts` are safe only because they spread it explicitly.
 - **A unit test that enables telemetry must point `SONAR_USER_HOME` at a temp dir.** Egress `off` stops _that process_ transmitting, but events still land in the developer's real `~/.sonar` queue, and their next genuine `sonar` command drains and POSTs them. This is the one leak path the egress mode cannot close, because the transmitting process is legitimate.
 - **Clearing `__SQ_CLI_TELEMETRY_EGRESS`** to exercise the spawn or drain means the real code paths run: mock `Bun.spawn` and `fetch` in the same file.
 - **`flushTelemetryEvents` transmits unconditionally** — its guards are in `flushTelemetry`. Call it directly only with `fetch` mocked.
@@ -214,7 +214,7 @@ Before writing a test, find an existing spec for the same command area and follo
 
 ### Integration test harness
 
-Each test creates a fresh `TestHarness` and disposes it in `afterEach`. The harness runs the compiled binary in a fully isolated environment (temp dir, fake keychain, fake servers). For fine-grained state setup beyond `withAuth`, use `harness.state()` builder (see `tests/integration/harness/environment-builder.ts`). For git hook tests, use `initGitRepo` / `stageFile` from `tests/integration/specs/hook/git-test-helpers.ts`. Use `harness.run()` for non-interactive commands. Drive stdin and prompt-by-prompt flows with `harness.runInteractive()`, which returns an `InteractiveSession` (`waitText`, `write` / `keyEnter` / `keyUp` / `keyDown` / `keySpace` / `keyCtrlC`, then `waitFinish()`). `dispose()` kills any session that is still running.
+Each test creates a fresh `TestHarness` and disposes it in `afterEach`. The harness runs the compiled binary in a fully isolated environment (temp dir, fake keychain, fake servers). For fine-grained state setup beyond `withAuth`, use `harness.state()` builder (see `tests/integration/harness/environment-builder.ts`). For git hook tests, use `initGitRepo` / `stageFile` from `tests/integration/specs/hook/git-test-helpers.ts`. Use `harness.run()` for non-interactive commands. Use `harness.runWithStdin()` to dump stdin and wait for exit. Drive prompt-by-prompt flows with `harness.runInteractive()`, which returns an `InteractiveSession` (`waitText`, `accept` / `decline`, `write` / `keyEnter` / `keyUp` / `keyDown` / `keySpace` / `keyCtrlC`, then `waitFinish()`). `dispose()` kills any session that is still running.
 
 ### Coverage
 

--- a/build-scripts/ux-report/generate-ux-report.ts
+++ b/build-scripts/ux-report/generate-ux-report.ts
@@ -856,8 +856,7 @@ uxDescribe('Interactive auth login', () => {
         extraEnv: cloudEnvFor(cloudUrl),
         browserToken: TOKEN,
       });
-      await session.waitText('Select an organization');
-      session.keyEnter();
+      await session.accept('Select an organization');
       return session.waitFinish();
     }),
   );
@@ -903,10 +902,8 @@ uxDescribe('Interactive auth login', () => {
         extraEnv: cloudEnvFor(cloudUrl),
         browserToken: TOKEN,
       });
-      await session.waitText('Where would you like to connect?');
-      session.keyEnter();
-      await session.waitText('Which SonarQube Cloud region?');
-      session.keyEnter();
+      await session.accept('Where would you like to connect?');
+      await session.accept('Which SonarQube Cloud region?');
       return session.waitFinish();
     }),
   );

--- a/build-scripts/ux-report/generate-ux-report.ts
+++ b/build-scripts/ux-report/generate-ux-report.ts
@@ -522,10 +522,13 @@ uxDescribe('SonarQube Cloud — Happy Path', () => {
         })
         .start();
       h.state().withAuth(server.baseUrl(), TOKEN, ORG);
-      return h.run(`remediate -p ${PROJECT}`, {
+      const session = h.runInteractive(`remediate -p ${PROJECT}`, {
         extraEnv: { SONARQUBE_CLI_MOCK_TTY: '1' },
-        stdinChunks: [' ', '\r'],
       });
+      await session.waitText('Which issues should the agent fix?');
+      session.keySpace();
+      session.keyEnter();
+      return session.waitFinish();
     }),
   );
   uxIt('auth logout (Cloud)', () => harness.run('auth logout'));
@@ -827,11 +830,14 @@ uxDescribe('Interactive auth login', () => {
         ])
         .start();
       const cloudUrl = server.baseUrl();
-      return h.run(`auth login --server ${cloudUrl}`, {
+      const session = h.runInteractive(`auth login --server ${cloudUrl}`, {
         extraEnv: cloudEnvFor(cloudUrl),
         browserToken: TOKEN,
-        stdin: '\x1b[B\r',
       });
+      await session.waitText('Select an organization');
+      session.keyDown();
+      session.keyEnter();
+      return session.waitFinish();
     }),
   );
 
@@ -846,11 +852,13 @@ uxDescribe('Interactive auth login', () => {
         .withOrganizationTotal(200)
         .start();
       const cloudUrl = server.baseUrl();
-      return h.run(`auth login --server ${cloudUrl}`, {
+      const session = h.runInteractive(`auth login --server ${cloudUrl}`, {
         extraEnv: cloudEnvFor(cloudUrl),
         browserToken: TOKEN,
-        stdin: '\r',
       });
+      await session.waitText('Select an organization');
+      session.keyEnter();
+      return session.waitFinish();
     }),
   );
 
@@ -858,11 +866,14 @@ uxDescribe('Interactive auth login', () => {
     withHarness(async (h) => {
       const server = await h.newFakeServer().withAuthToken(TOKEN).start();
       const cloudUrl = server.baseUrl();
-      return h.run(`auth login --server ${cloudUrl}`, {
+      const session = h.runInteractive(`auth login --server ${cloudUrl}`, {
         extraEnv: cloudEnvFor(cloudUrl),
         browserToken: TOKEN,
-        stdin: 'open-source-org\r',
       });
+      await session.waitText('Enter organization key');
+      session.write('open-source-org');
+      session.keyEnter();
+      return session.waitFinish();
     }),
   );
 
@@ -870,11 +881,13 @@ uxDescribe('Interactive auth login', () => {
     withHarness(async (h) => {
       const server = await h.newFakeServer().withAuthToken(TOKEN).start();
       const cloudUrl = server.baseUrl();
-      return h.run(`auth login --server ${cloudUrl}`, {
+      const session = h.runInteractive(`auth login --server ${cloudUrl}`, {
         extraEnv: cloudEnvFor(cloudUrl),
         browserToken: TOKEN,
-        stdin: '\x03',
       });
+      await session.waitText('Enter organization key');
+      session.keyCtrlC();
+      return session.waitFinish();
     }),
   );
 
@@ -886,11 +899,15 @@ uxDescribe('Interactive auth login', () => {
         .withOrganizations([{ key: ORG, name: 'My Org' }])
         .start();
       const cloudUrl = server.baseUrl();
-      return h.run('auth login', {
+      const session = h.runInteractive('auth login', {
         extraEnv: cloudEnvFor(cloudUrl),
         browserToken: TOKEN,
-        stdinChunks: ['\r', '\r'], // Enter (Cloud), Enter (EU)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyEnter();
+      await session.waitText('Which SonarQube Cloud region?');
+      session.keyEnter();
+      return session.waitFinish();
     }),
   );
 });

--- a/tests/e2e/claude/claude-integration.test.ts
+++ b/tests/e2e/claude/claude-integration.test.ts
@@ -263,11 +263,13 @@ describe.skipIf(!isClaudeCodeEnvSetup())(
       serverUrl: string,
       options?: IntegrateOptions,
     ) {
-      const login = await harness.run(`auth login --server ${serverUrl}`, {
+      const session = harness.runInteractive(`auth login --server ${serverUrl}`, {
         extraEnv,
         browserToken: TEST_TOKEN,
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
+      await session.waitText('Connect to:');
+      session.keyEnter();
+      const login = await session.waitFinish();
       const integrate = await harness.run(
         `integrate claude --non-interactive${options?.global ? ' -g' : ''}`,
         {

--- a/tests/e2e/claude/claude-integration.test.ts
+++ b/tests/e2e/claude/claude-integration.test.ts
@@ -267,8 +267,7 @@ describe.skipIf(!isClaudeCodeEnvSetup())(
         extraEnv,
         browserToken: TEST_TOKEN,
       });
-      await session.waitText('Connect to:');
-      session.keyEnter();
+      await session.accept('Connect to:');
       const login = await session.waitFinish();
       const integrate = await harness.run(
         `integrate claude --non-interactive${options?.global ? ' -g' : ''}`,

--- a/tests/e2e/context/cag-passthrough.test.ts
+++ b/tests/e2e/context/cag-passthrough.test.ts
@@ -114,10 +114,12 @@ describe('sonar-context-augmentation passthrough behaviors (offline, real binary
   });
 
   it('forwards a Claude Bash hook payload to the real CAG binary and applies Gradle compression', async () => {
-    const result = await harness.run('context __hook Claude', {
+    const session = harness.runInteractive('context __hook Claude', {
       timeoutMs: PASSTHROUGH_TIMEOUT_MS,
       extraEnv: authEnv,
-      stdin: JSON.stringify({
+    });
+    session.write(
+      JSON.stringify({
         hook_event_name: 'PostToolUse',
         tool_name: 'Bash',
         tool_input: { command: './gradlew build', description: 'Run Gradle build' },
@@ -129,7 +131,8 @@ describe('sonar-context-augmentation passthrough behaviors (offline, real binary
           noOutputExpected: false,
         },
       }),
-    });
+    );
+    const result = await session.waitFinish();
     expect(result.exitCode, result.stderr).toBe(0);
     expect(result.stderr).not.toContain('unrecognized subcommand');
     expect(result.stdout).toContain('hookSpecificOutput');

--- a/tests/e2e/context/cag-passthrough.test.ts
+++ b/tests/e2e/context/cag-passthrough.test.ts
@@ -114,11 +114,8 @@ describe('sonar-context-augmentation passthrough behaviors (offline, real binary
   });
 
   it('forwards a Claude Bash hook payload to the real CAG binary and applies Gradle compression', async () => {
-    const session = harness.runInteractive('context __hook Claude', {
-      timeoutMs: PASSTHROUGH_TIMEOUT_MS,
-      extraEnv: authEnv,
-    });
-    session.write(
+    const result = await harness.runWithStdin(
+      'context __hook Claude',
       JSON.stringify({
         hook_event_name: 'PostToolUse',
         tool_name: 'Bash',
@@ -131,8 +128,11 @@ describe('sonar-context-augmentation passthrough behaviors (offline, real binary
           noOutputExpected: false,
         },
       }),
+      {
+        timeoutMs: PASSTHROUGH_TIMEOUT_MS,
+        extraEnv: authEnv,
+      },
     );
-    const result = await session.waitFinish();
     expect(result.exitCode, result.stderr).toBe(0);
     expect(result.stderr).not.toContain('unrecognized subcommand');
     expect(result.stdout).toContain('hookSpecificOutput');

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -235,8 +235,22 @@ export class TestHarness {
   }
 
   /**
+   * Dump stdin on a session and wait for exit. Use `waitText` + keystrokes for prompts.
+   */
+  async runWithStdin(
+    command: string,
+    stdin: string,
+    options?: RunInteractiveOptions,
+  ): Promise<CliResult> {
+    const session = this.runInteractive(command, options);
+    session.write(stdin);
+    return session.waitFinish();
+  }
+
+  /**
    * Spawns the CLI and returns a session the test drives prompt-by-prompt.
-   * Use `run()` when the command is non-interactive or only needs dump-all stdin.
+   * Use `run()` when the command is non-interactive. Drive stdin through the session
+   * (`runWithStdin` for dump-all, or `waitText` + keys for prompts).
    */
   runInteractive(command: string, options?: RunInteractiveOptions): InteractiveSession {
     const session = startInteractiveSession(command, this.env(options), {

--- a/tests/integration/harness/interactive-session.ts
+++ b/tests/integration/harness/interactive-session.ts
@@ -240,6 +240,16 @@ export class InteractiveSession {
     stdin.write(this.encoder.encode(keys));
   }
 
+  async accept(prompt: PromptText): Promise<void> {
+    await this.waitText(prompt);
+    this.keyEnter();
+  }
+
+  async decline(prompt: PromptText): Promise<void> {
+    await this.waitText(prompt);
+    this.write('n');
+  }
+
   keyEnter(): void {
     this.write(ENTER);
   }

--- a/tests/integration/specs/analyze/analyze-secrets.test.ts
+++ b/tests/integration/specs/analyze/analyze-secrets.test.ts
@@ -107,7 +107,9 @@ describe('analyze secrets', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('analyze secrets --stdin', { stdin: CLEAN_CONTENT });
+      const session = harness.runInteractive('analyze secrets --stdin');
+      session.write(CLEAN_CONTENT);
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('No issues found');
@@ -121,9 +123,9 @@ describe('analyze secrets', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('analyze secrets --stdin', {
-        stdin: `const token = "${GITHUB_TEST_TOKEN}";`,
-      });
+      const session = harness.runInteractive('analyze secrets --stdin');
+      session.write(`const token = "${GITHUB_TEST_TOKEN}";`);
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(EXIT_CODE_SECRETS_FOUND);
       // Binary reports auth failure when credentials point to an unreachable server

--- a/tests/integration/specs/analyze/analyze-secrets.test.ts
+++ b/tests/integration/specs/analyze/analyze-secrets.test.ts
@@ -107,9 +107,7 @@ describe('analyze secrets', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('analyze secrets --stdin');
-      session.write(CLEAN_CONTENT);
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('analyze secrets --stdin', CLEAN_CONTENT);
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('No issues found');
@@ -123,9 +121,10 @@ describe('analyze secrets', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('analyze secrets --stdin');
-      session.write(`const token = "${GITHUB_TEST_TOKEN}";`);
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'analyze secrets --stdin',
+        `const token = "${GITHUB_TEST_TOKEN}";`,
+      );
 
       expect(result.exitCode).toBe(EXIT_CODE_SECRETS_FOUND);
       // Binary reports auth failure when credentials point to an unreachable server

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -39,7 +39,7 @@ import {
 } from '../../../_common/agent-hint-assertions.js';
 import type { StoredAnalysisCompletedEvent } from '../../../_common/telemetry-helpers';
 import { readAnalysisEvents, readCommandEvents } from '../../../_common/telemetry-helpers';
-import { TestHarness } from '../../harness';
+import { type CliResult, TestHarness } from '../../harness';
 import { commitFile, git, initGitRepo, stageFile } from '../hook/git-test-helpers';
 import {
   allSqaaRequestsUseDeep,
@@ -1636,13 +1636,19 @@ describe('analyze agentic — change-set mode (no --file)', () => {
         harness.cwd.writeFile(`file${i}.ts`, `const x${i} = ${i};`);
       }
 
-      const result = await harness.run(`analyze agentic${isInteractive ? '' : ' --force'}`, {
-        ...(isInteractive ? { stdinChunks: ['\r'] } : {}),
-        extraEnv: {
-          SONARQUBE_CLI_MOCK_TTY: '1',
-          ...(isAgent ? { CLAUDECODE: '1' } : {}),
-        },
-      });
+      const extraEnv = {
+        SONARQUBE_CLI_MOCK_TTY: '1',
+        ...(isAgent ? { CLAUDECODE: '1' } : {}),
+      };
+      let result: CliResult;
+      if (isInteractive) {
+        const session = harness.runInteractive('analyze agentic', { extraEnv });
+        await session.waitText('Do you wish to proceed?');
+        session.keyEnter();
+        result = await session.waitFinish();
+      } else {
+        result = await harness.run('analyze agentic --force', { extraEnv });
+      }
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {

--- a/tests/integration/specs/analyze/analyze-sqaa.test.ts
+++ b/tests/integration/specs/analyze/analyze-sqaa.test.ts
@@ -1643,8 +1643,7 @@ describe('analyze agentic — change-set mode (no --file)', () => {
       let result: CliResult;
       if (isInteractive) {
         const session = harness.runInteractive('analyze agentic', { extraEnv });
-        await session.waitText('Do you wish to proceed?');
-        session.keyEnter();
+        await session.accept('Do you wish to proceed?');
         result = await session.waitFinish();
       } else {
         result = await harness.run('analyze agentic --force', { extraEnv });

--- a/tests/integration/specs/auth/auth.test.ts
+++ b/tests/integration/specs/auth/auth.test.ts
@@ -36,8 +36,7 @@ async function confirmTrust(
   options?: RunInteractiveOptions,
 ) {
   const session = harness.runInteractive(command, options);
-  await session.waitText('Connect to:');
-  session.keyEnter();
+  await session.accept('Connect to:');
   return session.waitFinish();
 }
 
@@ -47,8 +46,7 @@ async function declineTrust(
   options?: RunInteractiveOptions,
 ) {
   const session = harness.runInteractive(command, options);
-  await session.waitText('Connect to:');
-  session.write('n');
+  await session.decline('Connect to:');
   return session.waitFinish();
 }
 
@@ -388,8 +386,7 @@ describe('auth login — organization selection', () => {
       },
       browserToken: 'my-token',
     });
-    await session.waitText('Enter organization key');
-    session.keyEnter();
+    await session.accept('Enter organization key');
     const result = await session.waitFinish();
 
     expect(result.exitCode).not.toBe(0);
@@ -778,10 +775,8 @@ describe('auth login — server selection', () => {
         },
         browserToken: 'my-token',
       });
-      await session.waitText('Where would you like to connect?');
-      session.keyEnter();
-      await session.waitText('Which SonarQube Cloud region?');
-      session.keyEnter();
+      await session.accept('Where would you like to connect?');
+      await session.accept('Which SonarQube Cloud region?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -810,8 +805,7 @@ describe('auth login — server selection', () => {
         },
         browserToken: 'my-token',
       });
-      await session.waitText('Where would you like to connect?');
-      session.keyEnter();
+      await session.accept('Where would you like to connect?');
       await session.waitText('Which SonarQube Cloud region?');
       session.keyDown();
       session.keyEnter();
@@ -846,10 +840,8 @@ describe('auth login — server selection', () => {
         },
         browserToken: 'my-token',
       });
-      await session.waitText('Where would you like to connect?');
-      session.keyEnter();
-      await session.waitText('Which SonarQube Cloud region?');
-      session.keyEnter();
+      await session.accept('Where would you like to connect?');
+      await session.accept('Which SonarQube Cloud region?');
       await session.waitText('Select an organization');
       session.keyDown();
       session.keyEnter();
@@ -877,8 +869,7 @@ describe('auth login — server selection', () => {
       await session.waitText('Enter server URL');
       session.write(`${server.baseUrl()}`);
       session.keyEnter();
-      await session.waitText('Connect to:');
-      session.keyEnter();
+      await session.accept('Connect to:');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -931,13 +922,11 @@ describe('auth login — server selection', () => {
       await session.waitText('Where would you like to connect?');
       session.keyDown();
       session.keyEnter();
-      await session.waitText('Enter server URL');
-      session.keyEnter();
+      await session.accept('Enter server URL');
       await session.waitText('Please enter a valid URL');
       session.write(`${server.baseUrl()}`);
       session.keyEnter();
-      await session.waitText('Connect to:');
-      session.keyEnter();
+      await session.accept('Connect to:');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -966,8 +955,7 @@ describe('auth login — server selection', () => {
       await session.waitText('Please enter a valid URL');
       session.write(`${server.baseUrl()}`);
       session.keyEnter();
-      await session.waitText('Connect to:');
-      session.keyEnter();
+      await session.accept('Connect to:');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -1002,8 +990,7 @@ describe('auth login — server selection', () => {
       await session.waitText('Please enter a valid URL');
       session.write(`${server.baseUrl()}`);
       session.keyEnter();
-      await session.waitText('Connect to:');
-      session.keyEnter();
+      await session.accept('Connect to:');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -1044,8 +1031,7 @@ describe('auth login — server selection', () => {
       await session.waitText('Enter server URL');
       session.write(`${server.baseUrl()}`);
       session.keyEnter();
-      await session.waitText('Connect to:');
-      session.keyEnter();
+      await session.accept('Connect to:');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -1067,8 +1053,7 @@ describe('auth login — server selection', () => {
       await session.waitText('Enter server URL');
       session.write(`${server.baseUrl()}`);
       session.keyEnter();
-      await session.waitText('Connect to:');
-      session.write('n');
+      await session.decline('Connect to:');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);

--- a/tests/integration/specs/auth/auth.test.ts
+++ b/tests/integration/specs/auth/auth.test.ts
@@ -28,7 +28,29 @@ import { ENV_ORG, ENV_SERVER, ENV_TOKEN } from '@/core/auth/auth-resolver.ts';
 import { SONARCLOUD_URL, SONARCLOUD_US_URL } from '@/core/config-constants.ts';
 import { generateKeychainAccount } from '@/core/host/keychain.ts';
 
-import { TestHarness } from '../../harness';
+import { type RunInteractiveOptions, TestHarness } from '../../harness';
+
+async function confirmTrust(
+  harness: TestHarness,
+  command: string,
+  options?: RunInteractiveOptions,
+) {
+  const session = harness.runInteractive(command, options);
+  await session.waitText('Connect to:');
+  session.keyEnter();
+  return session.waitFinish();
+}
+
+async function declineTrust(
+  harness: TestHarness,
+  command: string,
+  options?: RunInteractiveOptions,
+) {
+  const session = harness.runInteractive(command, options);
+  await session.waitText('Connect to:');
+  session.write('n');
+  return session.waitFinish();
+}
 
 function readKeychainToken(keychainFile: string, account: string): string | undefined {
   try {
@@ -68,9 +90,8 @@ describe('auth login', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-login-token').start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'my-login-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -92,10 +113,9 @@ describe('auth login', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('browser-login-token').start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'browser-login-token',
         browserTokenName: 'cli-browser-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -119,9 +139,7 @@ describe('auth login', () => {
         .withTokenName('cli-browser-token')
         .withKeychainToken(server.baseUrl(), 'browser-login-token');
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
-        stdin: '\r', // Enter (confirm trust, Yes is default)
-      });
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`);
 
       expect(result.exitCode).toBe(0);
       const state = harness.stateJsonFile.asJson() as {
@@ -214,17 +232,15 @@ describe('auth login', () => {
       const server1 = await harness.newFakeServer().withAuthToken('tok-1').start();
       const server2 = await harness.newFakeServer().withAuthToken('tok-2').start();
 
-      await harness.run(`auth login --server ${server1.baseUrl()}`, {
+      await confirmTrust(harness, `auth login --server ${server1.baseUrl()}`, {
         browserToken: 'tok-1',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
       const { installationId } = (
         harness.stateJsonFile.asJson() as { telemetry: { installationId: string } }
       ).telemetry;
 
-      await harness.run(`auth login --server ${server2.baseUrl()}`, {
+      await confirmTrust(harness, `auth login --server ${server2.baseUrl()}`, {
         browserToken: 'tok-2',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
       const stateAfter = harness.stateJsonFile.asJson() as {
         telemetry: { installationId: string };
@@ -242,9 +258,8 @@ describe('auth login', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -259,9 +274,7 @@ describe('auth login', () => {
     async () => {
       const server = await harness.newFakeServer().start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
-        stdin: 'n\n', // n (decline trust)
-      });
+      const result = await declineTrust(harness, `auth login --server ${server.baseUrl()}`);
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('Only connect to servers you trust');
@@ -323,14 +336,17 @@ describe('auth login — organization selection', () => {
         .withVisibleOrganizations([{ key: 'open-source-org', name: 'Open Source Org' }])
         .start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
           SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
         },
         browserToken: 'my-token',
-        stdin: 'open-source-org\r',
       });
+      await session.waitText('Enter organization key');
+      session.write('open-source-org');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(
@@ -345,14 +361,16 @@ describe('auth login — organization selection', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
           SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
         },
         browserToken: 'my-token',
-        stdin: '\x03', // Ctrl+C
       });
+      await session.waitText('Enter organization key');
+      session.keyCtrlC();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toContain('Organization selection cancelled');
@@ -363,14 +381,16 @@ describe('auth login — organization selection', () => {
   it('exits with error when user enters an empty organization key', async () => {
     const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-    const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+    const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
       extraEnv: {
         SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
         SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
       },
       browserToken: 'my-token',
-      stdin: '\r', // Enter
     });
+    await session.waitText('Enter organization key');
+    session.keyEnter();
+    const result = await session.waitFinish();
 
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain('Organization key is required');
@@ -386,14 +406,17 @@ describe('auth login — organization selection', () => {
       ])
       .start();
 
-    const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+    const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
       extraEnv: {
         SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
         SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
       },
       browserToken: 'my-token',
-      stdin: '\x1b[B\r', // down once, enter
     });
+    await session.waitText('Select an organization');
+    session.keyDown();
+    session.keyEnter();
+    const result = await session.waitFinish();
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain(
@@ -411,14 +434,18 @@ describe('auth login — organization selection', () => {
       .withOrganizationTotal(LARGE_ORG_TOTAL)
       .start();
 
-    const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+    const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
       extraEnv: {
         SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
         SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
       },
       browserToken: 'my-token',
-      stdin: '\x1b[B\x1b[B\r', // down twice, enter
     });
+    await session.waitText('Select an organization');
+    session.keyDown();
+    session.keyDown();
+    session.keyEnter();
+    const result = await session.waitFinish();
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain(
@@ -437,14 +464,17 @@ describe('auth login — organization selection', () => {
       ])
       .start();
 
-    const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+    const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
       extraEnv: {
         SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
         SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
       },
       browserToken: 'my-token',
-      stdin: '\x1b[B\r', // down once, enter
     });
+    await session.waitText('Select an organization');
+    session.keyDown();
+    session.keyEnter();
+    const result = await session.waitFinish();
 
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain(
@@ -526,11 +556,14 @@ describe('auth login — organization validation', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
         extraEnv: cloudEnv(server.baseUrl()),
         browserToken: 'my-token',
-        stdin: 'hgfjhgfhj\r',
       });
+      await session.waitText('Enter organization key');
+      session.write('hgfjhgfhj');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("Organization 'hgfjhgfhj' not found or not accessible");
@@ -738,14 +771,18 @@ describe('auth login — server selection', () => {
         .withOrganizations([{ key: 'my-org', name: 'My Org' }])
         .start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
           SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
         },
         browserToken: 'my-token',
-        stdinChunks: ['\r', '\r'], // Enter (Cloud), Enter (EU)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyEnter();
+      await session.waitText('Which SonarQube Cloud region?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Authentication successful');
@@ -766,14 +803,19 @@ describe('auth login — server selection', () => {
         .withOrganizations([{ key: 'us-org', name: 'US Org' }])
         .start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_US_URL: server.baseUrl(),
           SONARQUBE_CLI_SONARCLOUD_US_API_URL: server.baseUrl(),
         },
         browserToken: 'my-token',
-        stdinChunks: ['\r', '\x1b[B\r'], // Enter (Cloud), down+Enter (US)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyEnter();
+      await session.waitText('Which SonarQube Cloud region?');
+      session.keyDown();
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Authentication successful');
@@ -797,14 +839,21 @@ describe('auth login — server selection', () => {
         ])
         .start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: server.baseUrl(),
           SONARQUBE_CLI_SONARCLOUD_API_URL: server.baseUrl(),
         },
         browserToken: 'my-token',
-        stdinChunks: ['\r', '\r', '\x1b[B\r'], // Enter (Cloud), Enter (EU), down+Enter (org 2)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyEnter();
+      await session.waitText('Which SonarQube Cloud region?');
+      session.keyEnter();
+      await session.waitText('Select an organization');
+      session.keyDown();
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(
@@ -819,10 +868,18 @@ describe('auth login — server selection', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         browserToken: 'my-token',
-        stdinChunks: ['\x1b[B\r', `${server.baseUrl()}\r`, '\r'], // down+Enter (Server), URL+Enter, Enter (confirm trust, Yes is default)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyDown();
+      session.keyEnter();
+      await session.waitText('Enter server URL');
+      session.write(`${server.baseUrl()}`);
+      session.keyEnter();
+      await session.waitText('Connect to:');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('Authentication successful');
@@ -841,13 +898,11 @@ describe('auth login — server selection', () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
       const login = `auth login --server ${server.baseUrl()} --org some-org`;
 
-      const first = await harness.run(login, {
+      const first = await confirmTrust(harness, login, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
-      const second = await harness.run(login, {
+      const second = await confirmTrust(harness, login, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(first.exitCode).toBe(0);
@@ -870,10 +925,20 @@ describe('auth login — server selection', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         browserToken: 'my-token',
-        stdinChunks: ['\x1b[B\r', '\r', `${server.baseUrl()}\r`, '\r'], // Server, blank, valid URL, Enter (confirm trust, Yes is default)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyDown();
+      session.keyEnter();
+      await session.waitText('Enter server URL');
+      session.keyEnter();
+      await session.waitText('Please enter a valid URL');
+      session.write(`${server.baseUrl()}`);
+      session.keyEnter();
+      await session.waitText('Connect to:');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(
@@ -889,10 +954,21 @@ describe('auth login — server selection', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         browserToken: 'my-token',
-        stdinChunks: ['\x1b[B\r', 'not-a-url\r', `${server.baseUrl()}\r`, '\r'], // Server, invalid, valid URL, Enter (confirm trust, Yes is default)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyDown();
+      session.keyEnter();
+      await session.waitText('Enter server URL');
+      session.write('not-a-url');
+      session.keyEnter();
+      await session.waitText('Please enter a valid URL');
+      session.write(`${server.baseUrl()}`);
+      session.keyEnter();
+      await session.waitText('Connect to:');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain(
@@ -908,17 +984,27 @@ describe('auth login — server selection', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         browserToken: 'my-token',
-        stdinChunks: [
-          '\x1b[B\r', // down+Enter (Server)
-          'bad-url-1\r', // invalid attempt 1
-          'bad-url-2\r', // invalid attempt 2
-          'bad-url-3\r', // invalid attempt 3
-          `${server.baseUrl()}\r`, // valid URL
-          '\r', // Enter (confirm trust, Yes is default)
-        ],
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyDown();
+      session.keyEnter();
+      await session.waitText('Enter server URL');
+      session.write('bad-url-1');
+      session.keyEnter();
+      await session.waitText('Please enter a valid URL');
+      session.write('bad-url-2');
+      session.keyEnter();
+      await session.waitText('Please enter a valid URL');
+      session.write('bad-url-3');
+      session.keyEnter();
+      await session.waitText('Please enter a valid URL');
+      session.write(`${server.baseUrl()}`);
+      session.keyEnter();
+      await session.waitText('Connect to:');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const errorMsg =
@@ -933,9 +1019,10 @@ describe('auth login — server selection', () => {
   it(
     'exits with error when user cancels the server selection prompt',
     async () => {
-      const result = await harness.run('auth login', {
-        stdin: '\x03', // Ctrl+C
-      });
+      const session = harness.runInteractive('auth login');
+      await session.waitText('Where would you like to connect?');
+      session.keyCtrlC();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stderr).toContain('Server selection cancelled');
@@ -948,10 +1035,18 @@ describe('auth login — server selection', () => {
     async () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
 
-      const result = await harness.run('auth login', {
+      const session = harness.runInteractive('auth login', {
         browserToken: 'my-token',
-        stdinChunks: ['\x1b[B\r', `${server.baseUrl()}\r`, '\r'], // Server, URL, Enter (confirm trust, Yes is default)
       });
+      await session.waitText('Where would you like to connect?');
+      session.keyDown();
+      session.keyEnter();
+      await session.waitText('Enter server URL');
+      session.write(`${server.baseUrl()}`);
+      session.keyEnter();
+      await session.waitText('Connect to:');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('Only connect to servers you trust');
@@ -965,9 +1060,16 @@ describe('auth login — server selection', () => {
     async () => {
       const server = await harness.newFakeServer().start();
 
-      const result = await harness.run('auth login', {
-        stdinChunks: ['\x1b[B\r', `${server.baseUrl()}\r`, 'n\r'], // Server, URL, n (decline trust)
-      });
+      const session = harness.runInteractive('auth login');
+      await session.waitText('Where would you like to connect?');
+      session.keyDown();
+      session.keyEnter();
+      await session.waitText('Enter server URL');
+      session.write(`${server.baseUrl()}`);
+      session.keyEnter();
+      await session.waitText('Connect to:');
+      session.write('n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('Only connect to servers you trust');
@@ -983,9 +1085,8 @@ describe('auth login — server selection', () => {
       const server = await harness.newFakeServer().withAuthToken('my-token').start();
       harness.cwd.writeFile('sonar-project.properties', `sonar.host.url=${server.baseUrl()}\n`);
 
-      const result = await harness.run('auth login', {
+      const result = await confirmTrust(harness, 'auth login', {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -1001,9 +1102,7 @@ describe('auth login — server selection', () => {
       const server = await harness.newFakeServer().start();
       harness.cwd.writeFile('sonar-project.properties', `sonar.host.url=${server.baseUrl()}\n`);
 
-      const result = await harness.run('auth login', {
-        stdin: 'n\n', // n (decline trust)
-      });
+      const result = await declineTrust(harness, 'auth login');
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('Only connect to servers you trust');
@@ -1022,9 +1121,8 @@ describe('auth login — server selection', () => {
         JSON.stringify({ sonarQubeUri: server.baseUrl(), projectKey: 'my-project' }),
       );
 
-      const result = await harness.run('auth login', {
+      const result = await confirmTrust(harness, 'auth login', {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -1219,9 +1317,8 @@ describe('auth login — auth URL', () => {
         .withVersion('2026.2')
         .start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -1240,9 +1337,8 @@ describe('auth login — auth URL', () => {
         .withVersion('26.2')
         .start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -1261,9 +1357,8 @@ describe('auth login — auth URL', () => {
         .withVersion('2025.1')
         .start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -1281,9 +1376,8 @@ describe('auth login — auth URL', () => {
         .withVersion('25.1')
         .start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);
@@ -1301,9 +1395,8 @@ describe('auth login — auth URL', () => {
         .withSystemStatusCode(HTTP_503_SERVICE_UNAVAILABLE)
         .start();
 
-      const result = await harness.run(`auth login --server ${server.baseUrl()}`, {
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
         browserToken: 'my-token',
-        stdin: '\r', // Enter (confirm trust, Yes is default)
       });
 
       expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
@@ -66,9 +66,9 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-        stdin: postToolUseStdin(filePath),
-      });
+      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
+      session.write(postToolUseStdin(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -92,9 +92,9 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-        stdin: postToolUseStdin(filePath),
-      });
+      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
+      session.write(postToolUseStdin(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -128,9 +128,9 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-        stdin: postToolUseStdin(filePath),
-      });
+      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
+      session.write(postToolUseStdin(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe('');
@@ -151,10 +151,13 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.state().withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
-      const runHook = () =>
-        harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-          stdin: postToolUseStdin(filePath),
-        });
+      const runHook = async () => {
+        const session = harness.runInteractive(
+          `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        );
+        session.write(postToolUseStdin(filePath));
+        return session.waitFinish();
+      };
 
       const firstResult = await runHook();
       const secondResult = await runHook();
@@ -180,9 +183,9 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-        stdin: postToolUseStdin(filePath),
-      });
+      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
+      session.write(postToolUseStdin(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe('');
@@ -205,10 +208,12 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('../outside.ts', 'const x = 1;');
       const outsidePath = join(harness.cwd.path, '..', 'outside.ts');
 
-      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-        stdin: postToolUseStdin(outsidePath),
-        extraEnv: { LOG_LEVEL: 'DEBUG' },
-      });
+      const session = harness.runInteractive(
+        `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        { extraEnv: { LOG_LEVEL: 'DEBUG' } },
+      );
+      session.write(postToolUseStdin(outsidePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe('');
@@ -239,9 +244,9 @@ describe('sonar hook claude-post-tool-use', () => {
       // The helper must rewrite them to POSIX before sending to SQAA.
       const filePath = join(harness.cwd.path, 'src', 'main.ts');
 
-      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-        stdin: postToolUseStdin(filePath),
-      });
+      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
+      session.write(postToolUseStdin(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const sqaaCalls = server
@@ -274,9 +279,9 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const result = await harness.run(`hook claude-post-tool-use --project ${TEST_PROJECT}`, {
-        stdin: postToolUseStdin(filePath),
-      });
+      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
+      session.write(postToolUseStdin(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const [analysisEvent] = readAnalysisEvents(harness.sonarUserHome.path);

--- a/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-agent-post-tool-use.test.ts
@@ -66,9 +66,10 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
-      session.write(postToolUseStdin(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        postToolUseStdin(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -92,9 +93,10 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
-      session.write(postToolUseStdin(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        postToolUseStdin(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -128,9 +130,10 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
-      session.write(postToolUseStdin(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        postToolUseStdin(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe('');
@@ -152,11 +155,10 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
       const runHook = async () => {
-        const session = harness.runInteractive(
+        return harness.runWithStdin(
           `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+          postToolUseStdin(filePath),
         );
-        session.write(postToolUseStdin(filePath));
-        return session.waitFinish();
       };
 
       const firstResult = await runHook();
@@ -183,9 +185,10 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
-      session.write(postToolUseStdin(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        postToolUseStdin(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe('');
@@ -208,12 +211,11 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('../outside.ts', 'const x = 1;');
       const outsidePath = join(harness.cwd.path, '..', 'outside.ts');
 
-      const session = harness.runInteractive(
+      const result = await harness.runWithStdin(
         `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        postToolUseStdin(outsidePath),
         { extraEnv: { LOG_LEVEL: 'DEBUG' } },
       );
-      session.write(postToolUseStdin(outsidePath));
-      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toBe('');
@@ -244,9 +246,10 @@ describe('sonar hook claude-post-tool-use', () => {
       // The helper must rewrite them to POSIX before sending to SQAA.
       const filePath = join(harness.cwd.path, 'src', 'main.ts');
 
-      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
-      session.write(postToolUseStdin(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        postToolUseStdin(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       const sqaaCalls = server
@@ -279,9 +282,10 @@ describe('sonar hook claude-post-tool-use', () => {
       harness.cwd.writeFile('src/main.ts', 'const x = 1;');
       const filePath = join(harness.cwd.path, 'src/main.ts');
 
-      const session = harness.runInteractive(`hook claude-post-tool-use --project ${TEST_PROJECT}`);
-      session.write(postToolUseStdin(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        `hook claude-post-tool-use --project ${TEST_PROJECT}`,
+        postToolUseStdin(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       const [analysisEvent] = readAnalysisEvents(harness.sonarUserHome.path);

--- a/tests/integration/specs/hook/hook-agent-prompt-submit.test.ts
+++ b/tests/integration/specs/hook/hook-agent-prompt-submit.test.ts
@@ -61,9 +61,10 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook claude-prompt-submit');
-      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-prompt-submit',
+        JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
+      );
 
       expect(result.exitCode).toBe(0);
       const blockLine = result.stdout
@@ -84,9 +85,10 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook claude-prompt-submit');
-      session.write(JSON.stringify({ prompt: 'please help me refactor this function' }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-prompt-submit',
+        JSON.stringify({ prompt: 'please help me refactor this function' }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');
@@ -100,9 +102,7 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook claude-prompt-submit');
-      session.write('not valid json {{');
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook claude-prompt-submit', 'not valid json {{');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');
@@ -116,9 +116,10 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook claude-prompt-submit');
-      session.write(JSON.stringify({ tool_name: 'Read' }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-prompt-submit',
+        JSON.stringify({ tool_name: 'Read' }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');
@@ -132,9 +133,10 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       // no withAuth — no active connection
 
-      const session = harness.runInteractive('hook claude-prompt-submit');
-      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-prompt-submit',
+        JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
+      );
 
       expect(result.exitCode).toBe(0);
       const payload = JSON.parse(result.stdout.trim()) as { decision: string; reason: string };
@@ -149,9 +151,10 @@ describe('sonar hook claude-prompt-submit', () => {
     async () => {
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook claude-prompt-submit');
-      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-prompt-submit',
+        JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
+      );
 
       expect(result.exitCode).toBe(0);
       const payload = JSON.parse(result.stdout.trim()) as { decision: string; reason: string };
@@ -172,9 +175,10 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const session = harness.runInteractive('hook claude-prompt-submit');
-      session.write(JSON.stringify({ prompt: 'please help me refactor' }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-prompt-submit',
+        JSON.stringify({ prompt: 'please help me refactor' }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');

--- a/tests/integration/specs/hook/hook-agent-prompt-submit.test.ts
+++ b/tests/integration/specs/hook/hook-agent-prompt-submit.test.ts
@@ -61,9 +61,9 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook claude-prompt-submit', {
-        stdin: JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
-      });
+      const session = harness.runInteractive('hook claude-prompt-submit');
+      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const blockLine = result.stdout
@@ -84,9 +84,9 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook claude-prompt-submit', {
-        stdin: JSON.stringify({ prompt: 'please help me refactor this function' }),
-      });
+      const session = harness.runInteractive('hook claude-prompt-submit');
+      session.write(JSON.stringify({ prompt: 'please help me refactor this function' }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');
@@ -100,9 +100,9 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook claude-prompt-submit', {
-        stdin: 'not valid json {{',
-      });
+      const session = harness.runInteractive('hook claude-prompt-submit');
+      session.write('not valid json {{');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');
@@ -116,9 +116,9 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook claude-prompt-submit', {
-        stdin: JSON.stringify({ tool_name: 'Read' }),
-      });
+      const session = harness.runInteractive('hook claude-prompt-submit');
+      session.write(JSON.stringify({ tool_name: 'Read' }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');
@@ -132,9 +132,9 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       // no withAuth — no active connection
 
-      const result = await harness.run('hook claude-prompt-submit', {
-        stdin: JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
-      });
+      const session = harness.runInteractive('hook claude-prompt-submit');
+      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const payload = JSON.parse(result.stdout.trim()) as { decision: string; reason: string };
@@ -149,9 +149,9 @@ describe('sonar hook claude-prompt-submit', () => {
     async () => {
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook claude-prompt-submit', {
-        stdin: JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
-      });
+      const session = harness.runInteractive('hook claude-prompt-submit');
+      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const payload = JSON.parse(result.stdout.trim()) as { decision: string; reason: string };
@@ -172,9 +172,9 @@ describe('sonar hook claude-prompt-submit', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const result = await harness.run('hook claude-prompt-submit', {
-        stdin: JSON.stringify({ prompt: 'please help me refactor' }),
-      });
+      const session = harness.runInteractive('hook claude-prompt-submit');
+      session.write(JSON.stringify({ prompt: 'please help me refactor' }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"block"');

--- a/tests/integration/specs/hook/hook-antigravity-pre-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-antigravity-pre-tool-use.test.ts
@@ -73,9 +73,7 @@ describe('sonar hook antigravity-pre-tool-use', () => {
   it(
     'exits 0 and allows when stdin is malformed JSON',
     async () => {
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write('not valid json');
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook antigravity-pre-tool-use', 'not valid json');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -91,8 +89,8 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
         JSON.stringify({
           toolCall: {
             name: 'run_command',
@@ -100,7 +98,6 @@ describe('sonar hook antigravity-pre-tool-use', () => {
           },
         }),
       );
-      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -114,13 +111,12 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
         JSON.stringify({
           toolCall: { name: 'view_file', args: {} },
         }),
       );
-      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -134,9 +130,10 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(viewFilePayload('/nonexistent/path/file.js'));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
+        viewFilePayload('/nonexistent/path/file.js'),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -151,9 +148,10 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(viewFilePayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
+        viewFilePayload(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -170,9 +168,10 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(viewFilePayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
+        viewFilePayload(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -190,9 +189,10 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
       const filePath = join(harness.cwd.path, 'clean.js');
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(viewFilePayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
+        viewFilePayload(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -208,9 +208,10 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(viewFilePayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
+        viewFilePayload(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('"decision"');
@@ -232,9 +233,10 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const session = harness.runInteractive('hook antigravity-pre-tool-use');
-      session.write(viewFilePayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook antigravity-pre-tool-use',
+        viewFilePayload(filePath),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');

--- a/tests/integration/specs/hook/hook-antigravity-pre-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-antigravity-pre-tool-use.test.ts
@@ -73,9 +73,9 @@ describe('sonar hook antigravity-pre-tool-use', () => {
   it(
     'exits 0 and allows when stdin is malformed JSON',
     async () => {
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: 'not valid json',
-      });
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write('not valid json');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -91,14 +91,16 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: JSON.stringify({
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(
+        JSON.stringify({
           toolCall: {
             name: 'run_command',
             args: { CommandLine: `cat ${filePath}` },
           },
         }),
-      });
+      );
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -112,11 +114,13 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: JSON.stringify({
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(
+        JSON.stringify({
           toolCall: { name: 'view_file', args: {} },
         }),
-      });
+      );
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -130,9 +134,9 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: viewFilePayload('/nonexistent/path/file.js'),
-      });
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(viewFilePayload('/nonexistent/path/file.js'));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -147,9 +151,9 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: viewFilePayload(filePath),
-      });
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(viewFilePayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -166,9 +170,9 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: viewFilePayload(filePath),
-      });
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(viewFilePayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -186,9 +190,9 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
       const filePath = join(harness.cwd.path, 'clean.js');
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: viewFilePayload(filePath),
-      });
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(viewFilePayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -204,9 +208,9 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: viewFilePayload(filePath),
-      });
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(viewFilePayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('"decision"');
@@ -228,9 +232,9 @@ describe('sonar hook antigravity-pre-tool-use', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const result = await harness.run('hook antigravity-pre-tool-use', {
-        stdin: viewFilePayload(filePath),
-      });
+      const session = harness.runInteractive('hook antigravity-pre-tool-use');
+      session.write(viewFilePayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');

--- a/tests/integration/specs/hook/hook-claude-pre-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-claude-pre-tool-use.test.ts
@@ -64,9 +64,9 @@ describe('sonar hook claude-pre-tool-use', () => {
   it(
     'exits 0 and allows when stdin is malformed JSON',
     async () => {
-      const result = await harness.run('hook claude-pre-tool-use', {
-        stdin: 'not valid json',
-      });
+      const session = harness.runInteractive('hook claude-pre-tool-use');
+      session.write('not valid json');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -82,9 +82,9 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook claude-pre-tool-use', {
-        stdin: JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }),
-      });
+      const session = harness.runInteractive('hook claude-pre-tool-use');
+      session.write(JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -98,9 +98,9 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook claude-pre-tool-use', {
-        stdin: readPayload('/nonexistent/path/file.js'),
-      });
+      const session = harness.runInteractive('hook claude-pre-tool-use');
+      session.write(readPayload('/nonexistent/path/file.js'));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -116,9 +116,9 @@ describe('sonar hook claude-pre-tool-use', () => {
       const filePath = join(harness.cwd.path, 'secret.js');
       // No auth configured
 
-      const result = await harness.run('hook claude-pre-tool-use', {
-        stdin: readPayload(filePath),
-      });
+      const session = harness.runInteractive('hook claude-pre-tool-use');
+      session.write(readPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -138,9 +138,9 @@ describe('sonar hook claude-pre-tool-use', () => {
       const filePath = join(harness.cwd.path, 'secret.js');
       // No binary installed
 
-      const result = await harness.run('hook claude-pre-tool-use', {
-        stdin: readPayload(filePath),
-      });
+      const session = harness.runInteractive('hook claude-pre-tool-use');
+      session.write(readPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -160,9 +160,9 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
       const filePath = join(harness.cwd.path, 'clean.js');
 
-      const result = await harness.run('hook claude-pre-tool-use', {
-        stdin: readPayload(filePath),
-      });
+      const session = harness.runInteractive('hook claude-pre-tool-use');
+      session.write(readPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -178,9 +178,9 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook claude-pre-tool-use', {
-        stdin: readPayload(filePath),
-      });
+      const session = harness.runInteractive('hook claude-pre-tool-use');
+      session.write(readPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('"permissionDecision"');

--- a/tests/integration/specs/hook/hook-claude-pre-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-claude-pre-tool-use.test.ts
@@ -64,9 +64,7 @@ describe('sonar hook claude-pre-tool-use', () => {
   it(
     'exits 0 and allows when stdin is malformed JSON',
     async () => {
-      const session = harness.runInteractive('hook claude-pre-tool-use');
-      session.write('not valid json');
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook claude-pre-tool-use', 'not valid json');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -82,9 +80,10 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook claude-pre-tool-use');
-      session.write(JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-pre-tool-use',
+        JSON.stringify({ tool_name: 'Write', tool_input: { file_path: filePath } }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -98,9 +97,10 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook claude-pre-tool-use');
-      session.write(readPayload('/nonexistent/path/file.js'));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook claude-pre-tool-use',
+        readPayload('/nonexistent/path/file.js'),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -116,9 +116,7 @@ describe('sonar hook claude-pre-tool-use', () => {
       const filePath = join(harness.cwd.path, 'secret.js');
       // No auth configured
 
-      const session = harness.runInteractive('hook claude-pre-tool-use');
-      session.write(readPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook claude-pre-tool-use', readPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -138,9 +136,7 @@ describe('sonar hook claude-pre-tool-use', () => {
       const filePath = join(harness.cwd.path, 'secret.js');
       // No binary installed
 
-      const session = harness.runInteractive('hook claude-pre-tool-use');
-      session.write(readPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook claude-pre-tool-use', readPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -160,9 +156,7 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
       const filePath = join(harness.cwd.path, 'clean.js');
 
-      const session = harness.runInteractive('hook claude-pre-tool-use');
-      session.write(readPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook claude-pre-tool-use', readPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -178,9 +172,7 @@ describe('sonar hook claude-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook claude-pre-tool-use');
-      session.write(readPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook claude-pre-tool-use', readPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('"permissionDecision"');

--- a/tests/integration/specs/hook/hook-copilot-pre-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-copilot-pre-tool-use.test.ts
@@ -70,9 +70,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
   it(
     'exits 0 and allows when stdin is malformed JSON',
     async () => {
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: 'not valid json',
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write('not valid json');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -88,12 +88,14 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: JSON.stringify({
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(
+        JSON.stringify({
           toolName: 'edit',
           toolArgs: JSON.stringify({ path: filePath }),
         }),
-      });
+      );
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -107,9 +109,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: JSON.stringify({ toolName: 'view', toolArgs: 'not-json-string' }),
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(JSON.stringify({ toolName: 'view', toolArgs: 'not-json-string' }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -123,12 +125,14 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: JSON.stringify({
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(
+        JSON.stringify({
           toolName: 'view',
           toolArgs: JSON.stringify({ other: 'something' }),
         }),
-      });
+      );
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -142,9 +146,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: viewPayload('/nonexistent/path/file.js'),
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(viewPayload('/nonexistent/path/file.js'));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -159,9 +163,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: viewPayload(filePath),
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(viewPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -178,9 +182,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: viewPayload(filePath),
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(viewPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -198,9 +202,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
       const filePath = join(harness.cwd.path, 'clean.js');
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: viewPayload(filePath),
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(viewPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -216,9 +220,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: viewPayload(filePath),
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(viewPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('"permissionDecision"');
@@ -245,9 +249,9 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const result = await harness.run('hook copilot-pre-tool-use', {
-        stdin: viewPayload(filePath),
-      });
+      const session = harness.runInteractive('hook copilot-pre-tool-use');
+      session.write(viewPayload(filePath));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');

--- a/tests/integration/specs/hook/hook-copilot-pre-tool-use.test.ts
+++ b/tests/integration/specs/hook/hook-copilot-pre-tool-use.test.ts
@@ -70,9 +70,7 @@ describe('sonar hook copilot-pre-tool-use', () => {
   it(
     'exits 0 and allows when stdin is malformed JSON',
     async () => {
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write('not valid json');
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook copilot-pre-tool-use', 'not valid json');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -88,14 +86,13 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(
+      const result = await harness.runWithStdin(
+        'hook copilot-pre-tool-use',
         JSON.stringify({
           toolName: 'edit',
           toolArgs: JSON.stringify({ path: filePath }),
         }),
       );
-      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -109,9 +106,10 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(JSON.stringify({ toolName: 'view', toolArgs: 'not-json-string' }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook copilot-pre-tool-use',
+        JSON.stringify({ toolName: 'view', toolArgs: 'not-json-string' }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -125,14 +123,13 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(
+      const result = await harness.runWithStdin(
+        'hook copilot-pre-tool-use',
         JSON.stringify({
           toolName: 'view',
           toolArgs: JSON.stringify({ other: 'something' }),
         }),
       );
-      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -146,9 +143,10 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(viewPayload('/nonexistent/path/file.js'));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook copilot-pre-tool-use',
+        viewPayload('/nonexistent/path/file.js'),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -163,9 +161,7 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(viewPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook copilot-pre-tool-use', viewPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -182,9 +178,7 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(viewPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook copilot-pre-tool-use', viewPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       const output = JSON.parse(result.stdout.trim());
@@ -202,9 +196,7 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('clean.js', CLEAN_CONTENT);
       const filePath = join(harness.cwd.path, 'clean.js');
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(viewPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook copilot-pre-tool-use', viewPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');
@@ -220,9 +212,7 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cwd.writeFile('secret.js', `const token = "${GITHUB_TEST_TOKEN}";`);
       const filePath = join(harness.cwd.path, 'secret.js');
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(viewPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook copilot-pre-tool-use', viewPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('"permissionDecision"');
@@ -249,9 +239,7 @@ describe('sonar hook copilot-pre-tool-use', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const session = harness.runInteractive('hook copilot-pre-tool-use');
-      session.write(viewPayload(filePath));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook copilot-pre-tool-use', viewPayload(filePath));
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"deny"');

--- a/tests/integration/specs/hook/hook-cursor-prompt-submit.test.ts
+++ b/tests/integration/specs/hook/hook-cursor-prompt-submit.test.ts
@@ -69,9 +69,10 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook cursor-prompt-submit');
-      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook cursor-prompt-submit',
+        JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
+      );
 
       expect(result.exitCode).toBe(0);
       const blockLine = findContinueLine(result.stdout);
@@ -89,9 +90,10 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook cursor-prompt-submit');
-      session.write(JSON.stringify({ prompt: 'please help me refactor this function' }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook cursor-prompt-submit',
+        JSON.stringify({ prompt: 'please help me refactor this function' }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');
@@ -105,9 +107,7 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook cursor-prompt-submit');
-      session.write('not valid json {{');
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook cursor-prompt-submit', 'not valid json {{');
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');
@@ -121,9 +121,10 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook cursor-prompt-submit');
-      session.write(JSON.stringify({ hook_event_name: 'beforeSubmitPrompt' }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook cursor-prompt-submit',
+        JSON.stringify({ hook_event_name: 'beforeSubmitPrompt' }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');
@@ -137,9 +138,10 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       // no withAuth — no active connection
 
-      const session = harness.runInteractive('hook cursor-prompt-submit');
-      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook cursor-prompt-submit',
+        JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
+      );
 
       expect(result.exitCode).toBe(0);
       const blockLine = findContinueLine(result.stdout);
@@ -156,9 +158,10 @@ describe('sonar hook cursor-prompt-submit', () => {
     async () => {
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const session = harness.runInteractive('hook cursor-prompt-submit');
-      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook cursor-prompt-submit',
+        JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
+      );
 
       expect(result.exitCode).toBe(0);
       const blockLine = findContinueLine(result.stdout);
@@ -180,9 +183,10 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const session = harness.runInteractive('hook cursor-prompt-submit');
-      session.write(JSON.stringify({ prompt: 'please help me refactor' }));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook cursor-prompt-submit',
+        JSON.stringify({ prompt: 'please help me refactor' }),
+      );
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');

--- a/tests/integration/specs/hook/hook-cursor-prompt-submit.test.ts
+++ b/tests/integration/specs/hook/hook-cursor-prompt-submit.test.ts
@@ -69,9 +69,9 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook cursor-prompt-submit', {
-        stdin: JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
-      });
+      const session = harness.runInteractive('hook cursor-prompt-submit');
+      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const blockLine = findContinueLine(result.stdout);
@@ -89,9 +89,9 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook cursor-prompt-submit', {
-        stdin: JSON.stringify({ prompt: 'please help me refactor this function' }),
-      });
+      const session = harness.runInteractive('hook cursor-prompt-submit');
+      session.write(JSON.stringify({ prompt: 'please help me refactor this function' }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');
@@ -105,9 +105,9 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook cursor-prompt-submit', {
-        stdin: 'not valid json {{',
-      });
+      const session = harness.runInteractive('hook cursor-prompt-submit');
+      session.write('not valid json {{');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');
@@ -121,9 +121,9 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook cursor-prompt-submit', {
-        stdin: JSON.stringify({ hook_event_name: 'beforeSubmitPrompt' }),
-      });
+      const session = harness.runInteractive('hook cursor-prompt-submit');
+      session.write(JSON.stringify({ hook_event_name: 'beforeSubmitPrompt' }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');
@@ -137,9 +137,9 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.state().withSecretsBinaryInstalled();
       // no withAuth — no active connection
 
-      const result = await harness.run('hook cursor-prompt-submit', {
-        stdin: JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
-      });
+      const session = harness.runInteractive('hook cursor-prompt-submit');
+      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const blockLine = findContinueLine(result.stdout);
@@ -156,9 +156,9 @@ describe('sonar hook cursor-prompt-submit', () => {
     async () => {
       harness.withAuth(FAKE_SERVER, 'fake-token');
 
-      const result = await harness.run('hook cursor-prompt-submit', {
-        stdin: JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }),
-      });
+      const session = harness.runInteractive('hook cursor-prompt-submit');
+      session.write(JSON.stringify({ prompt: `my token is ${GITHUB_TEST_TOKEN}` }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const blockLine = findContinueLine(result.stdout);
@@ -180,9 +180,9 @@ describe('sonar hook cursor-prompt-submit', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, 0o644);
 
-      const result = await harness.run('hook cursor-prompt-submit', {
-        stdin: JSON.stringify({ prompt: 'please help me refactor' }),
-      });
+      const session = harness.runInteractive('hook cursor-prompt-submit');
+      session.write(JSON.stringify({ prompt: 'please help me refactor' }));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).not.toContain('"continue"');

--- a/tests/integration/specs/hook/hook-git-pre-push.test.ts
+++ b/tests/integration/specs/hook/hook-git-pre-push.test.ts
@@ -65,7 +65,9 @@ describe('sonar hook git-pre-push', () => {
   it(
     'exits 0 when stdin is empty (no refs)',
     async () => {
-      const result = await harness.run('hook git-pre-push', { stdin: '' });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write('');
+      const result = await session.waitFinish();
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -75,7 +77,9 @@ describe('sonar hook git-pre-push', () => {
     'exits 0 for branch deletion (localSha is all zeros)',
     async () => {
       const stdin = pushRefLine(GIT_NULL_OID, 'abc1234abc1234abc1234abc1234abc1234abc123');
-      const result = await harness.run('hook git-pre-push', { stdin });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(stdin);
+      const result = await session.waitFinish();
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -85,7 +89,9 @@ describe('sonar hook git-pre-push', () => {
     'exits 0 when all lines are malformed (missing fields)',
     async () => {
       const stdin = 'invalid-line\nrefs/heads/main only-one-field\n';
-      const result = await harness.run('hook git-pre-push', { stdin });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(stdin);
+      const result = await session.waitFinish();
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -99,9 +105,9 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       // No auth configured
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(sha, GIT_NULL_OID),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(sha, GIT_NULL_OID));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(SECRETS_INACTIVE_UNAUTHENTICATED);
@@ -117,9 +123,9 @@ describe('sonar hook git-pre-push', () => {
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
       // No binary installed
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(sha, GIT_NULL_OID),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(sha, GIT_NULL_OID));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(SECRETS_INACTIVE_BINARY_MISSING);
@@ -132,9 +138,9 @@ describe('sonar hook git-pre-push', () => {
     async () => {
       harness.state().withSecretsBinaryInstalled();
       const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(sha, GIT_NULL_OID),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(sha, GIT_NULL_OID));
+      const result = await session.waitFinish();
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -149,9 +155,9 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(sha, GIT_NULL_OID),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(sha, GIT_NULL_OID));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
     },
@@ -171,9 +177,9 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(sha, GIT_NULL_OID),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(sha, GIT_NULL_OID));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
     },
@@ -190,9 +196,9 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(localSha, remoteSha),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(localSha, remoteSha));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
     },
@@ -213,9 +219,9 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(localSha, remoteSha),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(localSha, remoteSha));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
     },
@@ -233,10 +239,11 @@ describe('sonar hook git-pre-push', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, NON_EXECUTABLE_MODE);
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(sha, GIT_NULL_OID),
+      const session = harness.runInteractive('hook git-pre-push', {
         extraEnv: { SONARQUBE_CLI_TOKEN: VALID_TOKEN, SONARQUBE_CLI_SERVER: FAKE_SERVER },
       });
+      session.write(pushRefLine(sha, GIT_NULL_OID));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
     },
@@ -256,9 +263,9 @@ describe('sonar hook git-pre-push', () => {
 
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const result = await harness.run('hook git-pre-push', {
-        stdin: pushRefLine(sha, GIT_NULL_OID),
-      });
+      const session = harness.runInteractive('hook git-pre-push');
+      session.write(pushRefLine(sha, GIT_NULL_OID));
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
     },

--- a/tests/integration/specs/hook/hook-git-pre-push.test.ts
+++ b/tests/integration/specs/hook/hook-git-pre-push.test.ts
@@ -65,9 +65,7 @@ describe('sonar hook git-pre-push', () => {
   it(
     'exits 0 when stdin is empty (no refs)',
     async () => {
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write('');
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook git-pre-push', '');
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -77,9 +75,7 @@ describe('sonar hook git-pre-push', () => {
     'exits 0 for branch deletion (localSha is all zeros)',
     async () => {
       const stdin = pushRefLine(GIT_NULL_OID, 'abc1234abc1234abc1234abc1234abc1234abc123');
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(stdin);
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook git-pre-push', stdin);
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -89,9 +85,7 @@ describe('sonar hook git-pre-push', () => {
     'exits 0 when all lines are malformed (missing fields)',
     async () => {
       const stdin = 'invalid-line\nrefs/heads/main only-one-field\n';
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(stdin);
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin('hook git-pre-push', stdin);
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -105,9 +99,10 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       // No auth configured
 
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(sha, GIT_NULL_OID));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(sha, GIT_NULL_OID),
+      );
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(SECRETS_INACTIVE_UNAUTHENTICATED);
@@ -123,9 +118,10 @@ describe('sonar hook git-pre-push', () => {
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
       // No binary installed
 
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(sha, GIT_NULL_OID));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(sha, GIT_NULL_OID),
+      );
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain(SECRETS_INACTIVE_BINARY_MISSING);
@@ -138,9 +134,10 @@ describe('sonar hook git-pre-push', () => {
     async () => {
       harness.state().withSecretsBinaryInstalled();
       const sha = 'abc1234abc1234abc1234abc1234abc1234abc123';
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(sha, GIT_NULL_OID));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(sha, GIT_NULL_OID),
+      );
       expect(result.exitCode).toBe(0);
     },
     { timeout: 15000 },
@@ -155,9 +152,10 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(sha, GIT_NULL_OID));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(sha, GIT_NULL_OID),
+      );
 
       expect(result.exitCode).toBe(0);
     },
@@ -177,9 +175,10 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(sha, GIT_NULL_OID));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(sha, GIT_NULL_OID),
+      );
 
       expect(result.exitCode).toBe(1);
     },
@@ -196,9 +195,10 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(localSha, remoteSha));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(localSha, remoteSha),
+      );
 
       expect(result.exitCode).toBe(0);
     },
@@ -219,9 +219,10 @@ describe('sonar hook git-pre-push', () => {
       harness.state().withSecretsBinaryInstalled();
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(localSha, remoteSha));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(localSha, remoteSha),
+      );
 
       expect(result.exitCode).toBe(1);
     },
@@ -239,11 +240,13 @@ describe('sonar hook git-pre-push', () => {
       harness.cliHome.writeFile(`bin/${binaryName}`, 'not-a-binary');
       chmodSync(harness.cliHome.file('bin', binaryName).path, NON_EXECUTABLE_MODE);
 
-      const session = harness.runInteractive('hook git-pre-push', {
-        extraEnv: { SONARQUBE_CLI_TOKEN: VALID_TOKEN, SONARQUBE_CLI_SERVER: FAKE_SERVER },
-      });
-      session.write(pushRefLine(sha, GIT_NULL_OID));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(sha, GIT_NULL_OID),
+        {
+          extraEnv: { SONARQUBE_CLI_TOKEN: VALID_TOKEN, SONARQUBE_CLI_SERVER: FAKE_SERVER },
+        },
+      );
 
       expect(result.exitCode).toBe(1);
     },
@@ -263,9 +266,10 @@ describe('sonar hook git-pre-push', () => {
 
       harness.withAuth(FAKE_SERVER, VALID_TOKEN);
 
-      const session = harness.runInteractive('hook git-pre-push');
-      session.write(pushRefLine(sha, GIT_NULL_OID));
-      const result = await session.waitFinish();
+      const result = await harness.runWithStdin(
+        'hook git-pre-push',
+        pushRefLine(sha, GIT_NULL_OID),
+      );
 
       expect(result.exitCode).toBe(0);
     },

--- a/tests/integration/specs/import/import.test.ts
+++ b/tests/integration/specs/import/import.test.ts
@@ -392,8 +392,7 @@ describe('sonar import', () => {
         const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
-        await session.waitText('How do you want to import repositories?');
-        session.keyEnter();
+        await session.accept('How do you want to import repositories?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -439,8 +438,7 @@ describe('sonar import', () => {
         });
         await chooseManual(session);
         session.write('q');
-        await session.waitText('How do you want to import repositories?');
-        session.keyEnter();
+        await session.accept('How do you want to import repositories?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -2156,8 +2154,7 @@ describe('sonar import', () => {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
         await chooseByPattern(session);
-        await session.waitText('Import repositories whose name matches');
-        session.keyEnter();
+        await session.accept('Import repositories whose name matches');
         await session.waitText('Please enter a valid, non-empty regular expression');
         session.write('(');
         session.keyEnter();
@@ -2195,8 +2192,7 @@ describe('sonar import', () => {
         await chooseByPattern(session);
         await session.waitText('Import repositories whose name matches');
         session.keyCtrlC();
-        await session.waitText('How do you want to import repositories?');
-        session.keyEnter();
+        await session.accept('How do you want to import repositories?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/import/import.test.ts
+++ b/tests/integration/specs/import/import.test.ts
@@ -22,7 +22,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
-import { TestHarness } from '../../harness';
+import { type InteractiveSession, TestHarness } from '../../harness';
 
 const GITHUB_ALM = {
   key: 'github',
@@ -48,6 +48,20 @@ const ADMIN_ACTIONS = { admin: true };
 // `/organizations/organizations` defaults an org's legacy ID to its key
 // (see fake-sonarqube-server.ts), so repos are keyed by org key here too.
 const SAMPLE_REPOS = [{ id: 'repo-1', name: 'repo', slug: 'kevinmlsilva/repo' }];
+
+async function chooseManual(session: InteractiveSession): Promise<void> {
+  await session.waitText('How do you want to import repositories?');
+  session.keyDown();
+  session.keyEnter();
+  await session.waitText('Select repositories to import');
+}
+
+async function chooseByPattern(session: InteractiveSession): Promise<void> {
+  await session.waitText('How do you want to import repositories?');
+  session.keyDown();
+  session.keyDown();
+  session.keyEnter();
+}
 
 describe('sonar import', () => {
   let harness: TestHarness;
@@ -375,10 +389,12 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          stdin: '\r', // enter → Recommended (the default, first option)
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await session.waitText('How do you want to import repositories?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('How do you want to import repositories?');
@@ -417,12 +433,15 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        // down+enter → Manual mode; 'q' → cancel the picker, back to the mode menu; enter →
-        // Recommended this time (the re-shown menu's default, first option).
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', 'q', '\r'],
+        // Cancel the Manual picker, then Recommended on the re-shown mode menu.
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.write('q');
+        await session.waitText('How do you want to import repositories?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         // The picker is cancelled (not treated as an error) and the mode menu re-appears,
@@ -491,10 +510,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', ' \r'], // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('kevinmlsilva/repo');
@@ -519,11 +541,14 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          // down arrow+enter → Manual mode, down arrow+space+enter → toggles and confirms second repo
-          stdinChunks: ['\x1b[B\r', '\x1b[B \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keyDown();
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('kevinmlsilva/repo-two');
@@ -663,15 +688,16 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          stdinChunks: [
-            '\x1b[B\r', // down arrow+enter → Manual mode
-            // toggle the eligible repo (cursor starts on it), move down to the already-imported
-            // row, attempt to toggle it too (must be a no-op), then confirm.
-            ' \x1b[B \r',
-          ],
+        // Toggle the eligible repo, then attempt to toggle the already-imported row (no-op).
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyDown();
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         // The already-imported repo is listed (dimmed/non-toggleable), not hidden.
@@ -741,15 +767,21 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        // down arrow+enter → Manual mode, then navigate to "Load more..." (50 repos precede it
-        // on the first page), select it — which fetches page two — then toggle and confirm the
-        // newly revealed 51st repo (cursor carries over onto it, since the multi-select prompt
-        // never resets its cursor).
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', '\x1b[B'.repeat(50) + '\r', ' \r'],
+        // 50 downs reach "Load more..."; after the next page loads, toggle the 51st repo
+        // (cursor carries over onto it).
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
           timeoutMs: 20000,
         });
+        await chooseManual(session);
+        for (let i = 0; i < 50; i++) {
+          session.keyDown();
+        }
+        session.keyEnter();
+        await session.waitText('kevinmlsilva/repo-51');
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('kevinmlsilva/repo-51');
@@ -782,11 +814,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          // down arrow+enter → Manual mode, space+enter → toggles and confirms the first repo
-          stdinChunks: ['\x1b[B\r', ' \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('kevinmlsilva/repo-01');
@@ -822,11 +856,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          // down arrow+enter → Manual mode, space+enter → toggles and confirms the first selectable repo
-          stdinChunks: ['\x1b[B\r', ' \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         // Exactly the 10 selectable repos (02,04,06,08,10,11-15), no "Load more" needed.
@@ -871,13 +907,19 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        // down arrow+enter → Manual mode; toggle the first repo, then (down+toggle) 25 more
-        // times — 26 toggle attempts across all 26 repos, all of which must be accepted.
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', ' ' + '\x1b[B '.repeat(25) + '\r'],
+        // Toggle the first repo, then (down+toggle) 25 more times — all 26 must be accepted.
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
           timeoutMs: 20000,
         });
+        await chooseManual(session);
+        session.keySpace();
+        for (let i = 0; i < 25; i++) {
+          session.keyDown();
+          session.keySpace();
+        }
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('26 of 26 selected');
@@ -911,11 +953,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
-          stdinChunks: ['\x1b[B\r', ' \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('Imported 1 repository');
@@ -945,10 +989,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', ' \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const recorded = server.getRecordedRequests();
@@ -1009,11 +1056,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
-          stdinChunks: ['\x1b[B\r', ' \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const recorded = server.getRecordedRequests();
@@ -1050,10 +1099,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', ' \r'], // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(1);
         const output = result.stdout + result.stderr;
@@ -1208,11 +1260,13 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        const result = await harness.run('import', {
-          // down arrow+enter → Manual mode, space+enter → toggles and confirms the only repo
-          stdinChunks: ['\x1b[B\r', ' \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('kevinmlsilva/repo - private');
@@ -1244,11 +1298,13 @@ describe('sonar import', () => {
 
         // No private-projects entitlement configured → org is public-only, so the private
         // repo must be dropped from the list rather than merely shown as disabled.
-        const result = await harness.run('import', {
-          // down arrow+enter → Manual mode, space+enter → toggles and confirms the only remaining (public) repo
-          stdinChunks: ['\x1b[B\r', ' \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('kevinmlsilva/public-repo');
@@ -1507,12 +1563,16 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        // down arrow+enter → Manual mode, space (toggle repo-a), down, down,
-        // space (toggle repo-c), enter (confirm)
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\r', ' \x1b[B\x1b[B \r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseManual(session);
+        session.keySpace();
+        session.keyDown();
+        session.keyDown();
+        session.keySpace();
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('Imported 2 repositories');
@@ -2057,12 +2117,14 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        // down+down+enter → "By pattern" (3rd option after Recommended/Manual); type a
-        // regex + enter → the mandatory pattern prompt shown only for this mode.
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\x1b[B\r', '^engineering-\r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseByPattern(session);
+        await session.waitText('Import repositories whose name matches');
+        session.write('^engineering-');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain(
@@ -2090,12 +2152,19 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        // down+down+enter → "By pattern"; blank enter (rejected, re-prompts); invalid regex
-        // syntax (rejected, re-prompts); finally a valid pattern + enter.
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\x1b[B\r', '\r', '(\r', '^engineering-\r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseByPattern(session);
+        await session.waitText('Import repositories whose name matches');
+        session.keyEnter();
+        await session.waitText('Please enter a valid, non-empty regular expression');
+        session.write('(');
+        session.keyEnter();
+        await session.waitText('Please enter a valid, non-empty regular expression');
+        session.write('^engineering-');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('my-org/engineering-tools');
@@ -2120,12 +2189,15 @@ describe('sonar import', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'test-token', 'my-org');
 
-        // down+down+enter → "By pattern"; Ctrl+C → cancel, back to the mode menu; enter →
-        // Recommended this time (the re-shown menu's default, first option).
-        const result = await harness.run('import', {
-          stdinChunks: ['\x1b[B\x1b[B\r', '\x03', '\r'],
+        const session = harness.runInteractive('import', {
           extraEnv: { SONARQUBE_CLI_SONARCLOUD_URL: serverUrl },
         });
+        await chooseByPattern(session);
+        await session.waitText('Import repositories whose name matches');
+        session.keyCtrlC();
+        await session.waitText('How do you want to import repositories?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain('Imported 2 repositories');

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -199,12 +199,9 @@ describe('integrate antigravity', () => {
               extraEnv,
             },
           );
-          await session.waitText('Install secret scanning hooks?');
-          session.keyEnter();
-          await session.waitText('Install MCP server?');
-          session.keyEnter();
-          await session.waitText('Install prompt-secrets workspace rules?');
-          session.keyEnter();
+          await session.accept('Install secret scanning hooks?');
+          await session.accept('Install MCP server?');
+          await session.accept('Install prompt-secrets workspace rules?');
           result = await session.waitFinish();
         } else {
           result = await harness.run(
@@ -334,14 +331,11 @@ describe('integrate antigravity', () => {
         const session = harness.runInteractive('integrate antigravity', {
           extraEnv: { __SQCLI_DEV_SKIP_CAG: '1' },
         });
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
-        await session.waitText(
+        await session.accept('Where should SonarQube be integrated?');
+        await session.accept('Install MCP server?');
+        await session.accept(
           'Global Antigravity rules already exist. Do you also want to create a project-local copy for this repo?',
         );
-        session.keyEnter();
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/integrate/antigravity.test.ts
+++ b/tests/integration/specs/integrate/antigravity.test.ts
@@ -35,7 +35,7 @@ import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
-import { IS_WINDOWS, normalizePath, TestHarness } from '../../harness';
+import { type CliResult, IS_WINDOWS, normalizePath, TestHarness } from '../../harness';
 import {
   type AntigravityHooksJson,
   expectAntigravityAlwaysOnRule,
@@ -190,13 +190,28 @@ describe('integrate antigravity', () => {
         // hooks, MCP server, prompt-secrets project rules) — Vortex is skipped
         // (Server hubs absent) and prompt-secrets global rules are
         // skipped (project scope). --non-interactive skips those asks too.
-        const result = await harness.run(
-          `integrate antigravity --project ${TEST_PROJECT}${isInteractive ? '' : ' --non-interactive'}`,
-          {
-            ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r', '\r'] } : {}),
-            extraEnv: isAgent ? { ANTIGRAVITY_AGENT: '1' } : {},
-          },
-        );
+        const extraEnv: Record<string, string> = isAgent ? { ANTIGRAVITY_AGENT: '1' } : {};
+        let result: CliResult;
+        if (isInteractive) {
+          const session = harness.runInteractive(
+            `integrate antigravity --project ${TEST_PROJECT}`,
+            {
+              extraEnv,
+            },
+          );
+          await session.waitText('Install secret scanning hooks?');
+          session.keyEnter();
+          await session.waitText('Install MCP server?');
+          session.keyEnter();
+          await session.waitText('Install prompt-secrets workspace rules?');
+          session.keyEnter();
+          result = await session.waitFinish();
+        } else {
+          result = await harness.run(
+            `integrate antigravity --project ${TEST_PROJECT} --non-interactive`,
+            { extraEnv },
+          );
+        }
 
         expect(result.exitCode).toBe(0);
         if (expectedShownPrompt) {
@@ -316,10 +331,18 @@ describe('integrate antigravity', () => {
         writeExistingGlobalHook(harness);
         writeExistingGlobalInstructions(harness);
 
-        const result = await harness.run('integrate antigravity', {
+        const session = harness.runInteractive('integrate antigravity', {
           extraEnv: { __SQCLI_DEV_SKIP_CAG: '1' },
-          stdinChunks: ['\r', '\r', '\r'],
         });
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        await session.waitText(
+          'Global Antigravity rules already exist. Do you also want to create a project-local copy for this repo?',
+        );
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -36,6 +36,7 @@ import {
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
 import {
+  type CliResult,
   hookScriptName,
   hookScriptPath,
   IS_WINDOWS,
@@ -43,8 +44,6 @@ import {
   TestHarness,
 } from '../../harness';
 import { findInstalledFeature, getInstalledIntegration } from './state-helpers';
-
-const CLAUDE_PROMPT_STDIN_DELAY_MS = 1000;
 
 function findClaudeFeature(harness: TestHarness, featureId: string, scope?: string) {
   return findInstalledFeature(harness, 'claude-code', featureId, scope);
@@ -1994,11 +1993,14 @@ describe('integrate claude — interactive feature selection', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      // '\r' selects project scope, then the hook + MCP feature prompts.
-      const result = await harness.run('integrate claude', {
-        stdinChunks: ['\r', '\r', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate claude');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install secret scanning hooks?');
+      session.keyEnter();
+      await session.waitText('Install MCP server?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = `${result.stdout}\n${result.stderr}`;
@@ -2042,15 +2044,20 @@ describe('integrate claude — interactive feature selection', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      const result = await harness.run(
-        `integrate claude${isInteractive ? '' : ' --non-interactive'}`,
-        {
-          ...(isInteractive
-            ? { stdinChunks: ['\r', '\r', '\r'], stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS }
-            : {}),
-          extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
-        },
-      );
+      const extraEnv: Record<string, string> = isAgent ? { CLAUDECODE: '1' } : {};
+      let result: CliResult;
+      if (isInteractive) {
+        const session = harness.runInteractive('integrate claude', { extraEnv });
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install secret scanning hooks?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        result = await session.waitFinish();
+      } else {
+        result = await harness.run('integrate claude --non-interactive', { extraEnv });
+      }
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {
@@ -2077,11 +2084,14 @@ describe('integrate claude — interactive feature selection', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      // '\r' selects project scope; decline the secret scanning hooks ('n'), accept MCP ('\r').
-      const result = await harness.run('integrate claude', {
-        stdinChunks: ['\r', 'n', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate claude');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install secret scanning hooks?');
+      session.write('n');
+      await session.waitText('Install MCP server?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       // Hooks were declined: no hook artifacts and no state entry.
@@ -2107,16 +2117,20 @@ describe('integrate claude — interactive feature selection', () => {
       const serverUrl = server.baseUrl();
       harness.withAuth(serverUrl, 'cloud-token', 'my-org');
 
-      // '\r' selects project scope, then the secrets, Vortex, and MCP prompts.
-      const result = await harness.run('integrate claude --project my-project', {
-        stdinChunks: ['\r', '\r', '\r', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
+      const session = harness.runInteractive('integrate claude --project my-project', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
           __SQCLI_DEV_SKIP_CAG: '1',
         },
       });
+      await session.waitText('Install secret scanning hooks?');
+      session.keyEnter();
+      await session.waitText('Install Vortex?');
+      session.keyEnter();
+      await session.waitText('Install MCP server?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = `${result.stdout}\n${result.stderr}`;
@@ -2157,16 +2171,19 @@ describe('integrate claude — interactive feature selection', () => {
       const serverUrl = server.baseUrl();
       harness.withAuth(serverUrl, 'cloud-token', 'my-org');
 
-      // '\r' selects project scope, then the secret scanning hooks + MCP prompts.
-      // Vortex is skipped without a prompt because entitlement could not be resolved.
-      const result = await harness.run('integrate claude --project my-project', {
-        stdinChunks: ['\r', '\r', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
+      // --project skips the scope prompt. Vortex is skipped without a prompt
+      // because entitlement could not be resolved.
+      const session = harness.runInteractive('integrate claude --project my-project', {
         extraEnv: {
           SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
         },
       });
+      await session.waitText('Install secret scanning hooks?');
+      session.keyEnter();
+      await session.waitText('Install MCP server?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = `${result.stdout}\n${result.stderr}`;
@@ -2220,12 +2237,16 @@ describe('integrate claude — keep/remove already-installed features', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      // Project scope, keep the hooks (default Yes), decline the MCP server ('n')
-      // then confirm removal (default Yes).
-      const result = await harness.run('integrate claude', {
-        stdinChunks: ['\r', '\r', 'n', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate claude');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('secret scanning hooks (currently installed)  Keep?');
+      session.keyEnter();
+      await session.waitText('MCP server (currently installed)  Keep?');
+      session.write('n');
+      await session.waitText('Proceed with removal?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = `${result.stdout}\n${result.stderr}`;
@@ -2252,11 +2273,16 @@ describe('integrate claude — keep/remove already-installed features', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      // Project scope, keep the hooks, decline MCP keep ('n') then decline removal ('n').
-      const result = await harness.run('integrate claude', {
-        stdinChunks: ['\r', '\r', 'n', 'n'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate claude');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('secret scanning hooks (currently installed)  Keep?');
+      session.keyEnter();
+      await session.waitText('MCP server (currently installed)  Keep?');
+      session.write('n');
+      await session.waitText('Proceed with removal?');
+      session.write('n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       // Declining removal leaves the MCP server installed.
@@ -2276,12 +2302,16 @@ describe('integrate claude — keep/remove already-installed features', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      // Project scope, decline keeping the secrets hooks ('n') then confirm removal
-      // (default Yes); keep the MCP server (default Yes).
-      const result = await harness.run('integrate claude', {
-        stdinChunks: ['\r', 'n', '\r', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate claude');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('secret scanning hooks (currently installed)  Keep?');
+      session.write('n');
+      await session.waitText('Proceed with removal?');
+      session.keyEnter();
+      await session.waitText('MCP server (currently installed)  Keep?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = `${result.stdout}\n${result.stderr}`;
@@ -2322,12 +2352,16 @@ describe('integrate claude — keep/remove already-installed features', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      // Project scope, decline keeping this project's secrets hooks ('n') then confirm
-      // removal (default Yes); keep the MCP server (default Yes).
-      const result = await harness.run('integrate claude', {
-        stdinChunks: ['\r', 'n', '\r', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate claude');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('secret scanning hooks (currently installed)  Keep?');
+      session.write('n');
+      await session.waitText('Proceed with removal?');
+      session.keyEnter();
+      await session.waitText('MCP server (currently installed)  Keep?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
 
@@ -2390,12 +2424,18 @@ describe('integrate claude — keep/remove already-installed features', () => {
         [`sonar.host.url=${server.baseUrl()}`, 'sonar.projectKey=proj'].join('\n'),
       );
 
-      // Project scope, then decline + confirm removal for both installed features
-      // (secret scanning hooks, then MCP server). No feature remains afterwards.
-      const result = await harness.run('integrate claude', {
-        stdinChunks: ['\r', 'n', '\r', 'n', '\r'],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate claude');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('secret scanning hooks (currently installed)  Keep?');
+      session.write('n');
+      await session.waitText('Proceed with removal?');
+      session.keyEnter();
+      await session.waitText('MCP server (currently installed)  Keep?');
+      session.write('n');
+      await session.waitText('Proceed with removal?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
 

--- a/tests/integration/specs/integrate/claude.test.ts
+++ b/tests/integration/specs/integrate/claude.test.ts
@@ -1994,12 +1994,9 @@ describe('integrate claude — interactive feature selection', () => {
       );
 
       const session = harness.runInteractive('integrate claude');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install secret scanning hooks?');
-      session.keyEnter();
-      await session.waitText('Install MCP server?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.accept('Install secret scanning hooks?');
+      await session.accept('Install MCP server?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2048,12 +2045,9 @@ describe('integrate claude — interactive feature selection', () => {
       let result: CliResult;
       if (isInteractive) {
         const session = harness.runInteractive('integrate claude', { extraEnv });
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install secret scanning hooks?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Where should SonarQube be integrated?');
+        await session.accept('Install secret scanning hooks?');
+        await session.accept('Install MCP server?');
         result = await session.waitFinish();
       } else {
         result = await harness.run('integrate claude --non-interactive', { extraEnv });
@@ -2085,12 +2079,9 @@ describe('integrate claude — interactive feature selection', () => {
       );
 
       const session = harness.runInteractive('integrate claude');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install secret scanning hooks?');
-      session.write('n');
-      await session.waitText('Install MCP server?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.decline('Install secret scanning hooks?');
+      await session.accept('Install MCP server?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2124,12 +2115,9 @@ describe('integrate claude — interactive feature selection', () => {
           __SQCLI_DEV_SKIP_CAG: '1',
         },
       });
-      await session.waitText('Install secret scanning hooks?');
-      session.keyEnter();
-      await session.waitText('Install Vortex?');
-      session.keyEnter();
-      await session.waitText('Install MCP server?');
-      session.keyEnter();
+      await session.accept('Install secret scanning hooks?');
+      await session.accept('Install Vortex?');
+      await session.accept('Install MCP server?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2179,10 +2167,8 @@ describe('integrate claude — interactive feature selection', () => {
           SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
         },
       });
-      await session.waitText('Install secret scanning hooks?');
-      session.keyEnter();
-      await session.waitText('Install MCP server?');
-      session.keyEnter();
+      await session.accept('Install secret scanning hooks?');
+      await session.accept('Install MCP server?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2238,14 +2224,10 @@ describe('integrate claude — keep/remove already-installed features', () => {
       );
 
       const session = harness.runInteractive('integrate claude');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('secret scanning hooks (currently installed)  Keep?');
-      session.keyEnter();
-      await session.waitText('MCP server (currently installed)  Keep?');
-      session.write('n');
-      await session.waitText('Proceed with removal?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.accept('secret scanning hooks (currently installed)  Keep?');
+      await session.decline('MCP server (currently installed)  Keep?');
+      await session.accept('Proceed with removal?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2274,14 +2256,10 @@ describe('integrate claude — keep/remove already-installed features', () => {
       );
 
       const session = harness.runInteractive('integrate claude');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('secret scanning hooks (currently installed)  Keep?');
-      session.keyEnter();
-      await session.waitText('MCP server (currently installed)  Keep?');
-      session.write('n');
-      await session.waitText('Proceed with removal?');
-      session.write('n');
+      await session.accept('Where should SonarQube be integrated?');
+      await session.accept('secret scanning hooks (currently installed)  Keep?');
+      await session.decline('MCP server (currently installed)  Keep?');
+      await session.decline('Proceed with removal?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2303,14 +2281,10 @@ describe('integrate claude — keep/remove already-installed features', () => {
       );
 
       const session = harness.runInteractive('integrate claude');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('secret scanning hooks (currently installed)  Keep?');
-      session.write('n');
-      await session.waitText('Proceed with removal?');
-      session.keyEnter();
-      await session.waitText('MCP server (currently installed)  Keep?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.decline('secret scanning hooks (currently installed)  Keep?');
+      await session.accept('Proceed with removal?');
+      await session.accept('MCP server (currently installed)  Keep?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2353,14 +2327,10 @@ describe('integrate claude — keep/remove already-installed features', () => {
       );
 
       const session = harness.runInteractive('integrate claude');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('secret scanning hooks (currently installed)  Keep?');
-      session.write('n');
-      await session.waitText('Proceed with removal?');
-      session.keyEnter();
-      await session.waitText('MCP server (currently installed)  Keep?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.decline('secret scanning hooks (currently installed)  Keep?');
+      await session.accept('Proceed with removal?');
+      await session.accept('MCP server (currently installed)  Keep?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -2425,16 +2395,11 @@ describe('integrate claude — keep/remove already-installed features', () => {
       );
 
       const session = harness.runInteractive('integrate claude');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('secret scanning hooks (currently installed)  Keep?');
-      session.write('n');
-      await session.waitText('Proceed with removal?');
-      session.keyEnter();
-      await session.waitText('MCP server (currently installed)  Keep?');
-      session.write('n');
-      await session.waitText('Proceed with removal?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.decline('secret scanning hooks (currently installed)  Keep?');
+      await session.accept('Proceed with removal?');
+      await session.decline('MCP server (currently installed)  Keep?');
+      await session.accept('Proceed with removal?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -42,6 +42,7 @@ import {
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
 import {
+  type CliResult,
   hookScriptName,
   hookScriptPath,
   IS_WINDOWS,
@@ -705,11 +706,17 @@ describe('integrate codex', () => {
       async () => {
         // Default beforeEach is on-premise with no entitlement stubs, so Vortex
         // is not_applicable. The three remaining features
-        // (secrets hook, secrets instructions, MCP) each ask. The leading '\r'
-        // selects project scope before the per-feature prompts.
-        const result = await harness.run('integrate codex', {
-          stdinChunks: ['\r', '\r', '\r', '\r'],
-        });
+        // (secrets hook, secrets instructions, MCP) each ask after the scope prompt.
+        const session = harness.runInteractive('integrate codex');
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install secret scanning hooks?');
+        session.keyEnter();
+        await session.waitText('Install secrets-on-read instructions?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = `${result.stdout}\n${result.stderr}`;
@@ -746,13 +753,24 @@ describe('integrate codex', () => {
     ])(
       'prints a non-interactive hint with --non-interactive plus -p/-g examples only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
       async (isAgent, isInteractive, expectedShownPrompt) => {
-        const result = await harness.run(
-          `integrate codex${isInteractive ? '' : ' --non-interactive'}`,
-          {
-            ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r', '\r'] } : {}),
-            extraEnv: isAgent ? { CODEX_SANDBOX_NETWORK_DISABLED: '1' } : {},
-          },
-        );
+        const extraEnv: Record<string, string> = isAgent
+          ? { CODEX_SANDBOX_NETWORK_DISABLED: '1' }
+          : {};
+        let result: CliResult;
+        if (isInteractive) {
+          const session = harness.runInteractive('integrate codex', { extraEnv });
+          await session.waitText('Where should SonarQube be integrated?');
+          session.keyEnter();
+          await session.waitText('Install secret scanning hooks?');
+          session.keyEnter();
+          await session.waitText('Install secrets-on-read instructions?');
+          session.keyEnter();
+          await session.waitText('Install MCP server?');
+          session.keyEnter();
+          result = await session.waitFinish();
+        } else {
+          result = await harness.run('integrate codex --non-interactive', { extraEnv });
+        }
 
         expect(result.exitCode).toBe(0);
         if (expectedShownPrompt) {
@@ -771,10 +789,16 @@ describe('integrate codex', () => {
     it(
       'skips a feature when the user declines its prompt',
       async () => {
-        // '\r' selects project scope; decline the hook ('n'), accept secrets instructions and MCP ('\r').
-        const result = await harness.run('integrate codex', {
-          stdinChunks: ['\r', 'n', '\r', '\r'],
-        });
+        const session = harness.runInteractive('integrate codex');
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install secret scanning hooks?');
+        session.write('n');
+        await session.waitText('Install secrets-on-read instructions?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         // Hook was declined: no hook artifacts and no state entry.
@@ -801,10 +825,19 @@ describe('integrate codex', () => {
 
         // Project install hits the state-probe branch: the secrets-instructions
         // feature asks a custom "project-local copy" question instead of the
-        // default one. The leading '\r' selects project scope first.
-        const result = await harness.run('integrate codex', {
-          stdinChunks: ['\r', '\r', '\r', '\r'],
-        });
+        // default one.
+        const session = harness.runInteractive('integrate codex');
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install secret scanning hooks?');
+        session.keyEnter();
+        await session.waitText(
+          'Global Codex instructions already exist. Do you also want to create a project-local copy for this repo?',
+        );
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = `${result.stdout}\n${result.stderr}`;
@@ -833,14 +866,22 @@ describe('integrate codex', () => {
         const serverUrl = server.baseUrl();
         harness.withAuth(serverUrl, 'cloud-token', testOrg);
 
-        const result = await harness.run(`integrate codex --project ${testProject}`, {
-          stdinChunks: ['\r', '\r', '\r', '\r', '\r'],
+        const session = harness.runInteractive(`integrate codex --project ${testProject}`, {
           extraEnv: {
             SONARQUBE_CLI_SONARCLOUD_URL: serverUrl,
             SONARQUBE_CLI_SONARCLOUD_API_URL: serverUrl,
             __SQCLI_DEV_SKIP_CAG: '1',
           },
         });
+        await session.waitText('Install secret scanning hooks?');
+        session.keyEnter();
+        await session.waitText('Install Vortex?');
+        session.keyEnter();
+        await session.waitText('Install secrets-on-read instructions?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = `${result.stdout}\n${result.stderr}`;

--- a/tests/integration/specs/integrate/codex.test.ts
+++ b/tests/integration/specs/integrate/codex.test.ts
@@ -708,14 +708,10 @@ describe('integrate codex', () => {
         // is not_applicable. The three remaining features
         // (secrets hook, secrets instructions, MCP) each ask after the scope prompt.
         const session = harness.runInteractive('integrate codex');
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install secret scanning hooks?');
-        session.keyEnter();
-        await session.waitText('Install secrets-on-read instructions?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Where should SonarQube be integrated?');
+        await session.accept('Install secret scanning hooks?');
+        await session.accept('Install secrets-on-read instructions?');
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -759,14 +755,10 @@ describe('integrate codex', () => {
         let result: CliResult;
         if (isInteractive) {
           const session = harness.runInteractive('integrate codex', { extraEnv });
-          await session.waitText('Where should SonarQube be integrated?');
-          session.keyEnter();
-          await session.waitText('Install secret scanning hooks?');
-          session.keyEnter();
-          await session.waitText('Install secrets-on-read instructions?');
-          session.keyEnter();
-          await session.waitText('Install MCP server?');
-          session.keyEnter();
+          await session.accept('Where should SonarQube be integrated?');
+          await session.accept('Install secret scanning hooks?');
+          await session.accept('Install secrets-on-read instructions?');
+          await session.accept('Install MCP server?');
           result = await session.waitFinish();
         } else {
           result = await harness.run('integrate codex --non-interactive', { extraEnv });
@@ -790,14 +782,10 @@ describe('integrate codex', () => {
       'skips a feature when the user declines its prompt',
       async () => {
         const session = harness.runInteractive('integrate codex');
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install secret scanning hooks?');
-        session.write('n');
-        await session.waitText('Install secrets-on-read instructions?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Where should SonarQube be integrated?');
+        await session.decline('Install secret scanning hooks?');
+        await session.accept('Install secrets-on-read instructions?');
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -827,16 +815,12 @@ describe('integrate codex', () => {
         // feature asks a custom "project-local copy" question instead of the
         // default one.
         const session = harness.runInteractive('integrate codex');
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install secret scanning hooks?');
-        session.keyEnter();
-        await session.waitText(
+        await session.accept('Where should SonarQube be integrated?');
+        await session.accept('Install secret scanning hooks?');
+        await session.accept(
           'Global Codex instructions already exist. Do you also want to create a project-local copy for this repo?',
         );
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -873,14 +857,10 @@ describe('integrate codex', () => {
             __SQCLI_DEV_SKIP_CAG: '1',
           },
         });
-        await session.waitText('Install secret scanning hooks?');
-        session.keyEnter();
-        await session.waitText('Install Vortex?');
-        session.keyEnter();
-        await session.waitText('Install secrets-on-read instructions?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Install secret scanning hooks?');
+        await session.accept('Install Vortex?');
+        await session.accept('Install secrets-on-read instructions?');
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -681,14 +681,10 @@ describe('integrate copilot', () => {
         const session = harness.runInteractive(`integrate copilot --project ${TEST_PROJECT}`, {
           extraEnv: { ...extraEnv, __SQCLI_DEV_SKIP_CAG: '1' },
         });
-        await session.waitText('Install pre-tool-use hook?');
-        session.keyEnter();
-        await session.waitText('Install prompt-secrets instructions?');
-        session.keyEnter();
-        await session.waitText('Install Vortex?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Install pre-tool-use hook?');
+        await session.accept('Install prompt-secrets instructions?');
+        await session.accept('Install Vortex?');
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -845,9 +841,8 @@ describe('integrate copilot', () => {
 
   // ─── Interactive feature selection ──────────────────────────────────────────
   //
-  // Without --non-interactive each feature is gated by a prompt (ask) or an
-  // automatic skip. InteractiveSession waits for each prompt, then enter()
-  // accepts the default Yes and write('n') declines.
+  // Without --non-interactive each feature is gated by a prompt or an automatic skip.
+  // `accept()` takes the default Yes; `decline()` answers No.
 
   describe('interactive feature selection', () => {
     it(
@@ -857,14 +852,10 @@ describe('integrate copilot', () => {
         // is not_applicable. The three remaining
         // features (hook, prompt-secrets, MCP) each ask.
         const session = harness.runInteractive('integrate copilot');
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install pre-tool-use hook?');
-        session.keyEnter();
-        await session.waitText('Install prompt-secrets instructions?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Where should SonarQube be integrated?');
+        await session.accept('Install pre-tool-use hook?');
+        await session.accept('Install prompt-secrets instructions?');
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -903,14 +894,10 @@ describe('integrate copilot', () => {
         let result: CliResult;
         if (isInteractive) {
           const session = harness.runInteractive('integrate copilot', { extraEnv });
-          await session.waitText('Where should SonarQube be integrated?');
-          session.keyEnter();
-          await session.waitText('Install pre-tool-use hook?');
-          session.keyEnter();
-          await session.waitText('Install prompt-secrets instructions?');
-          session.keyEnter();
-          await session.waitText('Install MCP server?');
-          session.keyEnter();
+          await session.accept('Where should SonarQube be integrated?');
+          await session.accept('Install pre-tool-use hook?');
+          await session.accept('Install prompt-secrets instructions?');
+          await session.accept('Install MCP server?');
           result = await session.waitFinish();
         } else {
           result = await harness.run('integrate copilot --non-interactive', { extraEnv });
@@ -935,14 +922,10 @@ describe('integrate copilot', () => {
       'skips a feature when the user declines its prompt',
       async () => {
         const session = harness.runInteractive('integrate copilot');
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install pre-tool-use hook?');
-        session.write('n');
-        await session.waitText('Install prompt-secrets instructions?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Where should SonarQube be integrated?');
+        await session.decline('Install pre-tool-use hook?');
+        await session.accept('Install prompt-secrets instructions?');
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -965,14 +948,11 @@ describe('integrate copilot', () => {
         writeExistingGlobalInstructions(harness);
 
         const session = harness.runInteractive('integrate copilot');
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText(
+        await session.accept('Where should SonarQube be integrated?');
+        await session.accept(
           'Global Copilot instructions already exist. Do you also want to create a project-local copy for this repo?',
         );
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/integrate/copilot.test.ts
+++ b/tests/integration/specs/integrate/copilot.test.ts
@@ -26,7 +26,7 @@ import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
-import { normalizePath, TestHarness } from '../../harness';
+import { type CliResult, normalizePath, TestHarness } from '../../harness';
 import {
   CopilotHookEntry,
   CopilotHooksJson,
@@ -678,10 +678,18 @@ describe('integrate copilot', () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
         // Interactive (no --non-interactive): the entitled org makes Vortex an ask.
-        const result = await harness.run(`integrate copilot --project ${TEST_PROJECT}`, {
+        const session = harness.runInteractive(`integrate copilot --project ${TEST_PROJECT}`, {
           extraEnv: { ...extraEnv, __SQCLI_DEV_SKIP_CAG: '1' },
-          stdinChunks: ['\r', '\r', '\r', '\r', '\r'],
         });
+        await session.waitText('Install pre-tool-use hook?');
+        session.keyEnter();
+        await session.waitText('Install prompt-secrets instructions?');
+        session.keyEnter();
+        await session.waitText('Install Vortex?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;
@@ -838,8 +846,8 @@ describe('integrate copilot', () => {
   // ─── Interactive feature selection ──────────────────────────────────────────
   //
   // Without --non-interactive each feature is gated by a prompt (ask) or an
-  // automatic skip. The harness drives the confirm prompts via stdin chunks
-  // (one keypress per prompt: '\r' accepts the default Yes, 'n' declines).
+  // automatic skip. InteractiveSession waits for each prompt, then enter()
+  // accepts the default Yes and write('n') declines.
 
   describe('interactive feature selection', () => {
     it(
@@ -848,9 +856,16 @@ describe('integrate copilot', () => {
         // Default beforeEach is on-premise with no entitlement stubs, so Vortex
         // is not_applicable. The three remaining
         // features (hook, prompt-secrets, MCP) each ask.
-        const result = await harness.run('integrate copilot', {
-          stdinChunks: ['\r', '\r', '\r', '\r'],
-        });
+        const session = harness.runInteractive('integrate copilot');
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install pre-tool-use hook?');
+        session.keyEnter();
+        await session.waitText('Install prompt-secrets instructions?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;
@@ -884,13 +899,22 @@ describe('integrate copilot', () => {
     ])(
       'prints a non-interactive hint with --non-interactive plus -p/-g examples only for a detected AI agent without --non-interactive (isAgent=%s, isInteractive=%s, expectedShownPrompt=%s)',
       async (isAgent, isInteractive, expectedShownPrompt) => {
-        const result = await harness.run(
-          `integrate copilot${isInteractive ? '' : ' --non-interactive'}`,
-          {
-            ...(isInteractive ? { stdinChunks: ['\r', '\r', '\r', '\r'] } : {}),
-            extraEnv: isAgent ? { COPILOT_CLI: '1' } : {},
-          },
-        );
+        const extraEnv: Record<string, string> = isAgent ? { COPILOT_CLI: '1' } : {};
+        let result: CliResult;
+        if (isInteractive) {
+          const session = harness.runInteractive('integrate copilot', { extraEnv });
+          await session.waitText('Where should SonarQube be integrated?');
+          session.keyEnter();
+          await session.waitText('Install pre-tool-use hook?');
+          session.keyEnter();
+          await session.waitText('Install prompt-secrets instructions?');
+          session.keyEnter();
+          await session.waitText('Install MCP server?');
+          session.keyEnter();
+          result = await session.waitFinish();
+        } else {
+          result = await harness.run('integrate copilot --non-interactive', { extraEnv });
+        }
 
         expect(result.exitCode).toBe(0);
         if (expectedShownPrompt) {
@@ -910,10 +934,16 @@ describe('integrate copilot', () => {
     it(
       'skips a feature when the user declines its prompt',
       async () => {
-        // '\r' selects project scope; 'n' + '\r' declines the hook; '\r' accepts the rest.
-        const result = await harness.run('integrate copilot', {
-          stdinChunks: ['\r', 'n', '\r', '\r', '\r'],
-        });
+        const session = harness.runInteractive('integrate copilot');
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install pre-tool-use hook?');
+        session.write('n');
+        await session.waitText('Install prompt-secrets instructions?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         // Hook was declined: no project-level hook artifacts and no state entry.
@@ -934,9 +964,16 @@ describe('integrate copilot', () => {
         writeExistingGlobalHook(harness);
         writeExistingGlobalInstructions(harness);
 
-        const result = await harness.run('integrate copilot', {
-          stdinChunks: ['\r', '\r', '\r'],
-        });
+        const session = harness.runInteractive('integrate copilot');
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText(
+          'Global Copilot instructions already exist. Do you also want to create a project-local copy for this repo?',
+        );
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -34,14 +34,19 @@ import {
   expectAgentPromptHint,
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
-import { hookScriptName, hookScriptPath, normalizePath, TestHarness } from '../../harness';
+import {
+  type CliResult,
+  hookScriptName,
+  hookScriptPath,
+  normalizePath,
+  TestHarness,
+} from '../../harness';
 import { findInstalledFeature, getInstalledIntegration } from './state-helpers';
 
 const MCP_JSON_DIRS = ['.cursor', 'mcp.json'];
 const SQAA_RULE_DIRS = ['.cursor', 'rules', 'sonar-agentic-analysis.mdc'];
 const HOOK_BUILD_SCRIPT_DIRS = ['.cursor', 'hooks', 'sonar-secrets', 'build-scripts'];
 const HOOKS_JSON_DIRS = ['.cursor', 'hooks.json'];
-const CURSOR_PROMPT_STDIN_DELAY_MS = 1000;
 
 interface CursorMcpFile {
   mcpServers?: Record<string, { command?: string; args?: string[]; env?: Record<string, string> }>;
@@ -566,11 +571,16 @@ describe('integrate cursor', () => {
       async () => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run(`integrate cursor --project ${TEST_PROJECT}`, {
+        const session = harness.runInteractive(`integrate cursor --project ${TEST_PROJECT}`, {
           extraEnv: { ...extraEnv, __SQCLI_DEV_SKIP_CAG: '1' },
-          stdinChunks: ['\r', '\r', '\r', '\r'],
-          stdinChunkDelayMs: CURSOR_PROMPT_STDIN_DELAY_MS,
         });
+        await session.waitText('Install secret scanning hooks?');
+        session.keyEnter();
+        await session.waitText('Install Vortex?');
+        session.keyEnter();
+        await session.waitText('Install MCP server?');
+        session.keyEnter();
+        const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
         const output = result.stdout + result.stderr;
@@ -592,22 +602,29 @@ describe('integrate cursor', () => {
       async (isAgent, isInteractive, expectedShownPrompt) => {
         const { extraEnv } = await setupCloudWithEntitlement();
 
-        const result = await harness.run(
-          `integrate cursor --project ${TEST_PROJECT}${isInteractive ? '' : ' --non-interactive'}`,
-          {
-            extraEnv: {
-              ...extraEnv,
-              __SQCLI_DEV_SKIP_CAG: '1',
-              ...(isAgent ? { CURSOR_AGENT: '1' } : {}),
-            },
-            ...(isInteractive
-              ? {
-                  stdinChunks: ['\r', '\r', '\r', '\r'],
-                  stdinChunkDelayMs: CURSOR_PROMPT_STDIN_DELAY_MS,
-                }
-              : {}),
-          },
-        );
+        const runEnv = {
+          ...extraEnv,
+          __SQCLI_DEV_SKIP_CAG: '1',
+          ...(isAgent ? { CURSOR_AGENT: '1' } : {}),
+        };
+        let result: CliResult;
+        if (isInteractive) {
+          const session = harness.runInteractive(`integrate cursor --project ${TEST_PROJECT}`, {
+            extraEnv: runEnv,
+          });
+          await session.waitText('Install secret scanning hooks?');
+          session.keyEnter();
+          await session.waitText('Install Vortex?');
+          session.keyEnter();
+          await session.waitText('Install MCP server?');
+          session.keyEnter();
+          result = await session.waitFinish();
+        } else {
+          result = await harness.run(
+            `integrate cursor --project ${TEST_PROJECT} --non-interactive`,
+            { extraEnv: runEnv },
+          );
+        }
 
         expect(result.exitCode).toBe(0);
         if (expectedShownPrompt) {

--- a/tests/integration/specs/integrate/cursor.test.ts
+++ b/tests/integration/specs/integrate/cursor.test.ts
@@ -574,12 +574,9 @@ describe('integrate cursor', () => {
         const session = harness.runInteractive(`integrate cursor --project ${TEST_PROJECT}`, {
           extraEnv: { ...extraEnv, __SQCLI_DEV_SKIP_CAG: '1' },
         });
-        await session.waitText('Install secret scanning hooks?');
-        session.keyEnter();
-        await session.waitText('Install Vortex?');
-        session.keyEnter();
-        await session.waitText('Install MCP server?');
-        session.keyEnter();
+        await session.accept('Install secret scanning hooks?');
+        await session.accept('Install Vortex?');
+        await session.accept('Install MCP server?');
         const result = await session.waitFinish();
 
         expect(result.exitCode).toBe(0);
@@ -612,12 +609,9 @@ describe('integrate cursor', () => {
           const session = harness.runInteractive(`integrate cursor --project ${TEST_PROJECT}`, {
             extraEnv: runEnv,
           });
-          await session.waitText('Install secret scanning hooks?');
-          session.keyEnter();
-          await session.waitText('Install Vortex?');
-          session.keyEnter();
-          await session.waitText('Install MCP server?');
-          session.keyEnter();
+          await session.accept('Install secret scanning hooks?');
+          await session.accept('Install Vortex?');
+          await session.accept('Install MCP server?');
           result = await session.waitFinish();
         } else {
           result = await harness.run(

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -422,12 +422,9 @@ describe('integrate git (native hooks)', () => {
 
       // Project scope, accept pre-commit, decline pre-push. Dep-risks is auto-skipped (no project key).
       const session = harness.runInteractive('integrate git');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install pre-commit code scanning hook?');
-      session.keyEnter();
-      await session.waitText('Install pre-push code scanning hook?');
-      session.write('n');
+      await session.accept('Where should SonarQube be integrated?');
+      await session.accept('Install pre-commit code scanning hook?');
+      await session.decline('Install pre-push code scanning hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -453,12 +450,9 @@ describe('integrate git (native hooks)', () => {
       let result: CliResult;
       if (isInteractive) {
         const session = harness.runInteractive('integrate git', { extraEnv });
-        await session.waitText('Where should SonarQube be integrated?');
-        session.keyEnter();
-        await session.waitText('Install pre-commit code scanning hook?');
-        session.keyEnter();
-        await session.waitText('Install pre-push code scanning hook?');
-        session.write('n');
+        await session.accept('Where should SonarQube be integrated?');
+        await session.accept('Install pre-commit code scanning hook?');
+        await session.decline('Install pre-push code scanning hook?');
         result = await session.waitFinish();
       } else {
         result = await harness.run('integrate git --non-interactive', { extraEnv });
@@ -544,12 +538,9 @@ describe('integrate git (native hooks)', () => {
       initGitRepo(harness);
 
       const session = harness.runInteractive('integrate git');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install pre-commit code scanning hook?');
-      session.write('n');
-      await session.waitText('Install pre-push code scanning hook?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.decline('Install pre-commit code scanning hook?');
+      await session.accept('Install pre-push code scanning hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -568,12 +559,9 @@ describe('integrate git (native hooks)', () => {
 
       // Project scope, accept pre-commit and pre-push. Dep-risks is auto-skipped (no project key).
       const session = harness.runInteractive('integrate git');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install pre-commit code scanning hook?');
-      session.keyEnter();
-      await session.waitText('Install pre-push code scanning hook?');
-      session.keyEnter();
+      await session.accept('Where should SonarQube be integrated?');
+      await session.accept('Install pre-commit code scanning hook?');
+      await session.accept('Install pre-push code scanning hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -605,8 +593,7 @@ describe('integrate git (native hooks)', () => {
 
       // -p implies project scope (no scope prompt). Pre-commit is forced by --hook; pre-push is skipped.
       const session = harness.runInteractive('integrate git --hook pre-commit -p my-project');
-      await session.waitText('Enable dependency-risks scanning on the pre-commit hook?');
-      session.keyEnter();
+      await session.accept('Enable dependency-risks scanning on the pre-commit hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -665,8 +652,7 @@ describe('integrate git (native hooks)', () => {
       initGitRepo(harness);
 
       const session = harness.runInteractive('integrate git --hook pre-commit -p my-project');
-      await session.waitText('Enable dependency-risks scanning on the pre-commit hook?');
-      session.write('n');
+      await session.decline('Enable dependency-risks scanning on the pre-commit hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -759,14 +745,10 @@ describe('integrate git (native hooks)', () => {
 
       // Project key discovered from sonar-project.properties. Dep-risks prompts after pre-commit.
       const session = harness.runInteractive('integrate git');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install pre-commit code scanning hook?');
-      session.keyEnter();
-      await session.waitText('Enable dependency-risks scanning on the pre-commit hook?');
-      session.keyEnter();
-      await session.waitText('Install pre-push code scanning hook?');
-      session.write('n');
+      await session.accept('Where should SonarQube be integrated?');
+      await session.accept('Install pre-commit code scanning hook?');
+      await session.accept('Enable dependency-risks scanning on the pre-commit hook?');
+      await session.decline('Install pre-push code scanning hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -797,12 +779,9 @@ describe('integrate git (native hooks)', () => {
       initGitRepo(harness);
 
       const session = harness.runInteractive('integrate git');
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install pre-commit code scanning hook?');
-      session.write('n');
-      await session.waitText('Install pre-push code scanning hook?');
-      session.write('n');
+      await session.accept('Where should SonarQube be integrated?');
+      await session.decline('Install pre-commit code scanning hook?');
+      await session.decline('Install pre-push code scanning hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).not.toBe(0);
@@ -821,12 +800,9 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
       const session = harness.runInteractive('integrate git --global');
-      await session.waitText('Proceed with global installation?');
-      session.keyEnter();
-      await session.waitText('Install pre-commit code scanning hook?');
-      session.keyEnter();
-      await session.waitText('Install pre-push code scanning hook?');
-      session.write('n');
+      await session.accept('Proceed with global installation?');
+      await session.accept('Install pre-commit code scanning hook?');
+      await session.decline('Install pre-push code scanning hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -851,12 +827,9 @@ describe('integrate git (native hooks)', () => {
       let result: CliResult;
       if (isInteractive) {
         const session = harness.runInteractive('integrate git --global', { extraEnv });
-        await session.waitText('Proceed with global installation?');
-        session.keyEnter();
-        await session.waitText('Install pre-commit code scanning hook?');
-        session.keyEnter();
-        await session.waitText('Install pre-push code scanning hook?');
-        session.write('n');
+        await session.accept('Proceed with global installation?');
+        await session.accept('Install pre-commit code scanning hook?');
+        await session.decline('Install pre-push code scanning hook?');
         result = await session.waitFinish();
       } else {
         result = await harness.run('integrate git --global --non-interactive', { extraEnv });
@@ -899,12 +872,9 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
       const session = harness.runInteractive('integrate git --global');
-      await session.waitText('Proceed with global installation?');
-      session.keyEnter();
-      await session.waitText('Install pre-commit code scanning hook?');
-      session.write('n');
-      await session.waitText('Install pre-push code scanning hook?');
-      session.keyEnter();
+      await session.accept('Proceed with global installation?');
+      await session.decline('Install pre-commit code scanning hook?');
+      await session.accept('Install pre-push code scanning hook?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/integrate/git.test.ts
+++ b/tests/integration/specs/integrate/git.test.ts
@@ -39,7 +39,7 @@ import {
 } from '../../../_common/agent-hint-assertions.js';
 import { ISOLATED_CLI_SPAWN_ENV } from '../../../_common/isolated-cli-env.js';
 import { readCommandEvents } from '../../../_common/telemetry-helpers.ts';
-import { TestHarness } from '../../harness';
+import { type CliResult, TestHarness } from '../../harness';
 import { getCliBinaryPath } from '../../harness/cli-runner.js';
 import { buildHomeEnv, IS_WINDOWS } from '../../harness/platform';
 
@@ -123,12 +123,6 @@ function gitPush(
 
 const INTEGRATION_TEST_TOKEN = 'test-token';
 const LEGACY_PRE_COMMIT_REPO = 'https://github.com/SonarSource/sonar-secrets-pre-commit';
-
-// Project-scope interactive runs spawn `git` (e.g. resolveGitIntegrationId ->
-// usesHusky) between the per-feature confirm prompts. That latency races the
-// default 300 ms stdin chunk spacing and can drop a keystroke before the next
-// prompt starts listening, so give those chunks extra room.
-const PROJECT_PROMPT_CHUNK_DELAY_MS = 900;
 
 type InstalledSubfeatureJson = {
   featureId: string;
@@ -283,7 +277,10 @@ describe('integrate git (native hooks)', () => {
       harness.cwd.writeFile('.git/.keep', '');
 
       // Ctrl+C sent to stdin cancels the scope prompt after the repository summary
-      const result = await harness.run('integrate git', { stdin: '\x03' });
+      const session = harness.runInteractive('integrate git');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyCtrlC();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       expect(result.stdout + result.stderr).toContain('Installation cancelled');
@@ -423,12 +420,15 @@ describe('integrate git (native hooks)', () => {
       // and resolveGitHooksDir() resolves to .git/hooks as expected
       initGitRepo(harness);
 
-      // '\r' selects project scope, '\r' accepts 'Install pre-commit code scanning hook?',
-      // dep-risks is auto-skipped (no project key), 'n' declines 'Install pre-push code scanning hook?'.
-      const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', '\r', 'n'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      // Project scope, accept pre-commit, decline pre-push. Dep-risks is auto-skipped (no project key).
+      const session = harness.runInteractive('integrate git');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install pre-commit code scanning hook?');
+      session.keyEnter();
+      await session.waitText('Install pre-push code scanning hook?');
+      session.write('n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('✓  pre-commit code scanning hook');
@@ -449,15 +449,20 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      const result = await harness.run(
-        `integrate git${isInteractive ? '' : ' --non-interactive'}`,
-        {
-          ...(isInteractive
-            ? { stdinChunks: ['\r', '\r', 'n'], stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS }
-            : {}),
-          extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
-        },
-      );
+      const extraEnv: Record<string, string> = isAgent ? { CLAUDECODE: '1' } : {};
+      let result: CliResult;
+      if (isInteractive) {
+        const session = harness.runInteractive('integrate git', { extraEnv });
+        await session.waitText('Where should SonarQube be integrated?');
+        session.keyEnter();
+        await session.waitText('Install pre-commit code scanning hook?');
+        session.keyEnter();
+        await session.waitText('Install pre-push code scanning hook?');
+        session.write('n');
+        result = await session.waitFinish();
+      } else {
+        result = await harness.run('integrate git --non-interactive', { extraEnv });
+      }
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {
@@ -538,12 +543,14 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' selects project scope, 'n' declines the 'Install pre-commit code scanning hook?'
-      // prompt, '\r' accepts 'Install pre-push code scanning hook?'.
-      const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', 'n', '\r'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate git');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install pre-commit code scanning hook?');
+      session.write('n');
+      await session.waitText('Install pre-push code scanning hook?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('✓  pre-push code scanning hook');
@@ -559,12 +566,15 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' selects project scope, '\r' accepts 'Install pre-commit code scanning hook?',
-      // dep-risks is auto-skipped (no project key), '\r' accepts 'Install pre-push code scanning hook?'.
-      const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', '\r', '\r'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      // Project scope, accept pre-commit and pre-push. Dep-risks is auto-skipped (no project key).
+      const session = harness.runInteractive('integrate git');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install pre-commit code scanning hook?');
+      session.keyEnter();
+      await session.waitText('Install pre-push code scanning hook?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
@@ -593,13 +603,11 @@ describe('integrate git (native hooks)', () => {
       harness.state().withScaScannerBinaryInstalled();
       initGitRepo(harness);
 
-      // -p implies project scope (no scope prompt). '\r' accepts 'Enable dependency-risks scanning?'.
-      // Pre-commit is forced by --hook; pre-push is skipped. Dep-risks prompt appears
-      // because -p supplies a project key.
-      const result = await harness.run('integrate git --hook pre-commit -p my-project', {
-        stdinChunks: ['\r'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      // -p implies project scope (no scope prompt). Pre-commit is forced by --hook; pre-push is skipped.
+      const session = harness.runInteractive('integrate git --hook pre-commit -p my-project');
+      await session.waitText('Enable dependency-risks scanning on the pre-commit hook?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const hookContent = readFileSync(
@@ -656,11 +664,10 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true, scaEnabled: true });
       initGitRepo(harness);
 
-      // -p implies project scope (no scope prompt). 'n' declines 'Enable dependency-risks scanning?'.
-      const result = await harness.run('integrate git --hook pre-commit -p my-project', {
-        stdinChunks: ['n'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate git --hook pre-commit -p my-project');
+      await session.waitText('Enable dependency-risks scanning on the pre-commit hook?');
+      session.write('n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const hookContent = readFileSync(
@@ -688,11 +695,8 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // Only '\r' needed: scope prompt. Dep-risks prompt is suppressed because SCA is unavailable.
-      const result = await harness.run('integrate git --hook pre-commit -p my-project', {
-        stdinChunks: ['\r'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      // -p skips scope; --hook pre-commit skips hook prompts; SCA unavailable skips dep-risks.
+      const result = await harness.run('integrate git --hook pre-commit -p my-project');
 
       expect(result.exitCode).toBe(0);
       const hookContent = readFileSync(
@@ -753,14 +757,17 @@ describe('integrate git (native hooks)', () => {
       initGitRepo(harness);
       harness.cwd.writeFile('sonar-project.properties', 'sonar.projectKey=auto-project\n');
 
-      // '\r' selects project scope, '\r' accepts 'Install pre-commit hook?',
-      // '\r' accepts 'Enable dependency-risks?' (dep-risks is a pre-commit subfeature,
-      // so it prompts immediately after pre-commit is accepted), 'n' declines
-      // 'Install pre-push hook?'. Project key discovered from sonar-project.properties.
-      const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', '\r', '\r', 'n'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      // Project key discovered from sonar-project.properties. Dep-risks prompts after pre-commit.
+      const session = harness.runInteractive('integrate git');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install pre-commit code scanning hook?');
+      session.keyEnter();
+      await session.waitText('Enable dependency-risks scanning on the pre-commit hook?');
+      session.keyEnter();
+      await session.waitText('Install pre-push code scanning hook?');
+      session.write('n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const hookContent = readFileSync(
@@ -789,12 +796,14 @@ describe('integrate git (native hooks)', () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
       initGitRepo(harness);
 
-      // '\r' selects project scope, then 'n' declines both the
-      // 'Install pre-commit code scanning hook?' and 'Install pre-push code scanning hook?' prompts.
-      const result = await harness.run('integrate git', {
-        stdinChunks: ['\r', 'n', 'n'],
-        stdinChunkDelayMs: PROJECT_PROMPT_CHUNK_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate git');
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install pre-commit code scanning hook?');
+      session.write('n');
+      await session.waitText('Install pre-push code scanning hook?');
+      session.write('n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout + result.stderr).toContain(
@@ -811,11 +820,14 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      // Per-feature confirm flow: '\r' confirms the global hook warning, '\r' accepts
-      // 'Install pre-commit code scanning hook?', 'n' declines 'Install pre-push code scanning hook?'.
-      const result = await harness.run('integrate git --global', {
-        stdinChunks: ['\r', '\r', 'n'],
-      });
+      const session = harness.runInteractive('integrate git --global');
+      await session.waitText('Proceed with global installation?');
+      session.keyEnter();
+      await session.waitText('Install pre-commit code scanning hook?');
+      session.keyEnter();
+      await session.waitText('Install pre-push code scanning hook?');
+      session.write('n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('✓  pre-commit code scanning hook');
@@ -835,13 +847,20 @@ describe('integrate git (native hooks)', () => {
     async (isAgent, isInteractive, expectedShownPrompt) => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      const result = await harness.run(
-        `integrate git --global${isInteractive ? '' : ' --non-interactive'}`,
-        {
-          ...(isInteractive ? { stdinChunks: ['\r', '\r', 'n'] } : {}),
-          extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
-        },
-      );
+      const extraEnv: Record<string, string> = isAgent ? { CLAUDECODE: '1' } : {};
+      let result: CliResult;
+      if (isInteractive) {
+        const session = harness.runInteractive('integrate git --global', { extraEnv });
+        await session.waitText('Proceed with global installation?');
+        session.keyEnter();
+        await session.waitText('Install pre-commit code scanning hook?');
+        session.keyEnter();
+        await session.waitText('Install pre-push code scanning hook?');
+        session.write('n');
+        result = await session.waitFinish();
+      } else {
+        result = await harness.run('integrate git --global --non-interactive', { extraEnv });
+      }
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {
@@ -879,11 +898,14 @@ describe('integrate git (native hooks)', () => {
     async () => {
       await setupAuthenticated(harness, { withSecretsBinary: true });
 
-      // Per-feature confirm flow: '\r' confirms the global hook warning, 'n' declines
-      // 'Install pre-commit code scanning hook?', '\r' accepts 'Install pre-push code scanning hook?'.
-      const result = await harness.run('integrate git --global', {
-        stdinChunks: ['\r', 'n', '\r'],
-      });
+      const session = harness.runInteractive('integrate git --global');
+      await session.waitText('Proceed with global installation?');
+      session.keyEnter();
+      await session.waitText('Install pre-commit code scanning hook?');
+      session.write('n');
+      await session.waitText('Install pre-push code scanning hook?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('✓  pre-push code scanning hook');

--- a/tests/integration/specs/integrate/integrate-bare.test.ts
+++ b/tests/integration/specs/integrate/integrate-bare.test.ts
@@ -25,8 +25,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { hookScriptName, TestHarness } from '../../harness';
 import { findInstalledFeature } from './state-helpers';
 
-const CLAUDE_PROMPT_STDIN_DELAY_MS = 1000;
-
 describe('integrate (bare command)', () => {
   let harness: TestHarness;
 
@@ -46,8 +44,10 @@ describe('integrate (bare command)', () => {
       const server = await harness.newFakeServer().withAuthToken('test-token').start();
       harness.withAuth(server.baseUrl(), 'test-token');
 
-      // Ctrl+C cancels the single-select prompt.
-      const result = await harness.run('integrate', { stdinChunks: ['\x03'] });
+      const session = harness.runInteractive('integrate');
+      await session.waitText('Select the tool you want to integrate with');
+      session.keyCtrlC();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain('No integration selected');
@@ -87,18 +87,16 @@ describe('integrate (bare command)', () => {
       );
 
       // Single-select: the cursor starts on Claude (index 0); Enter confirms it.
-      const result = await harness.run('integrate', {
-        stdinChunks: [
-          // select Claude
-          '\r',
-          // scope prompt: keep "This project"
-          '\r',
-          // Claude: Install secret scanning hooks? + Install MCP server?
-          '\r',
-          '\r',
-        ],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate');
+      await session.waitText('Select the tool you want to integrate with');
+      session.keyEnter();
+      await session.waitText('Where should SonarQube be integrated?');
+      session.keyEnter();
+      await session.waitText('Install secret scanning hooks?');
+      session.keyEnter();
+      await session.waitText('Install MCP server?');
+      session.keyEnter();
+      const result = await session.waitFinish();
       const output = result.stdout + result.stderr;
 
       expect(result.exitCode).toBe(0);
@@ -128,16 +126,14 @@ describe('integrate (bare command)', () => {
 
       // --global is passed through to the integration: scope prompt is skipped and
       // the integration installs at global scope.
-      const result = await harness.run('integrate --global', {
-        stdinChunks: [
-          // select Claude
-          '\r',
-          // Claude: Install secret scanning hooks? + Install MCP server?
-          '\r',
-          '\r',
-        ],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate --global');
+      await session.waitText('Select the tool you want to integrate with');
+      session.keyEnter();
+      await session.waitText('Install secret scanning hooks?');
+      session.keyEnter();
+      await session.waitText('Install MCP server?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const feature = findInstalledFeature(harness, 'claude-code', 'sonar-secrets-hooks');
@@ -169,16 +165,14 @@ describe('integrate (bare command)', () => {
 
       // -p is passed through to the integration: scope prompt is skipped (explicit
       // project key implies project scope) and the key is baked into the install.
-      const result = await harness.run('integrate --project my-project', {
-        stdinChunks: [
-          // select Claude
-          '\r',
-          // Claude: Install secret scanning hooks? + Install MCP server?
-          '\r',
-          '\r',
-        ],
-        stdinChunkDelayMs: CLAUDE_PROMPT_STDIN_DELAY_MS,
-      });
+      const session = harness.runInteractive('integrate --project my-project');
+      await session.waitText('Select the tool you want to integrate with');
+      session.keyEnter();
+      await session.waitText('Install secret scanning hooks?');
+      session.keyEnter();
+      await session.waitText('Install MCP server?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const feature = findInstalledFeature(harness, 'claude-code', 'sonar-secrets-hooks');

--- a/tests/integration/specs/integrate/integrate-bare.test.ts
+++ b/tests/integration/specs/integrate/integrate-bare.test.ts
@@ -88,14 +88,10 @@ describe('integrate (bare command)', () => {
 
       // Single-select: the cursor starts on Claude (index 0); Enter confirms it.
       const session = harness.runInteractive('integrate');
-      await session.waitText('Select the tool you want to integrate with');
-      session.keyEnter();
-      await session.waitText('Where should SonarQube be integrated?');
-      session.keyEnter();
-      await session.waitText('Install secret scanning hooks?');
-      session.keyEnter();
-      await session.waitText('Install MCP server?');
-      session.keyEnter();
+      await session.accept('Select the tool you want to integrate with');
+      await session.accept('Where should SonarQube be integrated?');
+      await session.accept('Install secret scanning hooks?');
+      await session.accept('Install MCP server?');
       const result = await session.waitFinish();
       const output = result.stdout + result.stderr;
 
@@ -127,12 +123,9 @@ describe('integrate (bare command)', () => {
       // --global is passed through to the integration: scope prompt is skipped and
       // the integration installs at global scope.
       const session = harness.runInteractive('integrate --global');
-      await session.waitText('Select the tool you want to integrate with');
-      session.keyEnter();
-      await session.waitText('Install secret scanning hooks?');
-      session.keyEnter();
-      await session.waitText('Install MCP server?');
-      session.keyEnter();
+      await session.accept('Select the tool you want to integrate with');
+      await session.accept('Install secret scanning hooks?');
+      await session.accept('Install MCP server?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -166,12 +159,9 @@ describe('integrate (bare command)', () => {
       // -p is passed through to the integration: scope prompt is skipped (explicit
       // project key implies project scope) and the key is baked into the install.
       const session = harness.runInteractive('integrate --project my-project');
-      await session.waitText('Select the tool you want to integrate with');
-      session.keyEnter();
-      await session.waitText('Install secret scanning hooks?');
-      session.keyEnter();
-      await session.waitText('Install MCP server?');
-      session.keyEnter();
+      await session.accept('Select the tool you want to integrate with');
+      await session.accept('Install secret scanning hooks?');
+      await session.accept('Install MCP server?');
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -27,11 +27,27 @@ import {
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
 import { readCommandEvents } from '../../../_common/telemetry-helpers';
-import { type CliResult, TestHarness } from '../../harness';
+import { type CliResult, type InteractiveSession, TestHarness } from '../../harness';
 
 const VALID_TOKEN = 'integration-test-token';
 const TEST_ORG = 'my-org';
 const TEST_PROJECT = 'my-project';
+const ISSUE_PICKER = 'Which issues should the agent fix?';
+
+async function acceptIssuePicker(session: InteractiveSession) {
+  await session.accept(ISSUE_PICKER);
+}
+
+async function quitIssuePicker(session: InteractiveSession) {
+  await session.waitText(ISSUE_PICKER);
+  session.write('q');
+}
+
+async function selectFirstIssue(session: InteractiveSession) {
+  await session.waitText(ISSUE_PICKER);
+  session.keySpace();
+  session.keyEnter();
+}
 
 describe('sonar remediate', () => {
   let harness: TestHarness;
@@ -226,8 +242,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.write('q');
+      await quitIssuePicker(session);
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -249,8 +264,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.keyEnter();
+      await acceptIssuePicker(session);
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -283,8 +297,7 @@ describe('sonar remediate', () => {
       let result: CliResult;
       if (isInteractive) {
         const session = harness.runInteractive(command, { extraEnv });
-        await session.waitText('Which issues should the agent fix?');
-        session.keyEnter();
+        await acceptIssuePicker(session);
         result = await session.waitFinish();
       } else {
         result = await harness.run(command, { extraEnv });
@@ -316,9 +329,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.keySpace();
-      session.keyEnter();
+      await selectFirstIssue(session);
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -348,9 +359,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.keySpace();
-      session.keyEnter();
+      await selectFirstIssue(session);
       await session.waitFinish();
 
       const agentJobCalls = server
@@ -385,8 +394,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.keyEnter();
+      await acceptIssuePicker(session);
       await session.waitFinish();
 
       const issuesSearchCalls = server
@@ -419,9 +427,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.keySpace();
-      session.keyEnter();
+      await selectFirstIssue(session);
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
@@ -450,9 +456,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.keySpace();
-      session.keyEnter();
+      await selectFirstIssue(session);
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
@@ -477,8 +481,7 @@ describe('sonar remediate', () => {
       harness.cwd.writeFile('sonar-project.properties', `sonar.projectKey=${TEST_PROJECT}\n`);
 
       const session = harness.runInteractive('remediate');
-      await session.waitText('Which issues should the agent fix?');
-      session.keyEnter();
+      await acceptIssuePicker(session);
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -525,7 +528,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
+      await session.waitText(ISSUE_PICKER);
       session.keySpace();
       session.keyDown();
       session.keySpace();
@@ -574,8 +577,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.write('q');
+      await quitIssuePicker(session);
       const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
@@ -619,9 +621,7 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
       const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
-      await session.waitText('Which issues should the agent fix?');
-      session.keySpace();
-      session.keyEnter();
+      await selectFirstIssue(session);
       await session.waitFinish();
 
       const agentJobCalls = server

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -27,7 +27,7 @@ import {
   expectNoAgentPromptHint,
 } from '../../../_common/agent-hint-assertions.js';
 import { readCommandEvents } from '../../../_common/telemetry-helpers';
-import { TestHarness } from '../../harness';
+import { type CliResult, TestHarness } from '../../harness';
 
 const VALID_TOKEN = 'integration-test-token';
 const TEST_ORG = 'my-org';
@@ -225,9 +225,10 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      const result = await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: ['q'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.write('q');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('No issues selected');
@@ -247,10 +248,10 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      // Enter immediately without selecting any issue
-      const result = await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: ['\r'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain('No issues selected');
@@ -278,10 +279,16 @@ describe('sonar remediate', () => {
       const command = isInteractive
         ? `remediate --project ${TEST_PROJECT}`
         : `remediate --project ${TEST_PROJECT} --issues PROJ-1,PROJ-2`;
-      const result = await harness.run(command, {
-        ...(isInteractive ? { stdinChunks: ['\r'] } : {}),
-        extraEnv: isAgent ? { CLAUDECODE: '1' } : {},
-      });
+      const extraEnv: Record<string, string> = isAgent ? { CLAUDECODE: '1' } : {};
+      let result: CliResult;
+      if (isInteractive) {
+        const session = harness.runInteractive(command, { extraEnv });
+        await session.waitText('Which issues should the agent fix?');
+        session.keyEnter();
+        result = await session.waitFinish();
+      } else {
+        result = await harness.run(command, { extraEnv });
+      }
 
       expect(result.exitCode).toBe(0);
       if (expectedShownPrompt) {
@@ -308,10 +315,11 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      // Space to select the first issue, then Enter to confirm
-      const result = await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: [' ', '\r'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keySpace();
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
@@ -339,9 +347,11 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: [' ', '\r'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keySpace();
+      session.keyEnter();
+      await session.waitFinish();
 
       const agentJobCalls = server
         .getRecordedRequests()
@@ -374,8 +384,10 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      // Enter without selecting to avoid submitting a job
-      await harness.run(`remediate --project ${TEST_PROJECT}`, { stdinChunks: ['\r'] });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keyEnter();
+      await session.waitFinish();
 
       const issuesSearchCalls = server
         .getRecordedRequests()
@@ -406,9 +418,11 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      const result = await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: [' ', '\r'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keySpace();
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
@@ -435,9 +449,11 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      const result = await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: [' ', '\r'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keySpace();
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(1);
       const output = result.stdout + result.stderr;
@@ -460,7 +476,10 @@ describe('sonar remediate', () => {
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
       harness.cwd.writeFile('sonar-project.properties', `sonar.projectKey=${TEST_PROJECT}\n`);
 
-      const result = await harness.run('remediate', { stdinChunks: ['\r'] });
+      const session = harness.runInteractive('remediate');
+      await session.waitText('Which issues should the agent fix?');
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout + result.stderr).toContain(TEST_PROJECT);
@@ -505,10 +524,13 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      // Space selects item at cursor 0, Down moves cursor, Space selects cursor 1, Enter confirms
-      const result = await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: [' ', '\x1b[B', ' ', '\r'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keySpace();
+      session.keyDown();
+      session.keySpace();
+      session.keyEnter();
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
@@ -551,9 +573,10 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      const result = await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: ['q'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.write('q');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       const output = result.stdout + result.stderr;
@@ -595,10 +618,11 @@ describe('sonar remediate', () => {
         .start();
       harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
 
-      // Space selects the first item in the list - must be the BLOCKER after sorting
-      await harness.run(`remediate --project ${TEST_PROJECT}`, {
-        stdinChunks: [' ', '\r'],
-      });
+      const session = harness.runInteractive(`remediate --project ${TEST_PROJECT}`);
+      await session.waitText('Which issues should the agent fix?');
+      session.keySpace();
+      session.keyEnter();
+      await session.waitFinish();
 
       const agentJobCalls = server
         .getRecordedRequests()

--- a/tests/integration/specs/run/mcp.test.ts
+++ b/tests/integration/specs/run/mcp.test.ts
@@ -276,10 +276,11 @@ describe('run mcp', () => {
       harness.withAuth(server.baseUrl(), 'test-token');
       const fakeBinDir = setupFakeDocker();
 
-      const result = await harness.run('run mcp', {
+      const session = harness.runInteractive('run mcp', {
         extraEnv: { PATH: `${fakeBinDir}${PATH_SEP}${process.env.PATH ?? ''}` },
-        stdin: 'hello mcp\n',
       });
+      session.write('hello mcp\n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('hello mcp');
@@ -319,10 +320,11 @@ describe('run mcp', () => {
       );
       const fakeBinDir = setupFakeDocker();
 
-      const result = await harness.run('run mcp', {
+      const session = harness.runInteractive('run mcp', {
         extraEnv: { PATH: `${fakeBinDir}${PATH_SEP}${process.env.PATH ?? ''}` },
-        stdin: 'hello mcp\n',
       });
+      session.write('hello mcp\n');
+      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('hello mcp');

--- a/tests/integration/specs/run/mcp.test.ts
+++ b/tests/integration/specs/run/mcp.test.ts
@@ -276,11 +276,9 @@ describe('run mcp', () => {
       harness.withAuth(server.baseUrl(), 'test-token');
       const fakeBinDir = setupFakeDocker();
 
-      const session = harness.runInteractive('run mcp', {
+      const result = await harness.runWithStdin('run mcp', 'hello mcp\n', {
         extraEnv: { PATH: `${fakeBinDir}${PATH_SEP}${process.env.PATH ?? ''}` },
       });
-      session.write('hello mcp\n');
-      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('hello mcp');
@@ -320,11 +318,9 @@ describe('run mcp', () => {
       );
       const fakeBinDir = setupFakeDocker();
 
-      const session = harness.runInteractive('run mcp', {
+      const result = await harness.runWithStdin('run mcp', 'hello mcp\n', {
         extraEnv: { PATH: `${fakeBinDir}${PATH_SEP}${process.env.PATH ?? ''}` },
       });
-      session.write('hello mcp\n');
-      const result = await session.waitFinish();
 
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('hello mcp');

--- a/tests/unit/integration-harness/interactive-session.test.ts
+++ b/tests/unit/integration-harness/interactive-session.test.ts
@@ -187,6 +187,19 @@ describe('InteractiveSession', () => {
     expect(fake.ended).toBe(true);
   });
 
+  it('accept waits then sends enter, decline waits then sends n', async () => {
+    const fake = createFakeProcess();
+    const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });
+
+    fake.pushStdout('Install MCP server?');
+    await session.accept('Install MCP server?');
+    fake.pushStdout('Install secret scanning hooks?');
+    await session.decline('Install secret scanning hooks?');
+    expect(fake.writes).toEqual(['\r', 'n']);
+
+    session.kill();
+  });
+
   it('keeps unread stdout for a later waitText', async () => {
     const fake = createFakeProcess();
     const session = InteractiveSession.fromProcess(fake.handle, { timeoutMs: 2000 });


### PR DESCRIPTION
## Summary
- Moves interactive and dump-all stdin call sites to `runInteractive()`
- `run()` still accepts `stdin` / `stdinChunks` so this change is test-only