### PR TITLE
CLI-868 Warning on 'auth login' when env vars are set

### DIFF
--- a/src/commands/auth/login.ts
+++ b/src/commands/auth/login.ts
@@ -19,7 +19,7 @@
  */
 
 import { recordConnectionFromAuth } from '@/core/auth/auth-connection-recorder.ts';
-import { isSonarQubeCloud } from '@/core/auth/auth-resolver.ts';
+import { ENV_TOKEN, isEnvBasedAuth, isSonarQubeCloud } from '@/core/auth/auth-resolver.ts';
 import { type BrowserAuthResult, generateTokenViaBrowser } from '@/core/auth/token.ts';
 import { CommandFailedError, InvalidOptionError } from '@/core/commands/command-error.ts';
 import { type CommandInvocationContext } from '@/core/commands/invocation-context.ts';
@@ -39,6 +39,7 @@ import {
 import { cloudRegionFromUrl } from '@/core/server/sonarcloud-region.ts';
 import { addOrUpdateConnection, getActiveConnection } from '@/core/state/state-manager.ts';
 import { loadState, saveState } from '@/core/state/state-repository.ts';
+import { NOTE_STYLES } from '@/core/ui/colors.ts';
 import type { Console } from '@/core/ui/console.ts';
 
 import {
@@ -55,6 +56,7 @@ export async function authLogin(
 ): Promise<void> {
   const { console } = ctx;
   validateLoginOptions(options);
+  await warnIfEnvAuthPresent(console);
   const server = await resolveServer(options, console);
   await confirmServerTrust(server, console);
 
@@ -102,6 +104,11 @@ export async function authLogin(
 
     const displayServer = isCloud ? `${server} (${org})` : server;
     console.success(`Authentication successful for: ${displayServer}`);
+    if (isEnvBasedAuth()) {
+      console.warn(
+        ` Token saved, but environment variables take precedence and will be used instead.\n   → Unset ${ENV_TOKEN} to use the saved token`,
+      );
+    }
   } finally {
     // The token step leaves stdin resumed for Windows keypresses, and a resumed TTY keeps the
     // process alive. Release it on every exit path, not only on success. That step resumes stdin
@@ -109,6 +116,35 @@ export async function authLogin(
     if (process.stdin.isTTY) {
       process.stdin.pause();
     }
+  }
+}
+
+/**
+ * Environment variable authentication always wins over whatever this command saves (see
+ * `resolveAuth()` in `auth-resolver.ts`), so a login run while it is active would not change what
+ * the CLI actually uses. Warn instead of silently doing pointless work, and let the user opt out
+ * of a token they know will not be used.
+ */
+async function warnIfEnvAuthPresent(console: Console): Promise<void> {
+  if (!isEnvBasedAuth()) {
+    return;
+  }
+  console.note(
+    [
+      'You are already authenticated via environment variables.',
+      'This login will be ignored until those variables have been unset.',
+      "→ Run 'sonar auth status' to see which credentials are currently in use.",
+    ],
+    '⚠ Environment variable authentication detected',
+    NOTE_STYLES.warn,
+  );
+
+  const proceed = await console.confirmPrompt(
+    'Log in anyway and save a token to the keychain?',
+    false,
+  );
+  if (!proceed) {
+    throw new CommandFailedError('Login cancelled');
   }
 }
 

--- a/tests/integration/specs/auth/auth.test.ts
+++ b/tests/integration/specs/auth/auth.test.ts
@@ -281,6 +281,78 @@ describe('auth login', () => {
     },
     { timeout: 15000 },
   );
+
+  it(
+    'warns and prompts before logging in anyway when SQS env vars are set',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('my-login-token').start();
+
+      const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
+        browserToken: 'my-login-token',
+        extraEnv: {
+          [ENV_TOKEN]: 'env-token',
+          [ENV_SERVER]: 'http://env-sonarqube.example.com',
+        },
+      });
+      await session.waitText('Log in anyway');
+      session.write('y');
+      await session.accept('Connect to:');
+      const result = await session.waitFinish();
+
+      expect(result.exitCode).toBe(0);
+      const output = result.stdout + result.stderr;
+      expect(output).toContain('Environment variable authentication detected');
+      expect(output).toContain('This login will be ignored');
+      expect(output).toContain("Run 'sonar auth status'");
+      expect(output).toContain('Log in anyway and save a token to the keychain?');
+      // Login runs to completion once the user opts in.
+      expect(output).toContain('Authentication successful');
+      // ... but the saved token is moot until the env vars are unset.
+      expect(output).toContain(
+        'Token saved, but environment variables take precedence and will be used instead.',
+      );
+      expect(output).toContain(`Unset ${ENV_TOKEN} to use the saved token`);
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'cancels login when the user declines to continue with env vars set',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('my-login-token').start();
+
+      const session = harness.runInteractive(`auth login --server ${server.baseUrl()}`, {
+        browserToken: 'my-login-token',
+        extraEnv: {
+          [ENV_TOKEN]: 'env-token',
+          [ENV_SERVER]: 'http://env-sonarqube.example.com',
+        },
+      });
+      await session.decline('Log in anyway');
+      const result = await session.waitFinish();
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain('Login cancelled');
+      // Declined before the server-trust prompt was ever reached.
+      expect(result.stdout + result.stderr).not.toContain('Connect to:');
+    },
+    { timeout: 15000 },
+  );
+
+  it(
+    'does not warn about environment variable authentication when no env vars are set',
+    async () => {
+      const server = await harness.newFakeServer().withAuthToken('my-login-token').start();
+
+      const result = await confirmTrust(harness, `auth login --server ${server.baseUrl()}`, {
+        browserToken: 'my-login-token',
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toContain('Environment variable authentication');
+    },
+    { timeout: 15000 },
+  );
 });
 
 const LARGE_ORG_TOTAL = 200;


### PR DESCRIPTION
**Warn when logging in while environment-variable auth is active**

`sonar auth login` now detects when `SONARQUBE_CLI_TOKEN`-based env var authentication is active and warns the user before proceeding, since env vars always take precedence and would make any newly saved token unused. 

The user is then prompted to confirm (default "No"); declining cancels the login before the server is even contacted. If they proceed anyway, a reminder is printed after a successful login pointing out that the saved token won't be used until the env var is unset. 