### PR TITLE
CLI-1037 Make run() a session and drop stdin from the harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ The two inputs are separate because the single boolean made _collect but do not 
 
 **Writing tests that touch telemetry** — four traps, none of which lint or CI will catch:
 
-- **Spawn the CLI only through the harness** (`harness.run()`, `harness.runInteractive()`, `harness.runWithStdin()`) or by spreading `ISOLATED_CLI_SPAWN_ENV`. A hand-rolled `Bun.spawn` of the binary inherits production egress; the two such spawns in `tests/e2e/install-scripts.test.ts` are safe only because they spread it explicitly.
+- **Spawn the CLI only through the harness** (`harness.run()`, `harness.runInteractive()`, `harness.runWithStdin()`) or by spreading `ISOLATED_CLI_SPAWN_ENV`. A hand-rolled `Bun.spawn` of the binary inherits production egress; the two such spawns in `tests/e2e/install-scripts.test.ts` are safe only because they spread it explicitly. `tests/e2e/bun-secrets-keychain.test.ts` goes through `spawnCliProcess`, which applies the same isolation.
 - **A unit test that enables telemetry must point `SONAR_USER_HOME` at a temp dir.** Egress `off` stops _that process_ transmitting, but events still land in the developer's real `~/.sonar` queue, and their next genuine `sonar` command drains and POSTs them. This is the one leak path the egress mode cannot close, because the transmitting process is legitimate.
 - **Clearing `__SQ_CLI_TELEMETRY_EGRESS`** to exercise the spawn or drain means the real code paths run: mock `Bun.spawn` and `fetch` in the same file.
 - **`flushTelemetryEvents` transmits unconditionally** — its guards are in `flushTelemetry`. Call it directly only with `fetch` mocked.

--- a/tests/e2e/bun-secrets-keychain.test.ts
+++ b/tests/e2e/bun-secrets-keychain.test.ts
@@ -36,8 +36,12 @@ import { generateKeychainAccount } from '@/core/host/keychain.ts';
 import { getDefaultState } from '@/core/state/state.ts';
 import { addOrUpdateConnection } from '@/core/state/state-manager.ts';
 
-import { FakeSonarQubeServer, FakeSonarQubeServerBuilder } from '../integration/harness';
-import { getCliBinaryPath, runCli } from '../integration/harness/cli-runner';
+import {
+  type CliResult,
+  FakeSonarQubeServer,
+  FakeSonarQubeServerBuilder,
+} from '../integration/harness';
+import { getCliBinaryPath, spawnCliProcess } from '../integration/harness/cli-runner';
 import { buildHomeEnv } from '../integration/harness/platform';
 
 setDefaultTimeout(30_000);
@@ -101,13 +105,49 @@ async function setupAuth(ctx: E2eContext): Promise<string> {
   return account;
 }
 
