### PR TITLE
CLI-844 Restore SonarHttpClient.serverURL to private

### DIFF
--- a/src/core/server/http-client.ts
+++ b/src/core/server/http-client.ts
@@ -71,7 +71,7 @@ export interface SafeGetResult<T> {
 }
 
 export class SonarHttpClient {
-  public readonly serverURL: string;
+  private readonly serverURL: string;
   public readonly isCloud: boolean;
   private readonly token: string;
 


### PR DESCRIPTION
## Summary

CLI-842's client split temporarily widened `SonarHttpClient.serverURL` to `public readonly` so the
extracted domain clients could reach it. The split is done and nothing outside the class reads it
any more (verified: the other `serverURL`/`serverUrl` matches in the repo are unrelated —
`sonarlint-connected-mode.ts`'s config field, and plain parameters elsewhere). Closes the access
back to `private readonly`.

`postFormJson` stays public (used by `import-api.ts`) — out of scope here.


## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 7 pre-existing warnings, unrelated
- [x] `bun run test:unit` — 2636 pass, 5 skip, 0 fail
- [x] `bun run test:integration` — 1030 pass, 1 skip, 0 fail