### PR TITLE
CLI-1046 Update dependency mise to 2026.8.14

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -14,7 +14,7 @@ runs:
   steps:
     - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       with:
-        version: 2026.4.20
+        version: 2026.8.14
 
     - name: Cache Bun dependencies
       uses: SonarSource/gh-action_cache@339d9d71cc5210bfa866a831dd8eba8e32c40491 # v1.7.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
         with:
-          version: 2026.4.20
+          version: 2026.8.14
 
       - uses: SonarSource/ci-github-actions/get-build-number@de29c54be07c772c6afc381db8ae4bfcbfe4df12 # 1.8.0
         id: get-build-number


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependencies:**
    - Updated `mise` version to `2026.8.14` in workflow and action configurations

<sub>This will update automatically on new commits.</sub>