### PR TITLE
CLI-1076 Use OrganizationsClient for the AI remediation entitlement lookup

### DIFF
--- a/src/commands/remediate/remediate-api.ts
+++ b/src/commands/remediate/remediate-api.ts
@@ -21,11 +21,11 @@
 // Every SonarQube API call `sonar remediate` makes, in one place next to the command.
 
 import logger from '@/core/observability/logger.ts';
-import { okAsync, type ResultAsync } from '@/core/result.ts';
+import { okAsync } from '@/core/result.ts';
 import { ComponentsClient } from '@/core/server/components.ts';
-import type { HttpClientError } from '@/core/server/errors.ts';
 import { type SonarHttpClient } from '@/core/server/http-client.ts';
 import { IssuesClient } from '@/core/server/issues.ts';
+import { OrganizationsClient } from '@/core/server/organizations.ts';
 
 export interface AgentJobRequest {
   projectId: string;
@@ -43,23 +43,35 @@ export class RemediateApiClient {
   /** Shared APIs this command drives directly, exposed rather than re-declared. */
   readonly issues: IssuesClient;
   readonly components: ComponentsClient;
+  readonly organizations: OrganizationsClient;
   private readonly client: SonarHttpClient;
 
   constructor(client: SonarHttpClient) {
     this.client = client;
     this.components = new ComponentsClient(client);
     this.issues = new IssuesClient(client);
+    this.organizations = new OrganizationsClient(client);
   }
 
   checkAiRemediationEntitlement(orgKey: string): Promise<{ status: AiRemediationEntitlement }> {
-    const orgsEndpoint = '/organizations/organizations';
-    return this.client
-      .get<Array<{ id: string; uuidV4: string; name?: string }>>(
-        orgsEndpoint,
-        { organizationKey: orgKey, excludeEligibility: 'true' },
-        this.client.apiHostFor(orgsEndpoint),
-      )
-      .andThen((organizations) => this.resolveEntitlementForOrg(organizations.at(0)))
+    return this.organizations
+      .getOrganizationLegacyId(orgKey)
+      .andThen((orgId) => {
+        // A non-critical failure (e.g. a 403 on the organization) is treated the same as "not
+        // found": the caller is not eligible either way.
+        if (!orgId) return okAsync({ status: 'not_eligible' as const });
+
+        const configEndpoint = `/fix-suggestions/organization-configs/${orgId}`;
+        return this.client
+          .get<{
+            codeReviewAgent: { organizationEligible: boolean; delegateIssuesEnabled?: boolean };
+          }>(configEndpoint, undefined, this.client.apiHostFor(configEndpoint))
+          .map((config): { status: AiRemediationEntitlement } => {
+            if (!config.codeReviewAgent.organizationEligible) return { status: 'not_eligible' };
+            if (!config.codeReviewAgent.delegateIssuesEnabled) return { status: 'not_enabled' };
+            return { status: 'ok' };
+          });
+      })
       .match(
         (result) => result,
         (error) => {
@@ -67,23 +79,6 @@ export class RemediateApiClient {
           return { status: 'unknown' as const };
         },
       );
-  }
-
-  private resolveEntitlementForOrg(
-    org: { id: string } | undefined,
-  ): ResultAsync<{ status: AiRemediationEntitlement }, HttpClientError> {
-    if (!org) return okAsync({ status: 'not_eligible' as const });
-
-    const configEndpoint = `/fix-suggestions/organization-configs/${org.id}`;
-    return this.client
-      .get<{
-        codeReviewAgent: { organizationEligible: boolean; delegateIssuesEnabled?: boolean };
-      }>(configEndpoint, undefined, this.client.apiHostFor(configEndpoint))
-      .map((config): { status: AiRemediationEntitlement } => {
-        if (!config.codeReviewAgent.organizationEligible) return { status: 'not_eligible' };
-        if (!config.codeReviewAgent.delegateIssuesEnabled) return { status: 'not_enabled' };
-        return { status: 'ok' };
-      });
   }
 
   /**

--- a/src/commands/remediate/remediate-api.ts
+++ b/src/commands/remediate/remediate-api.ts
@@ -21,8 +21,9 @@
 // Every SonarQube API call `sonar remediate` makes, in one place next to the command.
 
 import logger from '@/core/observability/logger.ts';
-import { okAsync } from '@/core/result.ts';
+import { okAsync, type ResultAsync } from '@/core/result.ts';
 import { ComponentsClient } from '@/core/server/components.ts';
+import type { HttpClientError } from '@/core/server/errors.ts';
 import { type SonarHttpClient } from '@/core/server/http-client.ts';
 import { IssuesClient } from '@/core/server/issues.ts';
 import { OrganizationsClient } from '@/core/server/organizations.ts';
@@ -56,22 +57,7 @@ export class RemediateApiClient {
   checkAiRemediationEntitlement(orgKey: string): Promise<{ status: AiRemediationEntitlement }> {
     return this.organizations
       .getOrganizationLegacyId(orgKey)
-      .andThen((orgId) => {
-        // A non-critical failure (e.g. a 403 on the organization) is treated the same as "not
-        // found": the caller is not eligible either way.
-        if (!orgId) return okAsync({ status: 'not_eligible' as const });
-
-        const configEndpoint = `/fix-suggestions/organization-configs/${orgId}`;
-        return this.client
-          .get<{
-            codeReviewAgent: { organizationEligible: boolean; delegateIssuesEnabled?: boolean };
-          }>(configEndpoint, undefined, this.client.apiHostFor(configEndpoint))
-          .map((config): { status: AiRemediationEntitlement } => {
-            if (!config.codeReviewAgent.organizationEligible) return { status: 'not_eligible' };
-            if (!config.codeReviewAgent.delegateIssuesEnabled) return { status: 'not_enabled' };
-            return { status: 'ok' };
-          });
-      })
+      .andThen((orgId) => this.resolveEntitlementForOrgId(orgId))
       .match(
         (result) => result,
         (error) => {
@@ -79,6 +65,25 @@ export class RemediateApiClient {
           return { status: 'unknown' as const };
         },
       );
+  }
+
+  // A non-critical org-lookup failure (e.g. a 403) reaches here as a null orgId: it is
+  // treated the same as "not found" — the caller is not eligible either way.
+  private resolveEntitlementForOrgId(
+    orgId: string | null,
+  ): ResultAsync<{ status: AiRemediationEntitlement }, HttpClientError> {
+    if (!orgId) return okAsync({ status: 'not_eligible' as const });
+
+    const configEndpoint = `/fix-suggestions/organization-configs/${orgId}`;
+    return this.client
+      .get<{
+        codeReviewAgent: { organizationEligible: boolean; delegateIssuesEnabled?: boolean };
+      }>(configEndpoint, undefined, this.client.apiHostFor(configEndpoint))
+      .map((config): { status: AiRemediationEntitlement } => {
+        if (!config.codeReviewAgent.organizationEligible) return { status: 'not_eligible' };
+        if (!config.codeReviewAgent.delegateIssuesEnabled) return { status: 'not_enabled' };
+        return { status: 'ok' };
+      });
   }
 
   /**

--- a/src/commands/remediate/remediate-api.ts
+++ b/src/commands/remediate/remediate-api.ts
@@ -75,7 +75,7 @@ export class RemediateApiClient {
       .match(
         (result) => result,
         (error) => {
-          logger.warn('AI remediation entitlement check failed', error);
+          logger.warn(`AI remediation entitlement check failed: ${error.name}: ${error.message}`);
           return { status: 'unknown' as const };
         },
       );

--- a/src/core/server/organizations.ts
+++ b/src/core/server/organizations.ts
@@ -210,7 +210,9 @@ export class OrganizationsClient {
       .map((result) => result.entitlements.some((e) => e.allowedFeatures.includes(entitlement)))
       .orElse((error) => {
         if (isCriticalFailure(error)) return errAsync(error);
-        logger.debug(`Failed to check '${entitlement}' billing entitlement`, error);
+        logger.debug(
+          `Failed to check '${entitlement}' billing entitlement: ${error.name}: ${error.message}`,
+        );
         return okAsync(false);
       });
   }

--- a/src/core/server/organizations.ts
+++ b/src/core/server/organizations.ts
@@ -92,7 +92,13 @@ export class OrganizationsClient {
         this.client.apiHostFor(endpoint),
       )
       .map((result) => result[0] ?? null)
-      .orElse((error) => (isCriticalFailure(error) ? errAsync(error) : okAsync(null)));
+      .orElse((error) => {
+        if (isCriticalFailure(error)) return errAsync(error);
+        logger.debug(
+          `Organization lookup for '${organizationKey}' failed: ${error.name}: ${error.message}`,
+        );
+        return okAsync(null);
+      });
   }
 
   /**

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -208,6 +208,32 @@ describe('sonar remediate', () => {
   );
 
   it(
+    'exits with code 0 and shows buy-it message when the org lookup is forbidden',
+    async () => {
+      // A 403 on the org lookup is not a transport failure (unlike the 5xx case above): it is
+      // treated the same as "no such organization" — the caller is not eligible either way.
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken(VALID_TOKEN)
+        .withProject(TEST_PROJECT, (p) => {
+          p.withIssue({ ruleKey: 'java:S100', message: 'Fixable issue', fixableByAgent: true });
+        })
+        .withOrgsLookupError(403)
+        .start();
+      harness.withAuth(server.baseUrl(), VALID_TOKEN, TEST_ORG);
+
+      const result = await harness.run(`remediate --project ${TEST_PROJECT}`);
+
+      expect(result.exitCode).toBe(0);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('Remediation Agent is not available for your organisation');
+      expect(output).toContain('sonarsource.com/products/agent-essentials');
+      expect(output).not.toContain('Which issues');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'exits with code 0 and reports zero eligible issues when none are fixable by agent',
     async () => {
       const server = await harness


### PR DESCRIPTION
## Summary

`checkAiRemediationEntitlement` queried `/organizations/organizations` itself instead of going through `OrganizationsClient`, because that client used to hide network failures behind a `null`. CLI-844 (#782) fixed that: `OrganizationsClient.fetchOrganizationInfo` now throws on a critical/transport failure (via `isCriticalFailure`) and only returns `null` for an ordinary negative answer. The workaround comment (already removed from master in #782) can go too.

`RemediateApiClient` now exposes `organizations: OrganizationsClient` as a `readonly` field alongside `issues`/`components`, per the existing convention — no forwarding methods.

**Decision (per CLI-1076):** a non-critical failure (e.g. a 403 on the organization) is treated the same as "not found" — reported as `not_eligible`. This is the simpler of the two options laid out in the ticket, and matches "a 403 on the organization means the caller is not eligible".

Out of scope: the `/fix-suggestions/organization-configs/{id}` call stays as-is — remediation's own endpoint, not a shared client's domain.

Based on #782 (CLI-844) since this needs `isCriticalFailure`; will be retargeted to `master` once that merges.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — 7 pre-existing warnings, unrelated
- [x] `bun run test:unit` (remediate) — 5 pass
- [x] `bun run test:integration` (remediate) — 41 pass