### PR TITLE
CLI-1014 Add issues, reliability and maintainability category enrichment

### DIFF
--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -308,7 +308,10 @@ function buildCommandTree(runtime: CliRuntime, console: Console): SonarCommand {
       ),
     )
     .addOption(
-      new SonarOption('--top <top>', 'Number of files to include in the breakdown, per condition')
+      new SonarOption(
+        '--top <top>',
+        'Number of entries (files, or issues for the issues category) to include in the breakdown, per condition',
+      )
         .default(QUALITY_GATE_DEFAULT_TOP)
         .argParser(parseInteger),
     )

--- a/src/commands/quality-gate/status/breakdown.ts
+++ b/src/commands/quality-gate/status/breakdown.ts
@@ -22,6 +22,7 @@
 
 import logger from '@/core/observability/logger.ts';
 import type { SonarHttpClient } from '@/core/server/http-client.ts';
+import { IssuesClient } from '@/core/server/issues.ts';
 import { MeasuresClient } from '@/core/server/measures.ts';
 import type { Metric, QualityGateCondition } from '@/core/server/types.ts';
 
@@ -30,6 +31,7 @@ import type {
   QualityGateMetricBreakdown,
 } from './condition-summary.ts';
 import { fetchDuplicationsBreakdown } from './duplications-enrichment.ts';
+import { fetchIssuesBreakdown } from './issues-enrichment.ts';
 import { fetchWorstFileEntries } from './worst-file-entries.ts';
 
 /** Metric keys owned by each `--category` value, both overall and new-code variants. */
@@ -51,6 +53,18 @@ const CATEGORY_METRICS: Record<string, string[]> = {
     'new_duplicated_blocks',
     'new_duplicated_lines',
   ],
+  issues: [
+    'violations',
+    'new_violations',
+    'bugs',
+    'new_bugs',
+    'reliability_rating',
+    'new_reliability_rating',
+    'code_smells',
+    'new_code_smells',
+    'sqale_rating',
+    'new_maintainability_rating',
+  ],
 };
 
 /** Reverse lookup derived from `CATEGORY_METRICS`, for O(1) access by metric key. */
