### PR TITLE
CLI-1071 Use agentic-sdlc-development-experience-squad as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-.github/CODEOWNERS @sonarsource/remediation-ide-experience-squad
+.github/CODEOWNERS @sonarsource/agentic-sdlc-development-experience-squad
 
-src/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad @sonarsource/remediation-ide-experience-squad
-tests/integration/specs/admin/onboard-ci-gitlab.test.ts @sonarsource/orchestration-workflow-squad @sonarsource/remediation-ide-experience-squad
-tests/unit/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad @sonarsource/remediation-ide-experience-squad
+src/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad @sonarsource/agentic-sdlc-development-experience-squad
+tests/integration/specs/admin/onboard-ci-gitlab.test.ts @sonarsource/orchestration-workflow-squad @sonarsource/agentic-sdlc-development-experience-squad
+tests/unit/commands/admin/onboard-ci/ @sonarsource/orchestration-workflow-squad @sonarsource/agentic-sdlc-development-experience-squad


### PR DESCRIPTION
## Summary
- Replace `@sonarsource/remediation-ide-experience-squad` with `@sonarsource/agentic-sdlc-development-experience-squad` on every CODEOWNERS entry
- Covers the CODEOWNERS file itself and the onboard-ci co-owner paths