+async function runCli(
+  command: string,
+  env: Record<string, string>,
+  options: { cwd: string; timeoutMs?: number },
+): Promise<CliResult> {
+  const { proc, timeoutMs, startedAt } = spawnCliProcess(command, env, {
+    cwd: options.cwd,
+    timeoutMs: options.timeoutMs,
+    stdin: 'ignore',
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+
+  const [exitCode, stdout, stderr] = await Promise.all([
+    proc.exited,
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+
+  clearTimeout(timer);
+
+  if (timedOut) {
+    throw new Error(`CLI process timed out after ${timeoutMs}ms`);
+  }
+
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    durationMs: Date.now() - startedAt,
+  };
+}
+
 // macOS Keychain attaches a per-process ACL to entries written via
 // `Bun.secrets.set`. The test process is on the ACL list; the CLI subprocess
-// spawned by `runCli` is not, so its `Bun.secrets.get` call fails with
-// `errSecAuthFailed` (no GUI in headless test mode to grant access). CI never
-// runs e2e on macOS (only Linux + Windows in the Build workflow), so skip here
-// to keep `bun run test:e2e` clean on macOS dev machines without losing any
-// coverage CI relies on.
+// is not, so its `Bun.secrets.get` call fails with `errSecAuthFailed` (no GUI
+// in headless test mode to grant access). CI never runs e2e on macOS (only
+// Linux + Windows in the Build workflow), so skip here to keep `bun run test:e2e`
+// clean on macOS dev machines without losing any coverage CI relies on.
 const describeKeychain =
   process.platform === 'darwin' && process.env.CI !== 'true' ? describe.skip : describe;
 

--- a/tests/integration/harness/cli-runner.ts
+++ b/tests/integration/harness/cli-runner.ts
@@ -26,7 +26,7 @@ import { join } from 'node:path';
 import { applyIsolatedSpawnEnv } from '../../_common/isolated-cli-env.js';
 import { COVERAGE_BINARY, COVERAGE_RAW_DIR } from '../../coverage/paths.js';
 import { IS_WINDOWS } from './platform';
-import type { CliResult, InteractiveProcessHandle, SessionStdin } from './types.js';
+import type { InteractiveProcessHandle, SessionStdin } from './types.js';
 
 const PROJECT_ROOT = join(import.meta.dir, '../../..');
 const DEFAULT_BINARY = join(
@@ -46,7 +46,7 @@ function getBinaryPath(coverageMode: boolean, overridePath?: string): string {
   return binaryPath;
 }
 
-/** Same executable `runCli` uses (coverage binary when `SONARQUBE_CLI_USE_COVERAGE=1`). */
+/** Same executable the harness spawns (coverage binary when `SONARQUBE_CLI_USE_COVERAGE=1`). */
 export function getCliBinaryPath(): string {
   return getBinaryPath(process.env.SONARQUBE_CLI_USE_COVERAGE === '1');
 }
@@ -122,81 +122,6 @@ function requirePipedStream(
   throw new Error(`Expected piped ${name}`);
 }
 
-const STDIN_CHUNK_DELAY_MS = 300;
-
-export async function runCli(
-  command: string,
-  env: Record<string, string>,
-  options: {
-    stdin?: string;
-    stdinChunks?: string[];
-    stdinChunkDelayMs?: number;
-    timeoutMs?: number;
-    cwd: string;
-    browserToken?: string;
-    browserTokenName?: string;
-    binaryPath?: string;
-  },
-): Promise<CliResult> {
-  const hasStdin = options.stdin !== undefined || (options.stdinChunks?.length ?? 0) > 0;
-  const { proc, timeoutMs, startedAt } = spawnCliProcess(command, env, {
-    cwd: options.cwd,
-    timeoutMs: options.timeoutMs,
-    binaryPath: options.binaryPath,
-    stdin: hasStdin ? 'pipe' : 'ignore',
-  });
-
-  if (options.stdin !== undefined && proc.stdin) {
-    proc.stdin.write(new TextEncoder().encode(options.stdin));
-    proc.stdin.end();
-  }
-
-  if (options.stdinChunks !== undefined && proc.stdin) {
-    const encoder = new TextEncoder();
-    const chunkDelayMs = options.stdinChunkDelayMs ?? STDIN_CHUNK_DELAY_MS;
-    await (async () => {
-      for (const chunk of options.stdinChunks ?? []) {
-        await new Promise((r) => setTimeout(r, chunkDelayMs));
-        proc.stdin?.write(encoder.encode(chunk));
-      }
-      proc.stdin?.end();
-    })();
-  }
-
-  let timedOut = false;
-  const timer = setTimeout(() => {
-    timedOut = true;
-    proc.kill();
-  }, timeoutMs);
-
-  let stdout: string;
-
-  if (options.browserToken) {
-    stdout = await streamStdoutAndDeliverToken(
-      proc.stdout,
-      options.browserToken,
-      options.browserTokenName,
-    );
-  } else {
-    stdout = await new Response(proc.stdout).text();
-  }
-
-  const [exitCode, stderr] = await Promise.all([proc.exited, new Response(proc.stderr).text()]);
-
-  clearTimeout(timer);
-
-  if (timedOut) {
-    throw new Error(`CLI process timed out after ${timeoutMs}ms`);
-  }
-
-  return {
-    exitCode,
-    stdout,
-    stderr,
-    durationMs: Date.now() - startedAt,
-  };
-}
-
 /**
  * Extracts the loopback port from accumulated stdout and POSTs the token to it.
  * Returns true if the token was delivered, false if the port was not found yet.
@@ -213,39 +138,6 @@ export function tryDeliverToken(accumulated: string, token: string, tokenName?: 
     /* loopback server may close before response completes */
   });
   return true;
-}
-
-/**
- * Reads stdout incrementally. When the loopback auth port appears in the output
- * (pattern: `port=NNNNN`), delivers the token via POST to the loopback server.
- * Returns the full accumulated stdout once the stream ends.
- */
-async function streamStdoutAndDeliverToken(
-  stream: ReadableStream<Uint8Array>,
-  token: string,
-  tokenName?: string,
-): Promise<string> {
-  const decoder = new TextDecoder();
-  const reader = stream.getReader();
-  let accumulated = '';
-  let tokenDelivered = false;
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      accumulated += decoder.decode(value, { stream: true });
-
-      if (!tokenDelivered) {
-        tokenDelivered = tryDeliverToken(accumulated, token, tokenName);
-      }
-    }
-  } finally {
-    reader.releaseLock();
-  }
-
-  return accumulated;
 }
 
 /**

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -29,6 +29,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
@@ -656,6 +657,10 @@ const EXECUTABLE_PERMS = 0o755;
 function canWriteFile(path: string): boolean {
   if (!existsSync(path)) {
     return true;
+  }
+  // accessSync(W_OK) succeeds for root regardless of mode.
+  if ((statSync(path).mode & 0o222) === 0) {
+    return false;
   }
   try {
     accessSync(path, constants.W_OK);

--- a/tests/integration/harness/environment-builder.ts
+++ b/tests/integration/harness/environment-builder.ts
@@ -21,7 +21,16 @@
 // Declarative builder for the isolated test environment: state.json + binary setup
 
 import { randomUUID } from 'node:crypto';
-import { chmodSync, copyFileSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 import { CONTEXT_AUGMENTATION_FEATURE_ID } from '@/commands/integrate/_common/features/context-augmentation-feature.ts';
@@ -551,6 +560,8 @@ export class EnvironmentBuilder {
 
   /**
    * Writes state.json and the keychain JSON file, and if withSecretsBinaryInstalled() was called, copies the mock binary.
+   * Leaves an existing read-only keychain in place when it already holds the
+   * intended tokens, so a test can exercise delete failure.
    */
   writeTo(cliHome: string, keychainFile: string): void {
     mkdirSync(cliHome, { recursive: true });
@@ -561,10 +572,14 @@ export class EnvironmentBuilder {
     if (this.keychainTokens.length > 0) {
       const tokens: Record<string, string> = {};
       for (const { serverURL, token, org } of this.keychainTokens) {
-        const account = generateKeychainAccount(serverURL, org);
-        tokens[account] = token;
+        tokens[generateKeychainAccount(serverURL, org)] = token;
       }
-      writeFileSync(keychainFile, JSON.stringify({ tokens }, null, 2), 'utf-8');
+      const payload = JSON.stringify({ tokens }, null, 2);
+      if (canWriteFile(keychainFile)) {
+        writeFileSync(keychainFile, payload, 'utf-8');
+      } else if (readFileSync(keychainFile, 'utf-8') !== payload) {
+        throw new Error(`Cannot seed read-only keychain with different tokens: ${keychainFile}`);
+      }
     }
 
     if (this._installSecretsBinary) {
@@ -637,6 +652,18 @@ export class EnvironmentBuilder {
 }
 
 const EXECUTABLE_PERMS = 0o755;
+
+function canWriteFile(path: string): boolean {
+  if (!existsSync(path)) {
+    return true;
+  }
+  try {
+    accessSync(path, constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 function copyBinaryFixtureInto(cliHome: string, fixture: BinarySpec, versionedName: string): void {
   const binDir = join(cliHome, 'bin');

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -225,7 +225,15 @@ export class TestHarness {
    * when the command needs stdin.
    */
   async run(command: string, options?: RunOptions): Promise<CliResult> {
-    return this.runInteractive(command, options).waitFinish();
+    const session = this.runInteractive(command, options);
+    try {
+      return await session.waitFinish();
+    } finally {
+      const index = this.sessions.indexOf(session);
+      if (index >= 0) {
+        this.sessions.splice(index, 1);
+      }
+    }
   }
 
   /**

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -229,10 +229,7 @@ export class TestHarness {
     try {
       return await session.waitFinish();
     } finally {
-      const index = this.sessions.indexOf(session);
-      if (index >= 0) {
-        this.sessions.splice(index, 1);
-      }
+      this.dropSession(session);
     }
   }
 
@@ -245,8 +242,12 @@ export class TestHarness {
     options?: RunInteractiveOptions,
   ): Promise<CliResult> {
     const session = this.runInteractive(command, options);
-    session.write(stdin);
-    return session.waitFinish();
+    try {
+      session.write(stdin);
+      return await session.waitFinish();
+    } finally {
+      this.dropSession(session);
+    }
   }
 
   /**
@@ -323,6 +324,13 @@ export class TestHarness {
       composed[ENV_DO_NOT_TRACK] = '0';
     }
     return applyIsolatedSpawnEnv(composed);
+  }
+
+  private dropSession(session: InteractiveSession): void {
+    const index = this.sessions.indexOf(session);
+    if (index >= 0) {
+      this.sessions.splice(index, 1);
+    }
   }
 
   /**

--- a/tests/integration/harness/index.ts
+++ b/tests/integration/harness/index.ts
@@ -29,7 +29,7 @@ import { ENV_DO_NOT_TRACK, ENV_SQAA_RETRY_BASE_DELAY_MS } from '@/core/config-co
 import { canonicalizePath } from '@/core/io/fs-utils.ts';
 
 import { applyIsolatedSpawnEnv } from '../../_common/isolated-cli-env.js';
-import { getCliBinaryPath, runCli } from './cli-runner.js';
+import { getCliBinaryPath } from './cli-runner.js';
 import { Dir } from './dir';
 import { EnvironmentBuilder } from './environment-builder.js';
 import { FakeBinariesServer, FakeBinariesServerBuilder } from './fake-binaries-server.js';
@@ -215,23 +215,17 @@ export class TestHarness {
   }
 
   /**
-   * Runs the CLI binary with the given command string.
+   * Runs the CLI to completion with no stdin.
    *
    * Before spawning, applies the configured environment (writes state.json + seeds tokens).
    * Sets SONARQUBE_CLI_KEYCHAIN_FILE so the CLI uses the file-based keychain backend,
    * avoiding OS credential store access and macOS keychain prompts.
+   *
+   * Same process as `runInteractive()`, finished immediately. Use `runInteractive()`
+   * when the command needs stdin.
    */
   async run(command: string, options?: RunOptions): Promise<CliResult> {
-    return runCli(command, this.env(options), {
-      stdin: options?.stdin,
-      stdinChunks: options?.stdinChunks,
-      stdinChunkDelayMs: options?.stdinChunkDelayMs,
-      timeoutMs: options?.timeoutMs,
-      cwd: options?.cwd ?? this.cwd.path,
-      browserToken: options?.browserToken,
-      browserTokenName: options?.browserTokenName,
-      binaryPath: options?.binaryPath,
-    });
+    return this.runInteractive(command, options).waitFinish();
   }
 
   /**

--- a/tests/integration/harness/types.ts
+++ b/tests/integration/harness/types.ts
@@ -45,21 +45,6 @@ export interface RunOptions {
   /** Working directory for the CLI process. Defaults to harness.cwd.path. */
   cwd?: string;
   timeoutMs?: number;
-  stdin?: string;
-  /**
-   * Writes stdin in separate chunks with a delay between each (see
-   * `stdinChunkDelayMs`). Use this when the CLI shows multiple sequential
-   * interactive prompts: sending all bytes at once causes readline to buffer
-   * and discard later bytes before the next prompt has started listening.
-   */
-  stdinChunks?: string[];
-  /**
-   * Delay in milliseconds between successive `stdinChunks` writes. Defaults to
-   * 300 ms. The harness waits for the first stdout byte before writing any
-   * chunk, then pauses this long between chunks so readline is listening.
-   * Raise this when slow work happens between prompts (e.g. spawning `git`).
-   */
-  stdinChunkDelayMs?: number;
   /**
    * When set, the harness streams CLI stdout looking for the loopback OAuth
    * port (pattern: `port=\d+`), then delivers this token via POST request to

--- a/tests/integration/harness/types.ts
+++ b/tests/integration/harness/types.ts
@@ -57,10 +57,7 @@ export interface RunOptions {
 }
 
 /** Options for `harness.runInteractive()`. Stdin is driven by the session. */
-export type RunInteractiveOptions = Omit<
-  RunOptions,
-  'stdin' | 'stdinChunks' | 'stdinChunkDelayMs'
-> & {
+export type RunInteractiveOptions = RunOptions & {
   /** Per-`waitText` timeout. Defaults to `timeoutMs`. */
   waitTimeoutMs?: number;
 };

--- a/tests/integration/specs/system/reset.test.ts
+++ b/tests/integration/specs/system/reset.test.ts
@@ -43,7 +43,6 @@ import { generateKeychainAccount } from '@/core/host/keychain.ts';
 
 import { version as CLI_VERSION } from '../../../../package.json';
 import { hookScriptName, TestHarness } from '../../harness';
-import { runCli } from '../../harness/cli-runner.js';
 import { buildHomeEnv, IS_WINDOWS } from '../../harness/platform';
 import {
   PROJECT_HOOK_SCRIPT_PATH,
@@ -274,10 +273,11 @@ describe('system reset --force', () => {
         .withKeychainToken(server.baseUrl(), 'reset-token');
 
       const account = generateKeychainAccount(server.baseUrl());
-      const env = harness.env();
+      // Write keychain.json so chmod can make that file read-only before run().
+      harness.env();
       try {
         chmodSync(harness.keychainJsonFile, 0o444);
-        const result = await runCli('system reset --force', env, { cwd: harness.cwd.path });
+        const result = await harness.run('system reset --force');
 
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toMatch(/Authentication:.*could not delete keychain entry/);


### PR DESCRIPTION
## Summary
- Implements `run()` as `runInteractive().waitFinish()` and removes `stdin` / `stdinChunks` from the harness API
- Moves `runCli` into the OS-keychain e2e file; a read-only keychain is left in place only when it already holds the intended tokens