### PR TITLE
CLI-1069 Add the DevEx team as co-owners of onboard-ci CODEOWNERS paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 .github/CODEOWNERS @sonarsource/remediation-ide-experience-squad
 
-src/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad
-tests/integration/specs/admin/onboard-ci-gitlab.test.ts @sonarsource/orchestration-workflow-squad
-tests/unit/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad
+src/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad @sonarsource/remediation-ide-experience-squad
+tests/integration/specs/admin/onboard-ci-gitlab.test.ts @sonarsource/orchestration-workflow-squad @sonarsource/remediation-ide-experience-squad
+tests/unit/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad @sonarsource/remediation-ide-experience-squad


### PR DESCRIPTION
## Summary
- Add `@sonarsource/remediation-ide-experience-squad` as co-owners of the onboard-ci CODEOWNERS paths that currently belong only to Workflow & Orchestration
- PRs touching `src/commands/admin/onboard-ci/`, its unit tests, and the GitLab integration spec will now request both teams