### PR TITLE
CLI-1013 Add duplication category enrichment

### DIFF
--- a/src/commands/quality-gate/status/breakdown.ts
+++ b/src/commands/quality-gate/status/breakdown.ts
@@ -22,15 +22,15 @@
 
 import logger from '@/core/observability/logger.ts';
 import type { SonarHttpClient } from '@/core/server/http-client.ts';
-import { isNewCodeMetric, MeasuresClient } from '@/core/server/measures.ts';
-import type { ComponentTreeComponent, Metric, QualityGateCondition } from '@/core/server/types.ts';
+import { MeasuresClient } from '@/core/server/measures.ts';
+import type { Metric, QualityGateCondition } from '@/core/server/types.ts';
 
 import type {
-  QualityGateBreakdownEntry,
   QualityGateConditionSummary,
   QualityGateMetricBreakdown,
 } from './condition-summary.ts';
-import { formatMetricValue } from './format-metric-value.ts';
+import { fetchDuplicationsBreakdown } from './duplications-enrichment.ts';
+import { fetchWorstFileEntries } from './worst-file-entries.ts';
 
 /** Metric keys owned by each `--category` value, both overall and new-code variants. */
 const CATEGORY_METRICS: Record<string, string[]> = {
@@ -41,6 +41,15 @@ const CATEGORY_METRICS: Record<string, string[]> = {
     'new_coverage',
     'new_branch_coverage',
     'new_line_coverage',
+  ],
+  duplications: [
+    'duplicated_lines_density',
+    'duplicated_blocks',
+    'duplicated_files',
+    'duplicated_lines',
+    'new_duplicated_lines_density',
+    'new_duplicated_blocks',
+    'new_duplicated_lines',
   ],
 };
 
@@ -63,10 +72,7 @@ export interface AttachBreakdownsParams {
   pullRequest?: string;
 }
 
