### PR TITLE
CLI-1087 Fix issue-search project, raise minimum Server version to 25.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Before installing, you need:
 
 - **SonarQube Access** (choose one):
   - [SonarQube Cloud](https://sonarcloud.io) — Free for open source projects, paid for private repositories
-  - SonarQube Server — Self-hosted instance (v9.9+)
+  - SonarQube Server — Self-hosted instance (v25.1+)
 
 - **Operating System**: Linux (x86-64, ARM64), macOS (ARM64), or Windows (x86-64)
 

--- a/src/core/server/issues.ts
+++ b/src/core/server/issues.ts
@@ -20,8 +20,11 @@
 
 // SonarQube Issues API wrapper
 
-import { type SonarHttpClient } from './http-client.ts';
+import { type QueryParams, type SonarHttpClient } from './http-client.ts';
 import type { IssuesSearchParams, IssuesSearchResponse } from './types.ts';
+
+/** Booleans where `false` is a meaningful filter value, not "unset". */
+const KEYS_WHERE_FALSE_IS_MEANINGFUL = new Set(['resolved', 'asc']);
 
 export class IssuesClient {
   private readonly client: SonarHttpClient;
@@ -30,23 +33,45 @@ export class IssuesClient {
     this.client = client;
   }
 
+  /** Maps an `IssuesSearchParams` key to the wire param name for the current platform. */
+  private resolveQueryParamKey(key: string): string {
+    switch (key) {
+      case 'projects':
+        // Cloud has no `projects`/`components` param on this endpoint, only `componentKeys`.
+        return this.client.isCloud ? 'componentKeys' : 'components';
+      case 'sinceLeakPeriod':
+        // `sinceLeakPeriod` was removed on Server 10.0 in favor of `inNewCodePeriod`; Cloud
+        // never got the new name. Server 25.1 (our minimum) has had `inNewCodePeriod` since 9.4.
+        return this.client.isCloud ? 'sinceLeakPeriod' : 'inNewCodePeriod';
+      default:
+        return key;
+    }
+  }
+
+  /**
+   * Translates `IssuesSearchParams` into the query params `/api/issues/search` actually
+   * accepts, renaming the platform-specific ones (Cloud vs Server).
+   */
+  private buildSearchQueryParams(params: IssuesSearchParams): QueryParams {
+    const queryParams: QueryParams = {};
+
+    Object.entries(params).forEach(([key, value]) => {
+      const isSet = KEYS_WHERE_FALSE_IS_MEANINGFUL.has(key) ? value !== undefined : Boolean(value);
+      if (isSet) {
+        queryParams[this.resolveQueryParamKey(key)] = value as string | number | boolean;
+      }
+    });
+
+    return queryParams;
+  }
+
   /**
    * Search issues with filters
    */
   async searchIssues(params: IssuesSearchParams): Promise<IssuesSearchResponse> {
-    const queryParams: Record<string, string | number | boolean> = {};
-
-    Object.entries(params).forEach(([key, value]) => {
-      if (key === 'projects' && value) {
-        const projectParamKey = this.client.isCloud ? 'projects' : 'components';
-        queryParams[projectParamKey] = value as string;
-      } else if ((key === 'resolved' || key === 'asc') && value !== undefined) {
-        queryParams[key] = value as boolean;
-      } else if (value) {
-        queryParams[key] = value as string | number | boolean;
-      }
-    });
-
-    return await this.client.get<IssuesSearchResponse>('/api/issues/search', queryParams);
+    return await this.client.get<IssuesSearchResponse>(
+      '/api/issues/search',
+      this.buildSearchQueryParams(params),
+    );
   }
 }

--- a/tests/integration/harness/fake-sonarqube-server.ts
+++ b/tests/integration/harness/fake-sonarqube-server.ts
@@ -47,7 +47,7 @@ export interface IssueConfig {
   type?: string;
   line?: number;
   fixableByAgent?: boolean;
-  /** Marks the issue as introduced in the leak period, matched by `sinceLeakPeriod=true`. */
+  /** Marks the issue as introduced in the leak period, matched by `inNewCodePeriod=true`. */
   isNewCode?: boolean;
 }
 
@@ -372,7 +372,7 @@ export class FakeSonarQubeServerBuilder {
   private readonly privateProjectsEntitlements: Map<string, boolean> = new Map();
   private validToken?: string;
   private systemStatusCode = 200;
-  private systemVersion = '9.9.0.00001';
+  private systemVersion = '25.1.0.102122';
   private memberOrganizations: Organization[] = [];
   private memberOrganizationsTotal?: number;
   private visibleOrganizations: Organization[] = [];
@@ -787,6 +787,7 @@ export class FakeSonarQubeServerBuilder {
       hasProvisionProjects,
       boundProjectsStatusCode,
       analyzedProjectKeys,
+      treatAsCloud,
     } = this;
     const memberOrganizationsTotal = rawMemberOrganizationsTotal ?? memberOrganizations.length;
     const requests: RecordedRequest[] = [];
@@ -884,8 +885,10 @@ export class FakeSonarQubeServerBuilder {
         }
 
         if (path === '/api/issues/search') {
-          // SonarQube Server uses `components`, SonarQube Cloud uses `projects`
-          const projectKey = query.components ?? query.projects;
+          // SonarQube Server uses `components`, SonarQube Cloud uses `componentKeys` — accept
+          // only the spelling the current mode actually uses, so a client sending the wrong one
+          // fails the lookup instead of being silently tolerated.
+          const projectKey = treatAsCloud ? query.componentKeys : query.components;
           const projectData = projectKey ? projects.get(projectKey) : undefined;
 
           if (projectData?.issuesSearchStatusCode !== undefined) {
@@ -898,7 +901,10 @@ export class FakeSonarQubeServerBuilder {
           const severityFilter = query.severities ? query.severities.split(',') : null;
           const typeFilter = query.types ? query.types.split(',') : null;
           const resolvedFilter = query.resolved;
-          const sinceLeakPeriodFilter = query.sinceLeakPeriod === 'true';
+          // SonarQube Server uses `inNewCodePeriod`, SonarQube Cloud uses `sinceLeakPeriod`
+          const sinceLeakPeriodFilter = treatAsCloud
+            ? query.sinceLeakPeriod === 'true'
+            : query.inNewCodePeriod === 'true';
 
           const fixableByAgentFilter = query.fixableByAgent;
 

--- a/tests/integration/specs/quality-gate/status-breakdown-issues.test.ts
+++ b/tests/integration/specs/quality-gate/status-breakdown-issues.test.ts
@@ -101,7 +101,7 @@ describe('quality-gate status — issues breakdown', () => {
       const req = recorded.find((r) => r.path === '/api/issues/search');
       expect(req?.query.types).toBeUndefined();
       expect(req?.query.resolved).toBe('false');
-      expect(req?.query.sinceLeakPeriod).toBeUndefined();
+      expect(req?.query.inNewCodePeriod).toBeUndefined();
       expect(req?.query.s).toBe('SEVERITY');
       expect(req?.query.asc).toBe('false');
     },
@@ -109,7 +109,7 @@ describe('quality-gate status — issues breakdown', () => {
   );
 
   it(
-    'adds sinceLeakPeriod=true for a failing new_violations condition',
+    'adds inNewCodePeriod=true for a failing new_violations condition',
     async () => {
       const server = await harness
         .newFakeServer()
@@ -154,7 +154,7 @@ describe('quality-gate status — issues breakdown', () => {
 
       const recorded = server.getRecordedRequests();
       const req = recorded.find((r) => r.path === '/api/issues/search');
-      expect(req?.query.sinceLeakPeriod).toBe('true');
+      expect(req?.query.inNewCodePeriod).toBe('true');
     },
     { timeout: 15000 },
   );
@@ -420,7 +420,7 @@ describe('quality-gate status — issues breakdown', () => {
       const recorded = server.getRecordedRequests();
       const requests = recorded.filter((r) => r.path === '/api/issues/search');
       expect(requests.every((r) => r.query.types === 'CODE_SMELL')).toBe(true);
-      expect(requests.some((r) => r.query.sinceLeakPeriod === 'true')).toBe(true);
+      expect(requests.some((r) => r.query.inNewCodePeriod === 'true')).toBe(true);
     },
     { timeout: 15000 },
   );

--- a/tests/integration/specs/remediate/remediate.test.ts
+++ b/tests/integration/specs/remediate/remediate.test.ts
@@ -405,9 +405,9 @@ describe('sonar remediate', () => {
       expect(query['fixableByAgent']).toBe('true');
       expect(query['issueStatuses']).toContain('OPEN');
       expect(query['issueStatuses']).toContain('CONFIRMED');
-      // The CLI uses 'components' for on-premise and 'projects' for SonarCloud;
+      // The CLI uses 'components' for on-premise and 'componentKeys' for SonarCloud;
       // the fake server uses a 127.0.0.1 URL so isCloud is false → 'components' is sent
-      const projectParamValue = query['components'] ?? query['projects'];
+      const projectParamValue = query['components'] ?? query['componentKeys'];
       expect(projectParamValue).toBe(TEST_PROJECT);
     },
     { timeout: 15000 },

--- a/tests/unit/commands/list/list.test.ts
+++ b/tests/unit/commands/list/list.test.ts
@@ -125,9 +125,9 @@ describe('IssuesClient', () => {
       expect(mockGet).toHaveBeenCalledTimes(1);
     });
 
-    it('should pass projects parameter', async () => {
+    it('should pass projects parameter as componentKeys on Cloud', async () => {
       const mockGet = mock((_endpoint: string, params?: MockParams) => {
-        expect(params?.projects).toBe('my-project');
+        expect(params?.componentKeys).toBe('my-project');
         return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
       });
 
@@ -284,10 +284,11 @@ describe('IssuesClient', () => {
       });
     });
 
-    it('sends `projects` query param for SonarCloud (sonarcloud.io)', async () => {
+    it('sends `componentKeys` query param for SonarCloud (sonarcloud.io)', async () => {
       const mockGet = mock((_endpoint: string, params?: MockParams) => {
-        expect(params?.projects).toBe('my-project');
+        expect(params?.componentKeys).toBe('my-project');
         expect(params?.components).toBeUndefined();
+        expect(params?.projects).toBeUndefined();
         return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
       });
 
@@ -297,10 +298,11 @@ describe('IssuesClient', () => {
       await issuesClient.searchIssues({ projects: 'my-project' });
     });
 
-    it('sends `projects` query param for SonarQube Cloud US (sonarqube.us)', async () => {
+    it('sends `componentKeys` query param for SonarQube Cloud US (sonarqube.us)', async () => {
       const mockGet = mock((_endpoint: string, params?: MockParams) => {
-        expect(params?.projects).toBe('my-project');
+        expect(params?.componentKeys).toBe('my-project');
         expect(params?.components).toBeUndefined();
+        expect(params?.projects).toBeUndefined();
         return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
       });
 
@@ -313,6 +315,7 @@ describe('IssuesClient', () => {
     it('sends `components` query param for on-premise SonarQube', async () => {
       const mockGet = mock((_endpoint: string, params?: MockParams) => {
         expect(params?.components).toBe('my-project');
+        expect(params?.componentKeys).toBeUndefined();
         expect(params?.projects).toBeUndefined();
         return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
       });
@@ -326,6 +329,7 @@ describe('IssuesClient', () => {
     it('sends no project param when projects is not provided', async () => {
       const mockGet = mock((_endpoint: string, params?: MockParams) => {
         expect(params?.projects).toBeUndefined();
+        expect(params?.componentKeys).toBeUndefined();
         expect(params?.components).toBeUndefined();
         return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
       });
@@ -334,6 +338,45 @@ describe('IssuesClient', () => {
       const issuesClient = new IssuesClient(client);
 
       await issuesClient.searchIssues({});
+    });
+
+    it('sends `sinceLeakPeriod` query param for SonarCloud', async () => {
+      const mockGet = mock((_endpoint: string, params?: MockParams) => {
+        expect(params?.sinceLeakPeriod).toBe(true);
+        expect(params?.inNewCodePeriod).toBeUndefined();
+        return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
+      });
+
+      const client = createMockClient(mockGet, 'https://sonarcloud.io');
+      const issuesClient = new IssuesClient(client);
+
+      await issuesClient.searchIssues({ projects: 'my-project', sinceLeakPeriod: true });
+    });
+
+    it('sends `inNewCodePeriod` query param for on-premise SonarQube', async () => {
+      const mockGet = mock((_endpoint: string, params?: MockParams) => {
+        expect(params?.inNewCodePeriod).toBe(true);
+        expect(params?.sinceLeakPeriod).toBeUndefined();
+        return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
+      });
+
+      const client = createMockClient(mockGet, 'https://sonarqube.example.com');
+      const issuesClient = new IssuesClient(client);
+
+      await issuesClient.searchIssues({ projects: 'my-project', sinceLeakPeriod: true });
+    });
+
+    it('sends no leak-period param when sinceLeakPeriod is not provided', async () => {
+      const mockGet = mock((_endpoint: string, params?: MockParams) => {
+        expect(params?.sinceLeakPeriod).toBeUndefined();
+        expect(params?.inNewCodePeriod).toBeUndefined();
+        return Promise.resolve(createMockIssuesResponse([], 1, DEFAULT_PAGE_SIZE, 0));
+      });
+
+      const client = createMockClient(mockGet);
+      const issuesClient = new IssuesClient(client);
+
+      await issuesClient.searchIssues({ projects: 'my-project' });
     });
 
     it('should pass pagination parameters', async () => {


### PR DESCRIPTION
----
## Summary by Gitar

- **API client updates:**
    - Use `componentKeys` instead of `projects` for issue search on SonarCloud in `src/core/server/issues.ts`
    - Send `inNewCodePeriod` instead of `sinceLeakPeriod` for on-premise SonarQube
- **Documentation updates:**
    - Update minimum SonarQube Server version requirement to `v25.1+` in `README.md`

<sub>This will update automatically on new commits.</sub>