### PR TITLE
CLI-1073 Move telemetry identity lookups onto domain API clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ The two inputs are separate because the single boolean made _collect but do not 
 
 1. **Connection seed** — `identityFromConnection()` maps `AuthConnection.userUuid`, `organizationUuidV4`, `enterpriseUuid`, and `sqsInstallationId` — kept in sync for both keychain and env-var auth by `recordConnectionFromAuth()` (see CLI-866 below), not just at `sonar auth login`.
 2. **Disk cache** — `{SONAR_USER_HOME}/sonarqube-cli/telemetry/identity-cache.json`, one entry per auth fingerprint (`src/core/telemetry/identity-fetch.ts`). Avoids repeat API calls across CLI invocations, independently of the connection seed.
-3. **API enrichment** — `SonarHttpClient.getSafe()` fetches only missing fields: `/api/users/current` (cloud and server), `/organizations/organizations` (cloud only, when `orgKey` is set), `/enterprises/enterprise-organizations` (cloud only, keyed by the org's legacy `id` from that lookup), `/api/system/status` (server only).
+3. **API enrichment**: only missing fields are fetched, each through its domain client rather than the transport class (CLI-1073). `UsersClient.getCurrentUserId()` (`/api/users/current`, cloud and server), `OrganizationsClient.getOrganizationRecord()` (`/organizations/organizations`, cloud only, when `orgKey` is set), `EnterprisesClient.getEnterpriseIdForOrganization()` (`/enterprises/enterprise-organizations`, cloud only, keyed by the org's legacy `id` from that lookup), `SystemClient.getInstallationId()` (`/api/system/status`, server only). All four return `Ok(null)` only for a field the server answered without, and `Err` for any failure. That is what lets `fetchMissingFromApi` set `resolved` per field and cache only confirmed-absent values. `OrganizationsClient`'s two single-id getters collapse that distinction, so telemetry uses `getOrganizationRecord`.
 
 **Fast path** (skip resolving auth entirely, in `resolveStoreEventTelemetryIdentity`): when `conn` (the currently active `AuthConnection`, read fresh from state) already satisfies `needsIdentityEnrichment() === false`. This check is source-agnostic — it is not gated on `isEnvBasedAuth()` — because `resolveAuth()`'s env branch keeps `state.auth.connections` synced before this ever runs (see CLI-866 below), so a fully-populated `conn` is trustworthy regardless of which auth source produced it. When the fast path doesn't apply, telemetry calls `resolveAuth({ silent: true })` — `silent` suppresses the "partial env vars" warning so this best-effort, source-agnostic shadow resolution never prints a diagnostic the command's own `resolveAuth()` call would already have shown (or wouldn't have shown at all, for a non-authenticated command).
 
@@ -199,8 +199,10 @@ result as `baseUrl` instead of reaching for `resolveFromEndpoint` themselves.
 
 Everything above transport is a small per-domain wrapper taking a `SonarHttpClient`, living next to
 whoever uses it. Shared domains stay in `src/core/server/`: `OrganizationsClient`
-(`organizations.ts`, also home to `Organization` / `OrganizationAccess`), `ComponentsClient`
-(`components.ts`), `UsersClient` (`users.ts`), `SystemClient` (`system.ts`), `ProjectBindingsClient`
+(`organizations.ts`, also home to `Organization` / `OrganizationRecord` / `OrganizationAccess`),
+`ComponentsClient`
+(`components.ts`), `UsersClient` (`users.ts`), `SystemClient` (`system.ts`), `EnterprisesClient`
+(`enterprises.ts`, Cloud only), `ProjectBindingsClient`
 (`project-bindings.ts`) and `ScaClient` (`sca.ts`), alongside the pre-existing `BranchesClient`,
 `IssuesClient`, `MeasuresClient`, `MetricsClient`, `ProjectsClient` and `QualityGatesClient`.
 Command-specific surfaces sit with their command: `ImportApiClient`
@@ -212,7 +214,7 @@ Command-specific surfaces sit with their command: `ImportApiClient`
 `VortexEntitlementClient` (`src/core/vortex/entitlement.ts`, owning `VortexEntitlementResult` /
 `VortexEntitlementStatus` and `SERVER_ORGANIZATION_ID_PLACEHOLDER`).
 
-Three rules hold across all seventeen of them, with no exception — keep it that way when adding one.
+Three rules hold across all eighteen of them, with no exception — keep it that way when adding one.
 
 **Every API client is constructed from a `SonarHttpClient`**, never from a `(serverUrl, token)` pair
 it turns into one itself. The command handler builds the transport client once and passes it in, so

--- a/src/core/server/enterprises.ts
+++ b/src/core/server/enterprises.ts
@@ -18,30 +18,33 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-// SonarQube System API wrapper — instance status and clean-code policy mode.
+// SonarQube Cloud Enterprises API wrapper (SonarQube Server has no enterprises).
 
-import { okAsync, type ResultAsync } from '../result.ts';
+import type { ResultAsync } from '../result.ts';
 import type { HttpClientError } from './errors.ts';
 import type { SonarHttpClient } from './http-client.ts';
 
-export class SystemClient {
+export class EnterprisesClient {
   private readonly client: SonarHttpClient;
 
   constructor(client: SonarHttpClient) {
     this.client = client;
   }
 
-  getServerMode(): ResultAsync<'mqr' | 'standard', HttpClientError> {
-    if (this.client.isCloud) return okAsync('mqr');
+  /**
+   * Keyed by the organization's **legacy** `id`, not its `uuidV4`.
+   * `null` when the organization belongs to no enterprise.
+   */
+  getEnterpriseIdForOrganization(
+    organizationId: string,
+  ): ResultAsync<string | null, HttpClientError> {
+    const endpoint = '/enterprises/enterprise-organizations';
     return this.client
-      .getOrNullIf404<{ mode: string }>('/api/v2/clean-code-policy/mode')
-      .map((result) => (result?.mode === 'MQR' ? 'mqr' : 'standard'));
-  }
-
-  /** SonarQube Server only: Cloud has no installation id, and answers without one. */
-  getInstallationId(): ResultAsync<string | null, HttpClientError> {
-    return this.client
-      .get<{ id?: string }>('/api/system/status')
-      .map((result) => result.id ?? null);
+      .get<Array<{ enterpriseId?: string }>>(
+        endpoint,
+        { organizationId },
+        this.client.apiHostFor(endpoint),
+      )
+      .map((result) => result[0]?.enterpriseId ?? null);
   }
 }

--- a/src/core/server/http-client.ts
+++ b/src/core/server/http-client.ts
@@ -263,10 +263,10 @@ export class SonarHttpClient {
   /**
    * Resolves to `{ response, value }` and never rejects. Only the *status* is left
    * uninterpreted (`value` is `undefined` on a non-2xx response) for the handful of
-   * callers (`getOrNullIf404`, telemetry identity/project-uuid lookups) that need to branch
-   * on the status themselves instead of getting a single typed error for "not 2xx". A
-   * transport failure (DNS/TLS failure, connection refused, timeout) becomes
-   * `TransportError`; a body-parse failure on an otherwise-2xx response becomes
+   * callers (`getOrNullIf404`, `ProjectBindingsClient`, `checkHubEntitlement`, telemetry
+   * project-uuid lookups) that need to branch on the status themselves instead of getting a
+   * single typed error for "not 2xx". A transport failure (DNS/TLS, connection refused,
+   * timeout) becomes `TransportError`; a body-parse failure on an otherwise-2xx response becomes
    * `UnexpectedApiError` instead, since the server did answer. Same split as
    * `toStatusCheckedResult` below, so a malformed body classifies the same way regardless
    * of which method reads it.

--- a/src/core/server/organizations.ts
+++ b/src/core/server/organizations.ts
@@ -33,6 +33,12 @@ export interface Organization {
   onlyPrivateProjects?: { enabled: boolean };
 }
 
+/** The two server-side identifiers `/organizations/organizations` returns for an organization. */
+export interface OrganizationRecord {
+  id: string;
+  uuidV4: string;
+}
+
 /**
  * Result of an organization lookup: found, absent, or not checkable.
  *
@@ -46,7 +52,7 @@ export class OrganizationsClient {
   private readonly client: SonarHttpClient;
   private readonly orgInfoCache = new Map<
     string,
-    ResultAsync<{ id: string; uuidV4: string } | null, HttpClientError>
+    ResultAsync<OrganizationRecord | null, HttpClientError>
   >();
 
   constructor(client: SonarHttpClient) {
@@ -58,7 +64,7 @@ export class OrganizationsClient {
    * Uses the region-specific Cloud API host (SonarQube Cloud only).
    */
   getOrganizationId(organizationKey: string): ResultAsync<string | null, HttpClientError> {
-    return this.getOrganizationInfo(organizationKey).map((info) => info?.uuidV4 ?? null);
+    return this.organizationRecordOrNull(organizationKey).map((info) => info?.uuidV4 ?? null);
   }
 
   /**
@@ -67,37 +73,54 @@ export class OrganizationsClient {
    * than the uuidV4 (SonarQube Cloud only).
    */
   getOrganizationLegacyId(organizationKey: string): ResultAsync<string | null, HttpClientError> {
-    return this.getOrganizationInfo(organizationKey).map((info) => info?.id ?? null);
+    return this.organizationRecordOrNull(organizationKey).map((info) => info?.id ?? null);
   }
 
-  private getOrganizationInfo(
+  /**
+   * Both identifiers in one cached lookup. `null` means the server resolved no organization;
+   * a failed lookup stays an `Err`. The two getters above collapse that distinction, so a
+   * caller that needs it comes here.
+   */
+  getOrganizationRecord(
     organizationKey: string,
-  ): ResultAsync<{ id: string; uuidV4: string } | null, HttpClientError> {
+  ): ResultAsync<OrganizationRecord | null, HttpClientError> {
     let pending = this.orgInfoCache.get(organizationKey);
     if (!pending) {
-      pending = this.fetchOrganizationInfo(organizationKey);
+      pending = this.fetchOrganizationRecord(organizationKey);
       this.orgInfoCache.set(organizationKey, pending);
     }
     return pending;
   }
 
-  private fetchOrganizationInfo(
+  /**
+   * For the single-id getters: an unresolvable key and a refused one are both dead ends to
+   * their callers. A critical failure still propagates, so an outage stays retryable.
+   */
+  private organizationRecordOrNull(
     organizationKey: string,
-  ): ResultAsync<{ id: string; uuidV4: string } | null, HttpClientError> {
+  ): ResultAsync<OrganizationRecord | null, HttpClientError> {
+    return this.getOrganizationRecord(organizationKey).orElse((error) =>
+      isCriticalFailure(error) ? errAsync(error) : okAsync(null),
+    );
+  }
+
+  private fetchOrganizationRecord(
+    organizationKey: string,
+  ): ResultAsync<OrganizationRecord | null, HttpClientError> {
     const endpoint = '/organizations/organizations';
+    // Logging inside the cached chain: one failed lookup logs once, however many getters read it.
     return this.client
-      .get<Array<{ id: string; uuidV4: string }>>(
+      .get<OrganizationRecord[]>(
         endpoint,
         { organizationKey, excludeEligibility: 'true' },
         this.client.apiHostFor(endpoint),
       )
       .map((result) => result[0] ?? null)
-      .orElse((error) => {
-        if (isCriticalFailure(error)) return errAsync(error);
+      .mapErr((error) => {
         logger.debug(
           `Organization lookup for '${organizationKey}' failed: ${error.name}: ${error.message}`,
         );
-        return okAsync(null);
+        return error;
       });
   }
 

--- a/src/core/server/users.ts
+++ b/src/core/server/users.ts
@@ -46,6 +46,13 @@ export class UsersClient {
       .map((result) => (result.valid ? 'valid' : 'invalid'));
   }
 
+  /** `null` when the response carries no `id`: older SonarQube Server versions omit it. */
+  getCurrentUserId(): ResultAsync<string | null, HttpClientError> {
+    return this.client
+      .get<{ id?: string }>('/api/users/current')
+      .map((result) => result.id ?? null);
+  }
+
   /**
    * Revoke a user token on the server by its name.
    *

--- a/src/core/telemetry/identity-fetch.ts
+++ b/src/core/telemetry/identity-fetch.ts
@@ -25,13 +25,16 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
+import { errAsync, okAsync, type Result, type ResultAsync } from '@/core/result.ts';
+import { EnterprisesClient } from '@/core/server/enterprises.ts';
+import type { HttpClientError } from '@/core/server/errors.ts';
 import { SonarHttpClient } from '@/core/server/http-client.ts';
+import { type OrganizationRecord, OrganizationsClient } from '@/core/server/organizations.ts';
+import { SystemClient } from '@/core/server/system.ts';
+import { UsersClient } from '@/core/server/users.ts';
 
 import { getTelemetryDir } from '../config-constants.ts';
 import type { AuthConnection, ServerType } from '../state/state.ts';
-
-const ORGANIZATIONS_ENDPOINT = '/organizations/organizations';
-const ENTERPRISE_ORGANIZATIONS_ENDPOINT = '/enterprises/enterprise-organizations';
 
 export interface TelemetryIdentity {
   user_uuid: string | null;
@@ -205,105 +208,15 @@ function writeDiskCache(cache: IdentityCacheFile): void {
   }
 }
 
-interface FieldFetchResult {
-  value: string | null;
-  resolved: boolean;
-}
-
-interface OrganizationRecord {
-  id?: string;
-  uuidV4?: string;
-}
-
-interface OrganizationLookupResult {
-  uuidV4: string | null;
-  id: string | null;
-  resolved: boolean;
-}
-
-function fetchUserUuid(client: SonarHttpClient): Promise<FieldFetchResult> {
-  return client.getSafe<{ id: string }>('/api/users/current').match(
-    ({ response, value }): FieldFetchResult => {
-      if (!response.ok) {
-        return { value: null, resolved: false };
-      }
-      return { value: value?.id ?? null, resolved: true };
-    },
-    (): FieldFetchResult => ({ value: null, resolved: false }),
-  );
-}
-
-function fetchOrganizationRecord(
+/** No organization id means nothing left to ask: confirmed-absent, not a failed lookup. */
+function resolveEnterpriseUuid(
   client: SonarHttpClient,
-  orgKey: string,
-): Promise<OrganizationLookupResult> {
-  return client
-    .getSafe<OrganizationRecord[]>(
-      ORGANIZATIONS_ENDPOINT,
-      { organizationKey: orgKey, excludeEligibility: 'true' },
-      client.apiHostFor(ORGANIZATIONS_ENDPOINT),
-    )
-    .match(
-      ({ response, value }): OrganizationLookupResult => {
-        if (!response.ok) {
-          return { uuidV4: null, id: null, resolved: false };
-        }
-        const org = value?.[0];
-        return { uuidV4: org?.uuidV4 ?? null, id: org?.id ?? null, resolved: true };
-      },
-      (): OrganizationLookupResult => ({ uuidV4: null, id: null, resolved: false }),
-    );
-}
-
-function fetchEnterpriseUuid(
-  client: SonarHttpClient,
-  organizationId: string,
-): Promise<FieldFetchResult> {
-  return client
-    .getSafe<Array<{ enterpriseId?: string }>>(
-      ENTERPRISE_ORGANIZATIONS_ENDPOINT,
-      { organizationId },
-      client.apiHostFor(ENTERPRISE_ORGANIZATIONS_ENDPOINT),
-    )
-    .match(
-      ({ response, value }): FieldFetchResult => {
-        if (!response.ok) {
-          return { value: null, resolved: false };
-        }
-        return { value: value?.[0]?.enterpriseId ?? null, resolved: true };
-      },
-      (): FieldFetchResult => ({ value: null, resolved: false }),
-    );
-}
-
-/** Unresolved stays `undefined` so the next command retries; `null` is confirmed-absent. */
-async function resolveEnterpriseUuid(
-  client: SonarHttpClient,
-  org: OrganizationLookupResult,
-): Promise<{ value: string | null | undefined; resolved: boolean }> {
-  if (!org.resolved) {
-    return { value: undefined, resolved: false };
-  }
-  if (!org.id) {
-    return { value: null, resolved: true };
-  }
-  const enterprise = await fetchEnterpriseUuid(client, org.id);
-  return {
-    value: enterprise.resolved ? enterprise.value : undefined,
-    resolved: enterprise.resolved,
-  };
-}
-
-function fetchSqsInstallationId(client: SonarHttpClient): Promise<FieldFetchResult> {
-  return client.getSafe<{ id?: string }>('/api/system/status').match(
-    ({ response, value }): FieldFetchResult => {
-      if (!response.ok) {
-        return { value: null, resolved: false };
-      }
-      return { value: value?.id ?? null, resolved: true };
-    },
-    (): FieldFetchResult => ({ value: null, resolved: false }),
-  );
+  org: Result<OrganizationRecord | null, HttpClientError>,
+): ResultAsync<string | null, HttpClientError> {
+  if (org.isErr()) return errAsync(org.error);
+  const organizationId = org.value?.id;
+  if (!organizationId) return okAsync(null);
+  return new EnterprisesClient(client).getEnterpriseIdForOrganization(organizationId);
 }
 
 interface IdentityFetchResult {
@@ -321,26 +234,27 @@ async function fetchMissingFromApi(
   const resolved: IdentityFetchPlan = { user: false, org: false, enterprise: false, sqs: false };
 
   if (fetchPlan.user) {
-    const user = await fetchUserUuid(client);
-    user_uuid = user.value;
-    resolved.user = user.resolved;
+    const user = await new UsersClient(client).getCurrentUserId();
+    user_uuid = user.unwrapOr(null);
+    resolved.user = user.isOk();
   }
   if ((fetchPlan.org || fetchPlan.enterprise) && auth.orgKey) {
-    const org = await fetchOrganizationRecord(client, auth.orgKey);
+    const org = await new OrganizationsClient(client).getOrganizationRecord(auth.orgKey);
     if (fetchPlan.org) {
-      organization_uuid_v4 = org.uuidV4;
-      resolved.org = org.resolved;
+      organization_uuid_v4 = org.unwrapOr(null)?.uuidV4 ?? null;
+      resolved.org = org.isOk();
     }
     if (fetchPlan.enterprise) {
       const enterprise = await resolveEnterpriseUuid(client, org);
-      enterprise_uuid = enterprise.value;
-      resolved.enterprise = enterprise.resolved;
+      // `undefined` keeps the field unresolved so the next command retries it.
+      enterprise_uuid = enterprise.unwrapOr(undefined);
+      resolved.enterprise = enterprise.isOk();
     }
   }
   if (fetchPlan.sqs) {
-    const sqs = await fetchSqsInstallationId(client);
-    sqs_installation_id = sqs.value;
-    resolved.sqs = sqs.resolved;
+    const sqs = await new SystemClient(client).getInstallationId();
+    sqs_installation_id = sqs.unwrapOr(null);
+    resolved.sqs = sqs.isOk();
   }
 
   return {

--- a/tests/unit/core/server/enterprises.test.ts
+++ b/tests/unit/core/server/enterprises.test.ts
@@ -1,0 +1,91 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { SONARCLOUD_API_URL, SONARCLOUD_URL } from '@/core/config-constants.ts';
+import { EnterprisesClient } from '@/core/server/enterprises.ts';
+import { SonarHttpClient } from '@/core/server/http-client.ts';
+
+import { fakeResponse, lastFetchUrl, mockFetch } from '../../helpers/mock-fetch.ts';
+
+const TOKEN = 'squ_test_token';
+
+describe('EnterprisesClient', () => {
+  let client: EnterprisesClient;
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    client = new EnterprisesClient(new SonarHttpClient(SONARCLOUD_URL, TOKEN));
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  describe('getEnterpriseIdForOrganization', () => {
+    it('hits the region-specific Cloud API host, not the serverURL', async () => {
+      fetchSpy = mockFetch([{ enterpriseId: 'ent-uuid' }]);
+      await client.getEnterpriseIdForOrganization('org-legacy-id').orThrow();
+      expect(lastFetchUrl(fetchSpy)).toContain(SONARCLOUD_API_URL);
+      expect(lastFetchUrl(fetchSpy)).not.toContain(`${SONARCLOUD_URL}/api`);
+    });
+
+    it('calls /enterprises/enterprise-organizations with organizationId param', async () => {
+      fetchSpy = mockFetch([{ enterpriseId: 'ent-uuid' }]);
+      await client.getEnterpriseIdForOrganization('org-legacy-id').orThrow();
+      const url = new URL(lastFetchUrl(fetchSpy));
+      expect(url.pathname).toBe('/enterprises/enterprise-organizations');
+      expect(url.searchParams.get('organizationId')).toBe('org-legacy-id');
+    });
+
+    it('returns the enterpriseId of the first result on success', async () => {
+      fetchSpy = mockFetch([{ enterpriseId: 'ent-uuid' }]);
+      expect(await client.getEnterpriseIdForOrganization('org-legacy-id').orThrow()).toBe(
+        'ent-uuid',
+      );
+    });
+
+    it('returns null when the organization is in no enterprise (empty list)', async () => {
+      fetchSpy = mockFetch([]);
+      expect(await client.getEnterpriseIdForOrganization('org-legacy-id').orThrow()).toBeNull();
+    });
+
+    it('throws on a non-critical failure (e.g. 403) instead of caching it as absent', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+        fakeResponse('Access denied', { ok: false, status: 403 }),
+      );
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(
+        client.getEnterpriseIdForOrganization('org-legacy-id').orThrow(),
+      ).rejects.toThrow();
+    });
+
+    it('throws on a critical failure (e.g. 500)', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+        fakeResponse('boom', { ok: false, status: 500 }),
+      );
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(
+        client.getEnterpriseIdForOrganization('org-legacy-id').orThrow(),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/tests/unit/core/server/organizations.test.ts
+++ b/tests/unit/core/server/organizations.test.ts
@@ -26,6 +26,7 @@ import {
   SONARCLOUD_US_API_URL,
   SONARCLOUD_US_URL,
 } from '@/core/config-constants.ts';
+import logger from '@/core/observability/logger.ts';
 import { SonarHttpClient } from '@/core/server/http-client.ts';
 import { OrganizationsClient } from '@/core/server/organizations.ts';
 
@@ -81,9 +82,59 @@ describe('OrganizationsClient', () => {
       expect(await client.getOrganizationId('unknown-org').orThrow()).toBeNull();
     });
 
+    it('returns null on a non-critical failure (e.g. 403)', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
+      expect(await client.getOrganizationId('my-org').orThrow()).toBeNull();
+    });
+
+    it('propagates a critical failure (e.g. 500) rather than reporting the org as missing', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 500 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getOrganizationId('my-org').orThrow()).rejects.toThrow();
+    });
+
     it('returns null when result array is empty', async () => {
       fetchSpy = mockFetch([]);
       expect(await client.getOrganizationId('my-org').orThrow()).toBeNull();
+    });
+  });
+
+  describe('getOrganizationRecord', () => {
+    it('returns the id and uuidV4 of the first result on success', async () => {
+      fetchSpy = mockFetch([{ id: 'legacy-id', uuidV4: 'org-uuid-v4' }]);
+      expect(await client.getOrganizationRecord('my-org').orThrow()).toEqual({
+        id: 'legacy-id',
+        uuidV4: 'org-uuid-v4',
+      });
+    });
+
+    it('returns null when result array is empty', async () => {
+      fetchSpy = mockFetch([]);
+      expect(await client.getOrganizationRecord('my-org').orThrow()).toBeNull();
+    });
+
+    it('throws on a non-critical failure (e.g. 403), unlike the single-id getters', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getOrganizationRecord('my-org').orThrow()).rejects.toThrow();
+    });
+
+    it('throws on a critical failure (e.g. 500)', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 500 });
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getOrganizationRecord('my-org').orThrow()).rejects.toThrow();
+    });
+
+    it('fetches and logs a failed lookup once however many getters read it', async () => {
+      fetchSpy = mockFetch({}, { ok: false, status: 403 });
+      const debugSpy = spyOn(logger, 'debug');
+
+      expect(await client.getOrganizationId('my-org').orThrow()).toBeNull();
+      expect(await client.getOrganizationLegacyId('my-org').orThrow()).toBeNull();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(debugSpy).toHaveBeenCalledTimes(1);
+      debugSpy.mockRestore();
     });
   });
 

--- a/tests/unit/core/server/system.test.ts
+++ b/tests/unit/core/server/system.test.ts
@@ -24,7 +24,7 @@ import { SONARCLOUD_URL } from '@/core/config-constants.ts';
 import { SonarHttpClient } from '@/core/server/http-client.ts';
 import { SystemClient } from '@/core/server/system.ts';
 
-import { mockFetch } from '../../helpers/mock-fetch.ts';
+import { fakeResponse, mockFetch } from '../../helpers/mock-fetch.ts';
 
 const SERVER_URL = 'https://sonarqube.example.com';
 const TOKEN = 'squ_test_token';
@@ -80,6 +80,34 @@ describe('SystemClient', () => {
       } as Response);
       const result = await client.getServerMode();
       expect(result.isErr()).toBe(true);
+    });
+  });
+
+  describe('getInstallationId', () => {
+    it('returns the installation id on success', async () => {
+      fetchSpy = mockFetch({ id: 'installation-id' });
+      expect(await client.getInstallationId().orThrow()).toBe('installation-id');
+    });
+
+    it('returns null when the field is absent from a successful response', async () => {
+      fetchSpy = mockFetch({});
+      expect(await client.getInstallationId().orThrow()).toBeNull();
+    });
+
+    it('throws on a non-critical failure (e.g. 403) instead of caching it as absent', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+        fakeResponse('Access denied', { ok: false, status: 403 }),
+      );
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getInstallationId().orThrow()).rejects.toThrow();
+    });
+
+    it('throws on a critical failure (e.g. 500)', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+        fakeResponse('boom', { ok: false, status: 500 }),
+      );
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getInstallationId().orThrow()).rejects.toThrow();
     });
   });
 });

