### PR TITLE
CLI-1061 Add dependency-risks category enrichment

### DIFF
--- a/src/commands/command-tree.ts
+++ b/src/commands/command-tree.ts
@@ -314,10 +314,7 @@ function buildCommandTree(runtime: CliRuntime, console: Console): SonarCommand {
       ),
     )
     .addOption(
-      new SonarOption(
-        '--top <top>',
-        'Number of entries (files, or issues for the issues category) to include in the breakdown, per condition',
-      )
+      new SonarOption('--top <top>', 'Number of entries to include in the breakdown, per condition')
         .default(QUALITY_GATE_DEFAULT_TOP)
         .argParser(parseInteger),
     )

--- a/src/commands/quality-gate/status/breakdown.ts
+++ b/src/commands/quality-gate/status/breakdown.ts
@@ -30,10 +30,27 @@ import type {
   QualityGateConditionSummary,
   QualityGateMetricBreakdown,
 } from './condition-summary.ts';
+import { fetchDependencyRisksBreakdown } from './dependency-risks-enrichment.ts';
 import { fetchDuplicationsBreakdown } from './duplications-enrichment.ts';
 import type { IssuesBreakdownCache } from './issues-enrichment.ts';
 import { fetchIssuesBreakdown } from './issues-enrichment.ts';
 import { fetchWorstFileEntries } from './worst-file-entries.ts';
+
+const DEPENDENCY_RISK_KINDS = [
+  'any_issue',
+  'any_security',
+  'licensing',
+  'malware',
+  'vulnerability',
+];
+const DEPENDENCY_RISK_METRICS = DEPENDENCY_RISK_KINDS.flatMap((kind) => [
+  `sca_count_${kind}`,
+  `sca_rating_${kind}`,
+  `sca_severity_${kind}`,
+  `new_sca_count_${kind}`,
+  `new_sca_rating_${kind}`,
+  `new_sca_severity_${kind}`,
+]);
 
 /** Metric keys owned by each `--category` value, both overall and new-code variants. */
 const CATEGORY_METRICS: Record<string, string[]> = {
@@ -66,6 +83,7 @@ const CATEGORY_METRICS: Record<string, string[]> = {
     'sqale_rating',
     'new_maintainability_rating',
   ],
+  'dependency-risks': DEPENDENCY_RISK_METRICS,
 };
 
 /** Reverse lookup derived from `CATEGORY_METRICS`, for O(1) access by metric key. */
@@ -173,6 +191,8 @@ function fetchCategoryBreakdown(
       return fetchDuplicationsBreakdown(measuresClient, params, condition, metric);
     case 'issues':
       return fetchIssuesBreakdown(issuesClient, params, condition, issuesCache);
+    case 'dependency-risks':
+      return fetchDependencyRisksBreakdown(params, condition);
     default:
       return Promise.resolve(undefined);
   }

--- a/src/commands/quality-gate/status/condition-summary.ts
+++ b/src/commands/quality-gate/status/condition-summary.ts
@@ -22,6 +22,10 @@
 // metadata (human-readable name, type, and type-aware formatted values) looked up from the
 // server's metric catalog.
 
+import type {
+  ScaIssueType,
+  Severity,
+} from '@/commands/analyze/dependency-risk-helpers/sca-scanner.ts';
 import type { Metric, QualityGateCondition } from '@/core/server/types.ts';
 
 import { formatMetricValue } from './format-metric-value.ts';
