### PR TITLE
CLI-1095 Rename getOrNotFound to getOrNullIf404

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Known gap: **Sentry** (`src/core/observability/sentry.ts`) transmits through the
 
 HTTP is split in two (CLI-842). `SonarHttpClient` (`src/core/server/http-client.ts`) is the **only**
 class that knows about transport: headers, timeouts, request bodies, and how a non-2xx response
-becomes a typed error (`get` / `getIfFound` / `getSafe` / `post` / `postForm` / `postFormJson`,
+becomes a typed error (`get` / `getOrNullIf404` / `getSafe` / `post` / `postForm` / `postFormJson`,
 plus `genericRequest` for `sonar api` only); every one of them issues its request through
 `fetchAuthenticated`, since they all carry the bearer token. It also exposes `apiHostFor(endpoint)`,
 which resolves the region-specific Cloud API host for an endpoint family — call sites pass its

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,7 +191,7 @@ Known gap: **Sentry** (`src/core/observability/sentry.ts`) transmits through the
 
 HTTP is split in two (CLI-842). `SonarHttpClient` (`src/core/server/http-client.ts`) is the **only**
 class that knows about transport: headers, timeouts, request bodies, and how a non-2xx response
-becomes a typed error (`get` / `getOrNotFound` / `getSafe` / `post` / `postForm` / `postFormJson`,
+becomes a typed error (`get` / `getIfFound` / `getSafe` / `post` / `postForm` / `postFormJson`,
 plus `genericRequest` for `sonar api` only); every one of them issues its request through
 `fetchAuthenticated`, since they all carry the bearer token. It also exposes `apiHostFor(endpoint)`,
 which resolves the region-specific Cloud API host for an endpoint family — call sites pass its

--- a/src/core/server/components.ts
+++ b/src/core/server/components.ts
@@ -79,7 +79,7 @@ export class ComponentsClient {
       queryParams.pullRequest = scope.pullRequest;
     }
     return this.client
-      .getIfFound('/api/components/show', queryParams)
+      .getOrNullIf404('/api/components/show', queryParams)
       .map((component) => component !== null);
   }
 
@@ -91,13 +91,13 @@ export class ComponentsClient {
    */
   getComponentId(componentKey: string): ResultAsync<string | null, HttpClientError> {
     return this.client
-      .getIfFound<{ id: string }>('/api/navigation/component', { component: componentKey })
+      .getOrNullIf404<{ id: string }>('/api/navigation/component', { component: componentKey })
       .map((value) => value?.id ?? null);
   }
 
   hasProjectBeenAnalyzed(projectKey: string): ResultAsync<boolean, HttpClientError> {
     return this.client
-      .getIfFound<{ analyses?: unknown[] }>('/api/project_analyses/search', {
+      .getOrNullIf404<{ analyses?: unknown[] }>('/api/project_analyses/search', {
         project: projectKey,
         ps: 1,
       })
@@ -114,7 +114,7 @@ export class ComponentsClient {
     projectKey: string,
   ): ResultAsync<SettingsValue[], HttpClientError | ProjectNotFoundError> {
     return this.client
-      .getIfFound<{ settings?: SettingsValue[] }>('/api/settings/values', {
+      .getOrNullIf404<{ settings?: SettingsValue[] }>('/api/settings/values', {
         component: projectKey,
       })
       .andThen((result) =>

--- a/src/core/server/components.ts
+++ b/src/core/server/components.ts
@@ -79,7 +79,7 @@ export class ComponentsClient {
       queryParams.pullRequest = scope.pullRequest;
     }
     return this.client
-      .getOrNotFound('/api/components/show', queryParams)
+      .getIfFound('/api/components/show', queryParams)
       .map((component) => component !== null);
   }
 
@@ -91,13 +91,13 @@ export class ComponentsClient {
    */
   getComponentId(componentKey: string): ResultAsync<string | null, HttpClientError> {
     return this.client
-      .getOrNotFound<{ id: string }>('/api/navigation/component', { component: componentKey })
+      .getIfFound<{ id: string }>('/api/navigation/component', { component: componentKey })
       .map((value) => value?.id ?? null);
   }
 
   hasProjectBeenAnalyzed(projectKey: string): ResultAsync<boolean, HttpClientError> {
     return this.client
-      .getOrNotFound<{ analyses?: unknown[] }>('/api/project_analyses/search', {
+      .getIfFound<{ analyses?: unknown[] }>('/api/project_analyses/search', {
         project: projectKey,
         ps: 1,
       })
@@ -114,7 +114,7 @@ export class ComponentsClient {
     projectKey: string,
   ): ResultAsync<SettingsValue[], HttpClientError | ProjectNotFoundError> {
     return this.client
-      .getOrNotFound<{ settings?: SettingsValue[] }>('/api/settings/values', {
+      .getIfFound<{ settings?: SettingsValue[] }>('/api/settings/values', {
         component: projectKey,
       })
       .andThen((result) =>

--- a/src/core/server/http-client.ts
+++ b/src/core/server/http-client.ts
@@ -223,8 +223,10 @@ export class SonarHttpClient {
   }
 
   /**
-   * Like `get`, but resolves to `Ok(null)` instead of an error when the server responds
-   * 404. Every other non-2xx status still yields its normal typed error.
+   * Like `get`, but treats a 404 as a meaningful, expected answer instead of a failure:
+   * resolves to `Ok(null)` when the server responds 404. Every other non-2xx status
+   * (403, 429, 503, network error, ...) still yields the normal typed error, exactly
+   * as `get` would.
    */
   getIfFound<T>(
     endpoint: string,

--- a/src/core/server/http-client.ts
+++ b/src/core/server/http-client.ts
@@ -228,7 +228,7 @@ export class SonarHttpClient {
    * (403, 429, 503, network error, ...) still yields the normal typed error, exactly
    * as `get` would.
    */
-  getIfFound<T>(
+  getOrNullIf404<T>(
     endpoint: string,
     params?: QueryParams,
     baseUrl?: string,
@@ -263,7 +263,7 @@ export class SonarHttpClient {
   /**
    * Resolves to `{ response, value }` and never rejects. Only the *status* is left
    * uninterpreted (`value` is `undefined` on a non-2xx response) for the handful of
-   * callers (`getIfFound`, telemetry identity/project-uuid lookups) that need to branch
+   * callers (`getOrNullIf404`, telemetry identity/project-uuid lookups) that need to branch
    * on the status themselves instead of getting a single typed error for "not 2xx". A
    * transport failure (DNS/TLS failure, connection refused, timeout) becomes
    * `TransportError`; a body-parse failure on an otherwise-2xx response becomes

--- a/src/core/server/http-client.ts
+++ b/src/core/server/http-client.ts
@@ -226,7 +226,7 @@ export class SonarHttpClient {
    * Like `get`, but resolves to `Ok(null)` instead of an error when the server responds
    * 404. Every other non-2xx status still yields its normal typed error.
    */
-  getOrNotFound<T>(
+  getIfFound<T>(
     endpoint: string,
     params?: QueryParams,
     baseUrl?: string,
@@ -261,7 +261,7 @@ export class SonarHttpClient {
   /**
    * Resolves to `{ response, value }` and never rejects. Only the *status* is left
    * uninterpreted (`value` is `undefined` on a non-2xx response) for the handful of
-   * callers (`getOrNotFound`, telemetry identity/project-uuid lookups) that need to branch
+   * callers (`getIfFound`, telemetry identity/project-uuid lookups) that need to branch
    * on the status themselves instead of getting a single typed error for "not 2xx". A
    * transport failure (DNS/TLS failure, connection refused, timeout) becomes
    * `TransportError`; a body-parse failure on an otherwise-2xx response becomes

--- a/src/core/server/pull-requests.ts
+++ b/src/core/server/pull-requests.ts
@@ -35,7 +35,7 @@ export class PullRequestsClient {
   // Resolves to `null` on a 404 (edition without PR analysis) instead of erroring.
   listPullRequests(projectKey: string): ResultAsync<ProjectPullRequest[] | null, HttpClientError> {
     return this.client
-      .getOrNotFound<ProjectPullRequestsResponse>('/api/project_pull_requests/list', {
+      .getIfFound<ProjectPullRequestsResponse>('/api/project_pull_requests/list', {
         project: projectKey,
       })
       .map((result) => result?.pullRequests ?? null);

--- a/src/core/server/pull-requests.ts
+++ b/src/core/server/pull-requests.ts
@@ -35,7 +35,7 @@ export class PullRequestsClient {
   // Resolves to `null` on a 404 (edition without PR analysis) instead of erroring.
   listPullRequests(projectKey: string): ResultAsync<ProjectPullRequest[] | null, HttpClientError> {
     return this.client
-      .getIfFound<ProjectPullRequestsResponse>('/api/project_pull_requests/list', {
+      .getOrNullIf404<ProjectPullRequestsResponse>('/api/project_pull_requests/list', {
         project: projectKey,
       })
       .map((result) => result?.pullRequests ?? null);

--- a/src/core/server/quality-gates.ts
+++ b/src/core/server/quality-gates.ts
@@ -49,7 +49,7 @@ export class QualityGatesClient {
       queryParams.pullRequest = params.pullRequest;
     }
     return this.client
-      .getOrNotFound<ProjectStatusResponse>('/api/qualitygates/project_status', queryParams)
+      .getIfFound<ProjectStatusResponse>('/api/qualitygates/project_status', queryParams)
       .map((result) => result?.projectStatus ?? null);
   }
 }

--- a/src/core/server/quality-gates.ts
+++ b/src/core/server/quality-gates.ts
@@ -49,7 +49,7 @@ export class QualityGatesClient {
       queryParams.pullRequest = params.pullRequest;
     }
     return this.client
-      .getIfFound<ProjectStatusResponse>('/api/qualitygates/project_status', queryParams)
+      .getOrNullIf404<ProjectStatusResponse>('/api/qualitygates/project_status', queryParams)
       .map((result) => result?.projectStatus ?? null);
   }
 }

--- a/src/core/server/system.ts
+++ b/src/core/server/system.ts
@@ -34,7 +34,7 @@ export class SystemClient {
   getServerMode(): ResultAsync<'mqr' | 'standard', HttpClientError> {
     if (this.client.isCloud) return okAsync('mqr');
     return this.client
-      .getIfFound<{ mode: string }>('/api/v2/clean-code-policy/mode')
+      .getOrNullIf404<{ mode: string }>('/api/v2/clean-code-policy/mode')
       .map((result) => (result?.mode === 'MQR' ? 'mqr' : 'standard'));
   }
 }

--- a/src/core/server/system.ts
+++ b/src/core/server/system.ts
@@ -34,7 +34,7 @@ export class SystemClient {
   getServerMode(): ResultAsync<'mqr' | 'standard', HttpClientError> {
     if (this.client.isCloud) return okAsync('mqr');
     return this.client
-      .getOrNotFound<{ mode: string }>('/api/v2/clean-code-policy/mode')
+      .getIfFound<{ mode: string }>('/api/v2/clean-code-policy/mode')
       .map((result) => (result?.mode === 'MQR' ? 'mqr' : 'standard'));
   }
 }

--- a/tests/unit/core/server/http-client.test.ts
+++ b/tests/unit/core/server/http-client.test.ts
@@ -189,10 +189,10 @@ describe('SonarHttpClient', () => {
     });
   });
 
-  describe('getIfFound', () => {
+  describe('getOrNullIf404', () => {
     it('returns an error result instead of throwing on a transport failure', async () => {
       fetchSpy = spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
-      const result = await client.getIfFound('/api/some/endpoint');
+      const result = await client.getOrNullIf404('/api/some/endpoint');
       expect(result.isErr()).toBe(true);
       expect(result._unsafeUnwrapErr().message).toBe('ECONNREFUSED');
     });

--- a/tests/unit/core/server/http-client.test.ts
+++ b/tests/unit/core/server/http-client.test.ts
@@ -189,10 +189,10 @@ describe('SonarHttpClient', () => {
     });
   });
 
-  describe('getOrNotFound', () => {
+  describe('getIfFound', () => {
     it('returns an error result instead of throwing on a transport failure', async () => {
       fetchSpy = spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
-      const result = await client.getOrNotFound('/api/some/endpoint');
+      const result = await client.getIfFound('/api/some/endpoint');
       expect(result.isErr()).toBe(true);
       expect(result._unsafeUnwrapErr().message).toBe('ECONNREFUSED');
     });


### PR DESCRIPTION
## Summary
- Renames `SonarHttpClient.getOrNotFound()` to `getOrNullIf404()` — purely mechanical, no behavior change. The old name reads as if the method decides between a value and "not found", or throws on any failure; the new name says exactly what the method does: resolve to `null` specifically on a 404, and propagate every other non-2xx status as a normal typed error.
- Clarifies the method's JSDoc to spell out that 403/429/503/network errors all still yield the normal typed error, exactly like `get`.
- Updates the definition, all five call sites (`components.ts` x3, `quality-gates.ts`, `pull-requests.ts`, `system.ts`), the method's own test `describe` block, and the mention in `CLAUDE.md`.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint:fix`
- [x] `bun run test:unit`
- [x] Vortex analysis (DEEP) on all touched files — clean (2 pre-existing findings on untouched lines in `http-client.ts` left as-is)