--- a/tests/unit/core/server/users.test.ts
+++ b/tests/unit/core/server/users.test.ts
@@ -23,7 +23,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { SonarHttpClient } from '@/core/server/http-client.ts';
 import { UsersClient } from '@/core/server/users.ts';
 
-import { lastFetchInit, lastFetchUrl, mockFetch } from '../../helpers/mock-fetch.ts';
+import { fakeResponse, lastFetchInit, lastFetchUrl, mockFetch } from '../../helpers/mock-fetch.ts';
 
 const SERVER_URL = 'https://sonarqube.example.com';
 const TOKEN = 'squ_test_token';
@@ -86,6 +86,34 @@ describe('UsersClient', () => {
       const result = await client.checkTokenValidity();
       expect(result.isErr()).toBe(true);
       expect(result._unsafeUnwrapErr().message).toContain('Network error');
+    });
+  });
+
+  describe('getCurrentUserId', () => {
+    it('returns the user id on success', async () => {
+      fetchSpy = mockFetch({ id: 'user-uuid' });
+      expect(await client.getCurrentUserId().orThrow()).toBe('user-uuid');
+    });
+
+    it('returns null when the field is absent from a successful response', async () => {
+      fetchSpy = mockFetch({});
+      expect(await client.getCurrentUserId().orThrow()).toBeNull();
+    });
+
+    it('throws on a non-critical failure (e.g. 403) instead of caching it as absent', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+        fakeResponse('Access denied', { ok: false, status: 403 }),
+      );
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getCurrentUserId().orThrow()).rejects.toThrow();
+    });
+
+    it('throws on a critical failure (e.g. 500)', async () => {
+      fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+        fakeResponse('boom', { ok: false, status: 500 }),
+      );
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(client.getCurrentUserId().orThrow()).rejects.toThrow();
     });
   });
 

