### PR TITLE
BUILD-12308 Migrate eligible jobs to self-hosted runners

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestMerged_job:
     name: Pull Request Merged
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   prepare:
     name: Prepare Build
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     outputs:
       BUILD_NUMBER: ${{ steps.get-build-number.outputs.BUILD_NUMBER }}
       PROJECT_VERSION: ${{ steps.project_version.outputs.PROJECT_VERSION }}
@@ -49,7 +49,7 @@ jobs:
 
   build-binaries:
     name: Build All Binaries
-    runs-on: github-ubuntu-latest-m
+    runs-on: warp-custom-ubuntu-24-04
     needs: prepare
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -245,7 +245,7 @@ jobs:
 
   publish-binaries:
     name: Publish Binaries to Artifactory
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     needs:
       - prepare
       - build-binaries
@@ -335,7 +335,7 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -364,7 +364,7 @@ jobs:
 
   unit-tests-linux:
     name: Unit Tests - linux
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -419,7 +419,7 @@ jobs:
 
   integration-and-e2e-linux:
     name: Integration and E2E Tests - linux
-    runs-on: github-ubuntu-latest-m
+    runs-on: sonar-m
     needs: [prepare, build-binaries]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -473,7 +473,7 @@ jobs:
 
   scan:
     name: SonarQube Analysis
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     # Coverage artifacts are Linux-only; Windows tests still gate publish and promote.
     needs: [prepare, lint, unit-tests-linux, integration-and-e2e-linux]
     steps:
@@ -521,7 +521,7 @@ jobs:
           .github/scripts/sonarqube-analysis.sh
 
   promote:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Promote
     needs:
       - prepare

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   check-draft-exists:
     name: Check draft release exists
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     # contents: write is required — draft releases are only visible to tokens with write access.
     permissions:
       contents: write
@@ -66,7 +66,7 @@ jobs:
 
   bump-version:
     name: Create a PR to bump version
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     needs:
       - release
     permissions:
@@ -126,7 +126,7 @@ jobs:
 
   publish-release-notes:
     name: Copy reviewed notes to published release
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     needs: [check-draft-exists, release]
     permissions:
       contents: write

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   notify:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Send Slack Notification
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:

--- a/.github/workflows/prepare-release-notes.yml
+++ b/.github/workflows/prepare-release-notes.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   prepare-release-notes:
     name: Generate notes and create draft release
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     permissions:
       id-token: write # required for Vault OIDC auth
       contents: write # required to create the draft GitHub release

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   update_releasability_status:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Releasability status
     permissions:
       id-token: write


### PR DESCRIPTION
BUILD-12308

## Purpose
Self-hosted runners should be used in all cases except approved use cases where self-hosted runners do not work. They are more cost-efficient and faster than GitHub-hosted runners.

This PR migrates eligible Linux workflow jobs to SonarSource self-hosted runner labels, including automation, release, build, test, analysis, and promotion jobs. Existing Windows jobs already use Warp runners.

## Retained jobs
- macOS signing and notarization remains on GitHub-hosted macOS because there is no supported self-hosted macOS equivalent.
- Generated agent lock workflows remain unchanged and require their supported regeneration path.
- The RequestReview workflow remains on its current hosted alias and needs squad confirmation; if it is not an approved exception, it should be moved to `sonar-xs` before merge.

The owning squad should validate these retained cases against the approved exceptions before merging.

## Validation
- `git diff --check`
- Scoped `actionlint`; passed after excluding expected unknown-label diagnostics for SonarSource custom runner labels and unrelated pre-existing shellcheck findings.

## Tracking
- Subtask: https://sonarsource.atlassian.net/browse/BUILD-12308
- Parent: https://sonarsource.atlassian.net/browse/BUILD-12470
- Migration initiative: https://sonarsource.atlassian.net/browse/BUILD-12260

Owning squad: please take over final workflow validation and merge this PR. Let us know if you encounter any issues.