### PR TITLE
CLI-1077 Reject non-Server connections before prompting for a GitLab token

### DIFF
--- a/src/commands/admin/onboard-ci/gitlab/index.ts
+++ b/src/commands/admin/onboard-ci/gitlab/index.ts
@@ -194,6 +194,22 @@ function applyReposFileFilter<T extends GitLabRepo>(
   return repos.filter((r) => entries.has(relativePath(r)));
 }
 
+/**
+ * Rejects a non-SonarQube-Server connection before any GitLab-specific work (including the
+ * token prompt) happens. Exported so the command handler can call it ahead of
+ * `resolveGitlabToken`, without duplicating the error message.
+ */
+export function assertOnPremiseConnection(auth: ResolvedAuth): void {
+  if (auth.connectionType !== 'on-premise') {
+    throw new CommandFailedError(
+      'sonar admin onboard-ci gitlab requires a SonarQube Server connection.',
+      {
+        remediationHint: "Authenticate against SonarQube Server with 'sonar auth login' and retry.",
+      },
+    );
+  }
+}
+
 async function preflight(
   auth: ResolvedAuth,
   gitlabToken: string,
@@ -205,14 +221,7 @@ async function preflight(
   dopSettingKey: string;
   gitlabUrl: string;
 }> {
-  if (auth.connectionType !== 'on-premise') {
-    throw new CommandFailedError(
-      'sonar admin onboard-ci gitlab requires a SonarQube Server connection.',
-      {
-        remediationHint: "Authenticate against SonarQube Server with 'sonar auth login' and retry.",
-      },
-    );
-  }
+  assertOnPremiseConnection(auth);
 
   const sqsClient = new OnboardCiSqsClient(new SonarHttpClient(auth.serverUrl, auth.token));
   if (!(await sqsClient.users.hasProvisionProjectsPermission())) {

--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -46,6 +46,7 @@ import type { Console } from '@/core/ui/console.ts';
 
 import { version as VERSION } from '../../package.json';
 import {
+  assertOnPremiseConnection,
   collectScannerProperty,
   onboardCiGitlab,
   type OnboardCiGitlabOptions,
@@ -865,6 +866,7 @@ function buildCommandTree(runtime: CliRuntime, console: Console): SonarCommand {
     .option('--dry-run', 'Preview what would be processed without making any changes', false)
     .authenticatedAction(async (ctx, options: OnboardCiGitlabOptions) => {
       validateOnboardCiGitlabOptions(options);
+      assertOnPremiseConnection(ctx.auth);
       const gitlabToken = await resolveGitlabToken(ctx.console);
       return onboardCiGitlab(ctx.auth, gitlabToken, options, ctx.console);
     });

--- a/tests/integration/specs/admin/onboard-ci-gitlab.test.ts
+++ b/tests/integration/specs/admin/onboard-ci-gitlab.test.ts
@@ -112,11 +112,12 @@ describe('sonar admin onboard-ci gitlab', () => {
       harness.withAuth(sqsServer.baseUrl(), 'test-token', 'my-org');
       harness.withExtraEnv({ SONARQUBE_CLI_MOCK_TTY: '1', GITLAB_TOKEN: '' });
 
-      const session = harness.runInteractive(`admin onboard-ci gitlab --group ${GROUP}`);
-      const result = await session.waitFinish();
+      const result = await harness.run(`admin onboard-ci gitlab --group ${GROUP}`);
 
       expect(result.exitCode).toBe(1);
-      expect(result.stderr).toContain('SonarQube Server');
+      expect(result.stderr).toContain(
+        'sonar admin onboard-ci gitlab requires a SonarQube Server connection.',
+      );
       expect(result.stdout).not.toContain('GitLab personal access token');
     });
 

--- a/tests/integration/specs/admin/onboard-ci-gitlab.test.ts
+++ b/tests/integration/specs/admin/onboard-ci-gitlab.test.ts
@@ -107,6 +107,19 @@ describe('sonar admin onboard-ci gitlab', () => {
       expect(result.stderr).toContain('SonarQube Server');
     });
 
+    it('exits 1 when connected to SonarQube Cloud without prompting for a GitLab token', async () => {
+      const sqsServer = await harness.newFakeServer().withAuthToken('test-token').start();
+      harness.withAuth(sqsServer.baseUrl(), 'test-token', 'my-org');
+      harness.withExtraEnv({ SONARQUBE_CLI_MOCK_TTY: '1', GITLAB_TOKEN: '' });
+
+      const session = harness.runInteractive(`admin onboard-ci gitlab --group ${GROUP}`);
+      const result = await session.waitFinish();
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('SonarQube Server');
+      expect(result.stdout).not.toContain('GitLab personal access token');
+    });
+
     it('exits 2 for invalid --sonar-token-var-name', async () => {
       await startServers(harness);
       const result = await harness.run(


### PR DESCRIPTION
## Summary
- `sonar admin onboard-ci gitlab` on a SonarQube Cloud connection used to prompt for a GitLab personal access token before rejecting the connection with "requires a SonarQube Server connection" — the user pastes a secret for nothing.
- Extracted the connection-type check into an exported `assertOnPremiseConnection()` guard (`src/commands/admin/onboard-ci/gitlab/index.ts`) so the message is defined once, and call it in the command handler (`src/commands/command-tree.ts`) before `resolveGitlabToken()`. `preflight()` still calls the same guard, so behavior for the on-premise path is unchanged.

## Test plan
- [x] Added an integration test asserting a Cloud connection exits 1 without ever printing the GitLab token prompt (interactive session, mock TTY).
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:unit`
- [x] `bun test tests/integration/specs/admin/onboard-ci-gitlab.test.ts` (48 pass)
- [x] `sonar analyze agentic --depth DEEP` on changed files — clean (one pre-existing file-size finding on `command-tree.ts`, unrelated to this change)

CC @sonarsource/orchestration-workflow-squad for review — this path is CODEOWNERS-owned by your squad.

Jira: https://sonarsource.atlassian.net/browse/CLI-1077