--- a/tests/unit/core/telemetry/identity-api-mock.ts
+++ b/tests/unit/core/telemetry/identity-api-mock.ts
@@ -26,9 +26,27 @@ import { SonarHttpClient } from '@/core/server/http-client.ts';
 
 interface ApiStep {
   ok: boolean;
+  /** HTTP status for a failing step. Defaults to 500 (a critical, retryable failure). */
+  status?: number;
   id?: string;
   uuidV4?: string;
   enterpriseId?: string;
+}
+
+/**
+ * Builds a `Response`-shaped stub realistic enough for `SonarHttpClient.get()`'s error
+ * classification (`buildStatusError`) to run without throwing: it reads `status` and, for
+ * non-403/404 statuses, calls `.text()`.
+ */
+function fakeStepResponse(step: ApiStep): Response {
+  const status = step.ok ? 200 : (step.status ?? 500);
+  return {
+    ok: step.ok,
+    status,
+    statusText: step.ok ? 'OK' : 'Error',
+    url: '',
+    text: () => Promise.resolve(''),
+  } as Response;
 }
 
 interface IdentityApiMockOptions {
@@ -65,14 +83,14 @@ export function mockIdentityGetSafe(
       if (endpoint === '/api/users/current') {
         const step = shiftStep(userSteps, { ok: true });
         return okAsync({
-          response: { ok: step.ok } as Response,
+          response: fakeStepResponse(step),
           value: (step.id ? { id: step.id } : {}) as TValue,
         });
       }
       if (endpoint === '/organizations/organizations') {
         const step = shiftStep(orgSteps, { ok: true });
         return okAsync({
-          response: { ok: step.ok } as Response,
+          response: fakeStepResponse(step),
           value: (step.uuidV4
             ? [{ uuidV4: step.uuidV4, id: step.id ?? `id-${step.uuidV4}` }]
             : []) as TValue,
@@ -81,14 +99,14 @@ export function mockIdentityGetSafe(
       if (endpoint === '/enterprises/enterprise-organizations') {
         const step = shiftStep(enterpriseSteps, { ok: true });
         return okAsync({
-          response: { ok: step.ok } as Response,
+          response: fakeStepResponse(step),
           value: (step.enterpriseId ? [{ enterpriseId: step.enterpriseId }] : []) as TValue,
         });
       }
       if (endpoint === '/api/system/status') {
         const step = shiftStep(statusSteps, { ok: true });
         return okAsync({
-          response: { ok: step.ok } as Response,
+          response: fakeStepResponse(step),
           value: {
             status: 'UP',
             version: '1',

--- a/tests/unit/core/telemetry/identity.test.ts
+++ b/tests/unit/core/telemetry/identity.test.ts
@@ -365,14 +365,34 @@ describe('resolveTelemetryIdentity()', () => {
     getSafeSpy.mockRestore();
   });
 
-  it('leaves sqs_installation_id null when system status fails', async () => {
+  it('leaves sqs_installation_id null when system status fails with a critical error (500)', async () => {
     const getSafeSpy = mockIdentityGetSafe({
-      status: [{ ok: false }],
+      status: [{ ok: false, status: 500 }],
     });
 
     const identity = await resolveTelemetryIdentity(serverAuth('sqs-token-2'));
 
     expect(identity.sqs_installation_id).toBeNull();
+    getSafeSpy.mockRestore();
+  });
+
+  it('leaves sqs_installation_id null and retries after a non-critical failure (403)', async () => {
+    const auth = serverAuth('sqs-token-403');
+    const getSafeSpy = mockIdentityGetSafe({
+      status: [
+        { ok: false, status: 403 },
+        { ok: true, id: 'sqs-after-403' },
+      ],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(serverAuth('sqs-token-403'));
+
+    expect(first.sqs_installation_id).toBeNull();
+    expect(second.sqs_installation_id).toBe('sqs-after-403');
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/system/status'),
+    ).toHaveLength(2);
     getSafeSpy.mockRestore();
   });
 
@@ -437,7 +457,7 @@ describe('resolveTelemetryIdentity()', () => {
     getSafeSpy.mockRestore();
   });
 
-  it('retries enterprise UUID fetch after a transient API failure', async () => {
+  it('retries enterprise UUID fetch after a transient API failure (500)', async () => {
     const auth = cloudAuth('transient-enterprise-token');
     const getSafeSpy = mockIdentityGetSafe({
       user: [{ ok: true, id: 'cloud-user' }],
@@ -445,7 +465,10 @@ describe('resolveTelemetryIdentity()', () => {
         { ok: true, uuidV4: 'cloud-org', id: 'legacy-org' },
         { ok: true, uuidV4: 'cloud-org', id: 'legacy-org' },
       ],
-      enterprise: [{ ok: false }, { ok: true, enterpriseId: 'ent-after-retry' }],
+      enterprise: [
+        { ok: false, status: 500 },
+        { ok: true, enterpriseId: 'ent-after-retry' },
+      ],
     });
 
     const first = await resolveTelemetryIdentity(auth);
@@ -457,6 +480,57 @@ describe('resolveTelemetryIdentity()', () => {
       getSafeSpy.mock.calls.filter(
         (call: [string]) => call[0] === '/enterprises/enterprise-organizations',
       ),
+    ).toHaveLength(2);
+    getSafeSpy.mockRestore();
+  });
+
+  it('retries enterprise UUID fetch after a non-critical failure (403) instead of caching it as absent', async () => {
+    const auth = cloudAuth('transient-enterprise-403-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'cloud-user' }],
+      org: [
+        { ok: true, uuidV4: 'cloud-org', id: 'legacy-org' },
+        { ok: true, uuidV4: 'cloud-org', id: 'legacy-org' },
+      ],
+      enterprise: [
+        { ok: false, status: 403 },
+        { ok: true, enterpriseId: 'ent-after-403-retry' },
+      ],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(cloudAuth('transient-enterprise-403-token'));
+
+    expect(first.enterprise_uuid).toBeUndefined();
+    expect(second.enterprise_uuid).toBe('ent-after-403-retry');
+    expect(
+      getSafeSpy.mock.calls.filter(
+        (call: [string]) => call[0] === '/enterprises/enterprise-organizations',
+      ),
+    ).toHaveLength(2);
+    getSafeSpy.mockRestore();
+  });
+
+  it('retries org (and enterprise) lookup after a non-critical org failure (403) instead of caching it as absent', async () => {
+    const auth = cloudAuth('transient-org-403-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [{ ok: true, id: 'cloud-user' }],
+      org: [
+        { ok: false, status: 403 },
+        { ok: true, uuidV4: 'cloud-org', id: 'legacy-org' },
+      ],
+      enterprise: [{ ok: true, enterpriseId: 'ent-after-org-retry' }],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(cloudAuth('transient-org-403-token'));
+
+    expect(first.organization_uuid_v4).toBeNull();
+    expect(first.enterprise_uuid).toBeUndefined();
+    expect(second.organization_uuid_v4).toBe('cloud-org');
+    expect(second.enterprise_uuid).toBe('ent-after-org-retry');
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/organizations/organizations'),
     ).toHaveLength(2);
     getSafeSpy.mockRestore();
   });
@@ -524,10 +598,13 @@ describe('resolveTelemetryIdentity()', () => {
     getSafeSpy.mockRestore();
   });
 
-  it('retries user_uuid fetch after a transient API failure', async () => {
+  it('retries user_uuid fetch after a transient API failure (500)', async () => {
     const auth = cloudAuth('transient-user-token');
     const getSafeSpy = mockIdentityGetSafe({
-      user: [{ ok: false }, { ok: true, id: 'user-after-retry' }],
+      user: [
+        { ok: false, status: 500 },
+        { ok: true, id: 'user-after-retry' },
+      ],
       org: [{ ok: true, uuidV4: 'cached-org' }],
     });
 
@@ -536,6 +613,27 @@ describe('resolveTelemetryIdentity()', () => {
 
     expect(first.user_uuid).toBeNull();
     expect(second.user_uuid).toBe('user-after-retry');
+    expect(
+      getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
+    ).toHaveLength(2);
+    getSafeSpy.mockRestore();
+  });
+
+  it('retries user_uuid fetch after a non-critical failure (403) instead of caching it as absent', async () => {
+    const auth = cloudAuth('transient-user-403-token');
+    const getSafeSpy = mockIdentityGetSafe({
+      user: [
+        { ok: false, status: 403 },
+        { ok: true, id: 'user-after-403-retry' },
+      ],
+      org: [{ ok: true, uuidV4: 'cached-org' }],
+    });
+
+    const first = await resolveTelemetryIdentity(auth);
+    const second = await resolveTelemetryIdentity(cloudAuth('transient-user-403-token'));
+
+    expect(first.user_uuid).toBeNull();
+    expect(second.user_uuid).toBe('user-after-403-retry');
     expect(
       getSafeSpy.mock.calls.filter((call: [string]) => call[0] === '/api/users/current'),
     ).toHaveLength(2);


### PR DESCRIPTION
## TL;DR

Telemetry resolved its four identity fields by calling `getSafe` directly, the last module outside the domain-client rule. Each lookup now sits behind the client that owns its area, with a new `EnterprisesClient` for the one that had none.

CLI-844 is why this lands now rather than with CLI-842: before it, `get<T>()` threw on any non-2xx, so a client method could not express the three states telemetry needs (value, confirmed-absent, retry later).

See : `UsersClient -> getCurrentUserId()`, `OrganizationsClient -> getOrganizationRecord()`, `EnterprisesClient -> getEnterpriseIdForOrganization()`, and `SystemClient -> getInstallationId()`.

## Worth challenging

The failure contract. The four methods return `Ok(null)` only for a field the server answered without, and `Err` for anything else, because telemetry caches `null` permanently as confirmed-absent.

`getOrganizationRecord` is shared with `getOrganizationId` and `getOrganizationLegacyId`, whose callers do want a non-critical failure collapsed to `null`. That swallow now lives in a private helper used only by those two. I checked their four callers, none changes behaviour, and tests pin both halves.

The alternative was a second public method for telemetry. I had it and dropped it: two identical signatures differing only in what `null` means.

## Already settled

- `FieldFetchResult` and `OrganizationLookupResult` are gone. Both were a `Result` re-encoded by hand: `resolved` is `isOk()`, `value` is `unwrapOr(null)`.
- `identity-api-mock.ts` built responses with no `status`, so the failure tests were passing through a `TypeError` instead of the status path. Fixed, with 403 cases added next to the 500s.
