### PR TITLE
CLI-1012 Add coverage category enrichment

### DIFF
--- a/src/commands/quality-gate/status/breakdown.ts
+++ b/src/commands/quality-gate/status/breakdown.ts
@@ -1,0 +1,137 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Builds the per-file breakdown for failing quality gate conditions
+
+import logger from '@/core/observability/logger.ts';
+import type { SonarQubeClient } from '@/core/server/client.ts';
+import { isNewCodeMetric, MeasuresClient } from '@/core/server/measures.ts';
+import type { ComponentTreeComponent, Metric, QualityGateCondition } from '@/core/server/types.ts';
+
+import { formatMetricValue } from './format-metric-value.ts';
+
+const METRIC_CATEGORIES: Record<string, string> = {
+  coverage: 'coverage',
+  branch_coverage: 'coverage',
+  line_coverage: 'coverage',
+  new_coverage: 'coverage',
+  new_branch_coverage: 'coverage',
+  new_line_coverage: 'coverage',
+};
+
+export interface QualityGateBreakdownEntry {
+  path: string;
+  value: string;
+  formattedValue: string;
+}
+
+export interface QualityGateMetricBreakdown {
+  metric: string;
+  totalCount: number;
+  fetchedCount: number;
+  entries: QualityGateBreakdownEntry[];
+}
+
+export interface BuildBreakdownParams {
+  client: SonarQubeClient;
+  projectKey: string;
+  conditions: QualityGateCondition[];
+  metrics: Metric[];
+  top: number;
+  branch?: string;
+  pullRequest?: string;
+}
+
+/** A failing condition whose metric falls into an implemented category. */
+function isEnrichableCondition(condition: QualityGateCondition): boolean {
+  return condition.status !== 'OK' && !!METRIC_CATEGORIES[condition.metricKey];
+}
+
+/**
+ * One breakdown per matching condition. Worst-first sort direction comes from the condition's own
+ * `comparator` (`LT` - lower is worse - sorts ascending, `GT` sorts descending).
+ */
+export async function buildBreakdown(
+  params: BuildBreakdownParams,
+): Promise<QualityGateMetricBreakdown[]> {
+  const measuresClient = new MeasuresClient(params.client);
+  const metricsByKey = new Map(params.metrics.map((metric) => [metric.key, metric]));
+
+  const results = await Promise.all(
+    params.conditions
+      .filter(isEnrichableCondition)
+      .map((condition) => fetchMetricBreakdown(measuresClient, params, condition, metricsByKey)),
+  );
+  return results.filter((result): result is QualityGateMetricBreakdown => result !== undefined);
+}
+
+async function fetchMetricBreakdown(
+  measuresClient: MeasuresClient,
+  params: BuildBreakdownParams,
+  condition: QualityGateCondition,
+  metricsByKey: Map<string, Metric>,
+): Promise<QualityGateMetricBreakdown | undefined> {
+  try {
+    const { components, totalCount } = await measuresClient.getWorstComponentsByMetric({
+      projectKey: params.projectKey,
+      metricKey: condition.metricKey,
+      ascending: condition.comparator === 'LT',
+      top: params.top,
+      branch: params.branch,
+      pullRequest: params.pullRequest,
+    });
+
+    const entries = components.flatMap((component) =>
+      toBreakdownEntry(component, condition.metricKey, metricsByKey.get(condition.metricKey)),
+    );
+    return entries.length > 0
+      ? { metric: condition.metricKey, totalCount, fetchedCount: components.length, entries }
+      : undefined;
+  } catch (err) {
+    logger.debug(`Failed to build quality gate breakdown for '${condition.metricKey}'`, err);
+    return undefined;
+  }
+}
+
+function toBreakdownEntry(
+  component: ComponentTreeComponent,
+  metricKey: string,
+  metric: Metric | undefined,
+): QualityGateBreakdownEntry[] {
+  if (!component.path) {
+    return [];
+  }
+  const measure = component.measures.find((m) => m.metric === metricKey);
+  const rawValue = isNewCodeMetric(metricKey)
+    ? measure?.periods?.[0]?.value
+    : (measure?.value ?? measure?.periods?.[0]?.value);
+  if (rawValue === undefined) {
+    return [];
+  }
+  return [
+    {
+      path: component.path,
+      value: rawValue,
+      formattedValue: metric
+        ? formatMetricValue(metric.type, rawValue, metric.decimalScale)
+        : rawValue,
+    },
+  ];
+}

--- a/src/commands/quality-gate/status/breakdown.ts
+++ b/src/commands/quality-gate/status/breakdown.ts
@@ -23,8 +23,13 @@
 import logger from '@/core/observability/logger.ts';
 import type { SonarQubeClient } from '@/core/server/client.ts';
 import { isNewCodeMetric, MeasuresClient } from '@/core/server/measures.ts';
-import type { ComponentTreeComponent, Metric, QualityGateCondition } from '@/core/server/types.ts';
+import type { ComponentTreeComponent, Metric } from '@/core/server/types.ts';
 
