### PR TITLE
CLI-1079 Harden change-set path handling

### DIFF
--- a/src/commands/analyze/sqaa-changeset.ts
+++ b/src/commands/analyze/sqaa-changeset.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import { CommandFailedError } from '@/core/commands/command-error.ts';
 import { resolveCurrentGitBranch, resolveGitBranchAtRepoRoot } from '@/core/host/git/branch.ts';
 import { resolveGitRepoRoot } from '@/core/host/git/worktree.ts';
+import { toRelativePosixPath as toRelativePosixPathOrNull } from '@/core/io/fs-utils.ts';
 import { spawnProcess } from '@/core/process/process.ts';
 
 /** Maximum byte size per file sent to SQAA. Files exceeding this are skipped. */
@@ -76,8 +77,9 @@ export async function resolveChangeSet(
   const diffFiles = await getDiffFiles(repoRoot, { staged, base });
   const untrackedFiles = staged ? [] : await getUntrackedNonIgnoredFiles(repoRoot);
   const absolute = [...diffFiles, ...untrackedFiles].map((f) => join(repoRoot, f));
+  const inRepo = absolute.filter((file) => toRelativePosixPathOrNull(file, repoRoot) !== null);
 
-  const { files: nonBinary, ignored: binaryIgnored } = partitionBinary(absolute);
+  const { files: nonBinary, ignored: binaryIgnored } = partitionBinary(inRepo);
   const { files, ignored: oversizedIgnored } = partitionBySize(nonBinary);
 
   return { files, ignored: [...binaryIgnored, ...oversizedIgnored], repoRoot };

--- a/src/commands/analyze/sqaa-changeset.ts
+++ b/src/commands/analyze/sqaa-changeset.ts
@@ -26,7 +26,7 @@ import { join } from 'node:path';
 import { CommandFailedError } from '@/core/commands/command-error.ts';
 import { resolveCurrentGitBranch, resolveGitBranchAtRepoRoot } from '@/core/host/git/branch.ts';
 import { resolveGitRepoRoot } from '@/core/host/git/worktree.ts';
-import { toRelativePosixPath as toRelativePosixPathOrNull } from '@/core/io/fs-utils.ts';
+import { canonicalizePath, isAncestorOrSelf } from '@/core/io/fs-utils.ts';
 import { spawnProcess } from '@/core/process/process.ts';
 
 /** Maximum byte size per file sent to SQAA. Files exceeding this are skipped. */
@@ -80,10 +80,10 @@ export async function resolveChangeSet(
   const inRepo: string[] = [];
   const outsideIgnored: IgnoredFile[] = [];
   for (const file of absolute) {
-    if (toRelativePosixPathOrNull(file, repoRoot) === null) {
-      outsideIgnored.push({ path: file, reason: 'outside-repository' });
-    } else {
+    if (isAncestorOrSelf(repoRoot, canonicalizePath(file))) {
       inRepo.push(file);
+    } else {
+      outsideIgnored.push({ path: file, reason: 'outside-repository' });
     }
   }
 

--- a/src/commands/analyze/sqaa-changeset.ts
+++ b/src/commands/analyze/sqaa-changeset.ts
@@ -42,7 +42,7 @@ export interface ChangeSetOptions {
 /** A file excluded from analysis with the reason it was skipped. */
 export interface IgnoredFile {
   path: string;
-  reason: 'binary' | 'oversized';
+  reason: 'binary' | 'oversized' | 'outside-repository';
 }
 
 /** Result of resolving a change set: files to analyze and files silently ignored. */
@@ -77,12 +77,20 @@ export async function resolveChangeSet(
   const diffFiles = await getDiffFiles(repoRoot, { staged, base });
   const untrackedFiles = staged ? [] : await getUntrackedNonIgnoredFiles(repoRoot);
   const absolute = [...diffFiles, ...untrackedFiles].map((f) => join(repoRoot, f));
-  const inRepo = absolute.filter((file) => toRelativePosixPathOrNull(file, repoRoot) !== null);
+  const inRepo: string[] = [];
+  const outsideIgnored: IgnoredFile[] = [];
+  for (const file of absolute) {
+    if (toRelativePosixPathOrNull(file, repoRoot) === null) {
+      outsideIgnored.push({ path: file, reason: 'outside-repository' });
+    } else {
+      inRepo.push(file);
+    }
+  }
 
   const { files: nonBinary, ignored: binaryIgnored } = partitionBinary(inRepo);
   const { files, ignored: oversizedIgnored } = partitionBySize(nonBinary);
 
-  return { files, ignored: [...binaryIgnored, ...oversizedIgnored], repoRoot };
+  return { files, ignored: [...outsideIgnored, ...binaryIgnored, ...oversizedIgnored], repoRoot };
 }
 
 /** Explicit `--branch` wins; otherwise auto-detect from git when possible. */

--- a/src/commands/analyze/sqaa-display-json.ts
+++ b/src/commands/analyze/sqaa-display-json.ts
@@ -20,7 +20,10 @@
 
 // JSON report builders for SQAA results.
 
-import { toRelativePosixPath as toRelativePosixPathOrNull } from '@/core/io/fs-utils.ts';
+import {
+  normalizePath,
+  toRelativePosixPath as toRelativePosixPathOrNull,
+} from '@/core/io/fs-utils.ts';
 
 import type { FileFailure, FileSuccess, RunTally } from './sqaa-analysis.ts';
 import type { IgnoredFile } from './sqaa-changeset.ts';
@@ -100,7 +103,7 @@ export function buildJsonReport(
   const report: SqaaJsonReport = {
     files,
     ignored: ignored.map((f) => ({
-      path: toRelativePosixPathOrNull(f.path, pathBase) ?? f.path,
+      path: toRelativePosixPathOrNull(f.path, pathBase) ?? normalizePath(f.path),
       reason: f.reason,
     })),
     failures,

--- a/src/commands/analyze/sqaa-display-json.ts
+++ b/src/commands/analyze/sqaa-display-json.ts
@@ -20,8 +20,9 @@
 
 // JSON report builders for SQAA results.
 
+import { toRelativePosixPath as toRelativePosixPathOrNull } from '@/core/io/fs-utils.ts';
+
 import type { FileFailure, FileSuccess, RunTally } from './sqaa-analysis.ts';
-import { toRelativePosixPath } from './sqaa-api.ts';
 import type { IgnoredFile } from './sqaa-changeset.ts';
 import { type GlobalSqaaErrorKind, globalSqaaErrorKind } from './sqaa-errors.ts';
 import type { SqaaAnalysisDepth, SqaaIssue } from './sqaa-wire-types.ts';
@@ -32,7 +33,7 @@ export interface SqaaJsonReport {
     issues: SqaaIssue[];
     errors?: Array<{ code: string; message: string }> | null;
   }>;
-  ignored: Array<{ path: string; reason: 'binary' | 'oversized' }>;
+  ignored: Array<{ path: string; reason: IgnoredFile['reason'] }>;
   failures: Array<{ path: string; message: string }>;
   /** Files in the change set that were never sent to the API (fail-fast skipped them). */
   skipped: string[];
@@ -99,7 +100,7 @@ export function buildJsonReport(
   const report: SqaaJsonReport = {
     files,
     ignored: ignored.map((f) => ({
-      path: toRelativePosixPath(f.path, pathBase),
+      path: toRelativePosixPathOrNull(f.path, pathBase) ?? f.path,
       reason: f.reason,
     })),
     failures,

--- a/src/commands/analyze/sqaa-run.ts
+++ b/src/commands/analyze/sqaa-run.ts
@@ -19,6 +19,7 @@
  */
 
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
+import { toRelativePosixPath as toRelativePosixPathOrNull } from '@/core/io/fs-utils.ts';
 import { timed } from '@/core/observability/timed.ts';
 import { SqaaForbiddenError } from '@/core/server/errors.ts';
 import type { Console } from '@/core/ui/console.ts';
@@ -340,7 +341,7 @@ export async function runSqaaAnalysisOnFiles(
     return;
   }
 
-  const ignoredPaths = ignored.map((f) => toRelativePosixPath(f.path, repoRoot));
+  const ignoredPaths = ignored.map((f) => toRelativePosixPathOrNull(f.path, repoRoot) ?? f.path);
   const progress = new SqaaProgress({
     files: allPaths,
     ignoredFiles: ignoredPaths,

--- a/src/commands/analyze/sqaa-run.ts
+++ b/src/commands/analyze/sqaa-run.ts
@@ -19,7 +19,10 @@
  */
 
 import type { ResolvedAuth } from '@/core/auth/auth-resolver.ts';
-import { toRelativePosixPath as toRelativePosixPathOrNull } from '@/core/io/fs-utils.ts';
+import {
+  normalizePath,
+  toRelativePosixPath as toRelativePosixPathOrNull,
+} from '@/core/io/fs-utils.ts';
 import { timed } from '@/core/observability/timed.ts';
 import { SqaaForbiddenError } from '@/core/server/errors.ts';
 import type { Console } from '@/core/ui/console.ts';
@@ -341,7 +344,9 @@ export async function runSqaaAnalysisOnFiles(
     return;
   }
 
-  const ignoredPaths = ignored.map((f) => toRelativePosixPathOrNull(f.path, repoRoot) ?? f.path);
+  const ignoredPaths = ignored.map(
+    (f) => toRelativePosixPathOrNull(f.path, repoRoot) ?? normalizePath(f.path),
+  );
   const progress = new SqaaProgress({
     files: allPaths,
     ignoredFiles: ignoredPaths,

--- a/src/commands/analyze/sqaa.ts
+++ b/src/commands/analyze/sqaa.ts
@@ -222,7 +222,7 @@ async function analyzeSqaaChangeSet(params: {
 
   if (changeSet.files.length === 0) {
     console.text(
-      'Vortex analysis: no files to analyze — all change set files were excluded (binary or oversized).',
+      'Vortex analysis: no files to analyze — all change set files were excluded (binary, oversized, or outside the repository).',
     );
     return;
   }

--- a/src/commands/hook/format-sqaa-hook-context.ts
+++ b/src/commands/hook/format-sqaa-hook-context.ts
@@ -86,7 +86,9 @@ function appendIgnoredLines(lines: string[], ignored: SqaaJsonReport['ignored'])
   if (ignored.length === 0) {
     return;
   }
-  lines.push(`Excluded ${ignored.length} file(s) from analysis (binary or oversized):`);
+  lines.push(
+    `Excluded ${ignored.length} file(s) from analysis (binary, oversized, or outside the repository):`,
+  );
   for (const file of ignored) {
     lines.push(`  ${file.path} (${file.reason})`);
   }
@@ -98,7 +100,7 @@ function formatNoAnalyzedContent(report: SqaaJsonReport): string {
     lines.push(`Skipped ${report.skipped.length} file(s) (analysis not completed).`);
   } else if (report.ignored.length > 0 && report.files.length === 0) {
     lines.push(
-      'Vortex analysis: no files to analyze — all change set files were excluded (binary or oversized).',
+      'Vortex analysis: no files to analyze — all change set files were excluded (binary, oversized, or outside the repository).',
     );
   } else {
     lines.push(formatSqaaRunSummaryPlain(hookSummaryFromReport(report)));

--- a/tests/unit/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/commands/analyze/analyze-sqaa.test.ts
@@ -21,6 +21,8 @@
 // Unit tests for analyzeSqaa command
 
 import * as fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
@@ -435,5 +437,26 @@ describe('analyzeSqaa: change-set mode', () => {
 
     expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
     expect(createAnalysisSpy.mock.calls[0][0].analysisDepth).toBe('DEEP');
+  });
+
+  it('does not abort when an ignored change-set file is outside the repository', async () => {
+    const filePath = `${process.cwd()}/src/index.ts`;
+    const outside = join(tmpdir(), 'outside-repo.ts');
+    resolveChangeSetSpy.mockResolvedValue({
+      files: [filePath],
+      ignored: [{ path: outside, reason: 'outside-repository' as const }],
+      repoRoot: process.cwd(),
+    });
+
+    await analyzeSqaa({ staged: true }, FAKE_AUTHENTICATED_CONTEXT);
+
+    expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
+    const output = fake.calls.map((c) => String(c.args[0])).join('\n');
+    expect(output).toContain(outside);
+
+    const report = await buildSqaaJsonReport({ staged: true }, FAKE_AUTH, {
+      telemetryCtx: FAKE_AUTHENTICATED_CONTEXT,
+    });
+    expect(report?.ignored).toEqual([{ path: outside, reason: 'outside-repository' }]);
   });
 });

--- a/tests/unit/commands/analyze/analyze-sqaa.test.ts
+++ b/tests/unit/commands/analyze/analyze-sqaa.test.ts
@@ -29,6 +29,7 @@ import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { SqaaAnalysisClient } from '@/commands/analyze/sqaa-analysis-client.ts';
 import { CommandFailedError, InvalidOptionError } from '@/core/commands/command-error.ts';
 import { CommandAuthenticatedInvocationContext } from '@/core/commands/invocation-context.ts';
+import { normalizePath } from '@/core/io/fs-utils.ts';
 import * as processLib from '@/core/process/process.ts';
 import * as projectInfo from '@/core/project-info.ts';
 import { getDefaultState } from '@/core/state/state.ts';
@@ -452,11 +453,13 @@ describe('analyzeSqaa: change-set mode', () => {
 
     expect(createAnalysisSpy).toHaveBeenCalledTimes(1);
     const output = fake.calls.map((c) => String(c.args[0])).join('\n');
-    expect(output).toContain(outside);
+    expect(output).toContain(normalizePath(outside));
 
     const report = await buildSqaaJsonReport({ staged: true }, FAKE_AUTH, {
       telemetryCtx: FAKE_AUTHENTICATED_CONTEXT,
     });
-    expect(report?.ignored).toEqual([{ path: outside, reason: 'outside-repository' }]);
+    expect(report?.ignored).toEqual([
+      { path: normalizePath(outside), reason: 'outside-repository' },
+    ]);
   });
 });

--- a/tests/unit/commands/analyze/sqaa-changeset.test.ts
+++ b/tests/unit/commands/analyze/sqaa-changeset.test.ts
@@ -18,16 +18,23 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 
 import * as processLib from '@/core/process/process.ts';
 
 import {
+  resolveChangeSet,
   resolveSqaaBranch,
   resolveSqaaBranchAtRepoRoot,
 } from '../../../../src/commands/analyze/sqaa-changeset.ts';
+import { clearGitStdoutCache } from '../../../../src/core/host/git/worktree.ts';
 
 let spawnProcessSpy: ReturnType<typeof spyOn>;
+let tempDir: string | undefined;
 
 function mockGitResponses(responses: Record<string, string | null>) {
   spawnProcessSpy.mockImplementation((_cmd: string, args: string[]) => {
@@ -49,6 +56,11 @@ beforeEach(() => {
 
 afterEach(() => {
   spawnProcessSpy.mockRestore();
+  clearGitStdoutCache();
+  if (tempDir !== undefined) {
+    rmSync(tempDir, { force: true, recursive: true });
+    tempDir = undefined;
+  }
 });
 
 describe('resolveSqaaBranch', () => {
@@ -100,5 +112,28 @@ describe('resolveSqaaBranch', () => {
     expect(
       spawnProcessSpy.mock.calls.some(([, args]: [string, string[]]) => args[0] === 'branch'),
     ).toBe(false);
+  });
+});
+
+describe('resolveChangeSet', () => {
+  it('excludes changed symlinks that resolve outside the repository', async () => {
+    tempDir = mkdtempSync(join(tmpdir(), 'sqaa-changeset-'));
+    const repoRoot = join(tempDir, 'repo');
+    const outsideFile = join(tempDir, 'outside.ts');
+    const symlinkPath = join(repoRoot, 'external.ts');
+    mkdirSync(repoRoot);
+    writeFileSync(outsideFile, 'outside content');
+    symlinkSync(outsideFile, symlinkPath);
+
+    mockGitResponses({
+      'rev-parse --show-toplevel': `${repoRoot}\n`,
+      'diff --name-only --diff-filter=ACMR -z HEAD': 'external.ts\0',
+      'ls-files -z --others --exclude-standard': '',
+    });
+
+    const result = await resolveChangeSet(repoRoot);
+
+    expect(result.files).toEqual([]);
+    expect(result.ignored).toEqual([]);
   });
 });

--- a/tests/unit/commands/analyze/sqaa-changeset.test.ts
+++ b/tests/unit/commands/analyze/sqaa-changeset.test.ts
@@ -116,24 +116,27 @@ describe('resolveSqaaBranch', () => {
 });
 
 describe('resolveChangeSet', () => {
-  it('excludes changed symlinks that resolve outside the repository', async () => {
-    tempDir = mkdtempSync(join(tmpdir(), 'sqaa-changeset-'));
-    const repoRoot = join(tempDir, 'repo');
-    const outsideFile = join(tempDir, 'outside.ts');
-    const symlinkPath = join(repoRoot, 'external.ts');
-    mkdirSync(repoRoot);
-    writeFileSync(outsideFile, 'outside content');
-    symlinkSync(outsideFile, symlinkPath);
+  it.skipIf(process.platform === 'win32')(
+    'excludes changed symlinks that resolve outside the repository',
+    async () => {
+      tempDir = mkdtempSync(join(tmpdir(), 'sqaa-changeset-'));
+      const repoRoot = join(tempDir, 'repo');
+      const outsideFile = join(tempDir, 'outside.ts');
+      const symlinkPath = join(repoRoot, 'external.ts');
+      mkdirSync(repoRoot);
+      writeFileSync(outsideFile, 'outside content');
+      symlinkSync(outsideFile, symlinkPath);
 
-    mockGitResponses({
-      'rev-parse --show-toplevel': `${repoRoot}\n`,
-      'diff --name-only --diff-filter=ACMR -z HEAD': 'external.ts\0',
-      'ls-files -z --others --exclude-standard': '',
-    });
+      mockGitResponses({
+        'rev-parse --show-toplevel': `${repoRoot}\n`,
+        'diff --name-only --diff-filter=ACMR -z HEAD': 'external.ts\0',
+        'ls-files -z --others --exclude-standard': '',
+      });
 
-    const result = await resolveChangeSet(repoRoot);
+      const result = await resolveChangeSet(repoRoot);
 
-    expect(result.files).toEqual([]);
-    expect(result.ignored).toEqual([]);
-  });
+      expect(result.files).toEqual([]);
+      expect(result.ignored).toEqual([{ path: symlinkPath, reason: 'outside-repository' }]);
+    },
+  );
 });

--- a/tests/unit/commands/analyze/sqaa-changeset.test.ts
+++ b/tests/unit/commands/analyze/sqaa-changeset.test.ts
@@ -18,7 +18,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -119,23 +119,25 @@ describe('resolveChangeSet', () => {
   it.skipIf(process.platform === 'win32')(
     'excludes changed symlinks that resolve outside the repository',
     async () => {
-      tempDir = mkdtempSync(join(tmpdir(), 'sqaa-changeset-'));
+      tempDir = realpathSync(mkdtempSync(join(tmpdir(), 'sqaa-changeset-')));
       const repoRoot = join(tempDir, 'repo');
       const outsideFile = join(tempDir, 'outside.ts');
       const symlinkPath = join(repoRoot, 'external.ts');
+      const insideFile = join(repoRoot, 'inside.ts');
       mkdirSync(repoRoot);
       writeFileSync(outsideFile, 'outside content');
+      writeFileSync(insideFile, 'inside content');
       symlinkSync(outsideFile, symlinkPath);
 
       mockGitResponses({
         'rev-parse --show-toplevel': `${repoRoot}\n`,
-        'diff --name-only --diff-filter=ACMR -z HEAD': 'external.ts\0',
+        'diff --name-only --diff-filter=ACMR -z HEAD': 'external.ts\0inside.ts\0',
         'ls-files -z --others --exclude-standard': '',
       });
 
       const result = await resolveChangeSet(repoRoot);
 
-      expect(result.files).toEqual([]);
+      expect(result.files).toEqual([insideFile]);
       expect(result.ignored).toEqual([{ path: symlinkPath, reason: 'outside-repository' }]);
     },
   );

--- a/tests/unit/commands/hook/format-sqaa-hook-context.test.ts
+++ b/tests/unit/commands/hook/format-sqaa-hook-context.test.ts
@@ -78,7 +78,7 @@ describe('formatSqaaJsonReportForHook', () => {
     );
 
     expect(text).not.toContain('no issues found');
-    expect(text).toContain('excluded (binary or oversized)');
+    expect(text).toContain('excluded (binary, oversized, or outside the repository)');
     expect(text).toContain('image.png');
     expect(text).toContain('binary');
   });


### PR DESCRIPTION
----
## Summary by Gitar

- **Changeset handling:**
    - Filter out files resolving outside the repository using `toRelativePosixPath` in `sqaa-changeset.ts`

<sub>This will update automatically on new commits.</sub>