-/**
- * True when a failing condition's metric falls into an implemented category, filtered to
- * `category` when given.
- */
+/** True when failing and in an implemented category, filtered to `category` if given. */
 function isFailingMetricInCategory(
   metricKey: string,
   status: string,
@@ -76,11 +82,7 @@ function isFailingMetricInCategory(
   return status !== 'OK' && !!conditionCategory && (!category || category === conditionCategory);
 }
 
-/**
- * True when at least one failing condition falls into `category` - distinct from the resulting
- * breakdown being empty for another reason (a matching condition's enrichment fetch failing, or
- * returning no files), which should stay silent rather than warn.
- */
+/** True when a failing condition falls into `category` - kept distinct from an empty breakdown result, which shouldn't warn. */
 export function hasFailingConditionInCategory(
   conditions: QualityGateCondition[],
   category: string,
@@ -90,12 +92,19 @@ export function hasFailingConditionInCategory(
   );
 }
 
-/** A failing condition whose metric falls into an implemented category, when given. */
-function isEnrichableCondition(
+/** The condition's category when enrichable, or undefined when there's nothing to build. */
+function resolveEnrichableCategory(
   condition: QualityGateConditionSummary,
-  category: string | undefined,
-): boolean {
-  return isFailingMetricInCategory(condition.metric, condition.status, category);
+  filterCategory: string | undefined,
+): string | undefined {
+  if (condition.status === 'OK') {
+    return undefined;
+  }
+  const conditionCategory = METRIC_CATEGORIES.get(condition.metric);
+  if (!conditionCategory || (filterCategory && filterCategory !== conditionCategory)) {
+    return undefined;
+  }
+  return conditionCategory;
 }
 
 /**
@@ -112,65 +121,58 @@ export async function attachBreakdowns(
 
   return Promise.all(
     conditions.map(async (condition) => {
-      if (!isEnrichableCondition(condition, params.category)) {
+      const category = resolveEnrichableCategory(condition, params.category);
+      if (!category) {
         return condition;
       }
-      const breakdown = await fetchMetricBreakdown(measuresClient, params, condition, metricsByKey);
+      const breakdown = await fetchCategoryBreakdown(
+        category,
+        measuresClient,
+        params,
+        condition,
+        metricsByKey.get(condition.metric),
+      );
       return breakdown ? { ...condition, breakdown } : condition;
     }),
   );
+}
+
+function fetchCategoryBreakdown(
+  category: string,
+  measuresClient: MeasuresClient,
+  params: AttachBreakdownsParams,
+  condition: QualityGateConditionSummary,
+  metric: Metric | undefined,
+): Promise<QualityGateMetricBreakdown | undefined> {
+  switch (category) {
+    case 'coverage':
+      return fetchMetricBreakdown(measuresClient, params, condition, metric);
+    case 'duplications':
+      return fetchDuplicationsBreakdown(measuresClient, params, condition, metric);
+    default:
+      return Promise.resolve(undefined);
+  }
 }
 
 async function fetchMetricBreakdown(
   measuresClient: MeasuresClient,
   params: AttachBreakdownsParams,
   condition: QualityGateConditionSummary,
-  metricsByKey: Map<string, Metric>,
+  metric: Metric | undefined,
 ): Promise<QualityGateMetricBreakdown | undefined> {
   try {
-    const { components, totalCount } = await measuresClient.getWorstComponentsByMetric({
-      projectKey: params.projectKey,
-      metricKey: condition.metric,
-      ascending: condition.comparator === 'LT',
-      top: params.top,
-      branch: params.branch,
-      pullRequest: params.pullRequest,
-    });
-
-    const entries = components.flatMap((component) =>
-      toBreakdownEntry(component, condition.metric, metricsByKey.get(condition.metric)),
+    const { entries, totalCount, fetchedCount } = await fetchWorstFileEntries(
+      measuresClient,
+      params,
+      condition,
+      metric,
     );
-    return entries.length > 0
-      ? { totalCount, fetchedCount: components.length, entries }
-      : undefined;
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return { category: 'coverage', totalCount, fetchedCount, entries };
   } catch (err) {
     logger.debug(`Failed to build quality gate breakdown for '${condition.metric}'`, err);
     return undefined;
   }
-}
-
-function toBreakdownEntry(
-  component: ComponentTreeComponent,
-  metricKey: string,
-  metric: Metric | undefined,
-): QualityGateBreakdownEntry[] {
-  if (!component.path) {
-    return [];
-  }
-  const measure = component.measures.find((m) => m.metric === metricKey);
-  const rawValue = isNewCodeMetric(metricKey)
-    ? measure?.periods?.[0]?.value
-    : (measure?.value ?? measure?.periods?.[0]?.value);
-  if (rawValue === undefined) {
-    return [];
-  }
-  return [
-    {
-      path: component.path,
-      value: rawValue,
-      formattedValue: metric
-        ? formatMetricValue(metric.type, rawValue, metric.decimalScale)
-        : rawValue,
-    },
-  ];
 }

--- a/src/commands/quality-gate/status/condition-summary.ts
+++ b/src/commands/quality-gate/status/condition-summary.ts
@@ -32,11 +32,26 @@ export interface QualityGateBreakdownEntry {
   formattedValue: string;
 }
 
-export interface QualityGateMetricBreakdown {
+export interface DuplicationsBreakdownEntry extends QualityGateBreakdownEntry {
+  blockCount?: number;
+  duplicatesWith?: string[];
+}
+
+export interface CoverageMetricBreakdown {
+  category: 'coverage';
   totalCount: number;
   fetchedCount: number;
   entries: QualityGateBreakdownEntry[];
 }
+
+export interface DuplicationsMetricBreakdown {
+  category: 'duplications';
+  totalCount: number;
+  fetchedCount: number;
+  entries: DuplicationsBreakdownEntry[];
+}
+
+export type QualityGateMetricBreakdown = CoverageMetricBreakdown | DuplicationsMetricBreakdown;
 
 export interface QualityGateConditionSummary {
   metric: string;

--- a/src/commands/quality-gate/status/duplications-enrichment.ts
+++ b/src/commands/quality-gate/status/duplications-enrichment.ts
@@ -1,0 +1,104 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Builds the duplications-category breakdown
+
+import { runWithConcurrencyLimit } from '@/core/concurrency/concurrency-pool.ts';
+import logger from '@/core/observability/logger.ts';
+import { DuplicationsClient } from '@/core/server/duplications.ts';
+import type { SonarHttpClient } from '@/core/server/http-client.ts';
+import type { MeasuresClient } from '@/core/server/measures.ts';
+import type { ComponentTreeComponent, Metric } from '@/core/server/types.ts';
+
+import type { AttachBreakdownsParams } from './breakdown.ts';
+import type {
+  DuplicationsBreakdownEntry,
+  QualityGateConditionSummary,
+  QualityGateMetricBreakdown,
+} from './condition-summary.ts';
+import { fetchWorstFileEntries } from './worst-file-entries.ts';
+
+export interface DuplicationsEnrichmentParams {
+  client: SonarHttpClient;
+  branch?: string;
+  pullRequest?: string;
+}
+
+/** Keeps per-file enrichment from fanning out to `--top` (up to 500) parallel requests. */
+const DUPLICATIONS_FETCH_CONCURRENCY = 8;
+
+export async function fetchDuplicationsBreakdown(
+  measuresClient: MeasuresClient,
+  params: AttachBreakdownsParams,
+  condition: QualityGateConditionSummary,
+  metric: Metric | undefined,
+): Promise<QualityGateMetricBreakdown | undefined> {
+  try {
+    const { components, entries, totalCount, fetchedCount } = await fetchWorstFileEntries(
+      measuresClient,
+      params,
+      condition,
+      metric,
+    );
+    await enrichDuplicationsEntries(entries, components, params);
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return { category: 'duplications', totalCount, fetchedCount, entries };
+  } catch (err) {
+    logger.debug(`Failed to build quality gate breakdown for '${condition.metric}'`, err);
+    return undefined;
+  }
+}
+
+/**
+ * Matched back to entries by path. Degrades per file on failure.
+ */
+export async function enrichDuplicationsEntries(
+  entries: DuplicationsBreakdownEntry[],
+  components: ComponentTreeComponent[],
+  params: DuplicationsEnrichmentParams,
+): Promise<void> {
+  const duplicationsClient = new DuplicationsClient(params.client);
+  const componentsByPath = new Map(components.map((component) => [component.path, component]));
+
+  const results = await runWithConcurrencyLimit(
+    entries,
+    DUPLICATIONS_FETCH_CONCURRENCY,
+    async (entry) => {
+      const componentKey = componentsByPath.get(entry.path)?.key;
+      if (!componentKey) {
+        return;
+      }
+      const info = await duplicationsClient.getDuplicationInfo({
+        componentKey,
+        branch: params.branch,
+        pullRequest: params.pullRequest,
+      });
+      entry.blockCount = info.blockCount;
+      entry.duplicatesWith = info.duplicatesWith;
+    },
+  );
+
+  const failedCount = results.filter((result) => result.status === 'rejected').length;
+  if (failedCount > 0) {
+    logger.debug(`Failed to fetch duplication info for ${failedCount}/${entries.length} files`);
+  }
+}

--- a/src/commands/quality-gate/status/format-table.ts
+++ b/src/commands/quality-gate/status/format-table.ts
@@ -23,6 +23,8 @@ import { cyan, green, red, yellow } from '@/core/ui/colors.ts';
 import { padColumns } from '@/core/ui/formatter/column-formatting.ts';
 
 import type {
+  DuplicationsBreakdownEntry,
+  QualityGateBreakdownEntry,
   QualityGateConditionSummary,
   QualityGateMetricBreakdown,
 } from './condition-summary.ts';
@@ -143,8 +145,8 @@ function formatBreakdownLines(condition: QualityGateConditionSummary): string[] 
     [],
     BREAKDOWN_VALUE_GAP,
   );
-  const lines = metricBreakdown.entries.map(
-    (entry, i) => `${BREAKDOWN_INDENT}${values[i]}${entry.path}`,
+  const lines = metricBreakdown.entries.map((_entry, i) =>
+    formatEntryLine(metricBreakdown, i, values[i]),
   );
 
   const remaining = metricBreakdown.totalCount - metricBreakdown.fetchedCount;
@@ -153,6 +155,35 @@ function formatBreakdownLines(condition: QualityGateConditionSummary): string[] 
   }
 
   return lines;
+}
+
+function formatEntryLine(
+  metricBreakdown: QualityGateMetricBreakdown,
+  index: number,
+  paddedValue: string,
+): string {
+  switch (metricBreakdown.category) {
+    case 'coverage':
+      return formatCoverageEntryLine(metricBreakdown.entries[index], paddedValue);
+    case 'duplications':
+      return formatDuplicationsEntryLine(metricBreakdown.entries[index], paddedValue);
+  }
+}
+
+function formatCoverageEntryLine(entry: QualityGateBreakdownEntry, paddedValue: string): string {
+  return `${BREAKDOWN_INDENT}${paddedValue}${entry.path}`;
+}
+
+function formatDuplicationsEntryLine(
+  entry: DuplicationsBreakdownEntry,
+  paddedValue: string,
+): string {
+  if (entry.blockCount === undefined) {
+    return `${BREAKDOWN_INDENT}${paddedValue}${entry.path}`;
+  }
+  const blocks = `${entry.blockCount} block${entry.blockCount === 1 ? '' : 's'}`;
+  const peers = entry.duplicatesWith?.length ? `, dup: ${entry.duplicatesWith.join(', ')}` : '';
+  return `${BREAKDOWN_INDENT}${paddedValue}${entry.path} (${blocks}${peers})`;
 }
 
 function formatMoreEntriesLine(

--- a/src/commands/quality-gate/status/worst-file-entries.ts
+++ b/src/commands/quality-gate/status/worst-file-entries.ts
@@ -1,0 +1,115 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Fetches the worst-N files for a metric and builds their base breakdown entries
+
+import type { MeasuresClient } from '@/core/server/measures.ts';
+import { isNewCodeMetric } from '@/core/server/measures.ts';
+import type { ComponentTreeComponent, Metric } from '@/core/server/types.ts';
+
+import type { AttachBreakdownsParams } from './breakdown.ts';
+import type {
+  QualityGateBreakdownEntry,
+  QualityGateConditionSummary,
+} from './condition-summary.ts';
+import { formatMetricValue } from './format-metric-value.ts';
+
+export interface WorstFileEntriesResult {
+  components: ComponentTreeComponent[];
+  entries: QualityGateBreakdownEntry[];
+  totalCount: number;
+  fetchedCount: number;
+}
+
+/**
+ * A value sitting at the metric's floor/ceiling (0% duplication, 100% coverage) has nothing left
+ * to contribute, so files there are excluded from the breakdown.
+ */
+const NON_CONTRIBUTING_BOUNDARY: Partial<Record<string, number>> = { LT: 100, GT: 0 };
+
+type BreakdownEntryOutcome =
+  | { kind: 'entry'; entry: QualityGateBreakdownEntry }
+  | { kind: 'missing-value' }
+  | { kind: 'non-contributing' };
+
+export async function fetchWorstFileEntries(
+  measuresClient: MeasuresClient,
+  params: AttachBreakdownsParams,
+  condition: QualityGateConditionSummary,
+  metric: Metric | undefined,
+): Promise<WorstFileEntriesResult> {
+  const { components, totalCount } = await measuresClient.getWorstComponentsByMetric({
+    projectKey: params.projectKey,
+    metricKey: condition.metric,
+    ascending: condition.comparator === 'LT',
+    top: params.top,
+    branch: params.branch,
+    pullRequest: params.pullRequest,
+  });
+
+  const outcomes = components.map((component) =>
+    toBreakdownEntryOutcome(component, condition, metric),
+  );
+  const entries = outcomes.flatMap((outcome) => (outcome.kind === 'entry' ? [outcome.entry] : []));
+
+  const exhausted = outcomes.some((outcome) => outcome.kind === 'non-contributing');
+  if (exhausted) {
+    return { components, entries, totalCount: entries.length, fetchedCount: entries.length };
+  }
+  return { components, entries, totalCount, fetchedCount: components.length };
+}
+
+function toBreakdownEntryOutcome(
+  component: ComponentTreeComponent,
+  condition: QualityGateConditionSummary,
+  metric: Metric | undefined,
+): BreakdownEntryOutcome {
+  if (!component.path) {
+    return { kind: 'missing-value' };
+  }
+  const measure = component.measures.find((m) => m.metric === condition.metric);
+  const rawValue = isNewCodeMetric(condition.metric)
+    ? measure?.periods?.[0]?.value
+    : (measure?.value ?? measure?.periods?.[0]?.value);
+  if (rawValue === undefined) {
+    return { kind: 'missing-value' };
+  }
+  if (!isContributing(condition.comparator, rawValue)) {
+    return { kind: 'non-contributing' };
+  }
+  return {
+    kind: 'entry',
+    entry: {
+      path: component.path,
+      value: rawValue,
+      formattedValue: metric
+        ? formatMetricValue(metric.type, rawValue, metric.decimalScale)
+        : rawValue,
+    },
+  };
+}
+
+function isContributing(comparator: string, rawValue: string): boolean {
+  const boundary = NON_CONTRIBUTING_BOUNDARY[comparator];
+  if (boundary === undefined) {
+    return true;
+  }
+  return comparator === 'LT' ? Number(rawValue) < boundary : Number(rawValue) > boundary;
+}

--- a/src/core/server/duplications.ts
+++ b/src/core/server/duplications.ts
@@ -1,0 +1,96 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// SonarQube Duplications API wrapper
+
+import type { QueryParams, SonarHttpClient } from './http-client.ts';
+import type { DuplicationsShowBlock, DuplicationsShowResponse } from './types.ts';
+
+export interface DuplicationInfo {
+  /** Count of this file's own occurrences flagged as duplicated, not the number of duplication groups. */
+  blockCount: number;
+  duplicatesWith: string[];
+}
+
+export interface GetDuplicationInfoParams {
+  componentKey: string;
+  branch?: string;
+  pullRequest?: string;
+}
+
+export class DuplicationsClient {
+  private readonly client: SonarHttpClient;
+
+  constructor(client: SonarHttpClient) {
+    this.client = client;
+  }
+
+  async getDuplicationInfo(params: GetDuplicationInfoParams): Promise<DuplicationInfo> {
+    const queryParams: QueryParams = { key: params.componentKey };
+    if (params.branch) {
+      queryParams.branch = params.branch;
+    }
+    if (params.pullRequest) {
+      queryParams.pullRequest = params.pullRequest;
+    }
+    const response = await this.client.get<DuplicationsShowResponse>(
+      '/api/duplications/show',
+      queryParams,
+    );
+    return toDuplicationInfo(response, params.componentKey);
+  }
+}
+
+/** Resolves the self-ref by matching `files[ref].key` - `_ref` values have no fixed meaning across calls. */
+function toDuplicationInfo(
+  response: DuplicationsShowResponse,
+  componentKey: string,
+): DuplicationInfo {
+  const files = response.files;
+  const [selfRef] = Object.entries(files).find(([, file]) => file?.key === componentKey) ?? [];
+
+  let thisFileBlockCount = 0;
+  const peerPaths = new Set<string>();
+  for (const duplication of response.duplications) {
+    for (const block of duplication.blocks) {
+      if (selfRef !== undefined && block._ref === selfRef) {
+        thisFileBlockCount++;
+      } else {
+        addPeerName(files, block, peerPaths);
+      }
+    }
+  }
+
+  return {
+    blockCount: thisFileBlockCount,
+    duplicatesWith: [...peerPaths],
+  };
+}
+
+function addPeerName(
+  files: DuplicationsShowResponse['files'],
+  block: DuplicationsShowBlock,
+  peerPaths: Set<string>,
+): void {
+  const peerName = block._ref === undefined ? undefined : files[block._ref]?.name;
+  if (peerName !== undefined) {
+    peerPaths.add(peerName);
+  }
+}

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -207,3 +207,28 @@ export interface ComponentTreeResponse {
   baseComponent: ComponentTreeComponent;
   components: ComponentTreeComponent[];
 }
+
+export interface DuplicationsShowBlock {
+  from: number;
+  size: number;
+  _ref?: string;
+}
+
+export interface DuplicationsShowDuplication {
+  blocks: DuplicationsShowBlock[];
+}
+
+export interface DuplicationsShowFile {
+  key: string;
+  name: string;
+  uuid: string;
+  project: string;
+  projectUuid: string;
+  projectName: string;
+}
+
+export interface DuplicationsShowResponse {
+  duplications: DuplicationsShowDuplication[];
+  /** Keyed by block `_ref` - a ref for a peer that isn't browsable or was since removed has no entry. */
+  files: Record<string, DuplicationsShowFile | undefined>;
+}

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -23,6 +23,7 @@
 import type { Organization } from '@/core/server/organizations.ts';
 import type { SettingsValue } from '@/core/server/settings-value.ts';
 import type {
+  DuplicationsShowFile,
   Metric,
   QualityGateCondition,
   QualityGateStatus,
@@ -71,6 +72,16 @@ interface ComponentTreeErrorConfig {
   body?: string;
 }
 
+export interface DuplicationsShowConfig {
+  blockCount: number;
+  duplicatesWith?: string[];
+}
+
+interface DuplicationsShowErrorConfig {
+  statusCode: number;
+  body?: string;
+}
+
 interface ProjectData {
   key: string;
   name: string;
@@ -86,6 +97,8 @@ interface ProjectData {
   pullRequests?: PullRequestConfig[];
   pullRequestsUnsupported: boolean;
   pullRequestsErrorStatus?: number;
+  duplicationsByFile: Map<string, DuplicationsShowConfig>;
+  duplicationsErrorsByFile: Map<string, DuplicationsShowErrorConfig>;
 }
 
 export interface DopRepositoryConfig {
@@ -112,6 +125,8 @@ export class ProjectBuilder {
   private pullRequests?: PullRequestConfig[];
   private pullRequestsUnsupported = false;
   private pullRequestsErrorStatus?: number;
+  private readonly duplicationsByFile: Map<string, DuplicationsShowConfig> = new Map();
+  private readonly duplicationsErrorsByFile: Map<string, DuplicationsShowErrorConfig> = new Map();
 
   constructor(projectKey: string) {
     this.projectKey = projectKey;
@@ -224,6 +239,27 @@ export class ProjectBuilder {
     return this;
   }
 
+  /**
+   * Configure `GET /api/duplications/show` for one file path - `blockCount` duplication
+   * groups, each containing this file plus every path in `duplicatesWith` (omit for
+   * self-duplication only). This fake server doesn't distribute peers across groups the way a
+   * real analysis would; `DuplicationsClient` only extracts the group count and the
+   * deduplicated peer set, so the distribution is irrelevant to what it's tested against.
+   */
+  withDuplications(path: string, config: DuplicationsShowConfig): this {
+    this.duplicationsByFile.set(path, config);
+    return this;
+  }
+
+  /**
+   * Force `GET /api/duplications/show` to fail with the given HTTP status code for one file
+   * path, simulating a per-file enrichment failure independent of the primary breakdown fetch.
+   */
+  withDuplicationsError(path: string, statusCode: number, body?: string): this {
+    this.duplicationsErrorsByFile.set(path, { statusCode, body });
+    return this;
+  }
+
   getData(): ProjectData {
     return {
       key: this.projectKey,
@@ -240,6 +276,8 @@ export class ProjectBuilder {
       pullRequests: this.pullRequests,
       pullRequestsUnsupported: this.pullRequestsUnsupported,
       pullRequestsErrorStatus: this.pullRequestsErrorStatus,
+      duplicationsByFile: this.duplicationsByFile,
+      duplicationsErrorsByFile: this.duplicationsErrorsByFile,
     };
   }
 }
@@ -941,6 +979,50 @@ export class FakeSonarQubeServerBuilder {
             }),
             { headers: { 'Content-Type': 'application/json' } },
           );
+        }
+
+        if (path === '/api/duplications/show') {
+          const key = query.key ?? '';
+          const separatorIndex = key.indexOf(':');
+          const projectKey = separatorIndex === -1 ? key : key.slice(0, separatorIndex);
+          const filePath = separatorIndex === -1 ? '' : key.slice(separatorIndex + 1);
+          const projectData = projects.get(projectKey);
+
+          const error = projectData?.duplicationsErrorsByFile.get(filePath);
+          if (error) {
+            return new Response(error.body ?? '', { status: error.statusCode });
+          }
+
+          const config = projectData?.duplicationsByFile.get(filePath);
+          if (!config || config.blockCount === 0) {
+            return new Response(JSON.stringify({ duplications: [], files: {} }), {
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          const toFile = (p: string): DuplicationsShowFile => ({
+            key: `${projectKey}:${p}`,
+            name: p,
+            uuid: `${projectKey}:${p}-uuid`,
+            project: projectKey,
+            projectUuid: `${projectKey}-uuid`,
+            projectName: projectKey,
+          });
+
+          const peerPaths = config.duplicatesWith ?? [];
+          const refs = ['1', ...peerPaths.map((_, i) => String(i + 2))];
+          const files: Record<string, DuplicationsShowFile> = { '1': toFile(filePath) };
+          peerPaths.forEach((peerPath, i) => {
+            files[String(i + 2)] = toFile(peerPath);
+          });
+
+          const duplications = Array.from({ length: config.blockCount }, (_, i) => ({
+            blocks: refs.map((ref) => ({ from: i * 10 + 1, size: 10, _ref: ref })),
+          }));
+
+          return new Response(JSON.stringify({ duplications, files }), {
+            headers: { 'Content-Type': 'application/json' },
+          });
         }
 
         // sonar-context-augmentation calls /api/project_branches/list to

--- a/tests/integration/specs/quality-gate/status-breakdown-coverage.test.ts
+++ b/tests/integration/specs/quality-gate/status-breakdown-coverage.test.ts
@@ -70,6 +70,7 @@ describe('quality-gate status — coverage breakdown', () => {
         (c: { metric: string }) => c.metric === 'new_coverage',
       );
       expect(condition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 2,
         fetchedCount: 2,
         entries: [
@@ -115,6 +116,7 @@ describe('quality-gate status — coverage breakdown', () => {
         (c: { metric: string }) => c.metric === 'coverage',
       );
       expect(condition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 2,
         fetchedCount: 2,
         entries: [
@@ -160,6 +162,7 @@ describe('quality-gate status — coverage breakdown', () => {
         (c: { metric: string }) => c.metric === 'new_coverage',
       );
       expect(condition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 1,
         fetchedCount: 1,
         entries: [
@@ -208,6 +211,7 @@ describe('quality-gate status — coverage breakdown', () => {
         (c: { metric: string }) => c.metric === 'new_coverage',
       );
       expect(condition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 1,
         fetchedCount: 1,
         entries: [
@@ -217,6 +221,48 @@ describe('quality-gate status — coverage breakdown', () => {
             formattedValue: '38.85%',
           },
         ],
+      });
+    },
+    { timeout: 15000 },
+  );
+  it(
+    'excludes a file at 100% coverage - it has nothing left to cover',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/checkout.ts', value: '31.0' },
+              { path: 'src/perfect.ts', value: '100.0' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'coverage',
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
       });
     },
     { timeout: 15000 },
@@ -338,6 +384,7 @@ describe('quality-gate status — coverage breakdown', () => {
         (c: { metric: string }) => c.metric === 'new_coverage',
       );
       expect(condition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 1,
         fetchedCount: 1,
         entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],

--- a/tests/integration/specs/quality-gate/status-breakdown-duplications.test.ts
+++ b/tests/integration/specs/quality-gate/status-breakdown-duplications.test.ts
@@ -1,0 +1,494 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integration tests for the duplications category breakdown in `quality-gate status`
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { TestHarness } from '../../harness';
+
+describe('quality-gate status — duplications breakdown', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'includes a duplications breakdown in JSON for a failing new_duplicated_lines_density condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'new_duplicated_lines_density',
+            type: 'PERCENT',
+            name: 'Duplicated Lines (%) on New Code',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_duplicated_lines_density',
+                comparator: 'GT',
+                errorThreshold: '3',
+                actualValue: '10.6',
+              },
+            ])
+            .withComponentTreeFiles('new_duplicated_lines_density', [
+              { path: 'src/core/gitlab/client.ts', value: '10.6' },
+              { path: 'src/checkout.ts', value: '4.2' },
+            ])
+            .withDuplications('src/core/gitlab/client.ts', { blockCount: 2 })
+            .withDuplications('src/checkout.ts', {
+              blockCount: 1,
+              duplicatesWith: ['src/other.ts'],
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_duplicated_lines_density',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'duplications',
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          {
+            path: 'src/core/gitlab/client.ts',
+            value: '10.6',
+            formattedValue: '10.6%',
+            blockCount: 2,
+            duplicatesWith: [],
+          },
+          {
+            path: 'src/checkout.ts',
+            value: '4.2',
+            formattedValue: '4.2%',
+            blockCount: 1,
+            duplicatesWith: ['src/other.ts'],
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+  it(
+    'includes a duplications breakdown in JSON for a failing overall duplicated_blocks condition, an INT metric',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'duplicated_blocks', type: 'INT', name: 'Duplicated Blocks' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'duplicated_blocks',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '3',
+              },
+            ])
+            .withComponentTreeFiles('duplicated_blocks', [
+              { path: 'ecosystem-map.html', value: '2' },
+              { path: 'index.html', value: '1' },
+            ])
+            .withDuplications('ecosystem-map.html', {
+              blockCount: 2,
+              duplicatesWith: ['index.html'],
+            })
+            .withDuplications('index.html', {
+              blockCount: 1,
+              duplicatesWith: ['ecosystem-map.html'],
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'duplicated_blocks',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'duplications',
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          // INT metric - no '%' suffix on formattedValue
+          {
+            path: 'ecosystem-map.html',
+            value: '2',
+            formattedValue: '2',
+            blockCount: 2,
+            duplicatesWith: ['index.html'],
+          },
+          {
+            path: 'index.html',
+            value: '1',
+            formattedValue: '1',
+            blockCount: 1,
+            duplicatesWith: ['ecosystem-map.html'],
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+  it(
+    'excludes a file with 0% duplication - it has nothing left to deduplicate',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'new_duplicated_lines_density',
+            type: 'PERCENT',
+            name: 'Duplicated Lines (%) on New Code',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_duplicated_lines_density',
+                comparator: 'GT',
+                errorThreshold: '3',
+                actualValue: '10.6',
+              },
+            ])
+            .withComponentTreeFiles('new_duplicated_lines_density', [
+              { path: 'src/core/gitlab/client.ts', value: '10.6' },
+              { path: 'src/clean.ts', value: '0.0' },
+            ])
+            .withDuplications('src/core/gitlab/client.ts', { blockCount: 2 }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_duplicated_lines_density',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'duplications',
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [
+          {
+            path: 'src/core/gitlab/client.ts',
+            value: '10.6',
+            formattedValue: '10.6%',
+            blockCount: 2,
+            duplicatesWith: [],
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+  it(
+    'excludes a file with a duplicated_blocks count of 0, an INT metric',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'duplicated_blocks', type: 'INT', name: 'Duplicated Blocks' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'duplicated_blocks',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '3',
+              },
+            ])
+            .withComponentTreeFiles('duplicated_blocks', [
+              { path: 'ecosystem-map.html', value: '2' },
+              { path: 'clean.html', value: '0' },
+            ])
+            .withDuplications('ecosystem-map.html', { blockCount: 2 }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'duplicated_blocks',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'duplications',
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [
+          {
+            path: 'ecosystem-map.html',
+            value: '2',
+            formattedValue: '2',
+            blockCount: 2,
+            duplicatesWith: [],
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+  it(
+    'renders the duplications breakdown in the table for a failing new-code duplications condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'new_duplicated_lines_density',
+            type: 'PERCENT',
+            name: 'Duplicated Lines (%) on New Code',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_duplicated_lines_density',
+                comparator: 'GT',
+                errorThreshold: '3',
+                actualValue: '10.6',
+              },
+            ])
+            .withComponentTreeFiles('new_duplicated_lines_density', [
+              { path: 'src/core/gitlab/client.ts', value: '10.6' },
+              { path: 'src/checkout.ts', value: '4.2' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const conditionIndex = lines.findIndex((l) => l.includes('Duplicated Lines'));
+      expect(lines[conditionIndex + 1]).toContain('src/core/gitlab/client.ts');
+      expect(lines[conditionIndex + 1]).toContain('10.6%');
+      expect(lines[conditionIndex + 2]).toContain('src/checkout.ts');
+      expect(lines[conditionIndex + 2]).toContain('4.2%');
+    },
+    { timeout: 15000 },
+  );
+  it(
+    'renders block count and peer files as a suffix in the table',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'new_duplicated_lines_density',
+            type: 'PERCENT',
+            name: 'Duplicated Lines (%) on New Code',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_duplicated_lines_density',
+                comparator: 'GT',
+                errorThreshold: '3',
+                actualValue: '10.6',
+              },
+            ])
+            .withComponentTreeFiles('new_duplicated_lines_density', [
+              { path: 'src/core/gitlab/client.ts', value: '10.6' },
+              { path: 'src/checkout.ts', value: '4.2' },
+            ])
+            .withDuplications('src/core/gitlab/client.ts', { blockCount: 2 })
+            .withDuplications('src/checkout.ts', {
+              blockCount: 1,
+              duplicatesWith: ['src/other.ts'],
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const conditionIndex = lines.findIndex((l) => l.includes('Duplicated Lines'));
+      expect(lines[conditionIndex + 1]).toContain('src/core/gitlab/client.ts (2 blocks)');
+      expect(lines[conditionIndex + 2]).toContain('src/checkout.ts (1 block, dup: src/other.ts)');
+    },
+    { timeout: 15000 },
+  );
+  it(
+    'includes the duplications breakdown when --category duplications is passed explicitly',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'new_duplicated_lines_density',
+            type: 'PERCENT',
+            name: 'Duplicated Lines (%) on New Code',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_duplicated_lines_density',
+                comparator: 'GT',
+                errorThreshold: '3',
+                actualValue: '10.6',
+              },
+            ])
+            .withComponentTreeFiles('new_duplicated_lines_density', [
+              { path: 'src/core/gitlab/client.ts', value: '10.6' },
+            ])
+            .withDuplications('src/core/gitlab/client.ts', { blockCount: 2 }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category duplications --format json`,
+      );
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_duplicated_lines_density',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'duplications',
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [
+          {
+            path: 'src/core/gitlab/client.ts',
+            value: '10.6',
+            formattedValue: '10.6%',
+            blockCount: 2,
+            duplicatesWith: [],
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'keeps the file entry, without block/peer detail, when duplications/show fails for that file',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'new_duplicated_lines_density',
+            type: 'PERCENT',
+            name: 'Duplicated Lines (%) on New Code',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_duplicated_lines_density',
+                comparator: 'GT',
+                errorThreshold: '3',
+                actualValue: '10.6',
+              },
+            ])
+            .withComponentTreeFiles('new_duplicated_lines_density', [
+              { path: 'src/core/gitlab/client.ts', value: '10.6' },
+              { path: 'src/checkout.ts', value: '4.2' },
+            ])
+            .withDuplicationsError('src/core/gitlab/client.ts', 500)
+            .withDuplications('src/checkout.ts', { blockCount: 1 }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_duplicated_lines_density',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'duplications',
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          // Failure degrades to no detail, not to dropping the entry
+          { path: 'src/core/gitlab/client.ts', value: '10.6', formattedValue: '10.6%' },
+          {
+            path: 'src/checkout.ts',
+            value: '4.2',
+            formattedValue: '4.2%',
+            blockCount: 1,
+            duplicatesWith: [],
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+});

--- a/tests/integration/specs/quality-gate/status-breakdown.test.ts
+++ b/tests/integration/specs/quality-gate/status-breakdown.test.ts
@@ -74,6 +74,7 @@ describe('quality-gate status — breakdown', () => {
         (c: { metric: string }) => c.metric === 'new_coverage',
       );
       expect(condition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 5,
         fetchedCount: 2,
         entries: [
@@ -119,6 +120,7 @@ describe('quality-gate status — breakdown', () => {
         (c: { metric: string }) => c.metric === 'new_coverage',
       );
       expect(condition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 3,
         fetchedCount: 3,
         entries: [
@@ -131,6 +133,67 @@ describe('quality-gate status — breakdown', () => {
       // no "N more" hint to show, even though entries.length (2) is less than totalCount (3).
       const tableResult = await harness.run(
         `quality-gate status --project my-project --format table`,
+      );
+      expect(tableResult.stdout).not.toContain('more');
+      expect(tableResult.stdout).not.toContain('--top');
+    },
+    { timeout: 15000 },
+  );
+  it(
+    "excludes files at the metric's non-contributing boundary, and grounds totalCount/fetchedCount to the exact contributing count once one is hit",
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            // Worst-first (ascending): the fetched page hits 100% (nothing left to cover) at
+            // index 2, before --top 3 is exhausted. Two more 100% files exist beyond the page,
+            // but the boundary hit already proves neither of them contributes either.
+            .withComponentTreeFiles('new_coverage', [
+              { path: 'src/a.ts', value: '10.0' },
+              { path: 'src/b.ts', value: '20.0' },
+              { path: 'src/perfect-1.ts', value: '100.0' },
+              { path: 'src/perfect-2.ts', value: '100.0' },
+              { path: 'src/perfect-3.ts', value: '100.0' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const jsonResult = await harness.run(
+        `quality-gate status --project my-project --top 3 --format json`,
+      );
+      const parsed = JSON.parse(jsonResult.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'coverage',
+        // Grounded to the real count of contributing files (2), not the API's
+        // "files with any measure" total (5) or the raw fetched page size (3).
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          { path: 'src/a.ts', value: '10.0', formattedValue: '10.0%' },
+          { path: 'src/b.ts', value: '20.0', formattedValue: '20.0%' },
+        ],
+      });
+
+      // No "N more" hint either - the boundary hit already proves there's nothing more to find.
+      const tableResult = await harness.run(
+        `quality-gate status --project my-project --top 3 --format table`,
       );
       expect(tableResult.stdout).not.toContain('more');
       expect(tableResult.stdout).not.toContain('--top');
@@ -403,6 +466,7 @@ describe('quality-gate status — breakdown', () => {
       );
       expect(coverageCondition.breakdown).toBeUndefined();
       expect(newCoverageCondition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 1,
         fetchedCount: 1,
         entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
@@ -461,6 +525,7 @@ describe('quality-gate status — breakdown', () => {
         expect.objectContaining({
           metric: 'coverage',
           breakdown: {
+            category: 'coverage',
             totalCount: 1,
             fetchedCount: 1,
             entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
@@ -469,6 +534,7 @@ describe('quality-gate status — breakdown', () => {
         expect.objectContaining({
           metric: 'branch_coverage',
           breakdown: {
+            category: 'coverage',
             totalCount: 1,
             fetchedCount: 1,
             entries: [{ path: 'src/cart.ts', value: '40.0', formattedValue: '40.0%' }],
@@ -477,6 +543,7 @@ describe('quality-gate status — breakdown', () => {
         expect.objectContaining({
           metric: 'new_coverage',
           breakdown: {
+            category: 'coverage',
             totalCount: 1,
             fetchedCount: 1,
             entries: [{ path: 'src/pay.ts', value: '55.0', formattedValue: '55.0%' }],
@@ -727,6 +794,7 @@ describe('quality-gate status — breakdown', () => {
       );
       expect(violationsCondition.breakdown).toBeUndefined();
       expect(coverageCondition.breakdown).toEqual({
+        category: 'coverage',
         totalCount: 1,
         fetchedCount: 1,
         entries: [{ path: 'src/checkout.ts', value: '31.0', formattedValue: '31.0%' }],
@@ -844,7 +912,7 @@ describe('quality-gate status — breakdown', () => {
 
       expect(result.exitCode).toBe(2);
       expect(result.stderr).toContain(
-        "Invalid --category option: 'security'. Must be one of: coverage",
+        "Invalid --category option: 'security'. Must be one of: coverage, duplications",
       );
       const statusRequests = server
         .getRecordedRequests()

--- a/tests/unit/core/server/duplications.test.ts
+++ b/tests/unit/core/server/duplications.test.ts
@@ -1,0 +1,287 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { DuplicationsClient } from '@/core/server/duplications.ts';
+import { SonarHttpClient } from '@/core/server/http-client.ts';
+import type { DuplicationsShowResponse } from '@/core/server/types.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SERVER_URL = 'https://sonarqube.example.com';
+const TOKEN = 'squ_test_token';
+
+/** A file with a block duplicated elsewhere in the same file - one entry in `files`. */
+const SELF_DUPLICATION_RESPONSE: DuplicationsShowResponse = {
+  duplications: [
+    {
+      blocks: [
+        { from: 207, size: 15, _ref: '1' },
+        { from: 224, size: 15, _ref: '1' },
+      ],
+    },
+  ],
+  files: {
+    '1': {
+      key: 'my-project:src/core/gitlab/client.ts',
+      name: 'src/core/gitlab/client.ts',
+      uuid: 'AaBYbezoKkZLV8MxeIcw',
+      project: 'my-project',
+      projectUuid: 'AZwuC4xd-j8g-N-Vcf-Z',
+      projectName: 'my-project',
+    },
+  },
+};
+
+/** A block duplicated between two distinct files - one entry per file in `files`. */
+const CROSS_FILE_DUPLICATION_RESPONSE: DuplicationsShowResponse = {
+  duplications: [
+    {
+      blocks: [
+        { from: 1, size: 3820, _ref: '1' },
+        { from: 1, size: 3820, _ref: '2' },
+      ],
+    },
+  ],
+  files: {
+    '1': {
+      key: 'my-project:ecosystem-map.html',
+      name: 'ecosystem-map.html',
+      uuid: 'AZ5LQbgSFcSfan2eOCYp',
+      project: 'my-project',
+      projectUuid: 'AZ5GTAApgb__dlBz5pu2',
+      projectName: 'my-project',
+    },
+    '2': {
+      key: 'my-project:index.html',
+      name: 'index.html',
+      uuid: 'AZ5LQbgSFcSfan2eOCYq',
+      project: 'my-project',
+      projectUuid: 'AZ5GTAApgb__dlBz5pu2',
+      projectName: 'my-project',
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DuplicationsClient', () => {
+  let client: DuplicationsClient;
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    client = new DuplicationsClient(new SonarHttpClient(SERVER_URL, TOKEN));
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it('requests /api/duplications/show with the component key', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(SELF_DUPLICATION_RESPONSE),
+    );
+
+    await client.getDuplicationInfo({ componentKey: 'my-project:src/core/gitlab/client.ts' });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).toContain('/api/duplications/show');
+    expect(url).toContain('key=my-project%3Asrc%2Fcore%2Fgitlab%2Fclient.ts');
+  });
+
+  it("counts each of the file's own occurrences, not the number of duplication groups", async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(SELF_DUPLICATION_RESPONSE),
+    );
+
+    const result = await client.getDuplicationInfo({
+      componentKey: 'my-project:src/core/gitlab/client.ts',
+    });
+
+    // One duplication group, but both of its blocks belong to the queried file itself.
+    expect(result.blockCount).toBe(2);
+  });
+
+  it('reports no peers when every block in every group belongs to the queried file itself', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(SELF_DUPLICATION_RESPONSE),
+    );
+
+    const result = await client.getDuplicationInfo({
+      componentKey: 'my-project:src/core/gitlab/client.ts',
+    });
+
+    expect(result.duplicatesWith).toEqual([]);
+  });
+
+  it('resolves peer file paths from the sibling files map, excluding the queried file itself', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(CROSS_FILE_DUPLICATION_RESPONSE),
+    );
+
+    const result = await client.getDuplicationInfo({
+      componentKey: 'my-project:ecosystem-map.html',
+    });
+
+    expect(result.blockCount).toBe(1);
+    expect(result.duplicatesWith).toEqual(['index.html']);
+  });
+
+  it('resolves peers correctly regardless of which side of the pair is queried', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(CROSS_FILE_DUPLICATION_RESPONSE),
+    );
+
+    const result = await client.getDuplicationInfo({ componentKey: 'my-project:index.html' });
+
+    expect(result.duplicatesWith).toEqual(['ecosystem-map.html']);
+  });
+
+  it('deduplicates a peer that recurs across multiple duplication groups', async () => {
+    const response: DuplicationsShowResponse = {
+      duplications: [
+        {
+          blocks: [
+            { from: 1, size: 10, _ref: '1' },
+            { from: 1, size: 10, _ref: '2' },
+          ],
+        },
+        {
+          blocks: [
+            { from: 20, size: 5, _ref: '1' },
+            { from: 20, size: 5, _ref: '2' },
+          ],
+        },
+      ],
+      files: CROSS_FILE_DUPLICATION_RESPONSE.files,
+    };
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(response));
+
+    const result = await client.getDuplicationInfo({
+      componentKey: 'my-project:ecosystem-map.html',
+    });
+
+    expect(result.blockCount).toBe(2);
+    expect(result.duplicatesWith).toEqual(['index.html']);
+  });
+
+  it('drops only the unresolvable peer instead of throwing when a ref has no entry in files', async () => {
+    const response: DuplicationsShowResponse = {
+      duplications: [
+        {
+          blocks: [
+            { from: 1, size: 10, _ref: '1' },
+            // '2' is not in `files` - a peer that isn't browsable, or since removed.
+            { from: 1, size: 10, _ref: '2' },
+          ],
+        },
+      ],
+      files: { '1': CROSS_FILE_DUPLICATION_RESPONSE.files['1'] },
+    };
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(response));
+
+    const result = await client.getDuplicationInfo({
+      componentKey: 'my-project:ecosystem-map.html',
+    });
+
+    expect(result.blockCount).toBe(1);
+    expect(result.duplicatesWith).toEqual([]);
+  });
+
+  it('skips a block with no ref at all instead of throwing', async () => {
+    const response: DuplicationsShowResponse = {
+      duplications: [
+        {
+          blocks: [
+            { from: 1, size: 10, _ref: '1' },
+            { from: 1, size: 10 },
+          ],
+        },
+      ],
+      files: { '1': CROSS_FILE_DUPLICATION_RESPONSE.files['1'] },
+    };
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(response));
+
+    const result = await client.getDuplicationInfo({
+      componentKey: 'my-project:ecosystem-map.html',
+    });
+
+    expect(result.duplicatesWith).toEqual([]);
+  });
+
+  it('reports zero blocks and no peers when the file has no duplications at all', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ duplications: [], files: {} }),
+    );
+
+    const result = await client.getDuplicationInfo({ componentKey: 'my-project:src/clean.ts' });
+
+    expect(result).toEqual({ blockCount: 0, duplicatesWith: [] });
+  });
+
+  it('omits branch and pull request from the query when not given', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(SELF_DUPLICATION_RESPONSE),
+    );
+
+    await client.getDuplicationInfo({ componentKey: 'my-project:src/core/gitlab/client.ts' });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).not.toContain('branch=');
+    expect(url).not.toContain('pullRequest=');
+  });
+
+  it('forwards branch and pull request when given - a file scoped to a branch or PR 404s otherwise', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse(SELF_DUPLICATION_RESPONSE),
+    );
+
+    await client.getDuplicationInfo({
+      componentKey: 'my-project:src/core/gitlab/client.ts',
+      branch: 'feature-x',
+    });
+    expect((fetchSpy.mock.calls[0][0] as URL).toString()).toContain('branch=feature-x');
+
+    await client.getDuplicationInfo({
+      componentKey: 'my-project:src/core/gitlab/client.ts',
+      pullRequest: '42',
+    });
+    expect((fetchSpy.mock.calls[1][0] as URL).toString()).toContain('pullRequest=42');
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Duplications category enrichment:**
    - Added support for fetching and formatting duplication breakdowns via `DuplicationsClient` and `fetchDuplicationsBreakdown`
    - Filtered out files with non-contributing boundary values such as 0% duplication

<sub>This will update automatically on new commits.</sub>