+import type {
+  QualityGateBreakdownEntry,
+  QualityGateConditionSummary,
+  QualityGateMetricBreakdown,
+} from './condition-summary.ts';
 import { formatMetricValue } from './format-metric-value.ts';
 
 const METRIC_CATEGORIES: Record<string, string> = {
@@ -36,23 +41,9 @@ const METRIC_CATEGORIES: Record<string, string> = {
   new_line_coverage: 'coverage',
 };
 
-export interface QualityGateBreakdownEntry {
-  path: string;
-  value: string;
-  formattedValue: string;
-}
-
-export interface QualityGateMetricBreakdown {
-  metric: string;
-  totalCount: number;
-  fetchedCount: number;
-  entries: QualityGateBreakdownEntry[];
-}
-
-export interface BuildBreakdownParams {
+export interface AttachBreakdownsParams {
   client: SonarQubeClient;
   projectKey: string;
-  conditions: QualityGateCondition[];
   metrics: Metric[];
   top: number;
   branch?: string;
@@ -60,38 +51,43 @@ export interface BuildBreakdownParams {
 }
 
 /** A failing condition whose metric falls into an implemented category. */
-function isEnrichableCondition(condition: QualityGateCondition): boolean {
-  return condition.status !== 'OK' && !!METRIC_CATEGORIES[condition.metricKey];
+function isEnrichableCondition(condition: QualityGateConditionSummary): boolean {
+  return condition.status !== 'OK' && !!METRIC_CATEGORIES[condition.metric];
 }
 
 /**
- * One breakdown per matching condition. Worst-first sort direction comes from the condition's own
+ * Returns each condition with its own `breakdown` attached when applicable, preserving order and
+ * count 1:1 with the input. Worst-first sort direction comes from the condition's own
  * `comparator` (`LT` - lower is worse - sorts ascending, `GT` sorts descending).
  */
-export async function buildBreakdown(
-  params: BuildBreakdownParams,
-): Promise<QualityGateMetricBreakdown[]> {
+export async function attachBreakdowns(
+  conditions: QualityGateConditionSummary[],
+  params: AttachBreakdownsParams,
+): Promise<QualityGateConditionSummary[]> {
   const measuresClient = new MeasuresClient(params.client);
   const metricsByKey = new Map(params.metrics.map((metric) => [metric.key, metric]));
 
-  const results = await Promise.all(
-    params.conditions
-      .filter(isEnrichableCondition)
-      .map((condition) => fetchMetricBreakdown(measuresClient, params, condition, metricsByKey)),
+  return Promise.all(
+    conditions.map(async (condition) => {
+      if (!isEnrichableCondition(condition)) {
+        return condition;
+      }
+      const breakdown = await fetchMetricBreakdown(measuresClient, params, condition, metricsByKey);
+      return breakdown ? { ...condition, breakdown } : condition;
+    }),
   );
-  return results.filter((result): result is QualityGateMetricBreakdown => result !== undefined);
 }
 
 async function fetchMetricBreakdown(
   measuresClient: MeasuresClient,
-  params: BuildBreakdownParams,
-  condition: QualityGateCondition,
+  params: AttachBreakdownsParams,
+  condition: QualityGateConditionSummary,
   metricsByKey: Map<string, Metric>,
 ): Promise<QualityGateMetricBreakdown | undefined> {
   try {
     const { components, totalCount } = await measuresClient.getWorstComponentsByMetric({
       projectKey: params.projectKey,
-      metricKey: condition.metricKey,
+      metricKey: condition.metric,
       ascending: condition.comparator === 'LT',
       top: params.top,
       branch: params.branch,
@@ -99,13 +95,13 @@ async function fetchMetricBreakdown(
     });
 
     const entries = components.flatMap((component) =>
-      toBreakdownEntry(component, condition.metricKey, metricsByKey.get(condition.metricKey)),
+      toBreakdownEntry(component, condition.metric, metricsByKey.get(condition.metric)),
     );
     return entries.length > 0
-      ? { metric: condition.metricKey, totalCount, fetchedCount: components.length, entries }
+      ? { totalCount, fetchedCount: components.length, entries }
       : undefined;
   } catch (err) {
-    logger.debug(`Failed to build quality gate breakdown for '${condition.metricKey}'`, err);
+    logger.debug(`Failed to build quality gate breakdown for '${condition.metric}'`, err);
     return undefined;
   }
 }

--- a/src/commands/quality-gate/status/condition-summary.ts
+++ b/src/commands/quality-gate/status/condition-summary.ts
@@ -54,7 +54,7 @@ function formatOptionalValue(
   if (rawValue === undefined || metric === undefined) {
     return rawValue;
   }
-  return formatMetricValue(metric.type, rawValue);
+  return formatMetricValue(metric.type, rawValue, metric.decimalScale);
 }
 
 function toSummary(

--- a/src/commands/quality-gate/status/condition-summary.ts
+++ b/src/commands/quality-gate/status/condition-summary.ts
@@ -26,6 +26,18 @@ import type { Metric, QualityGateCondition } from '@/core/server/types.ts';
 
 import { formatMetricValue } from './format-metric-value.ts';
 
+export interface QualityGateBreakdownEntry {
+  path: string;
+  value: string;
+  formattedValue: string;
+}
+
+export interface QualityGateMetricBreakdown {
+  totalCount: number;
+  fetchedCount: number;
+  entries: QualityGateBreakdownEntry[];
+}
+
 export interface QualityGateConditionSummary {
   metric: string;
   metricName: string;
@@ -36,6 +48,7 @@ export interface QualityGateConditionSummary {
   formattedThreshold?: string;
   actualValue?: string;
   formattedActualValue?: string;
+  breakdown?: QualityGateMetricBreakdown;
 }
 
 function isFailing(condition: QualityGateConditionSummary): boolean {

--- a/src/commands/quality-gate/status/format-json.ts
+++ b/src/commands/quality-gate/status/format-json.ts
@@ -18,6 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import type { QualityGateMetricBreakdown } from './breakdown.ts';
 import type { QualityGateConditionSummary } from './condition-summary.ts';
 import type { QualityGateScope } from './scope.ts';
 import type { QualityGateVerdict } from './verdict.ts';
@@ -27,6 +28,7 @@ export interface QualityGateJsonViewModel {
   project: string;
   scope: QualityGateScope;
   conditions: QualityGateConditionSummary[];
+  breakdown?: QualityGateMetricBreakdown[];
 }
 
 export function formatQualityGateJson(vm: QualityGateJsonViewModel): string {
@@ -39,6 +41,7 @@ export function formatQualityGateJson(vm: QualityGateJsonViewModel): string {
         branch: isPullRequest ? undefined : vm.scope.value,
         pullRequest: isPullRequest ? vm.scope.value : undefined,
         conditions: vm.conditions,
+        breakdown: vm.breakdown && vm.breakdown.length > 0 ? vm.breakdown : undefined,
       },
     },
     null,

--- a/src/commands/quality-gate/status/format-json.ts
+++ b/src/commands/quality-gate/status/format-json.ts
@@ -18,7 +18,6 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import type { QualityGateMetricBreakdown } from './breakdown.ts';
 import type { QualityGateConditionSummary } from './condition-summary.ts';
 import type { QualityGateScope } from './scope.ts';
 import type { QualityGateVerdict } from './verdict.ts';
@@ -28,7 +27,6 @@ export interface QualityGateJsonViewModel {
   project: string;
   scope: QualityGateScope;
   conditions: QualityGateConditionSummary[];
-  breakdown?: QualityGateMetricBreakdown[];
 }
 
 export function formatQualityGateJson(vm: QualityGateJsonViewModel): string {
@@ -41,7 +39,6 @@ export function formatQualityGateJson(vm: QualityGateJsonViewModel): string {
         branch: isPullRequest ? undefined : vm.scope.value,
         pullRequest: isPullRequest ? vm.scope.value : undefined,
         conditions: vm.conditions,
-        breakdown: vm.breakdown && vm.breakdown.length > 0 ? vm.breakdown : undefined,
       },
     },
     null,

--- a/src/commands/quality-gate/status/format-metric-value.ts
+++ b/src/commands/quality-gate/status/format-metric-value.ts
@@ -30,18 +30,25 @@ const RATING_LETTERS: Record<string, string> = {
 };
 
 /**
- * Only RATING, PERCENT, and WORK_DUR get a real transformation. Every other type - including
- * INT, and any type this doesn't recognize - is returned unchanged: the server already provides
- * the correct precision/representation, and `create_condition` never allows a condition metric
- * whose type isn't one of the 7 documented as valid (RATING/PERCENT/WORK_DUR plus INT/MILLISEC/
- * FLOAT/LEVEL, none of which need formatting here).
+ * Only reduces precision when there are more decimal digits than `decimalScale` to begin with.
  */
-export function formatMetricValue(type: string, rawValue: string): string {
+function roundPercent(rawValue: string, decimalScale: number): string {
+  const [, decimals = ''] = rawValue.split('.');
+  return decimals.length > decimalScale ? Number(rawValue).toFixed(decimalScale) : rawValue;
+}
+
+/**
+ * Only RATING, PERCENT, and WORK_DUR get a real transformation. Every other type - including
+ * INT, and any type this doesn't recognize - is returned unchanged, and `create_condition` never
+ * allows a condition metric whose type isn't one of the 7 documented as valid (RATING/PERCENT/
+ * WORK_DUR plus INT/MILLISEC/FLOAT/LEVEL, none of which need formatting here).
+ */
+export function formatMetricValue(type: string, rawValue: string, decimalScale = 1): string {
   switch (type) {
     case 'RATING':
       return RATING_LETTERS[rawValue] ?? rawValue;
     case 'PERCENT':
-      return `${rawValue}%`;
+      return `${roundPercent(rawValue, decimalScale)}%`;
     case 'WORK_DUR':
       return `${rawValue} min`;
     default:

--- a/src/commands/quality-gate/status/format-table.ts
+++ b/src/commands/quality-gate/status/format-table.ts
@@ -21,7 +21,6 @@
 import { cyan, green, red, yellow } from '@/core/ui/colors.ts';
 import { padColumns } from '@/core/ui/formatter/column-formatting.ts';
 
-import type { QualityGateMetricBreakdown } from './breakdown.ts';
 import type { QualityGateConditionSummary } from './condition-summary.ts';
 import type { QualityGateScope } from './scope.ts';
 import type { QualityGateVerdict } from './verdict.ts';
@@ -62,7 +61,6 @@ export interface QualityGateTableViewModel {
   project: string;
   scope: QualityGateScope;
   conditions: QualityGateConditionSummary[];
-  breakdown?: QualityGateMetricBreakdown[];
 }
 
 export function formatQualityGateTable(vm: QualityGateTableViewModel): string {
@@ -90,7 +88,7 @@ export function formatQualityGateTable(vm: QualityGateTableViewModel): string {
       'Conditions:',
       ...vm.conditions.flatMap((condition, i) => [
         formatConditionLine(condition, labels[i], values[i]),
-        ...formatBreakdownLines(vm.breakdown, condition.metric),
+        ...formatBreakdownLines(condition),
       ]),
     );
   }
@@ -130,11 +128,8 @@ function formatConditionLine(
   return `    ${marker}  ${paddedLabel}${paddedValue}${requirement}`;
 }
 
-function formatBreakdownLines(
-  breakdown: QualityGateMetricBreakdown[] | undefined,
-  metric: string,
-): string[] {
-  const metricBreakdown = breakdown?.find((candidate) => candidate.metric === metric);
+function formatBreakdownLines(condition: QualityGateConditionSummary): string[] {
+  const metricBreakdown = condition.breakdown;
   if (!metricBreakdown || metricBreakdown.entries.length === 0) {
     return [];
   }

--- a/src/commands/quality-gate/status/format-table.ts
+++ b/src/commands/quality-gate/status/format-table.ts
@@ -21,6 +21,7 @@
 import { cyan, green, red, yellow } from '@/core/ui/colors.ts';
 import { padColumns } from '@/core/ui/formatter/column-formatting.ts';
 
+import type { QualityGateMetricBreakdown } from './breakdown.ts';
 import type { QualityGateConditionSummary } from './condition-summary.ts';
 import type { QualityGateScope } from './scope.ts';
 import type { QualityGateVerdict } from './verdict.ts';
@@ -33,6 +34,11 @@ const MIN_CONDITION_LABEL_WIDTH = 20;
 const MIN_CONDITION_VALUE_WIDTH = 14;
 /** Guarantees at least this much space after each column even when its content sets the width. */
 const CONDITION_GAP = 2;
+
+/** Same floor/gap technique as the condition columns above, so a long file path never runs into its value. */
+const MIN_BREAKDOWN_PATH_WIDTH = 40;
+const BREAKDOWN_GAP = 2;
+const BREAKDOWN_INDENT = '       ';
 
 const VERDICT_BRACKETS: Record<QualityGateVerdict, string> = {
   OK: '[✓ Passed]',
@@ -56,6 +62,7 @@ export interface QualityGateTableViewModel {
   project: string;
   scope: QualityGateScope;
   conditions: QualityGateConditionSummary[];
+  breakdown?: QualityGateMetricBreakdown[];
 }
 
 export function formatQualityGateTable(vm: QualityGateTableViewModel): string {
@@ -81,7 +88,10 @@ export function formatQualityGateTable(vm: QualityGateTableViewModel): string {
     lines.push(
       '',
       'Conditions:',
-      ...vm.conditions.map((condition, i) => formatConditionLine(condition, labels[i], values[i])),
+      ...vm.conditions.flatMap((condition, i) => [
+        formatConditionLine(condition, labels[i], values[i]),
+        ...formatBreakdownLines(vm.breakdown, condition.metric),
+      ]),
     );
   }
 
@@ -118,6 +128,33 @@ function formatConditionLine(
       ? `(required ${INVERSE_COMPARATOR_SYMBOLS[condition.comparator] ?? condition.comparator} ${condition.formattedThreshold})`
       : '';
   return `    ${marker}  ${paddedLabel}${paddedValue}${requirement}`;
+}
+
+function formatBreakdownLines(
+  breakdown: QualityGateMetricBreakdown[] | undefined,
+  metric: string,
+): string[] {
+  const metricBreakdown = breakdown?.find((candidate) => candidate.metric === metric);
+  if (!metricBreakdown || metricBreakdown.entries.length === 0) {
+    return [];
+  }
+
+  const [paths, values] = padColumns(
+    [
+      metricBreakdown.entries.map((entry) => entry.path),
+      metricBreakdown.entries.map((entry) => entry.formattedValue),
+    ],
+    [MIN_BREAKDOWN_PATH_WIDTH],
+    BREAKDOWN_GAP,
+  );
+  const lines = metricBreakdown.entries.map((_, i) => `${BREAKDOWN_INDENT}${paths[i]}${values[i]}`);
+
+  const remaining = metricBreakdown.totalCount - metricBreakdown.fetchedCount;
+  if (remaining > 0) {
+    lines.push(`${BREAKDOWN_INDENT}… ${remaining} more not shown`);
+  }
+
+  return lines;
 }
 
 function notComputedHint(scope: QualityGateScope): string {

--- a/src/commands/quality-gate/status/index.ts
+++ b/src/commands/quality-gate/status/index.ts
@@ -29,6 +29,7 @@ import { QualityGatesClient } from '@/core/server/quality-gates.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import { print } from '@/core/ui';
 
+import { buildBreakdown } from './breakdown.ts';
 import { selectConditions } from './condition-summary.ts';
 import { formatQualityGateJson } from './format-json.ts';
 import { formatQualityGateTable } from './format-table.ts';
@@ -36,6 +37,8 @@ import { resolveDisplayScope, resolveScopeQueryParams } from './scope.ts';
 import { exitCodeFor, toVerdict } from './verdict.ts';
 
 export const VALID_FORMATS = ['json', 'table'];
+
+const DEFAULT_TOP = 3;
 
 export interface QualityGateStatusOptions {
   project?: string;
@@ -65,21 +68,31 @@ export async function qualityGateStatus(
   ]);
 
   const rawConditions = projectStatus?.conditions ?? [];
-  const hasConditionsToRender = options.all
-    ? rawConditions.length > 0
-    : rawConditions.some((condition) => condition.status !== 'OK');
+  const hasFailingConditions = rawConditions.some((condition) => condition.status !== 'OK');
+  const hasConditionsToRender = options.all ? rawConditions.length > 0 : hasFailingConditions;
 
   const metricsClient = new MetricsClient(client);
   const metrics = hasConditionsToRender ? await metricsClient.searchMetrics() : [];
 
   const verdict = toVerdict(projectStatus?.status);
   const conditions = selectConditions(rawConditions, metrics, options.all);
+  const breakdown = hasFailingConditions
+    ? await buildBreakdown({
+        client,
+        projectKey,
+        conditions: rawConditions,
+        metrics,
+        top: DEFAULT_TOP,
+        branch: queryParams.branch,
+        pullRequest: queryParams.pullRequest,
+      })
+    : [];
 
   const format = options.format ?? 'table';
   const message =
     format === 'table'
-      ? formatQualityGateTable({ verdict, project: projectKey, scope, conditions })
-      : formatQualityGateJson({ verdict, project: projectKey, scope, conditions });
+      ? formatQualityGateTable({ verdict, project: projectKey, scope, conditions, breakdown })
+      : formatQualityGateJson({ verdict, project: projectKey, scope, conditions, breakdown });
   print(message);
 
   process.exitCode = exitCodeFor(verdict);

--- a/src/commands/quality-gate/status/index.ts
+++ b/src/commands/quality-gate/status/index.ts
@@ -29,7 +29,7 @@ import { QualityGatesClient } from '@/core/server/quality-gates.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import { print } from '@/core/ui';
 
-import { buildBreakdown } from './breakdown.ts';
+import { attachBreakdowns } from './breakdown.ts';
 import { selectConditions } from './condition-summary.ts';
 import { formatQualityGateJson } from './format-json.ts';
 import { formatQualityGateTable } from './format-table.ts';
@@ -75,24 +75,23 @@ export async function qualityGateStatus(
   const metrics = hasConditionsToRender ? await metricsClient.searchMetrics() : [];
 
   const verdict = toVerdict(projectStatus?.status);
-  const conditions = selectConditions(rawConditions, metrics, options.all);
-  const breakdown = hasFailingConditions
-    ? await buildBreakdown({
+  const summaries = selectConditions(rawConditions, metrics, options.all);
+  const conditions = hasFailingConditions
+    ? await attachBreakdowns(summaries, {
         client,
         projectKey,
-        conditions: rawConditions,
         metrics,
         top: DEFAULT_TOP,
         branch: queryParams.branch,
         pullRequest: queryParams.pullRequest,
       })
-    : [];
+    : summaries;
 
   const format = options.format ?? 'table';
   const message =
     format === 'table'
-      ? formatQualityGateTable({ verdict, project: projectKey, scope, conditions, breakdown })
-      : formatQualityGateJson({ verdict, project: projectKey, scope, conditions, breakdown });
+      ? formatQualityGateTable({ verdict, project: projectKey, scope, conditions })
+      : formatQualityGateJson({ verdict, project: projectKey, scope, conditions });
   print(message);
 
   process.exitCode = exitCodeFor(verdict);

--- a/src/core/server/measures.ts
+++ b/src/core/server/measures.ts
@@ -1,0 +1,93 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// SonarQube Measures API wrapper
+
+import { type QueryParams, type SonarQubeClient } from './client.ts';
+import type { ComponentTreeComponent, ComponentTreeResponse } from './types.ts';
+
+export interface WorstComponentsByMetricParams {
+  projectKey: string;
+  metricKey: string;
+  ascending: boolean;
+  top: number;
+  branch?: string;
+  pullRequest?: string;
+}
+
+export interface WorstComponentsByMetricResult {
+  components: ComponentTreeComponent[];
+  totalCount: number;
+}
+
+/**
+ * A `new_*` metric's value lives under `measures[].periods[]`, not the flat `measures[].value`
+ * field.
+ */
+export function isNewCodeMetric(metricKey: string): boolean {
+  return metricKey.startsWith('new_');
+}
+
+/**
+ * Uses a different params sets for a new code metric.
+ */
+function buildComponentTreeQueryParams(params: WorstComponentsByMetricParams): QueryParams {
+  const queryParams: QueryParams = {
+    component: params.projectKey,
+    metricKeys: params.metricKey,
+    metricSort: params.metricKey,
+    metricSortFilter: 'withMeasuresOnly',
+    asc: params.ascending,
+    qualifiers: 'FIL',
+    ps: params.top,
+  };
+  if (isNewCodeMetric(params.metricKey)) {
+    queryParams.s = 'metricPeriod';
+    queryParams.metricPeriodSort = 1;
+  } else {
+    queryParams.s = 'metric';
+  }
+  if (params.branch) {
+    queryParams.branch = params.branch;
+  }
+  if (params.pullRequest) {
+    queryParams.pullRequest = params.pullRequest;
+  }
+  return queryParams;
+}
+
+export class MeasuresClient {
+  private readonly client: SonarQubeClient;
+
+  constructor(client: SonarQubeClient) {
+    this.client = client;
+  }
+
+  /** Worst-N files for a single metric, e.g. `new_coverage` or `coverage`. */
+  async getWorstComponentsByMetric(
+    params: WorstComponentsByMetricParams,
+  ): Promise<WorstComponentsByMetricResult> {
+    const response = await this.client.get<ComponentTreeResponse>(
+      '/api/measures/component_tree',
+      buildComponentTreeQueryParams(params),
+    );
+    return { components: response.components, totalCount: response.paging.total };
+  }
+}

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -160,6 +160,7 @@ export interface Metric {
   key: string;
   type: string;
   name: string;
+  decimalScale?: number;
 }
 
 export interface MetricsSearchResponse {
@@ -167,4 +168,32 @@ export interface MetricsSearchResponse {
   total: number;
   p: number;
   ps: number;
+}
+
+export interface ComponentTreeMeasurePeriod {
+  index: number;
+  value: string;
+  bestValue?: boolean;
+}
+
+export interface ComponentTreeMeasure {
+  metric: string;
+  value?: string;
+  bestValue?: boolean;
+  periods?: ComponentTreeMeasurePeriod[];
+}
+
+export interface ComponentTreeComponent {
+  key: string;
+  name: string;
+  qualifier: string;
+  path?: string;
+  language?: string;
+  measures: ComponentTreeMeasure[];
+}
+
+export interface ComponentTreeResponse {
+  paging: { pageIndex: number; pageSize: number; total: number };
+  baseComponent: ComponentTreeComponent;
+  components: ComponentTreeComponent[];
 }

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -56,6 +56,16 @@ export interface SqaaResponseConfig {
   errors?: Array<{ code: string; message: string }>;
 }
 
+export interface ComponentTreeFileConfig {
+  path: string;
+  value?: string;
+}
+
+interface ComponentTreeErrorConfig {
+  statusCode: number;
+  body?: string;
+}
+
 interface ProjectData {
   key: string;
   name: string;
@@ -64,6 +74,10 @@ interface ProjectData {
   qualityGateConditions?: QualityGateCondition[];
   defaultBranchName: string | null;
   unanalyzedBranch?: string;
+  componentTreeFilesByMetric: Map<string, ComponentTreeFileConfig[]>;
+  componentTreeStatusCode?: number;
+  componentTreeStatusBody?: string;
+  componentTreeErrorsByMetric: Map<string, ComponentTreeErrorConfig>;
 }
 
 export interface DopRepositoryConfig {
@@ -83,6 +97,10 @@ export class ProjectBuilder {
   private qualityGateConditions?: QualityGateCondition[];
   private defaultBranchName: string | null = 'main';
   private unanalyzedBranch?: string;
+  private readonly componentTreeFilesByMetric: Map<string, ComponentTreeFileConfig[]> = new Map();
+  private componentTreeStatusCode?: number;
+  private componentTreeStatusBody?: string;
+  private readonly componentTreeErrorsByMetric: Map<string, ComponentTreeErrorConfig> = new Map();
 
   constructor(projectKey: string) {
     this.projectKey = projectKey;
@@ -145,6 +163,38 @@ export class ProjectBuilder {
     return this;
   }
 
+  /**
+   * Files `GET /api/measures/component_tree` returns for one metric key, in the order given -
+   * this fake server doesn't replicate the real sort/filter query params (covered by
+   * `MeasuresClient`'s own unit tests), it just hands back whatever worst-first order the test
+   * configured, truncated to the request's `ps`.
+   */
+  withComponentTreeFiles(metricKey: string, files: ComponentTreeFileConfig[]): this {
+    this.componentTreeFilesByMetric.set(metricKey, files);
+    return this;
+  }
+
+  /**
+   * Force `GET /api/measures/component_tree` to fail with the given HTTP status code for this
+   * project, simulating a quality-gate breakdown enrichment failure (network error, a server
+   * rejecting the sort params, a permission error) independent of the primary verdict call.
+   */
+  withComponentTreeError(statusCode: number, body?: string): this {
+    this.componentTreeStatusCode = statusCode;
+    this.componentTreeStatusBody = body;
+    return this;
+  }
+
+  /**
+   * Scopes a `component_tree` failure to one metric key, leaving other metrics' requests
+   * unaffected - proves a per-condition enrichment failure doesn't discard sibling conditions'
+   * already-fetched breakdowns.
+   */
+  withComponentTreeErrorForMetric(metricKey: string, statusCode: number, body?: string): this {
+    this.componentTreeErrorsByMetric.set(metricKey, { statusCode, body });
+    return this;
+  }
+
   getData(): ProjectData {
     return {
       key: this.projectKey,
@@ -154,6 +204,10 @@ export class ProjectBuilder {
       qualityGateConditions: this.qualityGateConditions,
       defaultBranchName: this.defaultBranchName,
       unanalyzedBranch: this.unanalyzedBranch,
+      componentTreeFilesByMetric: this.componentTreeFilesByMetric,
+      componentTreeStatusCode: this.componentTreeStatusCode,
+      componentTreeStatusBody: this.componentTreeStatusBody,
+      componentTreeErrorsByMetric: this.componentTreeErrorsByMetric,
     };
   }
 }
@@ -756,6 +810,51 @@ export class FakeSonarQubeServerBuilder {
           return new Response(JSON.stringify({ metrics, total: metrics.length, p: 1, ps: 500 }), {
             headers: { 'Content-Type': 'application/json' },
           });
+        }
+
+        if (path === '/api/measures/component_tree') {
+          const projectKey = query.component;
+          const projectData = projectKey ? projects.get(projectKey) : undefined;
+          const metricKey = query.metricKeys;
+
+          const perMetricError = metricKey
+            ? projectData?.componentTreeErrorsByMetric.get(metricKey)
+            : undefined;
+          if (perMetricError) {
+            return new Response(perMetricError.body ?? '', { status: perMetricError.statusCode });
+          }
+
+          if (projectData?.componentTreeStatusCode !== undefined) {
+            return new Response(projectData.componentTreeStatusBody ?? '', {
+              status: projectData.componentTreeStatusCode,
+            });
+          }
+          const configuredFiles =
+            (metricKey && projectData?.componentTreeFilesByMetric.get(metricKey)) || [];
+          const pageSize = Number.parseInt(query.ps ?? '100', 10);
+          const pagedFiles = configuredFiles.slice(0, pageSize);
+
+          return new Response(
+            JSON.stringify({
+              paging: { pageIndex: 1, pageSize, total: configuredFiles.length },
+              baseComponent: { key: projectKey, name: projectKey, qualifier: 'TRK', measures: [] },
+              components: pagedFiles.map((file) => ({
+                key: `${projectKey}:${file.path}`,
+                name: file.path.split('/').pop() ?? file.path,
+                qualifier: 'FIL',
+                path: file.path,
+                measures:
+                  file.value === undefined
+                    ? []
+                    : [
+                        metricKey?.startsWith('new_')
+                          ? { metric: metricKey, periods: [{ index: 1, value: file.value }] }
+                          : { metric: metricKey, value: file.value },
+                      ],
+              })),
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
         }
 
         // sonar-context-augmentation calls /api/project_branches/list to

--- a/tests/integration/specs/quality-gate/status.test.ts
+++ b/tests/integration/specs/quality-gate/status.test.ts
@@ -764,17 +764,17 @@ describe('quality-gate status', () => {
 
       expect(result.exitCode).toBe(51);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'new_coverage',
-          totalCount: 2,
-          fetchedCount: 2,
-          entries: [
-            { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
-            { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
-          ],
-        },
-      ]);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
+          { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
+        ],
+      });
     },
     { timeout: 15000 },
   );
@@ -810,17 +810,17 @@ describe('quality-gate status', () => {
 
       expect(result.exitCode).toBe(51);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'coverage',
-          totalCount: 2,
-          fetchedCount: 2,
-          entries: [
-            { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
-            { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
-          ],
-        },
-      ]);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
+          { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
+        ],
+      });
     },
     { timeout: 15000 },
   );
@@ -858,18 +858,18 @@ describe('quality-gate status', () => {
       const result = await harness.run(`quality-gate status --project my-project --format json`);
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'new_coverage',
-          totalCount: 5,
-          fetchedCount: 3,
-          entries: [
-            { path: 'src/a.ts', value: '10.0', formattedValue: '10.0%' },
-            { path: 'src/b.ts', value: '20.0', formattedValue: '20.0%' },
-            { path: 'src/c.ts', value: '30.0', formattedValue: '30.0%' },
-          ],
-        },
-      ]);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        totalCount: 5,
+        fetchedCount: 3,
+        entries: [
+          { path: 'src/a.ts', value: '10.0', formattedValue: '10.0%' },
+          { path: 'src/b.ts', value: '20.0', formattedValue: '20.0%' },
+          { path: 'src/c.ts', value: '30.0', formattedValue: '30.0%' },
+        ],
+      });
     },
     { timeout: 15000 },
   );
@@ -905,17 +905,17 @@ describe('quality-gate status', () => {
       const result = await harness.run(`quality-gate status --project my-project --format json`);
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'new_coverage',
-          totalCount: 3,
-          fetchedCount: 3,
-          entries: [
-            { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
-            { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
-          ],
-        },
-      ]);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        totalCount: 3,
+        fetchedCount: 3,
+        entries: [
+          { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
+          { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
+        ],
+      });
 
       // The page already covered every matching file (fetchedCount === totalCount), so there's
       // no "N more" hint to show, even though entries.length (2) is less than totalCount (3).
@@ -959,20 +959,20 @@ describe('quality-gate status', () => {
       const result = await harness.run(`quality-gate status --project my-project --format json`);
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'new_coverage',
-          totalCount: 1,
-          fetchedCount: 1,
-          entries: [
-            {
-              path: 'src/checkout.ts',
-              value: '38.84615384615385',
-              formattedValue: '38.8%',
-            },
-          ],
-        },
-      ]);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [
+          {
+            path: 'src/checkout.ts',
+            value: '38.84615384615385',
+            formattedValue: '38.8%',
+          },
+        ],
+      });
     },
     { timeout: 15000 },
   );
@@ -1008,20 +1008,20 @@ describe('quality-gate status', () => {
       const result = await harness.run(`quality-gate status --project my-project --format json`);
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'new_coverage',
-          totalCount: 1,
-          fetchedCount: 1,
-          entries: [
-            {
-              path: 'src/checkout.ts',
-              value: '38.84615384615385',
-              formattedValue: '38.85%',
-            },
-          ],
-        },
-      ]);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [
+          {
+            path: 'src/checkout.ts',
+            value: '38.84615384615385',
+            formattedValue: '38.85%',
+          },
+        ],
+      });
     },
     { timeout: 15000 },
   );
@@ -1207,7 +1207,7 @@ describe('quality-gate status', () => {
       const result = await harness.run(`quality-gate status --project my-project --format json`);
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toBeUndefined();
+      expect(parsed.qualityGate.conditions[0].breakdown).toBeUndefined();
       const componentTreeRequests = server
         .getRecordedRequests()
         .filter((r) => r.path === '/api/measures/component_tree');
@@ -1264,7 +1264,7 @@ describe('quality-gate status', () => {
       expect(result.exitCode).toBe(51);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.qualityGate.status).toBe('ERROR');
-      expect(parsed.qualityGate.breakdown).toBeUndefined();
+      expect(parsed.qualityGate.conditions[0].breakdown).toBeUndefined();
     },
     { timeout: 15000 },
   );
@@ -1308,14 +1308,18 @@ describe('quality-gate status', () => {
 
       expect(result.exitCode).toBe(51);
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'new_coverage',
-          totalCount: 1,
-          fetchedCount: 1,
-          entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
-        },
-      ]);
+      const coverageCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'coverage',
+      );
+      const newCoverageCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(coverageCondition.breakdown).toBeUndefined();
+      expect(newCoverageCondition.breakdown).toEqual({
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
+      });
     },
     { timeout: 15000 },
   );
@@ -1367,25 +1371,31 @@ describe('quality-gate status', () => {
       const result = await harness.run(`quality-gate status --project my-project --format json`);
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
+      expect(parsed.qualityGate.conditions).toEqual([
+        expect.objectContaining({
           metric: 'coverage',
-          totalCount: 1,
-          fetchedCount: 1,
-          entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
-        },
-        {
+          breakdown: {
+            totalCount: 1,
+            fetchedCount: 1,
+            entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
+          },
+        }),
+        expect.objectContaining({
           metric: 'branch_coverage',
-          totalCount: 1,
-          fetchedCount: 1,
-          entries: [{ path: 'src/cart.ts', value: '40.0', formattedValue: '40.0%' }],
-        },
-        {
+          breakdown: {
+            totalCount: 1,
+            fetchedCount: 1,
+            entries: [{ path: 'src/cart.ts', value: '40.0', formattedValue: '40.0%' }],
+          },
+        }),
+        expect.objectContaining({
           metric: 'new_coverage',
-          totalCount: 1,
-          fetchedCount: 1,
-          entries: [{ path: 'src/pay.ts', value: '55.0', formattedValue: '55.0%' }],
-        },
+          breakdown: {
+            totalCount: 1,
+            fetchedCount: 1,
+            entries: [{ path: 'src/pay.ts', value: '55.0', formattedValue: '55.0%' }],
+          },
+        }),
       ]);
     },
     { timeout: 15000 },
@@ -1459,14 +1469,18 @@ describe('quality-gate status', () => {
       const result = await harness.run(`quality-gate status --project my-project --format json`);
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toEqual([
-        {
-          metric: 'new_coverage',
-          totalCount: 1,
-          fetchedCount: 1,
-          entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
-        },
-      ]);
+      const violationsCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_violations',
+      );
+      const coverageCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(violationsCondition.breakdown).toBeUndefined();
+      expect(coverageCondition.breakdown).toEqual({
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
+      });
       const componentTreeRequests = server
         .getRecordedRequests()
         .filter((r) => r.path === '/api/measures/component_tree');
@@ -1553,7 +1567,12 @@ describe('quality-gate status', () => {
       );
 
       const parsed = JSON.parse(result.stdout);
-      expect(parsed.qualityGate.breakdown).toBeUndefined();
+      expect(parsed.qualityGate.conditions).toHaveLength(2);
+      expect(
+        parsed.qualityGate.conditions.every(
+          (c: { breakdown?: unknown }) => c.breakdown === undefined,
+        ),
+      ).toBe(true);
       const componentTreeRequests = server
         .getRecordedRequests()
         .filter((r) => r.path === '/api/measures/component_tree');

--- a/tests/integration/specs/quality-gate/status.test.ts
+++ b/tests/integration/specs/quality-gate/status.test.ts
@@ -733,6 +733,834 @@ describe('quality-gate status', () => {
     },
     { timeout: 15000 },
   );
+  it(
+    'includes a coverage breakdown in JSON for a failing new_coverage condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/checkout.ts', value: '31.0' },
+              { path: 'src/cart.ts', value: '45.2' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'new_coverage',
+          totalCount: 2,
+          fetchedCount: 2,
+          entries: [
+            { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
+            { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
+          ],
+        },
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'includes a coverage breakdown in JSON for a failing overall coverage condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'coverage', type: 'PERCENT', name: 'Coverage' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('coverage', [
+              { path: 'src/checkout.ts', value: '31.0' },
+              { path: 'src/cart.ts', value: '45.2' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'coverage',
+          totalCount: 2,
+          fetchedCount: 2,
+          entries: [
+            { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
+            { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
+          ],
+        },
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'reports the total matching file count separately from the truncated default top-3 entries',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/a.ts', value: '10.0' },
+              { path: 'src/b.ts', value: '20.0' },
+              { path: 'src/c.ts', value: '30.0' },
+              { path: 'src/d.ts', value: '40.0' },
+              { path: 'src/e.ts', value: '50.0' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'new_coverage',
+          totalCount: 5,
+          fetchedCount: 3,
+          entries: [
+            { path: 'src/a.ts', value: '10.0', formattedValue: '10.0%' },
+            { path: 'src/b.ts', value: '20.0', formattedValue: '20.0%' },
+            { path: 'src/c.ts', value: '30.0', formattedValue: '30.0%' },
+          ],
+        },
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'excludes a fetched component with no readable value from entries, but not from fetchedCount',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/checkout.ts', value: '31.0' },
+              { path: 'src/generated.ts' }, // no measure for this metric - toBreakdownEntry drops it
+              { path: 'src/cart.ts', value: '45.2' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'new_coverage',
+          totalCount: 3,
+          fetchedCount: 3,
+          entries: [
+            { path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' },
+            { path: 'src/cart.ts', value: '45.2', formattedValue: '45.2%' },
+          ],
+        },
+      ]);
+
+      // The page already covered every matching file (fetchedCount === totalCount), so there's
+      // no "N more" hint to show, even though entries.length (2) is less than totalCount (3).
+      const tableResult = await harness.run(
+        `quality-gate status --project my-project --format table`,
+      );
+      expect(tableResult.stdout).not.toContain('more');
+      expect(tableResult.stdout).not.toContain('--top');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'rounds a full-precision component_tree coverage value to one decimal place',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            // Real SonarQube Cloud project_status conditions arrive pre-rounded, but
+            // component_tree per-file measures don't - e.g. 38.84615384615385.
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/checkout.ts', value: '38.84615384615385' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'new_coverage',
+          totalCount: 1,
+          fetchedCount: 1,
+          entries: [
+            {
+              path: 'src/checkout.ts',
+              value: '38.84615384615385',
+              formattedValue: '38.8%',
+            },
+          ],
+        },
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    "rounds a full-precision component_tree coverage value to the metric catalog's own decimalScale, not always one",
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          { key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code', decimalScale: 2 },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/checkout.ts', value: '38.84615384615385' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'new_coverage',
+          totalCount: 1,
+          fetchedCount: 1,
+          entries: [
+            {
+              path: 'src/checkout.ts',
+              value: '38.84615384615385',
+              formattedValue: '38.85%',
+            },
+          ],
+        },
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'renders the coverage breakdown in the table, nested under its condition, without long paths colliding with the value',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/checkout.ts', value: '31.0' },
+              { path: 'src/a-very-long-file-name-that-should-not-collide.ts', value: '45.2' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const shortLine = lines.find((l) => l.includes('src/checkout.ts'));
+      const longLine = lines.find((l) =>
+        l.includes('src/a-very-long-file-name-that-should-not-collide.ts'),
+      );
+      expect(shortLine).toBeDefined();
+      expect(longLine).toBeDefined();
+      // Both value columns must start at the same offset, proving the short path was padded
+      // out to the long path's width rather than butting straight up against its own value.
+      expect(shortLine?.indexOf('31.0')).toBe(longLine?.indexOf('45.2'));
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'renders the coverage breakdown in the table for a failing overall coverage condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'coverage', type: 'PERCENT', name: 'Coverage' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('coverage', [
+              { path: 'src/checkout.ts', value: '31.0' },
+              { path: 'src/cart.ts', value: '45.2' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const conditionIndex = lines.findIndex((l) => l.includes('Coverage'));
+      expect(lines[conditionIndex + 1]).toContain('src/checkout.ts');
+      // Asserting the '%' suffix, not just the bare number, proves the table renders
+      // `formattedValue`, not the raw `value` the JSON breakdown also carries.
+      expect(lines[conditionIndex + 1]).toContain('31.0%');
+      expect(lines[conditionIndex + 2]).toContain('src/cart.ts');
+      expect(lines[conditionIndex + 2]).toContain('45.2%');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'shows a "N more" hint with no suggestion when the table omits entries the JSON totalCount accounts for',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/a.ts', value: '10.0' },
+              { path: 'src/b.ts', value: '20.0' },
+              { path: 'src/c.ts', value: '30.0' },
+              { path: 'src/d.ts', value: '40.0' },
+              { path: 'src/e.ts', value: '50.0' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const conditionIndex = lines.findIndex((l) => l.includes('Coverage on New Code'));
+      expect(lines[conditionIndex + 1]).toContain('src/a.ts');
+      expect(lines[conditionIndex + 2]).toContain('src/b.ts');
+      expect(lines[conditionIndex + 3]).toContain('src/c.ts');
+      expect(lines[conditionIndex + 4]).toContain('… 2 more not shown');
+      expect(lines[conditionIndex + 4]).not.toContain('--top');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'omits the "N more" hint when the table already shows every entry',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      expect(result.stdout).not.toContain('more');
+      expect(result.stdout).not.toContain('--top');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'omits the breakdown entirely when no failing condition matches an implemented category',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p.withProjectStatus('ERROR').withConditions([
+            {
+              status: 'ERROR',
+              metricKey: 'new_violations',
+              comparator: 'GT',
+              errorThreshold: '0',
+              actualValue: '3',
+            },
+          ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toBeUndefined();
+      const componentTreeRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/measures/component_tree');
+      expect(componentTreeRequests).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not fetch a breakdown at all when the quality gate passes',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) => p.withProjectStatus('OK'))
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      await harness.run(`quality-gate status --project my-project`);
+
+      const componentTreeRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/measures/component_tree');
+      expect(componentTreeRequests).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'still reports the real verdict and exit code when the breakdown fetch itself fails',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeError(500),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.status).toBe('ERROR');
+      expect(parsed.qualityGate.breakdown).toBeUndefined();
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    "keeps a sibling condition's breakdown when only one condition's fetch fails",
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          { key: 'coverage', type: 'PERCENT', name: 'Coverage' },
+          { key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '55.0',
+              },
+            ])
+            .withComponentTreeErrorForMetric('coverage', 500)
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'new_coverage',
+          totalCount: 1,
+          fetchedCount: 1,
+          entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
+        },
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'includes an entry for every matching condition, in condition order, when several fetch concurrently',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          { key: 'coverage', type: 'PERCENT', name: 'Coverage' },
+          { key: 'branch_coverage', type: 'PERCENT', name: 'Condition Coverage' },
+          { key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+              {
+                status: 'ERROR',
+                metricKey: 'branch_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '50.0',
+              },
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '55.0',
+              },
+            ])
+            .withComponentTreeFiles('coverage', [{ path: 'src/checkout.ts', value: '31.0' }])
+            .withComponentTreeFiles('branch_coverage', [{ path: 'src/cart.ts', value: '40.0' }])
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/pay.ts', value: '55.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'coverage',
+          totalCount: 1,
+          fetchedCount: 1,
+          entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
+        },
+        {
+          metric: 'branch_coverage',
+          totalCount: 1,
+          fetchedCount: 1,
+          entries: [{ path: 'src/cart.ts', value: '40.0', formattedValue: '40.0%' }],
+        },
+        {
+          metric: 'new_coverage',
+          totalCount: 1,
+          fetchedCount: 1,
+          entries: [{ path: 'src/pay.ts', value: '55.0', formattedValue: '55.0%' }],
+        },
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'requests the top 3 files by default',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      await harness.run(`quality-gate status --project my-project`);
+
+      const componentTreeRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/measures/component_tree');
+      expect(componentTreeRequests).toHaveLength(1);
+      expect(componentTreeRequests[0].query.ps).toBe('3');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'only enriches the coverage condition when multiple conditions fail together',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_violations',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '3',
+              },
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toEqual([
+        {
+          metric: 'new_coverage',
+          totalCount: 1,
+          fetchedCount: 1,
+          entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
+        },
+      ]);
+      const componentTreeRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/measures/component_tree');
+      expect(componentTreeRequests).toHaveLength(1);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'attaches the breakdown to the correct condition in the table when multiple conditions fail',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_violations',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '3',
+              },
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const violationsIndex = lines.findIndex((l) => l.includes('new_violations'));
+      const coverageIndex = lines.findIndex((l) => l.includes('new_coverage'));
+      const fileIndex = lines.findIndex((l) => l.includes('src/checkout.ts'));
+
+      expect(violationsIndex).toBeGreaterThanOrEqual(0);
+      expect(coverageIndex).toBeGreaterThan(violationsIndex);
+      // The breakdown line must sit directly after the coverage condition's own line - proving
+      // it's attached to that condition specifically, not bleeding onto new_violations above it.
+      expect(fileIndex).toBe(coverageIndex + 1);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not enrich a passing coverage condition even when --all is given',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p.withProjectStatus('ERROR').withConditions([
+            {
+              status: 'OK',
+              metricKey: 'new_coverage',
+              comparator: 'LT',
+              errorThreshold: '80',
+              actualValue: '95.0',
+            },
+            {
+              status: 'ERROR',
+              metricKey: 'new_violations',
+              comparator: 'GT',
+              errorThreshold: '0',
+              actualValue: '3',
+            },
+          ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --all --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.breakdown).toBeUndefined();
+      const componentTreeRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/measures/component_tree');
+      expect(componentTreeRequests).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
 
   it(
     'rejects an invalid --format value',

--- a/tests/unit/commands/quality-gate/status/format-metric-value.test.ts
+++ b/tests/unit/commands/quality-gate/status/format-metric-value.test.ts
@@ -37,9 +37,27 @@ describe('formatMetricValue', () => {
     expect(formatMetricValue('RATING', '6')).toBe('6');
   });
 
-  it('appends a % suffix for PERCENT, preserving server-provided precision', () => {
+  it('appends a % suffix for PERCENT, already at one decimal place', () => {
     expect(formatMetricValue('PERCENT', '95.4')).toBe('95.4%');
     expect(formatMetricValue('PERCENT', '100.0')).toBe('100.0%');
+  });
+
+  it('does not invent a decimal place for a whole-number PERCENT threshold', () => {
+    expect(formatMetricValue('PERCENT', '80')).toBe('80%');
+  });
+
+  it('rounds a PERCENT value to one decimal place by default - component_tree measures are not pre-rounded, unlike project_status conditions', () => {
+    expect(formatMetricValue('PERCENT', '38.84615384615385')).toBe('38.8%');
+    expect(formatMetricValue('PERCENT', '74.609375')).toBe('74.6%');
+  });
+
+  it("rounds a PERCENT value to the metric catalog's own decimalScale instead of always one", () => {
+    expect(formatMetricValue('PERCENT', '38.84615384615385', 2)).toBe('38.85%');
+    expect(formatMetricValue('PERCENT', '38.84615384615385', 0)).toBe('39%');
+  });
+
+  it('does not invent decimal places to match a non-zero decimalScale', () => {
+    expect(formatMetricValue('PERCENT', '80', 2)).toBe('80%');
   });
 
   it('appends a min suffix for WORK_DUR', () => {

--- a/tests/unit/core/server/measures.test.ts
+++ b/tests/unit/core/server/measures.test.ts
@@ -1,0 +1,214 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { SonarQubeClient } from '@/core/server/client.ts';
+import { MeasuresClient } from '@/core/server/measures.ts';
+import type { ComponentTreeComponent, ComponentTreeResponse } from '@/core/server/types.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response;
+}
+
+function component(overrides: Partial<ComponentTreeComponent> = {}): ComponentTreeComponent {
+  return {
+    key: overrides.key ?? 'my-project:src/foo.ts',
+    name: overrides.name ?? 'foo.ts',
+    qualifier: overrides.qualifier ?? 'FIL',
+    path: overrides.path ?? 'src/foo.ts',
+    measures: overrides.measures ?? [
+      { metric: 'new_coverage', periods: [{ index: 1, value: '0.0' }] },
+    ],
+  };
+}
+
+function componentTreeResponse(
+  overrides: Partial<ComponentTreeResponse> = {},
+): ComponentTreeResponse {
+  const components = overrides.components ?? [component()];
+  return {
+    paging: overrides.paging ?? { pageIndex: 1, pageSize: 3, total: components.length },
+    baseComponent: overrides.baseComponent ?? {
+      key: 'my-project',
+      name: 'my-project',
+      qualifier: 'TRK',
+      measures: [],
+    },
+    components,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SERVER_URL = 'https://sonarqube.example.com';
+const TOKEN = 'squ_test_token';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MeasuresClient', () => {
+  let client: MeasuresClient;
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    client = new MeasuresClient(new SonarQubeClient(SERVER_URL, TOKEN));
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it('sorts by metricPeriod, not metric - new_* metrics store their value under periods[]', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(componentTreeResponse()));
+
+    await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'new_coverage',
+      ascending: true,
+      top: 3,
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).toContain('s=metricPeriod');
+    expect(url).toContain('metricPeriodSort=1');
+    expect(url).toContain('metricSort=new_coverage');
+    expect(url).toContain('metricSortFilter=withMeasuresOnly');
+    expect(url).not.toContain('s=metric&');
+  });
+
+  it('sorts by metric, not metricPeriod, for an overall (non-new_) metric - its value lives in the flat value field', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(componentTreeResponse()));
+
+    await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'coverage',
+      ascending: true,
+      top: 3,
+    });
+
+    const url = new URL(fetchSpy.mock.calls[0][0] as URL);
+    expect(url.searchParams.get('s')).toBe('metric');
+    expect(url.searchParams.get('metricSort')).toBe('coverage');
+    expect(url.searchParams.has('metricPeriodSort')).toBe(false);
+  });
+
+  it('scopes to files only, requests exactly `top` results, and passes ascending order through', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(componentTreeResponse()));
+
+    await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'new_coverage',
+      ascending: false,
+      top: 5,
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).toContain('component=my-project');
+    expect(url).toContain('metricKeys=new_coverage');
+    expect(url).toContain('qualifiers=FIL');
+    expect(url).toContain('ps=5');
+    expect(url).toContain('asc=false');
+  });
+
+  it('omits branch and pull request from the query when not given', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(componentTreeResponse()));
+
+    await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'new_coverage',
+      ascending: true,
+      top: 3,
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).not.toContain('branch=');
+    expect(url).not.toContain('pullRequest=');
+  });
+
+  it('forwards branch and pull request when given', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(componentTreeResponse()));
+
+    await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'new_coverage',
+      ascending: true,
+      top: 3,
+      branch: 'feature-x',
+    });
+    expect((fetchSpy.mock.calls[0][0] as URL).toString()).toContain('branch=feature-x');
+
+    await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'new_coverage',
+      ascending: true,
+      top: 3,
+      pullRequest: '42',
+    });
+    expect((fetchSpy.mock.calls[1][0] as URL).toString()).toContain('pullRequest=42');
+  });
+
+  it('returns the components array from the response', async () => {
+    const components = [component({ path: 'src/a.ts' }), component({ path: 'src/b.ts' })];
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(componentTreeResponse({ components })),
+    );
+
+    const result = await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'new_coverage',
+      ascending: true,
+      top: 3,
+    });
+
+    expect(result.components).toEqual(components);
+  });
+
+  it('returns the total count from paging, independent of how many components the page holds', async () => {
+    const components = [component({ path: 'src/a.ts' })];
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(
+        componentTreeResponse({ components, paging: { pageIndex: 1, pageSize: 1, total: 47 } }),
+      ),
+    );
+
+    const result = await client.getWorstComponentsByMetric({
+      projectKey: 'my-project',
+      metricKey: 'new_coverage',
+      ascending: true,
+      top: 1,
+    });
+
+    expect(result.totalCount).toBe(47);
+  });
+});


### PR DESCRIPTION
Show a per-file breakdown of the worst offenders under each failing coverage-related quality gate condition (top 3 files by default), in both the table and JSON output of `quality-gate status`.