@@ -35,6 +39,15 @@ export interface QualityGateBreakdownEntry {
 export interface DuplicationsBreakdownEntry extends QualityGateBreakdownEntry {
   blockCount?: number;
   duplicatesWith?: string[];
+}
+
+export interface DependencyRiskBreakdownEntry {
+  package: string;
+  version: string;
+  severity: Severity;
+  type: ScaIssueType;
+  key: string;
+  vulnerabilityId?: string;
 }
 
 export interface CoverageMetricBreakdown {
@@ -66,8 +79,18 @@ export interface IssuesMetricBreakdown {
   entries: IssuesBreakdownEntry[];
 }
 
+export interface DependencyRisksMetricBreakdown {
+  category: 'dependency-risks';
+  totalCount: number;
+  fetchedCount: number;
+  entries: DependencyRiskBreakdownEntry[];
+}
+
 export type QualityGateMetricBreakdown =
-  CoverageMetricBreakdown | DuplicationsMetricBreakdown | IssuesMetricBreakdown;
+  | CoverageMetricBreakdown
+  | DuplicationsMetricBreakdown
+  | IssuesMetricBreakdown
+  | DependencyRisksMetricBreakdown;
 
 export interface QualityGateConditionSummary {
   metric: string;

--- a/src/commands/quality-gate/status/dependency-risks-enrichment.ts
+++ b/src/commands/quality-gate/status/dependency-risks-enrichment.ts
@@ -1,0 +1,106 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import type {
+  ScaIssueType,
+  Severity,
+} from '@/commands/analyze/dependency-risk-helpers/sca-scanner.ts';
+import { ISSUE_TYPES } from '@/commands/analyze/dependency-risk-helpers/view-model/build/issue-types.ts';
+import { SEVERITIES } from '@/commands/analyze/dependency-risk-helpers/view-model/build/severity.ts';
+import logger from '@/core/observability/logger.ts';
+import { isNewCodeMetric } from '@/core/server/measures.ts';
+import { ScaClient } from '@/core/server/sca.ts';
+import type { ScaIssueRelease } from '@/core/server/types.ts';
+
+import type { AttachBreakdownsParams } from './breakdown.ts';
+import type {
+  DependencyRiskBreakdownEntry,
+  QualityGateConditionSummary,
+  QualityGateMetricBreakdown,
+} from './condition-summary.ts';
+
+const RISK_TYPES_BY_METRIC_SUFFIX: Record<string, ScaIssueType[]> = {
+  any_issue: ['MALWARE', 'PROHIBITED_LICENSE', 'VULNERABILITY'],
+  any_security: ['MALWARE', 'VULNERABILITY'],
+  licensing: ['PROHIBITED_LICENSE'],
+  malware: ['MALWARE'],
+  vulnerability: ['VULNERABILITY'],
+};
+
+function resolveRiskTypes(metricKey: string): ScaIssueType[] | undefined {
+  const suffix = metricKey.replace(/^new_/, '').replace(/^sca_(?:count|rating|severity)_/, '');
+  return RISK_TYPES_BY_METRIC_SUFFIX[suffix];
+}
+
+export async function fetchDependencyRisksBreakdown(
+  params: AttachBreakdownsParams,
+  condition: QualityGateConditionSummary,
+): Promise<QualityGateMetricBreakdown | undefined> {
+  const types = resolveRiskTypes(condition.metric);
+  if (!types) {
+    return undefined;
+  }
+  try {
+    const scaClient = new ScaClient(params.client);
+    const { issuesReleases, totalCount } = await scaClient.getWorstIssuesReleases({
+      projectKey: params.projectKey,
+      types,
+      newlyIntroduced: isNewCodeMetric(condition.metric),
+      top: params.top,
+      branch: params.branch,
+      pullRequest: params.pullRequest,
+      orgKey: params.orgKey,
+    });
+    const entries = issuesReleases
+      .map(toBreakdownEntry)
+      .filter((entry): entry is DependencyRiskBreakdownEntry => entry !== undefined);
+    if (entries.length === 0) {
+      return undefined;
+    }
+    return {
+      category: 'dependency-risks',
+      totalCount,
+      fetchedCount: entries.length,
+      entries,
+    };
+  } catch (err) {
+    logger.debug(`Failed to build quality gate breakdown for '${condition.metric}'`, err);
+    return undefined;
+  }
+}
+
+function toBreakdownEntry(issueRelease: ScaIssueRelease): DependencyRiskBreakdownEntry | undefined {
+  const severity = issueRelease.severity as Severity;
+  const type = issueRelease.type as ScaIssueType;
+  if (!SEVERITIES.includes(severity) || !ISSUE_TYPES.includes(type)) {
+    logger.debug(
+      `Skipping dependency risk '${issueRelease.key}' with unrecognized severity '${issueRelease.severity}' or type '${issueRelease.type}'`,
+    );
+    return undefined;
+  }
+  return {
+    package: issueRelease.release.packageName,
+    version: issueRelease.release.version,
+    severity,
+    type,
+    key: issueRelease.key,
+    vulnerabilityId: issueRelease.vulnerabilityId ?? undefined,
+  };
+}

--- a/src/commands/quality-gate/status/format-table.ts
+++ b/src/commands/quality-gate/status/format-table.ts
@@ -23,9 +23,8 @@ import { cyan, green, red, yellow } from '@/core/ui/colors.ts';
 import { padColumns } from '@/core/ui/formatter/column-formatting.ts';
 
 import type {
-  CoverageMetricBreakdown,
+  DependencyRiskBreakdownEntry,
   DuplicationsBreakdownEntry,
-  DuplicationsMetricBreakdown,
   IssuesBreakdownEntry,
   QualityGateBreakdownEntry,
   QualityGateConditionSummary,
@@ -143,10 +142,7 @@ function formatBreakdownLines(condition: QualityGateConditionSummary): string[] 
     return [];
   }
 
-  const lines =
-    metricBreakdown.category === 'issues'
-      ? formatIssuesEntryLines(metricBreakdown.entries)
-      : formatValueEntryLines(metricBreakdown);
+  const lines = formatEntryLines(metricBreakdown);
 
   const remaining = metricBreakdown.totalCount - metricBreakdown.fetchedCount;
   if (remaining > 0) {
@@ -156,28 +152,16 @@ function formatBreakdownLines(condition: QualityGateConditionSummary): string[] 
   return lines;
 }
 
-/** Coverage/duplications entries share a single leading numeric value column. */
-function formatValueEntryLines(
-  metricBreakdown: CoverageMetricBreakdown | DuplicationsMetricBreakdown,
-): string[] {
-  const [values] = padColumns(
-    [metricBreakdown.entries.map((entry) => entry.formattedValue)],
-    [],
-    BREAKDOWN_VALUE_GAP,
-  );
-  return metricBreakdown.entries.map((_entry, i) => formatEntryLine(metricBreakdown, i, values[i]));
-}
-
-function formatEntryLine(
-  metricBreakdown: CoverageMetricBreakdown | DuplicationsMetricBreakdown,
-  index: number,
-  paddedValue: string,
-): string {
+function formatEntryLines(metricBreakdown: QualityGateMetricBreakdown): string[] {
   switch (metricBreakdown.category) {
     case 'coverage':
-      return formatCoverageEntryLine(metricBreakdown.entries[index], paddedValue);
+      return formatFileEntryLines(metricBreakdown.entries, (entry) => entry.path);
     case 'duplications':
-      return formatDuplicationsEntryLine(metricBreakdown.entries[index], paddedValue);
+      return formatFileEntryLines(metricBreakdown.entries, formatDuplicationsSuffix);
+    case 'issues':
+      return formatIssuesEntryLines(metricBreakdown.entries);
+    case 'dependency-risks':
+      return formatDependencyRiskEntryLines(metricBreakdown.entries);
   }
 }
 
@@ -198,20 +182,40 @@ function formatIssuesEntryLines(entries: IssuesBreakdownEntry[]): string[] {
   );
 }
 
-function formatCoverageEntryLine(entry: QualityGateBreakdownEntry, paddedValue: string): string {
-  return `${BREAKDOWN_INDENT}${paddedValue}${entry.path}`;
+function formatFileEntryLines<T extends QualityGateBreakdownEntry>(
+  entries: T[],
+  renderSuffix: (entry: T) => string,
+): string[] {
+  const [values] = padColumns(
+    [entries.map((entry) => entry.formattedValue)],
+    [],
+    BREAKDOWN_VALUE_GAP,
+  );
+  return entries.map((entry, i) => `${BREAKDOWN_INDENT}${values[i]}${renderSuffix(entry)}`);
 }
 
-function formatDuplicationsEntryLine(
-  entry: DuplicationsBreakdownEntry,
-  paddedValue: string,
-): string {
+function formatDuplicationsSuffix(entry: DuplicationsBreakdownEntry): string {
   if (entry.blockCount === undefined) {
-    return `${BREAKDOWN_INDENT}${paddedValue}${entry.path}`;
+    return entry.path;
   }
   const blocks = `${entry.blockCount} block${entry.blockCount === 1 ? '' : 's'}`;
   const peers = entry.duplicatesWith?.length ? `, dup: ${entry.duplicatesWith.join(', ')}` : '';
-  return `${BREAKDOWN_INDENT}${paddedValue}${entry.path} (${blocks}${peers})`;
+  return `${entry.path} (${blocks}${peers})`;
+}
+
+function formatDependencyRiskEntryLines(entries: DependencyRiskBreakdownEntry[]): string[] {
+  const [identifiers, severities, types] = padColumns(
+    [
+      entries.map((entry) => `${entry.package}@${entry.version}`),
+      entries.map((entry) => entry.severity),
+      entries.map((entry) => entry.type),
+    ],
+    [],
+    BREAKDOWN_VALUE_GAP,
+  );
+  return entries.map((entry, i) =>
+    `${BREAKDOWN_INDENT}${identifiers[i]}${severities[i]}${types[i]}${entry.vulnerabilityId ?? ''}`.trimEnd(),
+  );
 }
 
 function formatMoreEntriesLine(

--- a/src/core/server/sca.ts
+++ b/src/core/server/sca.ts
@@ -20,9 +20,25 @@
 
 // Sonar Advanced Security (SCA) feature-enablement API wrapper.
 
-import type { SonarHttpClient } from './http-client.ts';
+import type { QueryParams, SonarHttpClient } from './http-client.ts';
+import type { ScaIssueRelease, ScaIssuesReleasesResponse } from './types.ts';
 
 export type ScaEnablement = 'enabled' | 'not_enabled' | 'check_failed';
+
+export interface GetWorstIssuesReleasesParams {
+  projectKey: string;
+  types: string[];
+  newlyIntroduced?: boolean;
+  top: number;
+  branch?: string;
+  pullRequest?: string;
+  orgKey?: string;
+}
+
+export interface GetWorstIssuesReleasesResult {
+  issuesReleases: ScaIssueRelease[];
+  totalCount: number;
+}
 
 export class ScaClient {
   private readonly client: SonarHttpClient;
@@ -64,5 +80,36 @@ export class ScaClient {
    */
   async checkScaEnabled(connectionType: 'cloud' | 'on-premise', orgKey?: string): Promise<boolean> {
     return (await this.getScaEnablement(connectionType, orgKey)) === 'enabled';
+  }
+
+  async getWorstIssuesReleases(
+    params: GetWorstIssuesReleasesParams,
+  ): Promise<GetWorstIssuesReleasesResult> {
+    const endpoint = this.client.isCloud ? '/sca/issues-releases' : '/api/v2/sca/issues-releases';
+    const queryParams: QueryParams = {
+      projectKey: params.projectKey,
+      types: params.types.join(','),
+      statuses: 'OPEN,CONFIRM',
+      sort: '-severity',
+      pageSize: params.top,
+    };
+    if (this.client.isCloud && params.orgKey) {
+      queryParams.organization = params.orgKey;
+    }
+    if (params.newlyIntroduced) {
+      queryParams.newlyIntroduced = true;
+    }
+    if (params.branch) {
+      queryParams.branchKey = params.branch;
+    }
+    if (params.pullRequest) {
+      queryParams.pullRequestKey = params.pullRequest;
+    }
+    const response = await this.client.get<ScaIssuesReleasesResponse>(
+      endpoint,
+      queryParams,
+      this.client.apiHostFor(endpoint),
+    );
+    return { issuesReleases: response.issuesReleases, totalCount: response.page.total };
   }
 }

--- a/src/core/server/types.ts
+++ b/src/core/server/types.ts
@@ -234,3 +234,21 @@ export interface DuplicationsShowResponse {
   /** Keyed by block `_ref` - a ref for a peer that isn't browsable or was since removed has no entry. */
   files: Record<string, DuplicationsShowFile | undefined>;
 }
+
+export interface ScaIssueReleaseInfo {
+  packageName: string;
+  version: string;
+}
+
+export interface ScaIssueRelease {
+  key: string;
+  severity: string;
+  type: string;
+  vulnerabilityId: string | null;
+  release: ScaIssueReleaseInfo;
+}
+
+export interface ScaIssuesReleasesResponse {
+  issuesReleases: ScaIssueRelease[];
+  page: { pageIndex: number; pageSize: number; total: number };
+}

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -87,6 +87,29 @@ interface DuplicationsShowErrorConfig {
   body?: string;
 }
 
+export interface DependencyRiskConfig {
+  key?: string;
+  packageName: string;
+  version: string;
+  severity: string;
+  type: 'MALWARE' | 'PROHIBITED_LICENSE' | 'VULNERABILITY';
+  status?: string;
+  vulnerabilityId?: string;
+  newlyIntroduced?: boolean;
+}
+
+const DEPENDENCY_RISK_SEVERITY_RANK: Record<string, number> = {
+  BLOCKER: 0,
+  HIGH: 1,
+  MEDIUM: 2,
+  LOW: 3,
+  INFO: 4,
+};
+
+function severityRank(severity: string): number {
+  return DEPENDENCY_RISK_SEVERITY_RANK[severity] ?? Number.MAX_SAFE_INTEGER;
+}
+
 interface ProjectData {
   key: string;
   name: string;
@@ -106,6 +129,7 @@ interface ProjectData {
   duplicationsErrorsByFile: Map<string, DuplicationsShowErrorConfig>;
   issuesSearchStatusCode?: number;
   issuesSearchStatusBody?: string;
+  dependencyRisks: DependencyRiskConfig[];
 }
 
 export interface DopRepositoryConfig {
@@ -136,6 +160,7 @@ export class ProjectBuilder {
   private readonly duplicationsErrorsByFile: Map<string, DuplicationsShowErrorConfig> = new Map();
   private issuesSearchStatusCode?: number;
   private issuesSearchStatusBody?: string;
+  private dependencyRisks: DependencyRiskConfig[] = [];
 
   constructor(projectKey: string) {
     this.projectKey = projectKey;
@@ -281,6 +306,11 @@ export class ProjectBuilder {
     return this;
   }
 
+  withDependencyRisks(risks: DependencyRiskConfig[]): this {
+    this.dependencyRisks = risks;
+    return this;
+  }
+
   getData(): ProjectData {
     return {
       key: this.projectKey,
@@ -301,6 +331,7 @@ export class ProjectBuilder {
       duplicationsErrorsByFile: this.duplicationsErrorsByFile,
       issuesSearchStatusCode: this.issuesSearchStatusCode,
       issuesSearchStatusBody: this.issuesSearchStatusBody,
+      dependencyRisks: this.dependencyRisks,
     };
   }
 }
@@ -1062,6 +1093,48 @@ export class FakeSonarQubeServerBuilder {
           return new Response(JSON.stringify({ duplications, files }), {
             headers: { 'Content-Type': 'application/json' },
           });
+        }
+
+        if (path === '/sca/issues-releases' || path === '/api/v2/sca/issues-releases') {
+          const projectKey = query.projectKey;
+          const projectData = projectKey ? projects.get(projectKey) : undefined;
+          const risks = projectData?.dependencyRisks ?? [];
+
+          const requestedTypes = new Set((query.types ?? '').split(',').filter(Boolean));
+          const requestedStatuses = new Set((query.statuses ?? '').split(',').filter(Boolean));
+          const newlyIntroducedOnly = query.newlyIntroduced === 'true';
+
+          const filtered = risks.filter((risk) => {
+            if (requestedTypes.size > 0 && !requestedTypes.has(risk.type)) {
+              return false;
+            }
+            if (requestedStatuses.size > 0 && !requestedStatuses.has(risk.status ?? 'OPEN')) {
+              return false;
+            }
+            return !newlyIntroducedOnly || (risk.newlyIntroduced ?? false);
+          });
+
+          const sorted =
+            query.sort === '-severity'
+              ? [...filtered].sort((a, b) => severityRank(a.severity) - severityRank(b.severity))
+              : filtered;
+
+          const pageSize = Number.parseInt(query.pageSize ?? '500', 10);
+          const paged = sorted.slice(0, pageSize);
+
+          return new Response(
+            JSON.stringify({
+              issuesReleases: paged.map((risk, i) => ({
+                key: risk.key ?? `RISK-${i + 1}`,
+                severity: risk.severity,
+                type: risk.type,
+                vulnerabilityId: risk.vulnerabilityId ?? null,
+                release: { packageName: risk.packageName, version: risk.version },
+              })),
+              page: { pageIndex: 1, pageSize, total: filtered.length },
+            }),
+            { headers: { 'Content-Type': 'application/json' } },
+          );
         }
 
         // sonar-context-augmentation calls /api/project_branches/list to

--- a/tests/integration/specs/quality-gate/status-breakdown-dependency-risks.test.ts
+++ b/tests/integration/specs/quality-gate/status-breakdown-dependency-risks.test.ts
@@ -1,0 +1,595 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+// Integration tests for the dependency-risks category breakdown in `quality-gate status`
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { TestHarness } from '../../harness';
+
+describe('quality-gate status — dependency-risks breakdown', () => {
+  let harness: TestHarness;
+
+  beforeEach(async () => {
+    harness = await TestHarness.create();
+  });
+
+  afterEach(async () => {
+    await harness.dispose();
+  });
+
+  it(
+    'includes a flat, multi-type breakdown in JSON for a failing any_issue count condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          { key: 'new_sca_count_any_issue', type: 'INT', name: 'Count of new dependency risks' },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_sca_count_any_issue',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '2',
+              },
+            ])
+            .withDependencyRisks([
+              {
+                key: 'RISK-1',
+                packageName: 'event-stream',
+                version: '3.3.6',
+                severity: 'BLOCKER',
+                type: 'MALWARE',
+                newlyIntroduced: true,
+              },
+              {
+                key: 'RISK-2',
+                packageName: 'lodash',
+                version: '4.17.20',
+                severity: 'HIGH',
+                type: 'VULNERABILITY',
+                vulnerabilityId: 'CVE-2021-23337',
+                newlyIntroduced: true,
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      expect(result.exitCode).toBe(51);
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_sca_count_any_issue',
+      );
+      expect(condition.breakdown).toEqual({
+        category: 'dependency-risks',
+        totalCount: 2,
+        fetchedCount: 2,
+        entries: [
+          {
+            package: 'event-stream',
+            version: '3.3.6',
+            severity: 'BLOCKER',
+            type: 'MALWARE',
+            key: 'RISK-1',
+          },
+          {
+            package: 'lodash',
+            version: '4.17.20',
+            severity: 'HIGH',
+            type: 'VULNERABILITY',
+            key: 'RISK-2',
+            vulnerabilityId: 'CVE-2021-23337',
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'restricts to a single risk type for a failing vulnerability-only condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'sca_severity_vulnerability',
+            type: 'INT',
+            name: 'Severity of a vulnerability dependency risk',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sca_severity_vulnerability',
+                comparator: 'GT',
+                errorThreshold: '14',
+                actualValue: '15',
+              },
+            ])
+            .withDependencyRisks([
+              {
+                packageName: 'axios',
+                version: '0.21.1',
+                severity: 'MEDIUM',
+                type: 'VULNERABILITY',
+              },
+              // A licensing risk must never show up under a vulnerability-only condition.
+              {
+                packageName: 'left-pad',
+                version: '1.0.0',
+                severity: 'HIGH',
+                type: 'PROHIBITED_LICENSE',
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'sca_severity_vulnerability',
+      );
+      expect(condition.breakdown.entries).toHaveLength(1);
+      expect(condition.breakdown.entries[0].package).toBe('axios');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'includes a dependency-risks breakdown for a failing rating condition',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'sca_rating_licensing',
+            type: 'RATING',
+            name: 'Dependency risk rating for licenses',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sca_rating_licensing',
+                comparator: 'GT',
+                errorThreshold: '1',
+                actualValue: '4',
+              },
+            ])
+            .withDependencyRisks([
+              {
+                packageName: 'gpl-lib',
+                version: '2.0.0',
+                severity: 'HIGH',
+                type: 'PROHIBITED_LICENSE',
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'sca_rating_licensing',
+      );
+      expect(condition.formattedActualValue).toBe('D');
+      expect(condition.breakdown).toEqual({
+        category: 'dependency-risks',
+        totalCount: 1,
+        fetchedCount: 1,
+        entries: [
+          {
+            package: 'gpl-lib',
+            version: '2.0.0',
+            severity: 'HIGH',
+            type: 'PROHIBITED_LICENSE',
+            key: 'RISK-1',
+          },
+        ],
+      });
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'excludes an already-fixed risk - the breakdown must match what the condition itself counted',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([{ key: 'sca_count_malware', type: 'INT', name: 'Count of malware risks' }])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sca_count_malware',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '1',
+              },
+            ])
+            .withDependencyRisks([
+              { packageName: 'evil-pkg', version: '1.0.0', severity: 'BLOCKER', type: 'MALWARE' },
+              {
+                packageName: 'already-fixed-pkg',
+                version: '2.0.0',
+                severity: 'BLOCKER',
+                type: 'MALWARE',
+                status: 'FIXED',
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'sca_count_malware',
+      );
+      expect(condition.breakdown.entries).toHaveLength(1);
+      expect(condition.breakdown.entries[0].package).toBe('evil-pkg');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'renders package@version, severity, type and the CVE in the table',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          { key: 'new_sca_count_any_issue', type: 'INT', name: 'Count of new dependency risks' },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_sca_count_any_issue',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '2',
+              },
+            ])
+            .withDependencyRisks([
+              {
+                packageName: 'event-stream',
+                version: '3.3.6',
+                severity: 'BLOCKER',
+                type: 'MALWARE',
+                newlyIntroduced: true,
+              },
+              {
+                packageName: 'lodash',
+                version: '4.17.20',
+                severity: 'HIGH',
+                type: 'VULNERABILITY',
+                vulnerabilityId: 'CVE-2021-23337',
+                newlyIntroduced: true,
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format table`);
+
+      const lines = result.stdout.split('\n');
+      const conditionIndex = lines.findIndex((l) => l.includes('Count of new dependency risks'));
+      expect(lines[conditionIndex + 1]).toContain('event-stream@3.3.6');
+      expect(lines[conditionIndex + 1]).toContain('BLOCKER');
+      expect(lines[conditionIndex + 1]).toContain('MALWARE');
+      expect(lines[conditionIndex + 2]).toContain('lodash@4.17.20');
+      expect(lines[conditionIndex + 2]).toContain('HIGH');
+      expect(lines[conditionIndex + 2]).toContain('VULNERABILITY');
+      expect(lines[conditionIndex + 2]).toContain('CVE-2021-23337');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'includes the dependency-risks breakdown when --category dependency-risks is passed explicitly',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          { key: 'new_coverage', type: 'PERCENT', name: 'Coverage on New Code' },
+          { key: 'new_sca_count_any_issue', type: 'INT', name: 'Count of new dependency risks' },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'new_coverage',
+                comparator: 'LT',
+                errorThreshold: '80',
+                actualValue: '50',
+              },
+              {
+                status: 'ERROR',
+                metricKey: 'new_sca_count_any_issue',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '1',
+              },
+            ])
+            .withDependencyRisks([
+              {
+                packageName: 'event-stream',
+                version: '3.3.6',
+                severity: 'BLOCKER',
+                type: 'MALWARE',
+                newlyIntroduced: true,
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --category dependency-risks --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      const coverageCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_coverage',
+      );
+      const riskCondition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'new_sca_count_any_issue',
+      );
+      expect(coverageCondition.breakdown).toBeUndefined();
+      expect(riskCondition.breakdown.category).toBe('dependency-risks');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'caps entries at --top and reports the remaining count',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'sca_count_vulnerability',
+            type: 'INT',
+            name: 'Count of vulnerability dependency risks',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sca_count_vulnerability',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '3',
+              },
+            ])
+            .withDependencyRisks([
+              { packageName: 'pkg-a', version: '1.0.0', severity: 'HIGH', type: 'VULNERABILITY' },
+              { packageName: 'pkg-b', version: '1.0.0', severity: 'MEDIUM', type: 'VULNERABILITY' },
+              { packageName: 'pkg-c', version: '1.0.0', severity: 'LOW', type: 'VULNERABILITY' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --top 2 --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'sca_count_vulnerability',
+      );
+      expect(condition.breakdown.totalCount).toBe(3);
+      expect(condition.breakdown.fetchedCount).toBe(2);
+      expect(condition.breakdown.entries).toHaveLength(2);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'sorts entries worst-first by severity regardless of configuration order',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'sca_count_vulnerability',
+            type: 'INT',
+            name: 'Count of vulnerability dependency risks',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sca_count_vulnerability',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '3',
+              },
+            ])
+            .withDependencyRisks([
+              { packageName: 'pkg-low', version: '1.0.0', severity: 'LOW', type: 'VULNERABILITY' },
+              {
+                packageName: 'pkg-blocker',
+                version: '1.0.0',
+                severity: 'BLOCKER',
+                type: 'VULNERABILITY',
+              },
+              {
+                packageName: 'pkg-medium',
+                version: '1.0.0',
+                severity: 'MEDIUM',
+                type: 'VULNERABILITY',
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(
+        `quality-gate status --project my-project --top 2 --format json`,
+      );
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'sca_count_vulnerability',
+      );
+      expect(condition.breakdown.entries.map((e: { package: string }) => e.package)).toEqual([
+        'pkg-blocker',
+        'pkg-medium',
+      ]);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'excludes risks with an unrecognized severity from fetchedCount',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'sca_count_vulnerability',
+            type: 'INT',
+            name: 'Count of vulnerability dependency risks',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sca_count_vulnerability',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '2',
+              },
+            ])
+            .withDependencyRisks([
+              { packageName: 'pkg-a', version: '1.0.0', severity: 'HIGH', type: 'VULNERABILITY' },
+              {
+                packageName: 'pkg-b',
+                version: '1.0.0',
+                severity: 'CRITICAL',
+                type: 'VULNERABILITY',
+              },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token');
+
+      const result = await harness.run(`quality-gate status --project my-project --format json`);
+
+      const parsed = JSON.parse(result.stdout);
+      const condition = parsed.qualityGate.conditions.find(
+        (c: { metric: string }) => c.metric === 'sca_count_vulnerability',
+      );
+      expect(condition.breakdown.entries).toHaveLength(1);
+      expect(condition.breakdown.fetchedCount).toBe(1);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'forwards the organization query param on a cloud connection',
+    async () => {
+      const server = await harness
+        .newFakeServer()
+        .asSonarCloud()
+        .withAuthToken('test-token')
+        .withMetrics([
+          {
+            key: 'sca_count_vulnerability',
+            type: 'INT',
+            name: 'Count of vulnerability dependency risks',
+          },
+        ])
+        .withProject('my-project', (p) =>
+          p
+            .withProjectStatus('ERROR')
+            .withConditions([
+              {
+                status: 'ERROR',
+                metricKey: 'sca_count_vulnerability',
+                comparator: 'GT',
+                errorThreshold: '0',
+                actualValue: '1',
+              },
+            ])
+            .withDependencyRisks([
+              { packageName: 'pkg-a', version: '1.0.0', severity: 'HIGH', type: 'VULNERABILITY' },
+            ]),
+        )
+        .start();
+      harness.withAuth(server.baseUrl(), 'test-token', 'my-org');
+
+      await harness.run(`quality-gate status --project my-project --format json`);
+
+      const scaRequest = server
+        .getRecordedRequests()
+        .find((r) => r.path === '/sca/issues-releases');
+      expect(scaRequest?.query.organization).toBe('my-org');
+    },
+    { timeout: 15000 },
+  );
+});

--- a/tests/unit/core/server/sca.test.ts
+++ b/tests/unit/core/server/sca.test.ts
@@ -1,0 +1,188 @@
+/*
+ * SonarQube CLI
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+
+import { SONARCLOUD_URL } from '@/core/config-constants.ts';
+import { SonarHttpClient } from '@/core/server/http-client.ts';
+import { ScaClient } from '@/core/server/sca.ts';
+import type { ScaIssuesReleasesResponse } from '@/core/server/types.ts';
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as Response;
+}
+
+const SERVER_URL = 'https://sonarqube.example.com';
+const TOKEN = 'squ_test_token';
+
+const SAMPLE_RESPONSE: ScaIssuesReleasesResponse = {
+  issuesReleases: [
+    {
+      key: 'RISK-1',
+      severity: 'HIGH',
+      type: 'VULNERABILITY',
+      vulnerabilityId: 'CVE-2021-23337',
+      release: { packageName: 'lodash', version: '4.17.20' },
+    },
+  ],
+  page: { pageIndex: 1, pageSize: 10, total: 1 },
+};
+
+describe('ScaClient.getWorstIssuesReleases', () => {
+  let client: ScaClient;
+  let fetchSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    client = new ScaClient(new SonarHttpClient(SERVER_URL, TOKEN));
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+  });
+
+  it('requests /api/v2/sca/issues-releases on a non-cloud connection', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    await client.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      top: 10,
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).toContain('/api/v2/sca/issues-releases');
+    expect(url).toContain('projectKey=my-project');
+    expect(url).toContain('types=VULNERABILITY');
+    expect(url).toContain('statuses=OPEN%2CCONFIRM');
+    expect(url).toContain('sort=-severity');
+    expect(url).toContain('pageSize=10');
+  });
+
+  it('joins multiple types with a comma', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    await client.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['MALWARE', 'VULNERABILITY'],
+      top: 10,
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).toContain('types=MALWARE%2CVULNERABILITY');
+  });
+
+  it('omits newlyIntroduced, branch and pull request from the query when not given', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    await client.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      top: 10,
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).not.toContain('newlyIntroduced');
+    expect(url).not.toContain('branchKey');
+    expect(url).not.toContain('pullRequestKey');
+  });
+
+  it('ignores orgKey on a non-cloud connection', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    await client.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      top: 10,
+      orgKey: 'my-org',
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).not.toContain('organization');
+  });
+
+  it('forwards orgKey as the organization query param on a cloud connection', async () => {
+    const cloudClient = new ScaClient(new SonarHttpClient(SONARCLOUD_URL, TOKEN));
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    await cloudClient.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      top: 10,
+      orgKey: 'my-org',
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).toContain('organization=my-org');
+  });
+
+  it('omits organization on a cloud connection when orgKey is not given', async () => {
+    const cloudClient = new ScaClient(new SonarHttpClient(SONARCLOUD_URL, TOKEN));
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    await cloudClient.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      top: 10,
+    });
+
+    const url = (fetchSpy.mock.calls[0][0] as URL).toString();
+    expect(url).not.toContain('organization');
+  });
+
+  it('forwards newlyIntroduced, branch and pull request when given', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    await client.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      newlyIntroduced: true,
+      top: 10,
+      branch: 'feature-x',
+    });
+    expect((fetchSpy.mock.calls[0][0] as URL).toString()).toContain('newlyIntroduced=true');
+    expect((fetchSpy.mock.calls[0][0] as URL).toString()).toContain('branchKey=feature-x');
+
+    await client.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      top: 10,
+      pullRequest: '42',
+    });
+    expect((fetchSpy.mock.calls[1][0] as URL).toString()).toContain('pullRequestKey=42');
+  });
+
+  it('returns the risks and the total count from the response paging', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse(SAMPLE_RESPONSE));
+
+    const result = await client.getWorstIssuesReleases({
+      projectKey: 'my-project',
+      types: ['VULNERABILITY'],
+      top: 10,
+    });
+
+    expect(result).toEqual({ issuesReleases: SAMPLE_RESPONSE.issuesReleases, totalCount: 1 });
+  });
+});


### PR DESCRIPTION
----
## Summary by Gitar

- **Quality gate breakdown:**
    - Added dependency-risks category enrichment via `fetchDependencyRisksBreakdown` and `ScaClient` integration
    - Formatted dependency risk entries in tables with package version, severity, type, and vulnerability ID

<sub>This will update automatically on new commits.</sub>