### PR TITLE
CLI-962 Introduce --category and --top flags

### DIFF
--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -36,8 +36,7 @@ import {
 import { resolveGitlabToken } from '@/core/gitlab/token.ts';
 import { CURRENT_DISTRIBUTION } from '@/core/host/distribution.ts';
 import { initSentry } from '@/core/observability/sentry.ts';
-import { GENERIC_HTTP_METHODS } from '@/core/server/client.ts';
-import { MAX_PAGE_SIZE } from '@/core/server/projects.ts';
+import { GENERIC_HTTP_METHODS, MAX_PAGE_SIZE } from '@/core/server/client.ts';
 import { tryLoadState } from '@/core/state/state-repository.ts';
 import { flushTelemetry, TELEMETRY_FLUSH_MODE_ENV } from '@/core/telemetry';
 import { resolveAgentSessionId } from '@/core/telemetry/agent-session.ts';
@@ -117,6 +116,7 @@ import {
 } from './list/issues.ts';
 import { listProjects, type ListProjectsOptions } from './list/projects.ts';
 import {
+  DEFAULT_TOP as QUALITY_GATE_DEFAULT_TOP,
   qualityGateStatus,
   type QualityGateStatusOptions,
   VALID_FORMATS as QUALITY_GATE_VALID_FORMATS,
@@ -297,6 +297,17 @@ function buildCommandTree(runtime: CliRuntime): SonarCommand {
     .option('--branch <branch>', 'Branch name. Cannot be combined with --pull-request.')
     .option('--pull-request <pull-request>', 'Pull request ID. Cannot be combined with --branch.')
     .option('--all', 'Also show passing conditions. By default only failing conditions are shown.')
+    .addOption(
+      new SonarOption(
+        '--category <category>',
+        'Only show the breakdown for one category of failing conditions',
+      ),
+    )
+    .addOption(
+      new SonarOption('--top <top>', 'Number of files to include in the breakdown, per condition')
+        .default(QUALITY_GATE_DEFAULT_TOP)
+        .argParser(parseInteger),
+    )
     .authenticatedAction((ctx, options: QualityGateStatusOptions) =>
       qualityGateStatus(options, ctx),
     );

--- a/src/commands/list/issues.ts
+++ b/src/commands/list/issues.ts
@@ -24,9 +24,8 @@ import { encode as encodeToToon } from '@toon-format/toon';
 
 import { InvalidOptionError } from '@/core/command-error.ts';
 import type { CommandAuthenticatedInvocationContext } from '@/core/commands/invocation-context.ts';
-import { SonarQubeClient } from '@/core/server/client.ts';
+import { MAX_PAGE_SIZE, SonarQubeClient } from '@/core/server/client.ts';
 import { IssuesClient } from '@/core/server/issues.ts';
-import { MAX_PAGE_SIZE } from '@/core/server/projects.ts';
 import type { IssuesSearchParams } from '@/core/server/types.ts';
 import { print } from '@/core/ui';
 import { formatCSV } from '@/core/ui/formatter/csv.ts';

--- a/src/commands/list/projects.ts
+++ b/src/commands/list/projects.ts
@@ -22,8 +22,8 @@
 
 import { InvalidOptionError } from '@/core/command-error.ts';
 import type { CommandAuthenticatedInvocationContext } from '@/core/commands/invocation-context.ts';
-import { SonarQubeClient } from '@/core/server/client.ts';
-import { MAX_PAGE_SIZE, ProjectsClient } from '@/core/server/projects.ts';
+import { MAX_PAGE_SIZE, SonarQubeClient } from '@/core/server/client.ts';
+import { ProjectsClient } from '@/core/server/projects.ts';
 import { print } from '@/core/ui';
 
 export interface ListProjectsOptions {

--- a/src/commands/quality-gate/status/breakdown.ts
+++ b/src/commands/quality-gate/status/breakdown.ts
@@ -23,7 +23,7 @@
 import logger from '@/core/observability/logger.ts';
 import type { SonarQubeClient } from '@/core/server/client.ts';
 import { isNewCodeMetric, MeasuresClient } from '@/core/server/measures.ts';
-import type { ComponentTreeComponent, Metric } from '@/core/server/types.ts';
+import type { ComponentTreeComponent, Metric, QualityGateCondition } from '@/core/server/types.ts';
 
 import type {
   QualityGateBreakdownEntry,
@@ -41,18 +41,51 @@ const METRIC_CATEGORIES: Record<string, string> = {
   new_line_coverage: 'coverage',
 };
 
+export const IMPLEMENTED_CATEGORIES = [...new Set(Object.values(METRIC_CATEGORIES))];
+
 export interface AttachBreakdownsParams {
   client: SonarQubeClient;
   projectKey: string;
   metrics: Metric[];
+  category?: string;
   top: number;
   branch?: string;
   pullRequest?: string;
 }
 
-/** A failing condition whose metric falls into an implemented category. */
-function isEnrichableCondition(condition: QualityGateConditionSummary): boolean {
-  return condition.status !== 'OK' && !!METRIC_CATEGORIES[condition.metric];
+/**
+ * True when a failing condition's metric falls into an implemented category, filtered to
+ * `category` when given.
+ */
+function isFailingMetricInCategory(
+  metricKey: string,
+  status: string,
+  category: string | undefined,
+): boolean {
+  const conditionCategory = METRIC_CATEGORIES[metricKey];
+  return status !== 'OK' && !!conditionCategory && (!category || category === conditionCategory);
+}
+
+/**
+ * True when at least one failing condition falls into `category` - distinct from the resulting
+ * breakdown being empty for another reason (a matching condition's enrichment fetch failing, or
+ * returning no files), which should stay silent rather than warn.
+ */
+export function hasFailingConditionInCategory(
+  conditions: QualityGateCondition[],
+  category: string,
+): boolean {
+  return conditions.some((condition) =>
+    isFailingMetricInCategory(condition.metricKey, condition.status, category),
+  );
+}
+
+/** A failing condition whose metric falls into an implemented category, when given. */
+function isEnrichableCondition(
+  condition: QualityGateConditionSummary,
+  category: string | undefined,
+): boolean {
+  return isFailingMetricInCategory(condition.metric, condition.status, category);
 }
 
 /**
@@ -69,7 +102,7 @@ export async function attachBreakdowns(
 
   return Promise.all(
     conditions.map(async (condition) => {
-      if (!isEnrichableCondition(condition)) {
+      if (!isEnrichableCondition(condition, params.category)) {
         return condition;
       }
       const breakdown = await fetchMetricBreakdown(measuresClient, params, condition, metricsByKey);

--- a/src/commands/quality-gate/status/format-table.ts
+++ b/src/commands/quality-gate/status/format-table.ts
@@ -18,10 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { MAX_PAGE_SIZE } from '@/core/server/client.ts';
 import { cyan, green, red, yellow } from '@/core/ui/colors.ts';
 import { padColumns } from '@/core/ui/formatter/column-formatting.ts';
 
-import type { QualityGateConditionSummary } from './condition-summary.ts';
+import type {
+  QualityGateConditionSummary,
+  QualityGateMetricBreakdown,
+} from './condition-summary.ts';
 import type { QualityGateScope } from './scope.ts';
 import type { QualityGateVerdict } from './verdict.ts';
 
@@ -146,10 +150,27 @@ function formatBreakdownLines(condition: QualityGateConditionSummary): string[] 
 
   const remaining = metricBreakdown.totalCount - metricBreakdown.fetchedCount;
   if (remaining > 0) {
-    lines.push(`${BREAKDOWN_INDENT}… ${remaining} more not shown`);
+    lines.push(formatMoreEntriesLine(metricBreakdown, remaining));
   }
 
   return lines;
+}
+
+function formatMoreEntriesLine(
+  metricBreakdown: QualityGateMetricBreakdown,
+  remaining: number,
+): string {
+  const suggestedTop = Math.min(metricBreakdown.totalCount, MAX_PAGE_SIZE);
+  const showsEverything = metricBreakdown.totalCount <= MAX_PAGE_SIZE;
+  // A suggestion that isn't higher than what was already requested would be a no-op - e.g.
+  // --top is already at MAX_PAGE_SIZE, so the API's own cap, not --top, is what's left out.
+  let suffix: string;
+  if (suggestedTop > metricBreakdown.fetchedCount) {
+    suffix = `use --top ${suggestedTop} to display ${showsEverything ? 'all' : 'more'}`;
+  } else {
+    suffix = `capped at ${MAX_PAGE_SIZE} results per fetch`;
+  }
+  return `${BREAKDOWN_INDENT}… ${remaining} more · ${suffix}`;
 }
 
 function notComputedHint(scope: QualityGateScope): string {

--- a/src/commands/quality-gate/status/index.ts
+++ b/src/commands/quality-gate/status/index.ts
@@ -20,16 +20,20 @@
 
 // quality-gate status command - fetch the quality gate verdict for a project
 
-import { CommandFailedError } from '@/core/command-error.ts';
+import { CommandFailedError, InvalidOptionError } from '@/core/command-error.ts';
 import type { CommandAuthenticatedInvocationContext } from '@/core/commands/invocation-context.ts';
 import { resolveProjectKey } from '@/core/project-info.ts';
-import { SonarQubeClient } from '@/core/server/client.ts';
+import { MAX_PAGE_SIZE, SonarQubeClient } from '@/core/server/client.ts';
 import { MetricsClient } from '@/core/server/metrics.ts';
 import { QualityGatesClient } from '@/core/server/quality-gates.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
-import { print } from '@/core/ui';
+import { print, warn } from '@/core/ui';
 
-import { attachBreakdowns } from './breakdown.ts';
+import {
+  attachBreakdowns,
+  hasFailingConditionInCategory,
+  IMPLEMENTED_CATEGORIES,
+} from './breakdown.ts';
 import { selectConditions } from './condition-summary.ts';
 import { formatQualityGateJson } from './format-json.ts';
 import { formatQualityGateTable } from './format-table.ts';
@@ -38,7 +42,9 @@ import { exitCodeFor, toVerdict } from './verdict.ts';
 
 export const VALID_FORMATS = ['json', 'table'];
 
-const DEFAULT_TOP = 3;
+export const VALID_CATEGORIES = IMPLEMENTED_CATEGORIES;
+
+export const DEFAULT_TOP = MAX_PAGE_SIZE;
 
 export interface QualityGateStatusOptions {
   project?: string;
@@ -46,6 +52,8 @@ export interface QualityGateStatusOptions {
   branch?: string;
   pullRequest?: string;
   all?: boolean;
+  category?: string;
+  top?: number;
 }
 
 export async function qualityGateStatus(
@@ -53,6 +61,18 @@ export async function qualityGateStatus(
   ctx: CommandAuthenticatedInvocationContext,
 ): Promise<void> {
   const { auth } = ctx;
+  const top = options.top ?? DEFAULT_TOP;
+  if (top < 1 || top > MAX_PAGE_SIZE) {
+    throw new InvalidOptionError(
+      `Invalid --top option: '${top}'. Must be an integer between 1 and ${MAX_PAGE_SIZE}`,
+    );
+  }
+  if (options.category && !VALID_CATEGORIES.includes(options.category)) {
+    throw new InvalidOptionError(
+      `Invalid --category option: '${options.category}'. Must be one of: ${VALID_CATEGORIES.join(', ')}`,
+    );
+  }
+
   const projectKey = await resolveProjectKey(options.project, auth, true);
   noteProject(auth, projectKey);
 
@@ -81,11 +101,20 @@ export async function qualityGateStatus(
         client,
         projectKey,
         metrics,
-        top: DEFAULT_TOP,
+        category: options.category,
+        top,
         branch: queryParams.branch,
         pullRequest: queryParams.pullRequest,
       })
     : summaries;
+
+  if (
+    options.category &&
+    hasFailingConditions &&
+    !hasFailingConditionInCategory(rawConditions, options.category)
+  ) {
+    warn(`No failing conditions match category '${options.category}'.`);
+  }
 
   const format = options.format ?? 'table';
   const message =

--- a/src/commands/remediate/index.ts
+++ b/src/commands/remediate/index.ts
@@ -30,9 +30,8 @@ import {
 } from '@/core/config-constants.ts';
 import logger from '@/core/observability/logger.ts';
 import { discoverProject } from '@/core/project-info.ts';
-import { SonarQubeClient } from '@/core/server/client.ts';
+import { MAX_PAGE_SIZE, SonarQubeClient } from '@/core/server/client.ts';
 import { IssuesClient } from '@/core/server/issues.ts';
-import { MAX_PAGE_SIZE } from '@/core/server/projects.ts';
 import type { SonarQubeIssue } from '@/core/server/types.ts';
 import { noteProject } from '@/core/telemetry/project-uuid.ts';
 import { blank, info, multiSelectPrompt, print, success, withSpinner } from '@/core/ui';

--- a/src/core/server/client.ts
+++ b/src/core/server/client.ts
@@ -62,6 +62,15 @@ export type HttpMethod = (typeof GENERIC_HTTP_METHODS)[number];
 export type QueryParams = Record<string, string | number | boolean>;
 
 /**
+ * The `ps` (page size) ceiling on nearly every paginated SonarQube list endpoint - not specific
+ * to any one resource. Confirmed identical across `components/search_projects`,
+ * `measures/component_tree`, `issues/search`, and `metrics/search`'s own param docs ("must be
+ * greater than 0 and less or equal than 500"). The unrelated, narrower
+ * `DOP_REPOSITORIES_MAX_PAGE_SIZE` below is a real exception specific to that one API.
+ */
+export const MAX_PAGE_SIZE = 500;
+
+/**
  * `not_applicable` is returned when Vortex cannot apply to this connection: Cloud without
  * an organization (see `resolveVortexEntitlement`), or a Server missing either hub (HTTP 404).
  */

--- a/src/core/server/projects.ts
+++ b/src/core/server/projects.ts
@@ -20,8 +20,6 @@
 import { type SonarQubeClient } from './client.ts';
 import type { ProjectsSearchParams, ProjectsSearchResponse } from './types.ts';
 
-export const MAX_PAGE_SIZE = 500;
-
 export class ProjectsClient {
   private readonly client: SonarQubeClient;
 

--- a/tests/integration/specs/quality-gate/status.test.ts
+++ b/tests/integration/specs/quality-gate/status.test.ts
@@ -733,6 +733,7 @@ describe('quality-gate status', () => {
     },
     { timeout: 15000 },
   );
+
   it(
     'includes a coverage breakdown in JSON for a failing new_coverage condition',
     async () => {
@@ -826,7 +827,7 @@ describe('quality-gate status', () => {
   );
 
   it(
-    'reports the total matching file count separately from the truncated default top-3 entries',
+    'reports the total matching file count separately from the truncated worst-N entries',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -855,7 +856,9 @@ describe('quality-gate status', () => {
         .start();
       harness.withAuth(server.baseUrl(), 'test-token');
 
-      const result = await harness.run(`quality-gate status --project my-project --format json`);
+      const result = await harness.run(
+        `quality-gate status --project my-project --top 2 --format json`,
+      );
 
       const parsed = JSON.parse(result.stdout);
       const condition = parsed.qualityGate.conditions.find(
@@ -863,11 +866,10 @@ describe('quality-gate status', () => {
       );
       expect(condition.breakdown).toEqual({
         totalCount: 5,
-        fetchedCount: 3,
+        fetchedCount: 2,
         entries: [
           { path: 'src/a.ts', value: '10.0', formattedValue: '10.0%' },
           { path: 'src/b.ts', value: '20.0', formattedValue: '20.0%' },
-          { path: 'src/c.ts', value: '30.0', formattedValue: '30.0%' },
         ],
       });
     },
@@ -1110,7 +1112,7 @@ describe('quality-gate status', () => {
   );
 
   it(
-    'shows a "N more" hint with no suggestion when the table omits entries the JSON totalCount accounts for',
+    'shows a "N more" hint with a --top suggestion when the table omits entries the JSON totalCount accounts for',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -1139,15 +1141,73 @@ describe('quality-gate status', () => {
         .start();
       harness.withAuth(server.baseUrl(), 'test-token');
 
-      const result = await harness.run(`quality-gate status --project my-project --format table`);
+      const result = await harness.run(
+        `quality-gate status --project my-project --top 2 --format table`,
+      );
 
       const lines = result.stdout.split('\n');
       const conditionIndex = lines.findIndex((l) => l.includes('Coverage on New Code'));
       expect(lines[conditionIndex + 1]).toContain('src/a.ts');
       expect(lines[conditionIndex + 2]).toContain('src/b.ts');
-      expect(lines[conditionIndex + 3]).toContain('src/c.ts');
-      expect(lines[conditionIndex + 4]).toContain('… 2 more not shown');
-      expect(lines[conditionIndex + 4]).not.toContain('--top');
+      expect(lines[conditionIndex + 3]).toContain('… 3 more');
+      expect(lines[conditionIndex + 3]).toContain('use --top 5 to display all');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'clamps the suggested --top to MAX_PAGE_SIZE and says "to display more" when totalCount exceeds it',
+    async () => {
+      const manyFiles = Array.from({ length: 501 }, (_, i) => ({
+        path: `src/file${i}.ts`,
+        value: '10.0',
+      }));
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', manyFiles),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --top 3 --format table`,
+      );
+
+      const lines = result.stdout.split('\n');
+      const hintLine = lines.find((l) => l.includes('more'));
+      expect(hintLine).toContain('… 498 more');
+      // 500 (MAX_PAGE_SIZE), not 501 (totalCount) - a suggested --top the command would reject
+      // defeats the purpose of the hint.
+      expect(hintLine).toContain('use --top 500 to display more');
+      expect(hintLine).not.toContain('use --top 501');
+
+      // The suggested --top must actually be runnable, not just look like a number.
+      const followUp = await harness.run(
+        `quality-gate status --project my-project --top 500 --format table`,
+      );
+      expect(followUp.exitCode).not.toBe(2);
+
+      // Having followed the suggestion, --top is now at MAX_PAGE_SIZE - raising it further
+      // wouldn't reveal the last remaining file, so the hint must stop suggesting a --top value
+      // instead of repeating the exact command the user just ran.
+      const followUpHintLine = followUp.stdout.split('\n').find((l) => l.includes('more'));
+      expect(followUpHintLine).toContain('… 1 more');
+      expect(followUpHintLine).toContain('capped at 500 results per fetch');
+      expect(followUpHintLine).not.toContain('--top');
     },
     { timeout: 15000 },
   );
@@ -1402,7 +1462,41 @@ describe('quality-gate status', () => {
   );
 
   it(
-    'requests the top 3 files by default',
+    'passes --top through to the component_tree request',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      await harness.run(`quality-gate status --project my-project --top 7`);
+
+      const componentTreeRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/measures/component_tree');
+      expect(componentTreeRequests).toHaveLength(1);
+      expect(componentTreeRequests[0].query.ps).toBe('7');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'requests the default --top of 500 files when --top is not given',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -1430,7 +1524,179 @@ describe('quality-gate status', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/api/measures/component_tree');
       expect(componentTreeRequests).toHaveLength(1);
-      expect(componentTreeRequests[0].query.ps).toBe('3');
+      expect(componentTreeRequests[0].query.ps).toBe('500');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'includes the coverage breakdown when --category coverage is passed explicitly',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category coverage --format json`,
+      );
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'omits the breakdown and warns on stderr for a non-coverage condition even when --category coverage is given',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p.withProjectStatus('ERROR').withConditions([
+            {
+              status: 'ERROR',
+              metricKey: 'new_violations',
+              comparator: 'GT',
+              errorThreshold: '0',
+              actualValue: '3',
+            },
+          ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category coverage --format json`,
+      );
+
+      // stdout must stay valid JSON even though a warning was also emitted, on stderr.
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.conditions).toHaveLength(1);
+      expect(
+        parsed.qualityGate.conditions.every(
+          (c: { breakdown?: unknown }) => c.breakdown === undefined,
+        ),
+      ).toBe(true);
+      expect(result.stderr).toContain("No failing conditions match category 'coverage'");
+      const componentTreeRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/measures/component_tree');
+      expect(componentTreeRequests).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not warn when --category matches a failing condition, even if enrichment finds no files',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p.withProjectStatus('ERROR').withConditions([
+            {
+              status: 'ERROR',
+              metricKey: 'new_coverage',
+              comparator: 'LT',
+              errorThreshold: '80',
+              actualValue: '62.4',
+            },
+          ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category coverage --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.conditions).toHaveLength(1);
+      expect(
+        parsed.qualityGate.conditions.every(
+          (c: { breakdown?: unknown }) => c.breakdown === undefined,
+        ),
+      ).toBe(true);
+      expect(result.stderr).not.toContain('No failing conditions match category');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not warn about an unmatched --category when the quality gate passed entirely',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p.withProjectStatus('OK').withConditions([
+            {
+              status: 'OK',
+              metricKey: 'new_violations',
+              comparator: 'GT',
+              errorThreshold: '0',
+              actualValue: '0',
+            },
+          ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category coverage --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.conditions).toEqual([]);
+      expect(result.stderr).not.toContain('No failing conditions match category');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not warn about an unmatched --category when the project has no quality gate status yet',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project')
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category coverage --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      expect(parsed.qualityGate.conditions).toEqual([]);
+      expect(result.stderr).not.toContain('No failing conditions match category');
     },
     { timeout: 15000 },
   );
@@ -1577,6 +1843,94 @@ describe('quality-gate status', () => {
         .getRecordedRequests()
         .filter((r) => r.path === '/api/measures/component_tree');
       expect(componentTreeRequests).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'rejects an invalid --category value, before making any network call',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) => p.withProjectStatus('OK'))
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category duplications`,
+      );
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain(
+        "Invalid --category option: 'duplications'. Must be one of: coverage",
+      );
+      const statusRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/qualitygates/project_status');
+      expect(statusRequests).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'rejects a non-numeric --top value',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) => p.withProjectStatus('OK'))
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --top abc`);
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain('Not a number');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'rejects a --top value below 1, before making any network call',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) => p.withProjectStatus('OK'))
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --top 0`);
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain(
+        "Invalid --top option: '0'. Must be an integer between 1 and 500",
+      );
+      const statusRequests = server
+        .getRecordedRequests()
+        .filter((r) => r.path === '/api/qualitygates/project_status');
+      expect(statusRequests).toHaveLength(0);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'rejects a --top value above 500',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) => p.withProjectStatus('OK'))
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --top 501`);
+
+      expect(result.exitCode).toBe(2);
+      expect(result.stderr).toContain(
+        "Invalid --top option: '501'. Must be an integer between 1 and 500",
+      );
     },
     { timeout: 15000 },
   );

--- a/tests/unit/commands/list/list.test.ts
+++ b/tests/unit/commands/list/list.test.ts
@@ -26,9 +26,9 @@ import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:te
 
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { CommandAuthenticatedInvocationContext } from '@/core/commands/invocation-context.ts';
-import { SonarQubeClient } from '@/core/server/client.ts';
+import { MAX_PAGE_SIZE, SonarQubeClient } from '@/core/server/client.ts';
 import { IssuesClient } from '@/core/server/issues.ts';
-import { MAX_PAGE_SIZE, ProjectsClient } from '@/core/server/projects.ts';
+import { ProjectsClient } from '@/core/server/projects.ts';
 import type {
   IssuesSearchResponse,
   ProjectsSearchResponse,

--- a/tests/unit/commands/list/projects-command.test.ts
+++ b/tests/unit/commands/list/projects-command.test.ts
@@ -6,8 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
 import { CommandAuthenticatedInvocationContext } from '@/core/commands/invocation-context.ts';
-import { SonarQubeClient } from '@/core/server/client.ts';
-import { MAX_PAGE_SIZE } from '@/core/server/projects.ts';
+import { MAX_PAGE_SIZE, SonarQubeClient } from '@/core/server/client.ts';
 import type { ProjectsSearchResponse } from '@/core/server/types.ts';
 import { clearMockUiCalls, getMockUiCalls, setMockUi } from '@/core/ui';
 


### PR DESCRIPTION
Layer configurability on top of the coverage breakdown from CLI-1012: --top overrides the default of 3 files per condition, and --category filters the breakdown down to a single implemented category.