@@ -65,6 +79,7 @@ export const IMPLEMENTED_CATEGORIES = Object.keys(CATEGORY_METRICS);
 export interface AttachBreakdownsParams {
   client: SonarHttpClient;
   projectKey: string;
+  orgKey?: string;
   metrics: Metric[];
   category?: string;
   top: number;
@@ -117,6 +132,7 @@ export async function attachBreakdowns(
   params: AttachBreakdownsParams,
 ): Promise<QualityGateConditionSummary[]> {
   const measuresClient = new MeasuresClient(params.client);
+  const issuesClient = new IssuesClient(params.client);
   const metricsByKey = new Map(params.metrics.map((metric) => [metric.key, metric]));
 
   return Promise.all(
@@ -128,6 +144,7 @@ export async function attachBreakdowns(
       const breakdown = await fetchCategoryBreakdown(
         category,
         measuresClient,
+        issuesClient,
         params,
         condition,
         metricsByKey.get(condition.metric),
@@ -140,6 +157,7 @@ export async function attachBreakdowns(
 function fetchCategoryBreakdown(
   category: string,
   measuresClient: MeasuresClient,
+  issuesClient: IssuesClient,
   params: AttachBreakdownsParams,
   condition: QualityGateConditionSummary,
   metric: Metric | undefined,
@@ -149,6 +167,8 @@ function fetchCategoryBreakdown(
       return fetchMetricBreakdown(measuresClient, params, condition, metric);
     case 'duplications':
       return fetchDuplicationsBreakdown(measuresClient, params, condition, metric);
+    case 'issues':
+      return fetchIssuesBreakdown(issuesClient, params, condition);
     default:
       return Promise.resolve(undefined);
   }

--- a/src/commands/quality-gate/status/breakdown.ts
+++ b/src/commands/quality-gate/status/breakdown.ts
@@ -31,6 +31,7 @@ import type {
   QualityGateMetricBreakdown,
 } from './condition-summary.ts';
 import { fetchDuplicationsBreakdown } from './duplications-enrichment.ts';
+import type { IssuesBreakdownCache } from './issues-enrichment.ts';
 import { fetchIssuesBreakdown } from './issues-enrichment.ts';
 import { fetchWorstFileEntries } from './worst-file-entries.ts';
 
@@ -133,6 +134,7 @@ export async function attachBreakdowns(
 ): Promise<QualityGateConditionSummary[]> {
   const measuresClient = new MeasuresClient(params.client);
   const issuesClient = new IssuesClient(params.client);
+  const issuesCache: IssuesBreakdownCache = new Map();
   const metricsByKey = new Map(params.metrics.map((metric) => [metric.key, metric]));
 
   return Promise.all(
@@ -145,6 +147,7 @@ export async function attachBreakdowns(
         category,
         measuresClient,
         issuesClient,
+        issuesCache,
         params,
         condition,
         metricsByKey.get(condition.metric),
@@ -158,6 +161,7 @@ function fetchCategoryBreakdown(
   category: string,
   measuresClient: MeasuresClient,
   issuesClient: IssuesClient,
+  issuesCache: IssuesBreakdownCache,
   params: AttachBreakdownsParams,
   condition: QualityGateConditionSummary,
   metric: Metric | undefined,
@@ -168,7 +172,7 @@ function fetchCategoryBreakdown(
     case 'duplications':
       return fetchDuplicationsBreakdown(measuresClient, params, condition, metric);
     case 'issues':
-      return fetchIssuesBreakdown(issuesClient, params, condition);
+      return fetchIssuesBreakdown(issuesClient, params, condition, issuesCache);
     default:
       return Promise.resolve(undefined);
   }

--- a/src/commands/quality-gate/status/condition-summary.ts
+++ b/src/commands/quality-gate/status/condition-summary.ts
@@ -51,7 +51,23 @@ export interface DuplicationsMetricBreakdown {
   entries: DuplicationsBreakdownEntry[];
 }
 
-export type QualityGateMetricBreakdown = CoverageMetricBreakdown | DuplicationsMetricBreakdown;
+export interface IssuesBreakdownEntry {
+  file: string;
+  line?: number;
+  key: string;
+  rule: string;
+  message: string;
+}
+
+export interface IssuesMetricBreakdown {
+  category: 'issues';
+  totalCount: number;
+  fetchedCount: number;
+  entries: IssuesBreakdownEntry[];
+}
+
+export type QualityGateMetricBreakdown =
+  CoverageMetricBreakdown | DuplicationsMetricBreakdown | IssuesMetricBreakdown;
 
 export interface QualityGateConditionSummary {
   metric: string;

--- a/src/commands/quality-gate/status/format-table.ts
+++ b/src/commands/quality-gate/status/format-table.ts
@@ -23,7 +23,10 @@ import { cyan, green, red, yellow } from '@/core/ui/colors.ts';
 import { padColumns } from '@/core/ui/formatter/column-formatting.ts';
 
 import type {
+  CoverageMetricBreakdown,
   DuplicationsBreakdownEntry,
+  DuplicationsMetricBreakdown,
+  IssuesBreakdownEntry,
   QualityGateBreakdownEntry,
   QualityGateConditionSummary,
   QualityGateMetricBreakdown,
@@ -140,14 +143,10 @@ function formatBreakdownLines(condition: QualityGateConditionSummary): string[] 
     return [];
   }
 
-  const [values] = padColumns(
-    [metricBreakdown.entries.map((entry) => entry.formattedValue)],
-    [],
-    BREAKDOWN_VALUE_GAP,
-  );
-  const lines = metricBreakdown.entries.map((_entry, i) =>
-    formatEntryLine(metricBreakdown, i, values[i]),
-  );
+  const lines =
+    metricBreakdown.category === 'issues'
+      ? formatIssuesEntryLines(metricBreakdown.entries)
+      : formatValueEntryLines(metricBreakdown);
 
   const remaining = metricBreakdown.totalCount - metricBreakdown.fetchedCount;
   if (remaining > 0) {
@@ -157,8 +156,20 @@ function formatBreakdownLines(condition: QualityGateConditionSummary): string[] 
   return lines;
 }
 
+/** Coverage/duplications entries share a single leading numeric value column. */
+function formatValueEntryLines(
+  metricBreakdown: CoverageMetricBreakdown | DuplicationsMetricBreakdown,
+): string[] {
+  const [values] = padColumns(
+    [metricBreakdown.entries.map((entry) => entry.formattedValue)],
+    [],
+    BREAKDOWN_VALUE_GAP,
+  );
+  return metricBreakdown.entries.map((_entry, i) => formatEntryLine(metricBreakdown, i, values[i]));
+}
+
 function formatEntryLine(
-  metricBreakdown: QualityGateMetricBreakdown,
+  metricBreakdown: CoverageMetricBreakdown | DuplicationsMetricBreakdown,
   index: number,
   paddedValue: string,
 ): string {
@@ -168,6 +179,23 @@ function formatEntryLine(
     case 'duplications':
       return formatDuplicationsEntryLine(metricBreakdown.entries[index], paddedValue);
   }
+}
+
+/** Issues have no single value to lead with - file:line/key/rule are their own aligned columns. */
+function formatIssuesEntryLines(entries: IssuesBreakdownEntry[]): string[] {
+  const [locationColumn, keyColumn, ruleColumn] = padColumns(
+    [
+      entries.map((entry) => `${entry.file}:${entry.line ?? '?'}`),
+      entries.map((entry) => entry.key),
+      entries.map((entry) => entry.rule),
+    ],
+    [],
+    BREAKDOWN_VALUE_GAP,
+  );
+  return entries.map(
+    (entry, i) =>
+      `${BREAKDOWN_INDENT}${locationColumn[i]}${keyColumn[i]}${ruleColumn[i]}${entry.message}`,
+  );
 }
 
 function formatCoverageEntryLine(entry: QualityGateBreakdownEntry, paddedValue: string): string {

--- a/src/commands/quality-gate/status/index.ts
+++ b/src/commands/quality-gate/status/index.ts
@@ -98,6 +98,7 @@ export async function qualityGateStatus(
     ? await attachBreakdowns(summaries, {
         client,
         projectKey,
+        orgKey: auth.orgKey,
         metrics,
         category: options.category,
         top,

--- a/src/commands/quality-gate/status/issues-enrichment.ts
+++ b/src/commands/quality-gate/status/issues-enrichment.ts
@@ -33,7 +33,7 @@ import type {
 } from './condition-summary.ts';
 
 /** Reliability and Maintainability conditions restrict enrichment to their own issue type; generic violations are unfiltered. */
-const ISSUE_TYPE_FILTER: Record<string, string> = {
+const ISSUE_TYPE_FILTER: Partial<Record<string, string>> = {
   bugs: 'BUG',
   new_bugs: 'BUG',
   reliability_rating: 'BUG',
@@ -44,18 +44,48 @@ const ISSUE_TYPE_FILTER: Record<string, string> = {
   new_maintainability_rating: 'CODE_SMELL',
 };
 
-export async function fetchIssuesBreakdown(
+/**
+ * Several condition pairs (`bugs`/`reliability_rating`, `code_smells`/`sqale_rating`, and their
+ * `new_*` equivalents) resolve to byte-identical search params - a gate failing both members of a
+ * pair would otherwise fire the same `/api/issues/search` request twice. Keyed by `types` +
+ * `sinceLeakPeriod` (the only params that vary by condition within one `attachBreakdowns` call)
+ * and shared across the whole call by `attachBreakdowns`.
+ */
+export type IssuesBreakdownCache = Map<string, Promise<QualityGateMetricBreakdown | undefined>>;
+
+export function fetchIssuesBreakdown(
   issuesClient: IssuesClient,
   params: AttachBreakdownsParams,
   condition: QualityGateConditionSummary,
+  cache: IssuesBreakdownCache,
+): Promise<QualityGateMetricBreakdown | undefined> {
+  const types = ISSUE_TYPE_FILTER[condition.metric];
+  const sinceLeakPeriod = isNewCodeMetric(condition.metric);
+  const cacheKey = `${types ?? ''}::${sinceLeakPeriod}`;
+
+  const cached = cache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const promise = searchIssuesBreakdown(issuesClient, params, condition, types, sinceLeakPeriod);
+  cache.set(cacheKey, promise);
+  return promise;
+}
+
+async function searchIssuesBreakdown(
+  issuesClient: IssuesClient,
+  params: AttachBreakdownsParams,
+  condition: QualityGateConditionSummary,
+  types: string | undefined,
+  sinceLeakPeriod: boolean,
 ): Promise<QualityGateMetricBreakdown | undefined> {
   try {
     const searchParams: IssuesSearchParams = {
       projects: params.projectKey,
       organization: params.orgKey,
-      types: ISSUE_TYPE_FILTER[condition.metric],
+      types,
       resolved: false,
-      sinceLeakPeriod: isNewCodeMetric(condition.metric) || undefined,
+      sinceLeakPeriod: sinceLeakPeriod || undefined,
       branch: params.branch,
       pullRequest: params.pullRequest,
       s: 'SEVERITY',
@@ -63,7 +93,7 @@ export async function fetchIssuesBreakdown(
       ps: params.top,
     };
     const { issues, paging } = await issuesClient.searchIssues(searchParams);
-    const entries = issues.map(toIssuesEntry);
+    const entries = issues.map((issue) => toIssuesEntry(issue, params.projectKey));
     if (entries.length === 0) {
       return undefined;
     }
@@ -74,11 +104,14 @@ export async function fetchIssuesBreakdown(
   }
 }
 
-/** `component` is `<projectKey>:<path>` - the project key prefix isn't useful in the breakdown. */
-function toIssuesEntry(issue: SonarQubeIssue): IssuesBreakdownEntry {
-  const separatorIndex = issue.component.indexOf(':');
+/** `component` is `<projectKey>:<path>` - strip the exact project key prefix, since the key
+ * itself may contain colons (e.g. Maven's default `groupId:artifactId`). */
+function toIssuesEntry(issue: SonarQubeIssue, projectKey: string): IssuesBreakdownEntry {
+  const prefix = `${projectKey}:`;
   return {
-    file: separatorIndex === -1 ? issue.component : issue.component.slice(separatorIndex + 1),
+    file: issue.component.startsWith(prefix)
+      ? issue.component.slice(prefix.length)
+      : issue.component,
     line: issue.line,
     key: issue.key,
     rule: issue.rule,

--- a/src/commands/quality-gate/status/issues-enrichment.ts
+++ b/src/commands/quality-gate/status/issues-enrichment.ts
@@ -1,0 +1,87 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Builds the issues-category breakdown (Issues, Reliability and Maintainability domains)
+
+import logger from '@/core/observability/logger.ts';
+import type { IssuesClient } from '@/core/server/issues.ts';
+import { isNewCodeMetric } from '@/core/server/measures.ts';
+import type { IssuesSearchParams, SonarQubeIssue } from '@/core/server/types.ts';
+
+import type { AttachBreakdownsParams } from './breakdown.ts';
+import type {
+  IssuesBreakdownEntry,
+  QualityGateConditionSummary,
+  QualityGateMetricBreakdown,
+} from './condition-summary.ts';
+
+/** Reliability and Maintainability conditions restrict enrichment to their own issue type; generic violations are unfiltered. */
+const ISSUE_TYPE_FILTER: Record<string, string> = {
+  bugs: 'BUG',
+  new_bugs: 'BUG',
+  reliability_rating: 'BUG',
+  new_reliability_rating: 'BUG',
+  code_smells: 'CODE_SMELL',
+  new_code_smells: 'CODE_SMELL',
+  sqale_rating: 'CODE_SMELL',
+  new_maintainability_rating: 'CODE_SMELL',
+};
+
+export async function fetchIssuesBreakdown(
+  issuesClient: IssuesClient,
+  params: AttachBreakdownsParams,
+  condition: QualityGateConditionSummary,
+): Promise<QualityGateMetricBreakdown | undefined> {
+  try {
+    const searchParams: IssuesSearchParams = {
+      projects: params.projectKey,
+      organization: params.orgKey,
+      types: ISSUE_TYPE_FILTER[condition.metric],
+      resolved: false,
+      sinceLeakPeriod: isNewCodeMetric(condition.metric) || undefined,
+      branch: params.branch,
+      pullRequest: params.pullRequest,
+      s: 'SEVERITY',
+      asc: false,
+      ps: params.top,
+    };
+    const { issues, paging } = await issuesClient.searchIssues(searchParams);
+    const entries = issues.map(toIssuesEntry);
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return { category: 'issues', totalCount: paging.total, fetchedCount: issues.length, entries };
+  } catch (err) {
+    logger.debug(`Failed to build quality gate breakdown for '${condition.metric}'`, err);
+    return undefined;
+  }
+}
+
+/** `component` is `<projectKey>:<path>` - the project key prefix isn't useful in the breakdown. */
+function toIssuesEntry(issue: SonarQubeIssue): IssuesBreakdownEntry {
+  const separatorIndex = issue.component.indexOf(':');
+  return {
+    file: separatorIndex === -1 ? issue.component : issue.component.slice(separatorIndex + 1),
+    line: issue.line,
+    key: issue.key,
+    rule: issue.rule,
+    message: issue.message,
+  };
+}

--- a/src/core/server/issues.ts
+++ b/src/core/server/issues.ts
@@ -40,8 +40,8 @@ export class IssuesClient {
       if (key === 'projects' && value) {
         const projectParamKey = this.client.isCloud ? 'projects' : 'components';
         queryParams[projectParamKey] = value as string;
-      } else if (key === 'resolved' && value !== undefined) {
-        queryParams.resolved = value as boolean;
+      } else if ((key === 'resolved' || key === 'asc') && value !== undefined) {
+        queryParams[key] = value as boolean;
       } else if (value) {
         queryParams[key] = value as string | number | boolean;
       }

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -70,7 +70,9 @@ export interface IssuesSearchParams {
   pullRequest?: string;
   resolved?: boolean;
   fixableByAgent?: boolean;
+  sinceLeakPeriod?: boolean;
   s?: string;
+  asc?: boolean;
   ps?: number;
   p?: number;
 }

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -34,6 +34,9 @@ import type { RecordedRequest } from './types.js';
 
 const HTTP_BAD_REQUEST = 400;
 
+/** Statuses `resolved=true` matches; `resolved=false` matches everything else. */
+const RESOLVED_ISSUE_STATUSES = new Set(['FALSE_POSITIVE', 'ACCEPTED', 'FIXED']);
+
 export interface IssueConfig {
   key?: string;
   ruleKey: string;
@@ -44,6 +47,8 @@ export interface IssueConfig {
   type?: string;
   line?: number;
   fixableByAgent?: boolean;
+  /** Marks the issue as introduced in the leak period, matched by `sinceLeakPeriod=true`. */
+  isNewCode?: boolean;
 }
 
 export interface SqaaIssueConfig {
@@ -99,6 +104,8 @@ interface ProjectData {
   pullRequestsErrorStatus?: number;
   duplicationsByFile: Map<string, DuplicationsShowConfig>;
   duplicationsErrorsByFile: Map<string, DuplicationsShowErrorConfig>;
+  issuesSearchStatusCode?: number;
+  issuesSearchStatusBody?: string;
 }
 
 export interface DopRepositoryConfig {
@@ -127,6 +134,8 @@ export class ProjectBuilder {
   private pullRequestsErrorStatus?: number;
   private readonly duplicationsByFile: Map<string, DuplicationsShowConfig> = new Map();
   private readonly duplicationsErrorsByFile: Map<string, DuplicationsShowErrorConfig> = new Map();
+  private issuesSearchStatusCode?: number;
+  private issuesSearchStatusBody?: string;
 
   constructor(projectKey: string) {
     this.projectKey = projectKey;
@@ -143,6 +152,7 @@ export class ProjectBuilder {
       type: issue.type ?? 'CODE_SMELL',
       line: issue.line ?? 1,
       fixableByAgent: issue.fixableByAgent ?? false,
+      isNewCode: issue.isNewCode ?? false,
     });
     return this;
   }
@@ -260,6 +270,17 @@ export class ProjectBuilder {
     return this;
   }
 
+  /**
+   * Force `GET /api/issues/search` to fail with the given HTTP status code for this project,
+   * simulating an issues-category breakdown enrichment failure independent of the primary
+   * verdict call.
+   */
+  withIssuesSearchError(statusCode: number, body?: string): this {
+    this.issuesSearchStatusCode = statusCode;
+    this.issuesSearchStatusBody = body;
+    return this;
+  }
+
   getData(): ProjectData {
     return {
       key: this.projectKey,
@@ -278,6 +299,8 @@ export class ProjectBuilder {
       pullRequestsErrorStatus: this.pullRequestsErrorStatus,
       duplicationsByFile: this.duplicationsByFile,
       duplicationsErrorsByFile: this.duplicationsErrorsByFile,
+      issuesSearchStatusCode: this.issuesSearchStatusCode,
+      issuesSearchStatusBody: this.issuesSearchStatusBody,
     };
   }
 }
@@ -865,8 +888,17 @@ export class FakeSonarQubeServerBuilder {
           const projectKey = query.components ?? query.projects;
           const projectData = projectKey ? projects.get(projectKey) : undefined;
 
+          if (projectData?.issuesSearchStatusCode !== undefined) {
+            return new Response(projectData.issuesSearchStatusBody ?? '', {
+              status: projectData.issuesSearchStatusCode,
+            });
+          }
+
           const issueStatusFilter = query.issueStatuses ? query.issueStatuses.split(',') : null;
           const severityFilter = query.severities ? query.severities.split(',') : null;
+          const typeFilter = query.types ? query.types.split(',') : null;
+          const resolvedFilter = query.resolved;
+          const sinceLeakPeriodFilter = query.sinceLeakPeriod === 'true';
 
           const fixableByAgentFilter = query.fixableByAgent;
 
@@ -874,6 +906,13 @@ export class FakeSonarQubeServerBuilder {
             projectData?.issues
               .filter((issue) => !issueStatusFilter || issueStatusFilter.includes(issue.status))
               .filter((issue) => !severityFilter || severityFilter.includes(issue.severity))
+              .filter((issue) => !typeFilter || typeFilter.includes(issue.type))
+              .filter(
+                (issue) =>
+                  resolvedFilter === undefined ||
+                  (resolvedFilter === 'false') !== RESOLVED_ISSUE_STATUSES.has(issue.status),
+              )
+              .filter((issue) => !sinceLeakPeriodFilter || issue.isNewCode)
               .filter((issue) => fixableByAgentFilter !== 'true' || issue.fixableByAgent)
               .map((issue) => ({
                 key: issue.key,

--- a/tests/integration/specs/quality-gate/status-breakdown-issues.test.ts
+++ b/tests/integration/specs/quality-gate/status-breakdown-issues.test.ts
@@ -252,6 +252,91 @@ describe('quality-gate status — issues breakdown', () => {
   );
 
   it(
+    'strips the project key prefix from `component` even when the key itself contains colons (Maven-style)',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('com.example:my-app', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'violations', comparator: 'GT', errorThreshold: '0' },
+            ])
+            .withIssue({
+              key: 'ISSUE-1',
+              ruleKey: 'java:S1234',
+              message: 'Fix this bug',
+              component: 'com.example:my-app:src/main/java/Foo.java',
+              line: 10,
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project com.example:my-app --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'violations',
+      );
+      expect(condition.breakdown.entries[0].file).toBe('src/main/java/Foo.java');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'fetches issues once and reuses the result for both members of a redundant metric pair (bugs and reliability_rating)',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'bugs', comparator: 'GT', errorThreshold: '0' },
+              {
+                status: 'ERROR',
+                metricKey: 'reliability_rating',
+                comparator: 'GT',
+                errorThreshold: '1',
+                actualValue: '3',
+              },
+            ])
+            .withIssue({
+              key: 'BUG-1',
+              ruleKey: 'java:S2189',
+              message: 'Blocker bug',
+              component: 'my-project:src/worker.ts',
+              type: 'BUG',
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const bugsCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'bugs',
+      );
+      const reliabilityCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'reliability_rating',
+      );
+      expect(bugsCondition.breakdown.entries).toHaveLength(1);
+      expect(reliabilityCondition.breakdown.entries).toHaveLength(1);
+
+      const recorded = server.getRecordedRequests();
+      const issuesRequests = recorded.filter((r) => r.path === '/api/issues/search');
+      expect(issuesRequests).toHaveLength(1);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
     'requests types=CODE_SMELL for a failing code_smells condition',
     async () => {
       const server = await harness

--- a/tests/integration/specs/quality-gate/status-breakdown-issues.test.ts
+++ b/tests/integration/specs/quality-gate/status-breakdown-issues.test.ts
@@ -1,0 +1,506 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integration tests for the issues category breakdown (Issues, Reliability and Maintainability
+// domains, all folded into `--category issues`) in `quality-gate status`
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { TestHarness } from '../../harness';
+
+describe('quality-gate status — issues breakdown', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'includes an issues breakdown in JSON for a failing overall violations condition, unfiltered by type',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'violations', comparator: 'GT', errorThreshold: '0' },
+            ])
+            .withIssue({
+              key: 'ISSUE-1',
+              ruleKey: 'java:S1234',
+              message: 'Fix this bug',
+              component: 'my-project:src/checkout.ts',
+              line: 12,
+              type: 'BUG',
+            })
+            .withIssue({
+              key: 'ISSUE-2',
+              ruleKey: 'java:S5678',
+              message: 'Simplify this',
+              component: 'my-project:src/cart.ts',
+              line: 3,
+              type: 'CODE_SMELL',
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'violations',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'issues',
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          {
+            file: 'src/checkout.ts',
+            line: 12,
+            key: 'ISSUE-1',
+            rule: 'java:S1234',
+            message: 'Fix this bug',
+          },
+          {
+            file: 'src/cart.ts',
+            line: 3,
+            key: 'ISSUE-2',
+            rule: 'java:S5678',
+            message: 'Simplify this',
+          },
+        ],
+      });
+
+      const recorded = server.getRecordedRequests();
+      const req = recorded.find((r) => r.path === '/api/issues/search');
+      expect(req?.query.types).toBeUndefined();
+      expect(req?.query.resolved).toBe('false');
+      expect(req?.query.sinceLeakPeriod).toBeUndefined();
+      expect(req?.query.s).toBe('SEVERITY');
+      expect(req?.query.asc).toBe('false');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'adds sinceLeakPeriod=true for a failing new_violations condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_violations',
+                comparator: 'GT',
+                errorThreshold: '0',
+              },
+            ])
+            .withIssue({
+              key: 'ISSUE-1',
+              ruleKey: 'java:S1234',
+              message: 'New issue',
+              component: 'my-project:src/checkout.ts',
+              isNewCode: true,
+            })
+            .withIssue({
+              key: 'ISSUE-2',
+              ruleKey: 'java:S5678',
+              message: 'Old issue',
+              component: 'my-project:src/cart.ts',
+              isNewCode: false,
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_violations',
+      );
+      expect(condition.breakdown.entries).toHaveLength(1);
+      expect(condition.breakdown.entries[0].key).toBe('ISSUE-1');
+
+      const recorded = server.getRecordedRequests();
+      const req = recorded.find((r) => r.path === '/api/issues/search');
+      expect(req?.query.sinceLeakPeriod).toBe('true');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'requests types=BUG for a failing bugs condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'bugs', comparator: 'GT', errorThreshold: '0' },
+            ])
+            .withIssue({
+              key: 'BUG-1',
+              ruleKey: 'java:S2189',
+              message: 'Reliability issue',
+              component: 'my-project:src/worker.ts',
+              type: 'BUG',
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'bugs',
+      );
+      expect(condition.breakdown.entries).toEqual([
+        {
+          file: 'src/worker.ts',
+          line: 1,
+          key: 'BUG-1',
+          rule: 'java:S2189',
+          message: 'Reliability issue',
+        },
+      ]);
+
+      const recorded = server.getRecordedRequests();
+      const req = recorded.find((r) => r.path === '/api/issues/search');
+      expect(req?.query.types).toBe('BUG');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'requests types=BUG and returns the driving issue for a failing reliability_rating condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'reliability_rating',
+                comparator: 'GT',
+                errorThreshold: '1',
+                actualValue: '3',
+              },
+            ])
+            .withIssue({
+              key: 'BUG-1',
+              ruleKey: 'java:S2189',
+              message: 'Blocker bug driving the rating',
+              component: 'my-project:src/worker.ts',
+              severity: 'BLOCKER',
+              type: 'BUG',
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'reliability_rating',
+      );
+      expect(condition.breakdown.entries).toHaveLength(1);
+      expect(condition.breakdown.entries[0].key).toBe('BUG-1');
+
+      const recorded = server.getRecordedRequests();
+      const req = recorded.find((r) => r.path === '/api/issues/search');
+      expect(req?.query.types).toBe('BUG');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'requests types=CODE_SMELL for a failing code_smells condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'code_smells', comparator: 'GT', errorThreshold: '0' },
+            ])
+            .withIssue({
+              key: 'SMELL-1',
+              ruleKey: 'java:S100',
+              message: 'Rename this',
+              component: 'my-project:src/naming.ts',
+              type: 'CODE_SMELL',
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      await harness.run(`quality-gate status --project my-project --format json`);
+
+      const recorded = server.getRecordedRequests();
+      const req = recorded.find((r) => r.path === '/api/issues/search');
+      expect(req?.query.types).toBe('CODE_SMELL');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'requests types=CODE_SMELL for overall sqale_rating and its new-code equivalent new_maintainability_rating',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sqale_rating',
+                comparator: 'GT',
+                errorThreshold: '1',
+                actualValue: '3',
+              },
+              {
+                status: 'ERROR',
+                metricKey: 'new_maintainability_rating',
+                comparator: 'GT',
+                errorThreshold: '1',
+                actualValue: '2',
+              },
+            ])
+            .withIssue({
+              key: 'SMELL-1',
+              ruleKey: 'java:S100',
+              message: 'Rename this',
+              component: 'my-project:src/naming.ts',
+              type: 'CODE_SMELL',
+              isNewCode: true,
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const sqaleCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'sqale_rating',
+      );
+      const newRatingCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_maintainability_rating',
+      );
+      expect(sqaleCondition.breakdown.category).toBe('issues');
+      expect(newRatingCondition.breakdown.category).toBe('issues');
+
+      const recorded = server.getRecordedRequests();
+      const requests = recorded.filter((r) => r.path === '/api/issues/search');
+      expect(requests.every((r) => r.query.types === 'CODE_SMELL')).toBe(true);
+      expect(requests.some((r) => r.query.sinceLeakPeriod === 'true')).toBe(true);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'renders the issues breakdown in the table as flat file:line/key/rule/message rows',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'violations', comparator: 'GT', errorThreshold: '0' },
+            ])
+            .withIssue({
+              key: 'ISSUE-1',
+              ruleKey: 'java:S1234',
+              message: 'Fix this bug',
+              component: 'my-project:src/checkout.ts',
+              line: 12,
+            })
+            .withIssue({
+              key: 'ISSUE-2',
+              ruleKey: 'java:S5678',
+              message: 'Simplify this expression',
+              component: 'my-project:src/a-very-long-file-name-that-should-not-collide.ts',
+              line: 3,
+            }),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const firstLine = lines.find((l) => l.includes('ISSUE-1'));
+      const secondLine = lines.find((l) => l.includes('ISSUE-2'));
+      expect(firstLine).toContain('src/checkout.ts:12');
+      expect(firstLine).toContain('java:S1234');
+      expect(firstLine).toContain('Fix this bug');
+      expect(secondLine).toContain('src/a-very-long-file-name-that-should-not-collide.ts:3');
+      expect(secondLine).toContain('java:S5678');
+      expect(secondLine).toContain('Simplify this expression');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'restricts enrichment to the issues category when --category issues is given, alongside a failing coverage condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'violations', comparator: 'GT', errorThreshold: '0' },
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '62.4',
+              },
+            ])
+            .withIssue({
+              key: 'ISSUE-1',
+              ruleKey: 'java:S1234',
+              message: 'Fix this bug',
+              component: 'my-project:src/checkout.ts',
+            })
+            .withComponentTreeFiles('new_coverage', [{ path: 'src/checkout.ts', value: '31.0' }]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category issues --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      const violationsCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'violations',
+      );
+      const coverageCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      expect(violationsCondition.breakdown.category).toBe('issues');
+      expect(coverageCondition.breakdown).toBeUndefined();
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'passes --top through as ps and reports the total issue count separately from the truncated worst-N entries',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) => {
+          p.withProjectStatus('ERROR').withConditions([
+            { status: 'ERROR', metricKey: 'violations', comparator: 'GT', errorThreshold: '0' },
+          ]);
+          for (let i = 1; i <= 3; i++) {
+            p.withIssue({
+              key: `ISSUE-${i}`,
+              ruleKey: 'java:S1234',
+              message: `Issue ${i}`,
+              component: `my-project:src/file${i}.ts`,
+            });
+          }
+          return p;
+        })
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --top 2 --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'violations',
+      );
+      expect(condition.breakdown.totalCount).toBe(3);
+      expect(condition.breakdown.fetchedCount).toBe(2);
+      expect(condition.breakdown.entries).toHaveLength(2);
+
+      const recorded = server.getRecordedRequests();
+      const req = recorded.find((r) => r.path === '/api/issues/search');
+      expect(req?.query.ps).toBe('2');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'still reports the real verdict and exit code when the issues search itself fails',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              { status: 'ERROR', metricKey: 'violations', comparator: 'GT', errorThreshold: '0' },
+            ])
+            .withIssuesSearchError(500, 'Internal error'),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'violations',
+      );
+      expect(condition.breakdown).toBeUndefined();
+    },
+    { timeout: 15000 },
+  );
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Quality gate issues enrichment:**
    - Added `fetchIssuesBreakdown` to query issues from `IssuesClient` and format entries by file, line, key, rule, and message.
    - Configured `ISSUE_TYPE_FILTER` to map metrics like `bugs`, `code_smells`, and ratings to their respective issue types.
- **CLI and test updates:**
    - Registered the `issues` category in `breakdown.ts` and updated table formatting rules for issues.
    - Added integration tests covering quality gate issues breakdown functionality.

<sub>This will update automatically on new commits.</sub>